### PR TITLE
Use shared_ptr<Bundle>

### DIFF
--- a/core/doc/snippets/uServices-bundlecontext/main.cpp
+++ b/core/doc/snippets/uServices-bundlecontext/main.cpp
@@ -12,7 +12,7 @@ using namespace us;
 void RetrieveBundleContext()
 {
   BundleContext* context = GetBundleContext();
-  Bundle* bundle = context->GetBundle();
+  auto bundle = context->GetBundle();
   std::cout << "Bundle name: " << bundle->GetName() << " [id: " << bundle->GetBundleId() << "]\n";
 }
 //! [GetBundleContext]

--- a/core/doc/snippets/uServices-registration/main.cpp
+++ b/core/doc/snippets/uServices-registration/main.cpp
@@ -54,12 +54,12 @@ context->RegisterService<InterfaceA, InterfaceB>(myService);
 //! [f1]
 class MyServiceFactory : public ServiceFactory
 {
-  virtual InterfaceMapConstPtr GetService(Bundle* /*bundle*/, const ServiceRegistrationBase& /*registration*/)
+  virtual InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& /*bundle*/, const ServiceRegistrationBase& /*registration*/)
   {
     return MakeInterfaceMap<InterfaceA>(std::make_shared<MyService>());;
   }
 
-  virtual void UngetService(Bundle* /*bundle*/, const ServiceRegistrationBase& /*registration*/,
+  virtual void UngetService(const std::shared_ptr<Bundle>& /*bundle*/, const ServiceRegistrationBase& /*registration*/,
                             const InterfaceMapConstPtr& /*service*/)
   {
     
@@ -76,12 +76,12 @@ context->RegisterService<InterfaceA>(ToFactory(myServiceFactory));
 //! [f2]
 class MyServiceFactory : public ServiceFactory
 {
-  virtual InterfaceMapConstPtr GetService(Bundle* /*bundle*/, const ServiceRegistrationBase& /*registration*/)
+  virtual InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& /*bundle*/, const ServiceRegistrationBase& /*registration*/)
   {
     return MakeInterfaceMap<InterfaceA,InterfaceB>(std::make_shared<MyService2>());
   }
 
-  virtual void UngetService(Bundle* /*bundle*/, const ServiceRegistrationBase& /*registration*/,
+  virtual void UngetService(const std::shared_ptr<Bundle>& /*bundle*/, const ServiceRegistrationBase& /*registration*/,
                             const InterfaceMapConstPtr& /*service*/)
   {
     

--- a/core/doc/snippets/uServices-resources/main.cpp
+++ b/core/doc/snippets/uServices-resources/main.cpp
@@ -13,7 +13,7 @@ void resourceExample()
 {
   //! [1]
   // Get this bundle's Bundle object
-  Bundle* bundle = GetBundleContext()->GetBundle();
+  auto bundle = GetBundleContext()->GetBundle();
 
   BundleResource resource = bundle->GetResource("config.properties");
   if (resource.IsValid())
@@ -44,14 +44,14 @@ void extenderPattern(BundleContext* bundleCtx)
 {
   //! [2]
   // Get all installed bundles
-  std::vector<Bundle*> bundles = bundleCtx->GetBundles();
+  std::vector<std::shared_ptr<Bundle>> bundles = bundleCtx->GetBundles();
 
   // Check if a bundle defines a "service-component" property
   // and use its value to retrieve an embedded resource containing
   // a component description.
   for(std::size_t i = 0; i < bundles.size(); ++i)
   {
-    Bundle* const bundle = bundles[i];
+    auto const bundle = bundles[i];
     std::string componentPath = bundle->GetProperty("service-component").ToString();
     if (!componentPath.empty())
     {
@@ -71,7 +71,7 @@ int main(int /*argc*/, char* /*argv*/[])
 {
   //! [0]
   BundleContext* bundleContext = GetBundleContext();
-  Bundle* bundle = bundleContext->GetBundle();
+  auto bundle = bundleContext->GetBundle();
 
   // List all XML files in the config directory
   std::vector<BundleResource> xmlFiles = bundle->FindResources("config", "*.xml", false);

--- a/core/examples/driver/main.cpp
+++ b/core/examples/driver/main.cpp
@@ -130,7 +130,7 @@ int main(int /*argc*/, char** /*argv*/)
       ss >> id;
       if (id > 0)
       {
-        Bundle* bundle = framework->GetBundleContext()->GetBundle(id);
+        auto bundle = framework->GetBundleContext()->GetBundle(id);
         if (!bundle)
         {
           std::cout << "Error: unknown id" << std::endl;
@@ -155,7 +155,7 @@ int main(int /*argc*/, char** /*argv*/)
       }
       else
       {
-        Bundle* bundle = framework->GetBundleContext()->GetBundle(idOrName);
+        auto bundle = framework->GetBundleContext()->GetBundle(idOrName);
         if (!bundle)
         {
           try
@@ -205,7 +205,7 @@ int main(int /*argc*/, char** /*argv*/)
       long int id = -1;
       ss >> id;
 
-      Bundle* const bundle = framework->GetBundleContext()->GetBundle(id);
+      auto const bundle = framework->GetBundleContext()->GetBundle(id);
       if (bundle)
       {
         try
@@ -230,7 +230,7 @@ int main(int /*argc*/, char** /*argv*/)
     }
     else if (strCmd == "s")
     {
-      std::vector<Bundle*> bundles = framework->GetBundleContext()->GetBundles();
+      std::vector<std::shared_ptr<Bundle>> bundles = framework->GetBundleContext()->GetBundles();
 
       std::cout << std::left;
 
@@ -243,7 +243,7 @@ int main(int /*argc*/, char** /*argv*/)
         std::cout << " - | " << std::setw(20) << *nameIter << " | " << std::setw(9) << "-" << std::endl;
       }
 
-      for (std::vector<Bundle*>::const_iterator bundleIter = bundles.begin();
+      for (std::vector<std::shared_ptr<Bundle>>::const_iterator bundleIter = bundles.begin();
            bundleIter != bundles.end(); ++bundleIter)
       {
         std::cout << std::right << std::setw(2) << (*bundleIter)->GetBundleId() << std::left << " | ";

--- a/core/include/usBundle.h
+++ b/core/include/usBundle.h
@@ -27,6 +27,7 @@
 #include "usBundleVersion.h"
 
 #include <vector>
+#include <memory>
 
 namespace us {
 
@@ -78,7 +79,7 @@ typedef ServiceReference<void> ServiceReferenceU;
  *
  * @remarks This class is thread safe.
  */
-class US_Core_EXPORT Bundle
+class US_Core_EXPORT Bundle : public std::enable_shared_from_this<Bundle>
 {
 
 public:

--- a/core/include/usBundleContext.h
+++ b/core/include/usBundleContext.h
@@ -103,24 +103,24 @@ public:
    * @throws std::logic_error If this BundleContext is no
    *         longer valid.
    */
-  Bundle* GetBundle() const;
+  std::shared_ptr<Bundle> GetBundle() const;
 
   /**
    * Returns the bundle with the specified identifier.
    *
    * @param id The identifier of the bundle to retrieve.
-   * @return A <code>Bundle</code> object or <code>0</code> if the
+   * @return A <code>Bundle</code> object or <code>nullptr</code> if the
    *         identifier does not match any previously installed bundle.
    */
-  Bundle* GetBundle(long id) const;
+  std::shared_ptr<Bundle> GetBundle(long id) const;
 
   /**
    * Get the bundle with the specified bundle name.
    *
    * @param name The name of the bundle to get.
-   * @return The requested \c Bundle or \c NULL.
+   * @return The requested \c Bundle or \c nullptr.
    */
-  Bundle* GetBundle(const std::string& name);
+  std::shared_ptr<Bundle> GetBundle(const std::string& name);
 
   /**
    * Returns a list of all known bundles.
@@ -132,7 +132,7 @@ public:
    * @return A std::vector of <code>Bundle</code> objects which
    *         will hold one object per known bundle.
    */
-  std::vector<Bundle*> GetBundles() const;
+  std::vector<std::shared_ptr<Bundle>> GetBundles() const;
 
   /**
    * Registers the specified service object with the specified properties
@@ -681,7 +681,7 @@ public:
    * @return The Bundle object of the installed bundle.
    * @throws std::runtime_error If the installation failed.
    */
-  Bundle* InstallBundle(const std::string& location);
+  std::shared_ptr<Bundle> InstallBundle(const std::string& location);
 
 private:
 

--- a/core/include/usBundleEvent.h
+++ b/core/include/usBundleEvent.h
@@ -24,6 +24,7 @@
 #define USBUNDLEEVENT_H
 
 #include <iostream>
+#include <memory>
 
 #include "usCoreExport.h"
 #include "usSharedData.h"
@@ -133,7 +134,7 @@ public:
    * @param type The event type.
    * @param bundle The bundle which had a lifecycle change.
    */
-  BundleEvent(Type type, Bundle* bundle);
+  BundleEvent(Type type, std::shared_ptr<Bundle> bundle);
 
   BundleEvent(const BundleEvent& other);
 
@@ -144,7 +145,7 @@ public:
    *
    * @return The bundle that had a change occur in its lifecycle.
    */
-  Bundle* GetBundle() const;
+  std::shared_ptr<Bundle> GetBundle() const;
 
   /**
    * Returns the type of lifecyle event. The type values are:

--- a/core/include/usBundleEvent.h
+++ b/core/include/usBundleEvent.h
@@ -134,7 +134,7 @@ public:
    * @param type The event type.
    * @param bundle The bundle which had a lifecycle change.
    */
-  BundleEvent(Type type, std::shared_ptr<Bundle> bundle);
+  BundleEvent(Type type, const std::shared_ptr<Bundle>& bundle);
 
   BundleEvent(const BundleEvent& other);
 

--- a/core/include/usBundleEvent.h
+++ b/core/include/usBundleEvent.h
@@ -134,7 +134,7 @@ public:
    * @param type The event type.
    * @param bundle The bundle which had a lifecycle change.
    */
-  BundleEvent(Type type, const std::shared_ptr<Bundle>& bundle);
+  BundleEvent(Type type, std::shared_ptr<Bundle> bundle);
 
   BundleEvent(const BundleEvent& other);
 

--- a/core/include/usBundleFindHook.h
+++ b/core/include/usBundleFindHook.h
@@ -64,7 +64,7 @@ struct US_Core_EXPORT BundleFindHook
    *        bundles from the list to prevent the bundles from being
    *        returned to the bundle performing the find operation.
    */
-  virtual void Find(const BundleContext* context, ShrinkableVector<Bundle*>& bundles) = 0;
+  virtual void Find(const BundleContext* context, ShrinkableVector<std::shared_ptr<Bundle>>& bundles) = 0;
 };
 
 }

--- a/core/include/usPrototypeServiceFactory.h
+++ b/core/include/usPrototypeServiceFactory.h
@@ -48,7 +48,7 @@ namespace us {
  *
  * A bundle can use both ServiceObjects and BundleContext::GetService(const ServiceReferenceBase&)
  * to obtain a service object for a service. ServiceObjects::GetService() will always
- * return an instance provided by a call to GetService(Bundle*, const ServiceRegistrationBase&)
+ * return an instance provided by a call to GetService(const std::shared_ptr<Bundle>&, const ServiceRegistrationBase&)
  * and BundleContext::GetService(const ServiceReferenceBase&) will always
  * return the bundle-scoped instance.
  * PrototypeServiceFactory objects are only used by the framework and are not made
@@ -78,7 +78,8 @@ struct PrototypeServiceFactory : public ServiceFactory
    * @see ServiceObjects#GetService()
    * @see InterfaceMapConstPtr
    */
-  virtual InterfaceMapConstPtr GetService(Bundle* bundle, const ServiceRegistrationBase& registration) = 0;
+  virtual InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& bundle, 
+                                            const ServiceRegistrationBase& registration) = 0;
 
   /**
    * Releases a service object created for a caller.
@@ -93,7 +94,7 @@ struct PrototypeServiceFactory : public ServiceFactory
    *
    * @see ServiceObjects::UngetService()
    */
-  virtual void UngetService(Bundle* bundle, const ServiceRegistrationBase& registration,
+  virtual void UngetService(const std::shared_ptr<Bundle>& bundle, const ServiceRegistrationBase& registration,
                             const InterfaceMapConstPtr& service) = 0;
 
 };

--- a/core/include/usServiceFactory.h
+++ b/core/include/usServiceFactory.h
@@ -94,7 +94,8 @@ public:
    * @see BundleContext#GetService
    * @see InterfaceMapConstPtr
    */
-  virtual InterfaceMapConstPtr GetService(Bundle* bundle, const ServiceRegistrationBase& registration) = 0;
+  virtual InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& bundle, 
+                                            const ServiceRegistrationBase& registration) = 0;
 
   /**
    * Releases a service object.
@@ -110,7 +111,8 @@ public:
    *        <code>ServiceFactory::GetService</code> method.
    * @see InterfaceMapConstPtr
    */
-  virtual void UngetService(Bundle* bundle, const ServiceRegistrationBase& registration,
+  virtual void UngetService(const std::shared_ptr<Bundle>& bundle, 
+                            const ServiceRegistrationBase& registration,
                             const InterfaceMapConstPtr& service) = 0;
 };
 

--- a/core/include/usServiceObjects.h
+++ b/core/include/usServiceObjects.h
@@ -100,7 +100,7 @@ public:
    *
    * <ol>
    *   <li>If the referenced service has been unregistered, \c NULL is returned.</li>
-   *   <li>The PrototypeServiceFactory::GetService(Bundle*, const ServiceRegistrationBase&)
+   *   <li>The PrototypeServiceFactory::GetService(const std::shared_ptr<Bundle>&, const ServiceRegistrationBase&)
    *       method is called to create a service object for the caller.</li>
    *   <li>If the service object (an instance of InterfaceMap) returned by the
    *       PrototypeServiceFactory object is empty, does not contain all the interfaces

--- a/core/include/usServiceReferenceBase.h
+++ b/core/include/usServiceReferenceBase.h
@@ -25,6 +25,8 @@
 
 #include <usAny.h>
 
+#include <memory>
+
 US_MSVC_PUSH_DISABLE_WARNING(4099) // type name first seen using 'struct' now seen using 'class'
 
 namespace us {
@@ -105,16 +107,16 @@ public:
    * <code>ServiceReferenceBase</code> object.
    *
    * <p>
-   * This method must return <code>0</code> when the service has been
+   * This method must return <code>nullptr</code> when the service has been
    * unregistered. This can be used to determine if the service has been
    * unregistered.
    *
    * @return The bundle that registered the service referenced by this
-   *         <code>ServiceReferenceBase</code> object; <code>0</code> if that
+   *         <code>ServiceReferenceBase</code> object; <code>nullptr</code> if that
    *         service has already been unregistered.
    * @see BundleContext::RegisterService(const InterfaceMap&, const ServiceProperties&)
    */
-  Bundle* GetBundle() const;
+  std::shared_ptr<Bundle> GetBundle() const;
 
   /**
    * Returns the bundles that are using the service referenced by this
@@ -125,7 +127,7 @@ public:
    *         by this <code>ServiceReferenceBase</code> object is greater than
    *         zero.
    */
-  void GetUsingBundles(std::vector<Bundle*>& bundles) const;
+  void GetUsingBundles(std::vector<std::shared_ptr<Bundle>>& bundles) const;
 
   /**
    * Returns the interface identifier this ServiceReferenceBase object

--- a/core/src/bundle/usBundle.cpp
+++ b/core/src/bundle/usBundle.cpp
@@ -61,7 +61,7 @@ Bundle::~Bundle()
 void Bundle::Init(CoreBundleContext* coreCtx,
                     BundleInfo* info)
 {
-  BundlePrivate* mp = new BundlePrivate(this, coreCtx, info);
+  BundlePrivate* mp = new BundlePrivate(this->shared_from_this(), coreCtx, info);
   std::swap(mp, d);
   delete mp;
 }
@@ -74,7 +74,7 @@ void Bundle::Uninit()
     d->RemoveBundleResources();
     delete d->bundleContext;
     d->bundleContext = nullptr;
-    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPED, this));
+    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPED, this->shared_from_this()));
 
     d->bundleActivator = nullptr;
   }
@@ -125,7 +125,7 @@ void Bundle::Start()
   void* activatorHookSym = BundleUtils::GetSymbol(d->info, activator_func.c_str());
   std::memcpy(&activatorHook, &activatorHookSym, sizeof(void*));
 
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTING, this));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTING, this->shared_from_this()));
   // try to get a BundleActivator instance
 
   if (activatorHook)
@@ -147,7 +147,7 @@ void Bundle::Start()
     d->bundleActivator->Start(d->bundleContext);
   }
 
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTED, this));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTED, this->shared_from_this()));
 }
 
 void Bundle::Stop()
@@ -161,7 +161,7 @@ void Bundle::Stop()
 
   try
   {
-    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPING, this));
+    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPING, this->shared_from_this()));
 
     if (d->bundleActivator)
     {
@@ -188,7 +188,7 @@ void Bundle::Uninstall()
 {
   Stop();
   d->coreCtx->bundleRegistry.UnRegister(&d->info);
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::UNINSTALLED, this));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::UNINSTALLED, this->shared_from_this()));
 }
 
 BundleContext* Bundle::GetBundleContext() const
@@ -259,7 +259,7 @@ std::vector<ServiceReferenceU> Bundle::GetServicesInUse() const
 {
   std::vector<ServiceRegistrationBase> sr;
   std::vector<ServiceReferenceU> res;
-  d->coreCtx->services.GetUsedByBundle(const_cast<Bundle*>(this), sr);
+  d->coreCtx->services.GetUsedByBundle(std::const_pointer_cast<Bundle>(this->shared_from_this()), sr);
   for (std::vector<ServiceRegistrationBase>::const_iterator i = sr.begin();
         i != sr.end(); ++i)
   {

--- a/core/src/bundle/usBundle.cpp
+++ b/core/src/bundle/usBundle.cpp
@@ -61,7 +61,7 @@ Bundle::~Bundle()
 void Bundle::Init(CoreBundleContext* coreCtx,
                     BundleInfo* info)
 {
-  BundlePrivate* mp = new BundlePrivate(this->shared_from_this(), coreCtx, info);
+  BundlePrivate* mp = new BundlePrivate(shared_from_this(), coreCtx, info);
   std::swap(mp, d);
   delete mp;
 }
@@ -74,7 +74,7 @@ void Bundle::Uninit()
     d->RemoveBundleResources();
     delete d->bundleContext;
     d->bundleContext = nullptr;
-    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPED, this->shared_from_this()));
+    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPED, shared_from_this()));
 
     d->bundleActivator = nullptr;
   }
@@ -125,7 +125,7 @@ void Bundle::Start()
   void* activatorHookSym = BundleUtils::GetSymbol(d->info, activator_func.c_str());
   std::memcpy(&activatorHook, &activatorHookSym, sizeof(void*));
 
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTING, this->shared_from_this()));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTING, shared_from_this()));
   // try to get a BundleActivator instance
 
   if (activatorHook)
@@ -147,7 +147,7 @@ void Bundle::Start()
     d->bundleActivator->Start(d->bundleContext);
   }
 
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTED, this->shared_from_this()));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STARTED, shared_from_this()));
 }
 
 void Bundle::Stop()
@@ -161,7 +161,7 @@ void Bundle::Stop()
 
   try
   {
-    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPING, this->shared_from_this()));
+    d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::STOPPING, shared_from_this()));
 
     if (d->bundleActivator)
     {
@@ -188,7 +188,7 @@ void Bundle::Uninstall()
 {
   Stop();
   d->coreCtx->bundleRegistry.UnRegister(&d->info);
-  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::UNINSTALLED, this->shared_from_this()));
+  d->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::UNINSTALLED, shared_from_this()));
 }
 
 BundleContext* Bundle::GetBundleContext() const
@@ -259,7 +259,7 @@ std::vector<ServiceReferenceU> Bundle::GetServicesInUse() const
 {
   std::vector<ServiceRegistrationBase> sr;
   std::vector<ServiceReferenceU> res;
-  d->coreCtx->services.GetUsedByBundle(std::const_pointer_cast<Bundle>(this->shared_from_this()), sr);
+  d->coreCtx->services.GetUsedByBundle(std::const_pointer_cast<Bundle>(shared_from_this()), sr);
   for (std::vector<ServiceRegistrationBase>::const_iterator i = sr.begin();
         i != sr.end(); ++i)
   {

--- a/core/src/bundle/usBundleContext.cpp
+++ b/core/src/bundle/usBundleContext.cpp
@@ -60,7 +60,7 @@ BundleContext::~BundleContext()
 
 std::shared_ptr<Bundle> BundleContext::GetBundle() const
 {
-  return d->bundle->q;
+  return d->bundle->q.lock();
 }
 
 std::shared_ptr<Bundle> BundleContext::GetBundle(long id) const
@@ -146,7 +146,7 @@ std::shared_ptr<void> BundleContext::GetService(const ServiceReferenceBase& refe
   {
     throw std::invalid_argument("Default constructed ServiceReference is not a valid input to GetService()");
   }
-  std::shared_ptr<ServiceHolder<void>> h(new ServiceHolder<void>(this, reference, reference.d->GetService(d->bundle->q)));
+  std::shared_ptr<ServiceHolder<void>> h(new ServiceHolder<void>( this, reference, reference.d->GetService(d->bundle->q.lock()) ));
   return std::shared_ptr<void>(h, h->service.get());
 }
 
@@ -159,7 +159,7 @@ InterfaceMapConstPtr BundleContext::GetService(const ServiceReferenceU& referenc
 
   // Although according to the API contract the returned map should not be modified, there is nothing stopping the consumer from
   // using a const_pointer_cast and modifying the map. This copy step is to protect the map stored within the framework.
-  InterfaceMapConstPtr imap_copy = std::make_shared<const InterfaceMap>(*(reference.d->GetServiceInterfaceMap(d->bundle->q).get()));
+  InterfaceMapConstPtr imap_copy = std::make_shared<const InterfaceMap>(*(reference.d->GetServiceInterfaceMap(d->bundle->q.lock()).get()));
   std::shared_ptr<ServiceHolder<const InterfaceMap>> h(new ServiceHolder<const InterfaceMap>(this, reference, imap_copy));
   return InterfaceMapConstPtr(h, h->service.get());
 }
@@ -167,7 +167,7 @@ InterfaceMapConstPtr BundleContext::GetService(const ServiceReferenceU& referenc
 bool BundleContext::UngetService(const ServiceReferenceBase& reference)
 {
   ServiceReferenceBase ref = reference;
-  return ref.d->UngetService(d->bundle->q, true);
+  return ref.d->UngetService(d->bundle->q.lock(), true);
 }
 
 void BundleContext::AddServiceListener(const ServiceListener& delegate,

--- a/core/src/bundle/usBundleContext.cpp
+++ b/core/src/bundle/usBundleContext.cpp
@@ -58,24 +58,24 @@ BundleContext::~BundleContext()
   delete d;
 }
 
-Bundle* BundleContext::GetBundle() const
+std::shared_ptr<Bundle> BundleContext::GetBundle() const
 {
   return d->bundle->q;
 }
 
-Bundle* BundleContext::GetBundle(long id) const
+std::shared_ptr<Bundle> BundleContext::GetBundle(long id) const
 {
   return d->bundle->coreCtx->bundleHooks.FilterBundle(this, d->bundle->coreCtx->bundleRegistry.GetBundle(id));
 }
 
-Bundle* BundleContext::GetBundle(const std::string& name)
+std::shared_ptr<Bundle> BundleContext::GetBundle(const std::string& name)
 {
   return d->bundle->coreCtx->bundleRegistry.GetBundle(name);
 }
 
-std::vector<Bundle*> BundleContext::GetBundles() const
+std::vector<std::shared_ptr<Bundle>> BundleContext::GetBundles() const
 {
-  std::vector<Bundle*> bundles = d->bundle->coreCtx->bundleRegistry.GetBundles();
+  std::vector<std::shared_ptr<Bundle>> bundles = d->bundle->coreCtx->bundleRegistry.GetBundles();
   d->bundle->coreCtx->bundleHooks.FilterBundles(this, bundles);
   return bundles;
 }
@@ -244,12 +244,12 @@ std::string BundleContext::GetDataFile(const std::string &filename) const
   return d->bundle->storagePath + filename;
 }
 
-Bundle* BundleContext::InstallBundle(const std::string& location)
+std::shared_ptr<Bundle> BundleContext::InstallBundle(const std::string& location)
 {
     BundleInfo* bundleInfo = new BundleInfo(GetBundleNameFromLocation(location));
     bundleInfo->location = GetBundleLocation(location);
 
-    Bundle* bundle = d->bundle->coreCtx->bundleRegistry.Register(bundleInfo);
+    auto bundle = d->bundle->coreCtx->bundleRegistry.Register(bundleInfo);
 
     d->bundle->coreCtx->listeners.BundleChanged(BundleEvent(BundleEvent::INSTALLED, bundle));
 

--- a/core/src/bundle/usBundleContext.cpp
+++ b/core/src/bundle/usBundleContext.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<void> BundleContext::GetService(const ServiceReferenceBase& refe
   {
     throw std::invalid_argument("Default constructed ServiceReference is not a valid input to GetService()");
   }
-  std::shared_ptr<ServiceHolder<void>> h(new ServiceHolder<void>( this, reference, reference.d->GetService(d->bundle->q.lock()) ));
+  std::shared_ptr<ServiceHolder<void>> h(new ServiceHolder<void>(this, reference, reference.d->GetService(d->bundle->q.lock())));
   return std::shared_ptr<void>(h, h->service.get());
 }
 

--- a/core/src/bundle/usBundleEvent.cpp
+++ b/core/src/bundle/usBundleEvent.cpp
@@ -32,7 +32,7 @@ public:
 
   BundleEventData& operator=(const BundleEventData&) = delete;
 
-  BundleEventData(BundleEvent::Type type, Bundle* bundle)
+  BundleEventData(BundleEvent::Type type, std::shared_ptr<Bundle> bundle)
     : type(type), bundle(bundle)
   {
 
@@ -45,12 +45,12 @@ public:
   }
 
   const BundleEvent::Type type;
-  Bundle* const bundle;
+  const std::shared_ptr<Bundle> bundle;
 
 };
 
 BundleEvent::BundleEvent()
-  : d(0)
+  : d(nullptr)
 {
 
 }
@@ -65,7 +65,7 @@ bool BundleEvent::IsNull() const
   return !d;
 }
 
-BundleEvent::BundleEvent(Type type, Bundle* bundle)
+BundleEvent::BundleEvent(Type type, std::shared_ptr<Bundle> bundle)
   : d(new BundleEventData(type, bundle))
 {
 
@@ -83,7 +83,7 @@ BundleEvent& BundleEvent::operator=(const BundleEvent& other)
   return *this;
 }
 
-Bundle* BundleEvent::GetBundle() const
+std::shared_ptr<Bundle> BundleEvent::GetBundle() const
 {
   return d->bundle;
 }
@@ -112,7 +112,7 @@ std::ostream& operator<<(std::ostream& os, const BundleEvent& event)
 {
   if (event.IsNull()) return os << "NONE";
 
-  Bundle* m = event.GetBundle();
+  auto m = event.GetBundle();
   os << event.GetType() << " #" << m->GetBundleId() << " (" << m->GetLocation() << ")";
   return os;
 }

--- a/core/src/bundle/usBundleEvent.cpp
+++ b/core/src/bundle/usBundleEvent.cpp
@@ -32,7 +32,7 @@ public:
 
   BundleEventData& operator=(const BundleEventData&) = delete;
 
-  BundleEventData(BundleEvent::Type type, const std::shared_ptr<Bundle>& bundle)
+  BundleEventData(BundleEvent::Type type, std::shared_ptr<Bundle> bundle)
     : type(type), bundle(bundle)
   {
 
@@ -65,7 +65,7 @@ bool BundleEvent::IsNull() const
   return !d;
 }
 
-BundleEvent::BundleEvent(Type type, const std::shared_ptr<Bundle>& bundle)
+BundleEvent::BundleEvent(Type type, std::shared_ptr<Bundle> bundle)
   : d(new BundleEventData(type, bundle))
 {
 

--- a/core/src/bundle/usBundleEvent.cpp
+++ b/core/src/bundle/usBundleEvent.cpp
@@ -32,7 +32,7 @@ public:
 
   BundleEventData& operator=(const BundleEventData&) = delete;
 
-  BundleEventData(BundleEvent::Type type, std::shared_ptr<Bundle> bundle)
+  BundleEventData(BundleEvent::Type type, const std::shared_ptr<Bundle>& bundle)
     : type(type), bundle(bundle)
   {
 
@@ -65,7 +65,7 @@ bool BundleEvent::IsNull() const
   return !d;
 }
 
-BundleEvent::BundleEvent(Type type, std::shared_ptr<Bundle> bundle)
+BundleEvent::BundleEvent(Type type, const std::shared_ptr<Bundle>& bundle)
   : d(new BundleEventData(type, bundle))
 {
 

--- a/core/src/bundle/usBundleHooks.cpp
+++ b/core/src/bundle/usBundleHooks.cpp
@@ -36,11 +36,11 @@ BundleHooks::BundleHooks(CoreBundleContext* ctx)
 {
 }
 
-Bundle* BundleHooks::FilterBundle(const BundleContext* context, Bundle* bundle) const
+std::shared_ptr<Bundle> BundleHooks::FilterBundle(const BundleContext* context, const std::shared_ptr<Bundle>& bundle) const
 {
-  if(bundle == NULL)
+  if(bundle == nullptr)
   {
-    return NULL;
+    return bundle;
   }
 
   std::vector<ServiceRegistrationBase> srl;
@@ -51,18 +51,18 @@ Bundle* BundleHooks::FilterBundle(const BundleContext* context, Bundle* bundle) 
   }
   else
   {
-    std::vector<Bundle*> ml;
+    std::vector<std::shared_ptr<Bundle>> ml;
     ml.push_back(bundle);
     this->FilterBundles(context, ml);
-    return ml.empty() ? NULL : bundle;
+    return ml.empty() ? nullptr : bundle;
   }
 }
 
-void BundleHooks::FilterBundles(const BundleContext* context, std::vector<Bundle*>& bundles) const
+void BundleHooks::FilterBundles(const BundleContext* context, std::vector<std::shared_ptr<Bundle>>& bundles) const
 {
   std::vector<ServiceRegistrationBase> srl;
   coreCtx->services.Get(us_service_interface_iid<BundleFindHook>(), srl);
-  ShrinkableVector<Bundle*> filtered(bundles);
+  ShrinkableVector<std::shared_ptr<Bundle>> filtered(bundles);
 
   std::sort(srl.begin(), srl.end());
   for (std::vector<ServiceRegistrationBase>::reverse_iterator srBaseIter = srl.rbegin(), srBaseEnd = srl.rend();

--- a/core/src/bundle/usBundleHooks_p.h
+++ b/core/src/bundle/usBundleHooks_p.h
@@ -26,6 +26,7 @@
 #include "usServiceListeners_p.h"
 
 #include <vector>
+#include <memory>
 
 namespace us {
 
@@ -45,9 +46,9 @@ public:
 
   BundleHooks(CoreBundleContext* ctx);
 
-  Bundle* FilterBundle(const BundleContext* context, Bundle* bundle) const;
+  std::shared_ptr<Bundle> FilterBundle(const BundleContext* context, const std::shared_ptr<Bundle>& bundle) const;
 
-  void FilterBundles(const BundleContext* context, std::vector<Bundle*>& bundles) const;
+  void FilterBundles(const BundleContext* context, std::vector<std::shared_ptr<Bundle>>& bundles) const;
 
   void FilterBundleEventReceivers(const BundleEvent& evt,
                                   ServiceListeners::BundleListenerMap& bundleListeners);

--- a/core/src/bundle/usBundlePrivate.cpp
+++ b/core/src/bundle/usBundlePrivate.cpp
@@ -40,7 +40,7 @@
 
 namespace us {
 
-BundlePrivate::BundlePrivate(Bundle* qq, CoreBundleContext* coreCtx,
+BundlePrivate::BundlePrivate(std::shared_ptr<Bundle> qq, CoreBundleContext* coreCtx,
                              BundleInfo* info)
   : coreCtx(coreCtx)
   , info(*info)

--- a/core/src/bundle/usBundlePrivate.cpp
+++ b/core/src/bundle/usBundlePrivate.cpp
@@ -40,7 +40,7 @@
 
 namespace us {
 
-BundlePrivate::BundlePrivate(std::shared_ptr<Bundle> qq, CoreBundleContext* coreCtx,
+BundlePrivate::BundlePrivate(const std::shared_ptr<Bundle>& qq, CoreBundleContext* coreCtx,
                              BundleInfo* info)
   : coreCtx(coreCtx)
   , info(*info)
@@ -160,11 +160,11 @@ void BundlePrivate::RemoveBundleResources()
   }
 
   srs.clear();
-  coreCtx->services.GetUsedByBundle(q, srs);
+  coreCtx->services.GetUsedByBundle(q.lock(), srs);
   for (std::vector<ServiceRegistrationBase>::const_iterator i = srs.begin();
        i != srs.end(); ++i)
   {
-    i->GetReference(std::string()).d->UngetService(q, false);
+    i->GetReference(std::string()).d->UngetService(q.lock(), false);
   }
 }
 

--- a/core/src/bundle/usBundlePrivate.h
+++ b/core/src/bundle/usBundlePrivate.h
@@ -31,6 +31,8 @@
 
 #include "usThreads_p.h"
 
+#include <memory>
+
 namespace us {
 
 class CoreBundleContext;
@@ -51,7 +53,7 @@ public:
   /**
    * Construct a new bundle based on a BundleInfo object.
    */
-  BundlePrivate(Bundle* qq, CoreBundleContext* coreCtx, BundleInfo* info);
+  BundlePrivate(std::shared_ptr<Bundle> qq, CoreBundleContext* coreCtx, BundleInfo* info);
 
   virtual ~BundlePrivate();
 
@@ -80,7 +82,7 @@ public:
   std::string baseStoragePath;
   std::string storagePath;
 
-  Bundle* const q;
+  const std::shared_ptr<Bundle> q;
 
   /** 
    * Responsible for platform specific loading and unloading

--- a/core/src/bundle/usBundlePrivate.h
+++ b/core/src/bundle/usBundlePrivate.h
@@ -53,7 +53,7 @@ public:
   /**
    * Construct a new bundle based on a BundleInfo object.
    */
-  BundlePrivate(std::shared_ptr<Bundle> qq, CoreBundleContext* coreCtx, BundleInfo* info);
+  BundlePrivate(const std::shared_ptr<Bundle>& qq, CoreBundleContext* coreCtx, BundleInfo* info);
 
   virtual ~BundlePrivate();
 
@@ -82,7 +82,7 @@ public:
   std::string baseStoragePath;
   std::string storagePath;
 
-  const std::shared_ptr<Bundle> q;
+  const std::weak_ptr<Bundle> q;
 
   /** 
    * Responsible for platform specific loading and unloading

--- a/core/src/bundle/usBundleRegistry.cpp
+++ b/core/src/bundle/usBundleRegistry.cpp
@@ -47,13 +47,13 @@ BundleRegistry::~BundleRegistry(void)
 {
 }
 
-Bundle* BundleRegistry::Register(BundleInfo* info)
+std::shared_ptr<Bundle> BundleRegistry::Register(BundleInfo* info)
 {
-  Bundle* bundle = GetBundle(info->name);
+  std::shared_ptr<Bundle> bundle(GetBundle(info->name));
 
   if (!bundle)
   {
-    bundle = new Bundle();
+    bundle = std::shared_ptr<Bundle>(new Bundle());
     {
       Lock l(id);
       info->id = id.value++;
@@ -75,16 +75,14 @@ Bundle* BundleRegistry::Register(BundleInfo* info)
     // mutex.
     if (!return_pair.second)
     {
-      BundleMap::iterator iter(return_pair.first);
-      delete bundle;
-      bundle = (*iter).second;
+      bundle = return_pair.first->second;
     }
   }
 
   return bundle;
 }
 
-void BundleRegistry::RegisterSystemBundle(Framework* const systemBundle, BundleInfo* info)
+void BundleRegistry::RegisterSystemBundle(std::shared_ptr<Framework> systemBundle, BundleInfo* info)
 {
   if (!systemBundle)
   {
@@ -113,21 +111,21 @@ void BundleRegistry::UnRegister(const BundleInfo* info)
   }
 }
 
-Bundle* BundleRegistry::GetBundle(long id) const
+std::shared_ptr<Bundle> BundleRegistry::GetBundle(long id) const
 {
   Lock l(this);
 
-  for (auto& m : bundles)
+  for (auto const& m : bundles)
   {
     if (m.second->GetBundleId() == id)
     {
       return m.second;
     }
   }
-  return 0;
+  return nullptr;
 }
 
-Bundle* BundleRegistry::GetBundle(const std::string& name) const
+std::shared_ptr<Bundle> BundleRegistry::GetBundle(const std::string& name) const
 {
   Lock l(this);
 
@@ -136,14 +134,14 @@ Bundle* BundleRegistry::GetBundle(const std::string& name) const
   {
     return iter->second;
   }
-  return 0;
+  return nullptr;
 }
 
-std::vector<Bundle*> BundleRegistry::GetBundles() const
+std::vector<std::shared_ptr<Bundle>> BundleRegistry::GetBundles() const
 {
   Lock l(this);
 
-  std::vector<Bundle*> result;
+  std::vector<std::shared_ptr<Bundle>> result;
   for (auto& m : bundles)
   {
     result.push_back(m.second);

--- a/core/src/bundle/usBundleRegistry_p.h
+++ b/core/src/bundle/usBundleRegistry_p.h
@@ -23,6 +23,7 @@
 #ifndef USBUNDLEREGISTRY_P_H
 #define USBUNDLEREGISTRY_P_H
 
+#include <memory>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -56,7 +57,7 @@ public:
    * @return Bundle or null
    *         if the bundle was not found.
    */
-  Bundle* GetBundle(long id) const;
+  std::shared_ptr<Bundle> GetBundle(long id) const;
 
   /**
    * Get the bundle that has specified bundle name.
@@ -64,21 +65,21 @@ public:
    * @param name The name of the bundle to get.
    * @return Bundle or null.
    */
-  Bundle* GetBundle(const std::string& name) const;
+  std::shared_ptr<Bundle> GetBundle(const std::string& name) const;
 
   /**
    * Get all known bundles.
    *
    * @return A list which is filled with all known bundles.
    */
-  std::vector<Bundle*> GetBundles() const;
+  std::vector<std::shared_ptr<Bundle>> GetBundles() const;
 
   /**
    * Register a bundle with the Framework
    *
    * @return The registered bundle.
    */
-  Bundle* Register(BundleInfo* info);
+  std::shared_ptr<Bundle> Register(BundleInfo* info);
 
   /**
    * Register the system bundle.
@@ -87,7 +88,7 @@ public:
    *
    * @param systemBundle The system bundle to register.
    */
-  void RegisterSystemBundle(Framework* const systemBundle, BundleInfo* info);
+  void RegisterSystemBundle(std::shared_ptr<Framework> systemBundle, BundleInfo* info);
 
   /**
    * Remove a bundle from the Framework.
@@ -105,7 +106,7 @@ private:
 
   CoreBundleContext* coreCtx;
 
-  typedef std::unordered_map<std::string, Bundle*> BundleMap;
+  typedef std::unordered_map<std::string, std::shared_ptr<Bundle>> BundleMap;
 
   /**
    * Table of all installed bundles in this framework.

--- a/core/src/service/usServiceReferenceBase.cpp
+++ b/core/src/service/usServiceReferenceBase.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<Bundle> ServiceReferenceBase::GetBundle() const
     return nullptr;
   }
 
-  return d->registration->bundle->q;
+  return d->registration->bundle->q.lock();
 }
 
 void ServiceReferenceBase::GetUsingBundles(std::vector<std::shared_ptr<Bundle>>& bundles) const

--- a/core/src/service/usServiceReferenceBase.cpp
+++ b/core/src/service/usServiceReferenceBase.cpp
@@ -95,17 +95,17 @@ void ServiceReferenceBase::GetPropertyKeys(std::vector<std::string>& keys) const
   keys.assign(ks.begin(), ks.end());
 }
 
-Bundle* ServiceReferenceBase::GetBundle() const
+std::shared_ptr<Bundle> ServiceReferenceBase::GetBundle() const
 {
   if (d->registration == nullptr || d->registration->bundle == nullptr)
   {
-    return 0;
+    return nullptr;
   }
 
   return d->registration->bundle->q;
 }
 
-void ServiceReferenceBase::GetUsingBundles(std::vector<Bundle*>& bundles) const
+void ServiceReferenceBase::GetUsingBundles(std::vector<std::shared_ptr<Bundle>>& bundles) const
 {
   typedef decltype(d->registration->propsLock) T; // gcc 4.6 workaround
   T::Lock l(d->registration->propsLock);

--- a/core/src/service/usServiceReferenceBasePrivate.cpp
+++ b/core/src/service/usServiceReferenceBasePrivate.cpp
@@ -53,7 +53,7 @@ ServiceReferenceBasePrivate::~ServiceReferenceBasePrivate()
     delete registration;
 }
 
-InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(Bundle* bundle,
+InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(std::shared_ptr<Bundle> bundle,
                                                                         const std::shared_ptr<ServiceFactory>& factory,
                                                                         bool isBundleScope)
 {
@@ -99,7 +99,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(Bundle* 
   return s;
 }
 
-InterfaceMapConstPtr ServiceReferenceBasePrivate::GetPrototypeService(Bundle* bundle)
+InterfaceMapConstPtr ServiceReferenceBasePrivate::GetPrototypeService(const std::shared_ptr<Bundle>& bundle)
 {
   InterfaceMapConstPtr s;
   {
@@ -115,7 +115,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetPrototypeService(Bundle* bu
   return s;
 }
 
-std::shared_ptr<void> ServiceReferenceBasePrivate::GetService(Bundle* bundle)
+std::shared_ptr<void> ServiceReferenceBasePrivate::GetService(const std::shared_ptr<Bundle>& bundle)
 {
   std::shared_ptr<void> s;
   {
@@ -161,7 +161,7 @@ std::shared_ptr<void> ServiceReferenceBasePrivate::GetService(Bundle* bundle)
   return s;
 }
 
-InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(Bundle* bundle)
+InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(const std::shared_ptr<Bundle>& bundle)
 {
   InterfaceMapConstPtr s;
   {
@@ -206,7 +206,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(Bundle*
   return s;
 }
 
-bool ServiceReferenceBasePrivate::UngetPrototypeService(Bundle* bundle, const InterfaceMapConstPtr& service)
+bool ServiceReferenceBasePrivate::UngetPrototypeService(const std::shared_ptr<Bundle>& bundle, const InterfaceMapConstPtr& service)
 {
   if (!service)
   {
@@ -253,7 +253,7 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(Bundle* bundle, const In
   return false;
 }
 
-bool ServiceReferenceBasePrivate::UngetService(Bundle* bundle, bool checkRefCounter)
+bool ServiceReferenceBasePrivate::UngetService(const std::shared_ptr<Bundle>& bundle, bool checkRefCounter)
 {
   typedef decltype(registration->propsLock) T; // gcc 4.6 workaround
   T::Lock l(registration->propsLock);

--- a/core/src/service/usServiceReferenceBasePrivate.h
+++ b/core/src/service/usServiceReferenceBasePrivate.h
@@ -58,9 +58,9 @@ public:
     * @param bundle requester of service.
     * @return Service requested or null in case of failure.
     */
-  std::shared_ptr<void> GetService(Bundle* bundle);
+  std::shared_ptr<void> GetService(const std::shared_ptr<Bundle>& bundle);
 
-  InterfaceMapConstPtr GetServiceInterfaceMap(Bundle* bundle);
+  InterfaceMapConstPtr GetServiceInterfaceMap(const std::shared_ptr<Bundle>& bundle);
 
   /**
     * Get new service instance.
@@ -68,7 +68,7 @@ public:
     * @param bundle requester of service.
     * @return Service requested or null in case of failure.
     */
-  InterfaceMapConstPtr GetPrototypeService(Bundle* bundle);
+  InterfaceMapConstPtr GetPrototypeService(const std::shared_ptr<Bundle>& bundle);
 
   /**
    * Unget the service object.
@@ -80,7 +80,7 @@ public:
    * @return True if service was removed or false if only reference counter was
    *         decremented.
    */
-  bool UngetService(Bundle* bundle, bool checkRefCounter);
+  bool UngetService(const std::shared_ptr<Bundle>& bundle, bool checkRefCounter);
 
   /**
    * Unget prototype scope service objects.
@@ -89,7 +89,7 @@ public:
    * @param service The prototype scope service pointer.
    * @return \c true if the service was removed, \c false otherwise.
    */
-  bool UngetPrototypeService(Bundle* bundle, const InterfaceMapConstPtr& service);
+  bool UngetPrototypeService(const std::shared_ptr<Bundle>& bundle, const InterfaceMapConstPtr& service);
 
   /**
    * Get all properties registered with this service.
@@ -139,9 +139,9 @@ public:
   std::string interfaceId;
 
 private:
-  InterfaceMapConstPtr GetServiceFromFactory(Bundle* bundle,
-                                     const std::shared_ptr<ServiceFactory>& factory,
-                                     bool isBundleScope);
+  InterfaceMapConstPtr GetServiceFromFactory(std::shared_ptr<Bundle> bundle,
+                                                const std::shared_ptr<ServiceFactory>& factory,
+                                                bool isBundleScope);
 };
 
 }

--- a/core/src/service/usServiceRegistrationBasePrivate.cpp
+++ b/core/src/service/usServiceRegistrationBasePrivate.cpp
@@ -44,10 +44,10 @@ ServiceRegistrationBasePrivate::~ServiceRegistrationBasePrivate()
 
 }
 
-bool ServiceRegistrationBasePrivate::IsUsedByBundle(Bundle* p) const
+bool ServiceRegistrationBasePrivate::IsUsedByBundle(const std::shared_ptr<Bundle>& bundle) const
 {
-  return (dependents.find(p) != dependents.end()) ||
-      (prototypeServiceInstances.find(p) != prototypeServiceInstances.end());
+  return (dependents.find(bundle) != dependents.end()) ||
+    (prototypeServiceInstances.find(bundle) != prototypeServiceInstances.end());
 }
 
 const InterfaceMapConstPtr& ServiceRegistrationBasePrivate::GetInterfaces() const

--- a/core/src/service/usServiceRegistrationBasePrivate.h
+++ b/core/src/service/usServiceRegistrationBasePrivate.h
@@ -65,9 +65,9 @@ protected:
 
 public:
 
-  typedef std::unordered_map<Bundle*,int> BundleToRefsMap;
-  typedef std::unordered_map<Bundle*, InterfaceMapConstPtr> BundleToServiceMap;
-  typedef std::unordered_map<Bundle*, std::list<InterfaceMapConstPtr> > BundleToServicesMap;
+  typedef std::unordered_map<std::shared_ptr<Bundle>, int> BundleToRefsMap;
+  typedef std::unordered_map<std::shared_ptr<Bundle>, InterfaceMapConstPtr> BundleToServiceMap;
+  typedef std::unordered_map<std::shared_ptr<Bundle>, std::list<InterfaceMapConstPtr> > BundleToServicesMap;
 
   ServiceRegistrationBasePrivate(const ServiceRegistrationBasePrivate&) = delete;
   ServiceRegistrationBasePrivate& operator=(const ServiceRegistrationBasePrivate&) = delete;
@@ -132,10 +132,10 @@ public:
   /**
    * Check if a bundle uses this service
    *
-   * @param p Bundle to check
+   * @param bundle Bundle to check
    * @return true if bundle uses this service
    */
-  bool IsUsedByBundle(Bundle* m) const;
+  bool IsUsedByBundle(const std::shared_ptr<Bundle>& bundle) const;
 
   const InterfaceMapConstPtr& GetInterfaces() const;
   std::shared_ptr<void> GetService(const std::string& interfaceId) const;

--- a/core/src/service/usServiceRegistry.cpp
+++ b/core/src/service/usServiceRegistry.cpp
@@ -323,7 +323,7 @@ void ServiceRegistry::GetRegisteredByBundle(BundlePrivate* p,
   }
 }
 
-void ServiceRegistry::GetUsedByBundle(Bundle* p,
+void ServiceRegistry::GetUsedByBundle(const std::shared_ptr<Bundle>& bundle,
                                       std::vector<ServiceRegistrationBase>& res) const
 {
   Lock l(this);
@@ -331,7 +331,7 @@ void ServiceRegistry::GetUsedByBundle(Bundle* p,
   for (std::vector<ServiceRegistrationBase>::const_iterator i = serviceRegistrations.begin();
        i != serviceRegistrations.end(); ++i)
   {
-    if (i->d->IsUsedByBundle(p))
+    if (i->d->IsUsedByBundle(bundle))
     {
       res.push_back(*i);
     }

--- a/core/src/service/usServiceRegistry_p.h
+++ b/core/src/service/usServiceRegistry_p.h
@@ -164,10 +164,10 @@ public:
   /**
    * Get all services that a bundle uses.
    *
-   * @param p The bundle
+   * @param bundle The bundle
    * @return A set of {@link ServiceRegistration} objects
    */
-  void GetUsedByBundle(Bundle* m, std::vector<ServiceRegistrationBase>& serviceRegs) const;
+  void GetUsedByBundle(const std::shared_ptr<Bundle>& bundle, std::vector<ServiceRegistrationBase>& serviceRegs) const;
 
 private:
 

--- a/core/src/util/usFramework.cpp
+++ b/core/src/util/usFramework.cpp
@@ -67,7 +67,7 @@ void Framework::Initialize(void)
   std::memcpy(&frameworkInit, &initFncPtr, sizeof(void*));
   bundleInfo->location = BundleUtils::GetLibraryPath(frameworkInit);
   
-  d->coreBundleContext.bundleRegistry.RegisterSystemBundle(std::static_pointer_cast<Framework>(this->shared_from_this()), bundleInfo);
+  d->coreBundleContext.bundleRegistry.RegisterSystemBundle(std::static_pointer_cast<Framework>(shared_from_this()), bundleInfo);
 
   d->initialized = true;
 }

--- a/core/src/util/usFramework.cpp
+++ b/core/src/util/usFramework.cpp
@@ -66,8 +66,8 @@ void Framework::Initialize(void)
   void* frameworkInit = NULL;
   std::memcpy(&frameworkInit, &initFncPtr, sizeof(void*));
   bundleInfo->location = BundleUtils::GetLibraryPath(frameworkInit);
-
-  d->coreBundleContext.bundleRegistry.RegisterSystemBundle(this, bundleInfo);
+  
+  d->coreBundleContext.bundleRegistry.RegisterSystemBundle(std::static_pointer_cast<Framework>(this->shared_from_this()), bundleInfo);
 
   d->initialized = true;
 }
@@ -81,14 +81,12 @@ void Framework::Start()
 void Framework::Stop() 
 {
   FrameworkPrivate::Lock lock(d);
-  std::vector<Bundle*> bundles(GetBundleContext()->GetBundles());
-  for (std::vector<Bundle*>::const_iterator iter = bundles.begin(); 
-      iter != bundles.end(); 
-      ++iter)
+  std::vector<std::shared_ptr<Bundle>> bundles(GetBundleContext()->GetBundles());
+  for (auto& bundle : bundles)
   {
-    if ((*iter)->GetName() != US_CORE_FRAMEWORK_NAME)
+    if (bundle->GetBundleId() > 0)
     {
-      (*iter)->Stop();
+      bundle->Stop();
     }
   }
 

--- a/core/src/util/usUtils.cpp
+++ b/core/src/util/usUtils.cpp
@@ -191,7 +191,7 @@ std::vector<std::string> AutoLoadBundlesFromPath(const std::string& absoluteBase
 
           // location will be in the form:
           //  <path to bundle plugin>\<bundle-name>.<lib-extension>/<bundle-name>
-          Bundle* installedBundle = GetBundleContext()->InstallBundle(location);
+          std::shared_ptr<Bundle> installedBundle = GetBundleContext()->InstallBundle(location);
 
           if (!installedBundle)
           {

--- a/core/test/bundles/libH/usTestBundleH.cpp
+++ b/core/test/bundles/libH/usTestBundleH.cpp
@@ -44,11 +44,11 @@ struct TestBundleH2
 
 class TestProduct : public TestBundleH
 {
-  // Bundle* caller;
+  // std::shared_ptr<Bundle> caller;
 
 public:
 
-  TestProduct(Bundle* /*caller*/)
+  TestProduct(const std::shared_ptr<Bundle>& /*caller*/)
     //: caller(caller)
   {}
 
@@ -58,7 +58,7 @@ class TestProduct2 : public TestProduct, public TestBundleH2
 {
 public:
 
-  TestProduct2(Bundle* caller)
+  TestProduct2(const std::shared_ptr<Bundle>& caller)
     : TestProduct(caller)
   {}
 
@@ -70,7 +70,7 @@ class TestBundleHPrototypeServiceFactory : public PrototypeServiceFactory
 
 public:
 
-  InterfaceMapConstPtr GetService(Bundle* caller, const ServiceRegistrationBase& /*sReg*/)
+  InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& caller, const ServiceRegistrationBase& /*sReg*/)
   {
     std::cout << "GetService (prototype) in H" << std::endl;
     std::shared_ptr<TestProduct2> product = std::make_shared<TestProduct2>(caller);
@@ -78,7 +78,7 @@ public:
     return MakeInterfaceMap<TestBundleH,TestBundleH2>(product);
   }
 
-  void UngetService(Bundle* caller, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& service)
+  void UngetService(const std::shared_ptr<Bundle>& caller, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& service)
   {
     std::shared_ptr<TestProduct2> product = std::dynamic_pointer_cast<TestProduct2>(ExtractInterface<TestBundleH>(service));
     fcbind[caller->GetBundleId()].remove(product);
@@ -91,7 +91,7 @@ class TestBundleHServiceFactory : public ServiceFactory
   std::map<long, std::shared_ptr<TestProduct>> fcbind;   // Map calling bundle with implementation
 public:
   
-  InterfaceMapConstPtr GetService(Bundle* caller, const ServiceRegistrationBase& /*sReg*/)
+  InterfaceMapConstPtr GetService(const std::shared_ptr<Bundle>& caller, const ServiceRegistrationBase& /*sReg*/)
   {
     std::cout << "GetService in H" << std::endl;
     std::shared_ptr<TestProduct> product = std::make_shared<TestProduct>(caller);
@@ -99,7 +99,7 @@ public:
     return MakeInterfaceMap<TestBundleH>(product);
   }
   
-  void UngetService(Bundle* caller, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& service)
+  void UngetService(const std::shared_ptr<Bundle>& caller, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& service)
   {
     std::shared_ptr<TestBundleH> product = ExtractInterface<TestBundleH>(service);
     fcbind.erase(caller->GetBundleId());

--- a/core/test/usBundleAutoLoadTest.cpp
+++ b/core/test/usBundleAutoLoadTest.cpp
@@ -49,15 +49,15 @@ void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framewo
 
   InstallTestBundle(context, "TestBundleAL");
 
-  Bundle* bundleAL = context->GetBundle("TestBundleAL");
-  US_TEST_CONDITION_REQUIRED(bundleAL != NULL, "Test for existing bundle TestBundleAL")
+  auto bundleAL = context->GetBundle("TestBundleAL");
+  US_TEST_CONDITION_REQUIRED(bundleAL != nullptr, "Test for existing bundle TestBundleAL")
 
   US_TEST_CONDITION(bundleAL->GetName() == "TestBundleAL", "Test bundle name")
 
   bundleAL->Start();
 
   Any installedBundles = bundleAL->GetProperty(Bundle::PROP_AUTOINSTALLED_BUNDLES);
-  Bundle* bundleAL_1 = context->GetBundle("TestBundleAL_1");
+  auto bundleAL_1 = context->GetBundle("TestBundleAL_1");
 
   // check the listeners for events
   std::vector<BundleEvent> pEvts;
@@ -71,7 +71,7 @@ void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framewo
 
   if (autoLoadEnabled)
   {
-    US_TEST_CONDITION_REQUIRED(bundleAL_1 != NULL, "Test for existing auto-installed bundle TestBundleAL_1")
+    US_TEST_CONDITION_REQUIRED(bundleAL_1 != nullptr, "Test for existing auto-installed bundle TestBundleAL_1")
     US_TEST_CONDITION(bundleAL_1->GetName() == "TestBundleAL_1", "Test bundle name")
     US_TEST_CONDITION_REQUIRED(!installedBundles.Empty(), "Test for PROP_AUTOINSTALLED_BUNDLES property")
     US_TEST_CONDITION_REQUIRED(installedBundles.Type() == typeid(std::vector<std::string>), "Test for PROP_AUTOINSTALLED_BUNDLES property type")
@@ -87,7 +87,7 @@ void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framewo
   }
   else
   {
-    US_TEST_CONDITION_REQUIRED(bundleAL_1 == NULL, "Test for non-existing auto-installed bundle TestBundleAL_1")
+    US_TEST_CONDITION_REQUIRED(bundleAL_1 == nullptr, "Test for non-existing auto-installed bundle TestBundleAL_1")
     US_TEST_CONDITION_REQUIRED(installedBundles.Empty(), "Test for empty PROP_AUTOINSTALLED_BUNDLES property")
   }
 
@@ -116,14 +116,14 @@ void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
 
   InstallTestBundle(context, "TestBundleAL2");
 
-  Bundle* bundleAL2 = context->GetBundle("TestBundleAL2");
-  US_TEST_CONDITION_REQUIRED(bundleAL2 != NULL, "Test for existing bundle TestBundleAL2")
+  auto bundleAL2 = context->GetBundle("TestBundleAL2");
+  US_TEST_CONDITION_REQUIRED(bundleAL2 != nullptr, "Test for existing bundle TestBundleAL2")
 
   US_TEST_CONDITION(bundleAL2->GetName() == "TestBundleAL2", "Test bundle name")
 
   bundleAL2->Start();
 
-  Bundle* bundleAL2_1 = context->GetBundle("TestBundleAL2_1");
+  auto bundleAL2_1 = context->GetBundle("TestBundleAL2_1");
 
   // check the listeners for events
   std::vector<BundleEvent> pEvts;
@@ -135,7 +135,7 @@ void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
   pEvts.push_back(BundleEvent(BundleEvent::STARTED, bundleAL2));
 
 #ifdef US_ENABLE_AUTOLOADING_SUPPORT
-  US_TEST_CONDITION_REQUIRED(bundleAL2_1 != NULL, "Test for existing auto-installed bundle TestBundleAL2_1")
+  US_TEST_CONDITION_REQUIRED(bundleAL2_1 != nullptr, "Test for existing auto-installed bundle TestBundleAL2_1")
   US_TEST_CONDITION(bundleAL2_1->GetName() == "TestBundleAL2_1", "Test bundle name")
 
   bundleAL2_1->Start();
@@ -143,7 +143,7 @@ void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
   pEvts.push_back(BundleEvent(BundleEvent::STARTED, bundleAL2_1));
 
 #else
-  US_TEST_CONDITION_REQUIRED(bundleAL2_1 == NULL, "Test for non-existing auto-installed bundle TestBundleAL2_1")
+  US_TEST_CONDITION_REQUIRED(bundleAL2_1 == nullptr, "Test for non-existing auto-installed bundle TestBundleAL2_1")
 #endif
 
   US_TEST_CONDITION(listener.CheckListenerEvents(pEvts), "Test for unexpected events");

--- a/core/test/usBundleHooksTest.cpp
+++ b/core/test/usBundleHooksTest.cpp
@@ -53,9 +53,9 @@ class TestBundleFindHook : public BundleFindHook
 {
 public:
 
-  void Find(const BundleContext* /*context*/, ShrinkableVector<Bundle*>& bundles)
+  void Find(const BundleContext* /*context*/, ShrinkableVector<std::shared_ptr<Bundle>>& bundles)
   {
-    for (ShrinkableVector<Bundle*>::iterator i = bundles.begin();
+    for (ShrinkableVector<std::shared_ptr<Bundle>>::iterator i = bundles.begin();
          i != bundles.end();)
     {
       if ((*i)->GetName() == "TestBundleA")
@@ -87,7 +87,7 @@ void TestFindHook(const std::shared_ptr<Framework>& framework)
 {
   InstallTestBundle(framework->GetBundleContext(), "TestBundleA");
 
-  Bundle* bundleA = framework->GetBundleContext()->GetBundle("TestBundleA");
+  auto bundleA = framework->GetBundleContext()->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
 
   US_TEST_CONDITION(bundleA->GetName() == "TestBundleA", "Test bundle name")
@@ -99,17 +99,16 @@ void TestFindHook(const std::shared_ptr<Framework>& framework)
   long bundleAId = bundleA->GetBundleId();
   US_TEST_CONDITION_REQUIRED(bundleAId > 0, "Test for valid bundle id")
 
-  US_TEST_CONDITION_REQUIRED(framework->GetBundleContext()->GetBundle(bundleAId) != NULL, "Test for non-filtered GetBundle(long) result")
+  US_TEST_CONDITION_REQUIRED(framework->GetBundleContext()->GetBundle(bundleAId) != nullptr, "Test for non-filtered GetBundle(long) result")
 
   ServiceRegistration<BundleFindHook> findHookReg = framework->GetBundleContext()->RegisterService<BundleFindHook>(std::make_shared<TestBundleFindHook>());
 
-  US_TEST_CONDITION_REQUIRED(framework->GetBundleContext()->GetBundle(bundleAId) == NULL, "Test for filtered GetBundle(long) result")
+  US_TEST_CONDITION_REQUIRED(framework->GetBundleContext()->GetBundle(bundleAId) == nullptr, "Test for filtered GetBundle(long) result")
 
-  std::vector<Bundle*> bundles = framework->GetBundleContext()->GetBundles();
-  for (std::vector<Bundle*>::iterator i = bundles.begin();
-       i != bundles.end(); ++i)
+  auto bundles = framework->GetBundleContext()->GetBundles();
+  for (auto const& i : bundles)
   {
-    if((*i)->GetName() == "TestBundleA")
+    if (i->GetName() == "TestBundleA")
     {
       US_TEST_FAILED_MSG(<< "TestBundleA not filtered from GetBundles()")
     }
@@ -127,7 +126,7 @@ void TestEventHook(std::shared_ptr<Framework> framework)
 
   InstallTestBundle(framework->GetBundleContext(), "TestBundleA");
 
-  Bundle* bundleA = framework->GetBundleContext()->GetBundle("TestBundleA");
+  auto bundleA = framework->GetBundleContext()->GetBundle("TestBundleA");
   bundleA->Start();
   US_TEST_CONDITION_REQUIRED(bundleListener.events.size() == 3, "Test for received load bundle events")
 

--- a/core/test/usBundleManifestTest.cpp
+++ b/core/test/usBundleManifestTest.cpp
@@ -49,7 +49,7 @@ int usBundleManifestTest(int /*argc*/, char* /*argv*/[])
 
   InstallTestBundle(framework->GetBundleContext(), "TestBundleM");
 
-  Bundle* bundleM = framework->GetBundleContext()->GetBundle("TestBundleM");
+  auto bundleM = framework->GetBundleContext()->GetBundle("TestBundleM");
   US_TEST_CONDITION_REQUIRED(bundleM != nullptr, "Test for existing bundle TestBundleM")
 
   US_TEST_CONDITION(bundleM->GetProperty(Bundle::PROP_NAME).ToString() == "TestBundleM", "Bundle name")

--- a/core/test/usBundleRegistryPerformanceTest.cpp
+++ b/core/test/usBundleRegistryPerformanceTest.cpp
@@ -75,8 +75,8 @@ namespace
 
         elapsedTimeInMilliSeconds = 0;
 
-        std::vector<Bundle*> bundles(f->GetBundleContext()->GetBundles());
-        for (auto bundle : bundles)
+        auto bundles = f->GetBundleContext()->GetBundles();
+        for (auto const& bundle : bundles)
         {
             timer.Start();
             bundle->Start();
@@ -127,7 +127,7 @@ int usBundleRegistryPerformanceTest(int /*argc*/, char* /*argv*/[])
     US_TEST_OUTPUT(<< "Testing serial installation of bundles");
     TestSerial(framework);
 
-    for (auto bundle : framework->GetBundleContext()->GetBundles())
+    for (auto& bundle : framework->GetBundleContext()->GetBundles())
     {
         if (bundle->GetBundleId() != 0)
         {

--- a/core/test/usBundleResourceTest.cpp
+++ b/core/test/usBundleResourceTest.cpp
@@ -35,6 +35,7 @@
 #include <cassert>
 
 #include <unordered_set>
+#include <memory>
 
 using namespace us;
 
@@ -61,7 +62,7 @@ void checkResourceInfo(const BundleResource& res, const std::string& path,
   US_TEST_CONDITION(res.GetCompleteSuffix() == completeSuffix, "Complete suffix")
 }
 
-void testTextResource(Bundle* bundle)
+void testTextResource(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("foo.txt");
 #ifdef US_PLATFORM_WINDOWS
@@ -109,7 +110,7 @@ void testTextResource(Bundle* bundle)
   US_TEST_CONDITION(lines[1] == "bar", "Check second line")
 }
 
-void testTextResourceAsBinary(Bundle* bundle)
+void testTextResourceAsBinary(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("foo.txt");
 
@@ -143,7 +144,7 @@ void testTextResourceAsBinary(Bundle* bundle)
   US_TEST_CONDITION(content == fileData, "Resource content");
 }
 
-void testInvalidResource(Bundle* bundle)
+void testInvalidResource(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("invalid");
   US_TEST_CONDITION_REQUIRED(res.IsValid() == false, "Check invalid resource")
@@ -164,7 +165,7 @@ void testInvalidResource(Bundle* bundle)
   US_TEST_CONDITION(rs.eof() == true, "Check invalid resource stream")
 }
 
-void testSpecialCharacters(Bundle* bundle)
+void testSpecialCharacters(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("special_chars.dummy.txt");
 #ifdef US_PLATFORM_WINDOWS
@@ -196,7 +197,7 @@ void testSpecialCharacters(Bundle* bundle)
   US_TEST_CONDITION(content == fileData, "Resource content");
 }
 
-void testBinaryResource(Bundle* bundle)
+void testBinaryResource(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("/icons/cppmicroservices.png");
   checkResourceInfo(res, "/icons/", "cppmicroservices", "cppmicroservices", "png", "png", 2424, false);
@@ -236,7 +237,7 @@ void testBinaryResource(Bundle* bundle)
   US_TEST_CONDITION(png.eof(), "EOF check");
 }
 
-void testCompressedResource(Bundle* bundle)
+void testCompressedResource(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("/icons/compressable.bmp");
   checkResourceInfo(res, "/icons/", "compressable", "compressable", "bmp", "bmp", 300122, false);
@@ -283,7 +284,7 @@ struct ResourceComparator {
   }
 };
 
-void testResourceTree(Bundle* bundle)
+void testResourceTree(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource res = bundle->GetResource("");
   US_TEST_CONDITION(res.GetResourcePath() == "/", "Check root file path")
@@ -350,7 +351,7 @@ void testResourceTree(Bundle* bundle)
   US_TEST_CONDITION(nodes.size() == 4, "Check recursive pattern matches")
 }
 
-void testResourceOperators(Bundle* bundle)
+void testResourceOperators(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource invalid = bundle->GetResource("invalid");
   BundleResource foo = bundle->GetResource("foo.txt");
@@ -385,7 +386,7 @@ void testResourceOperators(Bundle* bundle)
   US_TEST_CONDITION(oss.str() == foo.GetResourcePath(), "Check operator<<")
 }
 
-void testResourceFromExecutable(Bundle* bundle)
+void testResourceFromExecutable(const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource resource = bundle->GetResource("usTestResource.txt");
   US_TEST_CONDITION_REQUIRED(resource.IsValid(), "Check valid executable resource")
@@ -400,8 +401,8 @@ void testResourcesFrom(const std::string& bundleName, BundleContext* context)
 {
   InstallTestBundle(context, bundleName);
 
-  Bundle* bundleR = context->GetBundle(bundleName);
-  US_TEST_CONDITION_REQUIRED(bundleR != NULL, "Test for existing bundle")
+  auto bundleR = context->GetBundle(bundleName);
+  US_TEST_CONDITION_REQUIRED(bundleR != nullptr, "Test for existing bundle")
 
   US_TEST_CONDITION(bundleR->GetName() == bundleName, "Test bundle name")
 
@@ -425,18 +426,18 @@ int usBundleResourceTest(int /*argc*/, char* /*argv*/[])
 
   InstallTestBundle(context, "TestBundleR");
 
-  Bundle* bundleR = context->GetBundle("TestBundleR");
-  US_TEST_CONDITION_REQUIRED(bundleR != NULL, "Test for existing bundle TestBundleR")
+  auto bundleR = context->GetBundle("TestBundleR");
+  US_TEST_CONDITION_REQUIRED(bundleR != nullptr, "Test for existing bundle TestBundleR")
 
   US_TEST_CONDITION(bundleR->GetName() == "TestBundleR", "Test bundle name")
 
   testInvalidResource(bundleR);
 
-  Bundle* executableBundle = nullptr;
+  std::shared_ptr<Bundle> executableBundle = nullptr;
   try
   {
     executableBundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
-    US_TEST_CONDITION_REQUIRED(executableBundle != NULL, "Test installation of bundle main")
+    US_TEST_CONDITION_REQUIRED(executableBundle != nullptr, "Test installation of bundle main")
   }
   catch (const std::exception& e)
   {

--- a/core/test/usBundleTest.cpp
+++ b/core/test/usBundleTest.cpp
@@ -47,8 +47,8 @@ void frame01(BundleContext* context)
 {
   try
   {
-    Bundle* bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
-    US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle main")
+    auto bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
+    US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test installation of bundle main")
 
     bundle->Start();
   }
@@ -82,7 +82,7 @@ void frame02a(BundleContext* context)
 
   InstallTestBundle(context, "TestBundleA");
 
-  Bundle* bundleA = context->GetBundle("TestBundleA");
+  auto bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
 
   bundleA->Start();
@@ -107,7 +107,7 @@ void frame02a(BundleContext* context)
 // Verify information from the BundleInfo struct
 void frame005a(BundleContext* context)
 {
-  Bundle* m = context->GetBundle();
+  auto m = context->GetBundle();
   long systemId = 0;
   // check expected meta-data
   US_TEST_CONDITION("main" == m->GetName(), "Test bundle name")
@@ -118,7 +118,7 @@ void frame005a(BundleContext* context)
 // Get context id, location, persistent storage and status of the bundle
 void frame010a(const std::shared_ptr<Framework>& framework, BundleContext* context)
 {
-  Bundle* m = context->GetBundle();
+  auto m = context->GetBundle();
 
   long int contextid = m->GetBundleId();
   US_DEBUG << "CONTEXT ID:" << contextid;
@@ -166,7 +166,7 @@ void frame020a(const std::shared_ptr<Framework>& framework, TestBundleListener& 
 {
   BundleContext* context = framework->GetBundleContext();
 
-  Bundle* bundleA = context->GetBundle("TestBundleA");
+  auto bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
 
   US_TEST_CONDITION(bundleA->GetName() == "TestBundleA", "Test bundle name")
@@ -207,7 +207,7 @@ void frame02b(const std::shared_ptr<Framework>& framework)
 
   US_TEST_CONDITION(framework->GetProperty(Framework::PROP_STORAGE_LOCATION).ToString() == "/tmp", "Test for valid base storage path")
 
-  Bundle* bundleA = context->GetBundle("TestBundleA");
+  auto bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
   // launching properties should be accessible through any bundle
   US_TEST_CONDITION(bundleA->GetProperty(Framework::PROP_STORAGE_LOCATION).ToString() == "/tmp", "Test for valid base storage path")
@@ -229,7 +229,7 @@ void frame02b(const std::shared_ptr<Framework>& framework)
 // Stop libA and check for correct events
 void frame030b(BundleContext* context, TestBundleListener& listener)
 {
-  Bundle* bundleA = context->GetBundle("TestBundleA");
+  auto bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for non-null bundle")
 
   ServiceReferenceU sr1
@@ -294,11 +294,9 @@ void TestBundleStates()
     BundleContext* frameworkCtx = framework->GetBundleContext();
     frameworkCtx->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
 
-    Bundle* bundle = nullptr;
-
     // Test install -> uninstall
     // expect 2 event (INSTALLED, UNINSTALLED)
-    bundle = InstallTestBundle(frameworkCtx, "TestBundleA");
+    auto bundle = InstallTestBundle(frameworkCtx, "TestBundleA");
     bundle->Uninstall();
     US_TEST_CONDITION(0 == frameworkCtx->GetBundle("TestBundleA"), "Test bundle install -> uninstall")
     US_TEST_CONDITION(1 == frameworkCtx->GetBundles().size(), "Test # of installed bundles")
@@ -409,8 +407,8 @@ void TestDuplicateInstall()
 
     // Test installing the same bundle (i.e. a bundle with the same location) twice.
     // The exact same bundle should be returned on the second install.
-    Bundle* bundle = InstallTestBundle(frameworkCtx, "TestBundleA");
-    Bundle* bundleDuplicate = InstallTestBundle(frameworkCtx, "TestBundleA");
+    auto bundle = InstallTestBundle(frameworkCtx, "TestBundleA");
+    auto bundleDuplicate = InstallTestBundle(frameworkCtx, "TestBundleA");
 
     US_TEST_CONDITION(bundle == bundleDuplicate, "Test for the same bundle instance");
     US_TEST_CONDITION(bundle->GetBundleId() == bundleDuplicate->GetBundleId(), "Test for the same bundle id");
@@ -428,11 +426,10 @@ int usBundleTest(int /*argc*/, char* /*argv*/[])
   std::shared_ptr<Framework> framework = factory.NewFramework(std::map<std::string, std::string>());
   framework->Start();
 
-  std::vector<Bundle*> bundles = framework->GetBundleContext()->GetBundles();
-  for (std::vector<Bundle*>::iterator iter = bundles.begin(), iterEnd = bundles.end();
-       iter != iterEnd; ++iter)
+  auto bundles = framework->GetBundleContext()->GetBundles();
+  for (auto const& bundle : bundles)
   {
-    std::cout << "----- " << (*iter)->GetName() << std::endl;
+    std::cout << "----- " << bundle->GetName() << std::endl;
   }
 
   BundleContext* context = framework->GetBundleContext();

--- a/core/test/usFrameworkTest.cpp
+++ b/core/test/usFrameworkTest.cpp
@@ -130,7 +130,7 @@ namespace
         f->Stop();
         US_TEST_CONDITION(!f->IsStarted(), "Check framework is in the Stop state")
 
-        pEvts.push_back(BundleEvent(BundleEvent::STOPPING, f.get()));
+        pEvts.push_back(BundleEvent(BundleEvent::STOPPING, f));
 
         US_TEST_CONDITION(listener.CheckListenerEvents(pEvts), "Check framework bundle event listener")
 
@@ -153,7 +153,7 @@ namespace
         f->Start();
         InstallTestBundle(f->GetBundleContext(), "TestBundleA");
 
-        Bundle* bundleA = f->GetBundleContext()->GetBundle("TestBundleA");
+        auto bundleA = f->GetBundleContext()->GetBundle("TestBundleA");
         bundleA->Start();
 
         // Stopping the framework stops all active bundles.
@@ -179,7 +179,7 @@ namespace
         fmc->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
 
         // The bundles used to test bundle events when stopping the framework
-        Bundle* bundle = InstallTestBundle(fmc, "TestBundleA");
+        auto bundle = InstallTestBundle(fmc, "TestBundleA");
         pEvts.push_back(BundleEvent(BundleEvent::INSTALLED, bundle));
         bundle = InstallTestBundle(fmc, "TestBundleA2");
         pEvts.push_back(BundleEvent(BundleEvent::INSTALLED, bundle));
@@ -204,16 +204,15 @@ namespace
         bundle = InstallTestBundle(fmc, "TestBundleSL4");
         pEvts.push_back(BundleEvent(BundleEvent::INSTALLED, bundle));
 
-        std::vector<Bundle*> bundles(fmc->GetBundles());
-        for (std::vector<Bundle*>::iterator iter = bundles.begin();
-            iter != bundles.end(); ++iter)
+        auto bundles(fmc->GetBundles());
+        for (auto& bundle : bundles)
         {
-            (*iter)->Start();
+            bundle->Start();
             // no events will be fired for the framework, its already active at this point
-            if ((*iter) != f.get())
+            if (bundle != f)
             {
-                pEvts.push_back(BundleEvent(BundleEvent::STARTING, (*iter)));
-                pEvts.push_back(BundleEvent(BundleEvent::STARTED, (*iter)));
+                pEvts.push_back(BundleEvent(BundleEvent::STARTING, bundle));
+                pEvts.push_back(BundleEvent(BundleEvent::STARTED, bundle));
 
                 // bundles will be stopped in the same order in which they were started.
                 // It is easier to maintain this test if the stop events are setup in the
@@ -221,15 +220,15 @@ namespace
                 // the order of events somewhere else.
                 // Doing it this way also tests the order in which starting and stopping
                 // bundles occurs and when their events are fired.
-                pStopEvts.push_back(BundleEvent(BundleEvent::STOPPING, (*iter)));
-                pStopEvts.push_back(BundleEvent(BundleEvent::STOPPED, (*iter)));
+                pStopEvts.push_back(BundleEvent(BundleEvent::STOPPING, bundle));
+                pStopEvts.push_back(BundleEvent(BundleEvent::STOPPED, bundle));
             }
         }
 
         US_TEST_CONDITION(listener.CheckListenerEvents(pEvts), "Check for bundle start events")
 
         // Remember, the framework is stopped last, after all bundles are stopped.
-        pStopEvts.push_back(BundleEvent(BundleEvent::STOPPING, f.get()));
+        pStopEvts.push_back(BundleEvent(BundleEvent::STOPPING, f));
 
         // Stopping the framework stops all active bundles.
         f->Stop();

--- a/core/test/usServiceFactoryTest.cpp
+++ b/core/test/usServiceFactoryTest.cpp
@@ -56,7 +56,7 @@ void TestServiceFactoryBundleScope(BundleContext* context)
 
   InstallTestBundle(context, "TestBundleH");
 
-  Bundle* bundleH = context->GetBundle("TestBundleH");
+  auto bundleH = context->GetBundle("TestBundleH");
   US_TEST_CONDITION_REQUIRED(bundleH != nullptr, "Test for existing bundle TestBundleH")
 
   bundleH->Start();
@@ -103,7 +103,7 @@ void TestServiceFactoryPrototypeScope(BundleContext* context)
 
   InstallTestBundle(context, "TestBundleH");
 
-  Bundle* bundleH = context->GetBundle("TestBundleH");
+  auto bundleH = context->GetBundle("TestBundleH");
   US_TEST_CONDITION_REQUIRED(bundleH != nullptr, "Test for existing bundle TestBundleH")
 
   bundleH->Start();

--- a/core/test/usServiceHooksTest.cpp
+++ b/core/test/usServiceHooksTest.cpp
@@ -243,7 +243,7 @@ void TestEventListenerHook(const std::shared_ptr<Framework>& framework)
   US_TEST_CONDITION(serviceListener1.events.empty(), "service event of service event listener hook");
   US_TEST_CONDITION(serviceListener2.events.empty(), "no service event for filtered listener");
 
-  Bundle* bundle = InstallTestBundle(context, "TestBundleA");
+  auto bundle = InstallTestBundle(context, "TestBundleA");
 
   bundle->Start();
 
@@ -357,7 +357,7 @@ void TestFindHook(const std::shared_ptr<Framework>& framework)
   TestServiceListener serviceListener;
   context->AddServiceListener(&serviceListener, &TestServiceListener::ServiceChanged);
 
-  Bundle* bundle = InstallTestBundle(context, "TestBundleA");
+  auto bundle = InstallTestBundle(context, "TestBundleA");
 
   bundle->Start();
 
@@ -400,8 +400,8 @@ int usServiceHooksTest(int /*argc*/, char* /*argv*/[])
 
   try
   {
-    Bundle* bundle = framework->GetBundleContext()->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
-    US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle main")
+    auto bundle = framework->GetBundleContext()->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
+    US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test installation of bundle main")
     bundle->Start();
   }
   catch (const std::exception& e)

--- a/core/test/usServiceListenerTest.cpp
+++ b/core/test/usServiceListenerTest.cpp
@@ -42,7 +42,7 @@ class TestServiceListener
 
 private:
 
-  friend bool runStartStopTest(const std::string&, int cnt, Bundle&,
+  friend bool runStartStopTest(const std::string&, int cnt, const std::shared_ptr<Bundle>&,
                                 BundleContext* context,
                                 const std::vector<ServiceEvent::Type>&);
 
@@ -97,7 +97,7 @@ public:
       ServiceReferenceU sr = evt.GetServiceReference();
 
       // Validate that no bundle is marked as using the service
-      std::vector<Bundle*> usingBundles;
+      std::vector<std::shared_ptr<Bundle>> usingBundles;
       sr.GetUsingBundles(usingBundles);
       if (checkUsingBundles && !usingBundles.empty())
       {
@@ -186,11 +186,11 @@ public:
 
   void printUsingBundles(const ServiceReferenceU& sr, const std::string& caption)
   {
-    std::vector<Bundle*> usingBundles;
+    std::vector<std::shared_ptr<Bundle>> usingBundles;
     sr.GetUsingBundles(usingBundles);
 
     US_TEST_OUTPUT( << (caption.empty() ? "Using bundles: " : caption) );
-    for(std::vector<Bundle*>::const_iterator bundle = usingBundles.begin();
+    for (std::vector<std::shared_ptr<Bundle>>::const_iterator bundle = usingBundles.begin();
         bundle != usingBundles.end(); ++bundle)
     {
       US_TEST_OUTPUT( << "  -" << (*bundle) );
@@ -218,7 +218,7 @@ public:
 
 }; // end of class ServiceListener
 
-bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
+bool runStartStopTest(const std::string& name, int cnt, const std::shared_ptr<Bundle>& bundle,
                        BundleContext* context,
                        const std::vector<ServiceEvent::Type>& events)
 {
@@ -242,7 +242,7 @@ bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
     // Start the test target to get a service published.
     try
     {
-      bundle.Start();
+      bundle->Start();
     }
     catch (const std::exception& e)
     {
@@ -254,7 +254,7 @@ bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
     // Stop the test target to get a service unpublished.
     try
     {
-      bundle.Stop();
+      bundle->Stop();
     }
     catch (const std::exception& e)
     {
@@ -306,7 +306,7 @@ void frameSL02a(const std::shared_ptr<Framework>& framework)
                         << " : frameSL02a:FAIL" );
   }
 
-  Bundle* bundle = InstallTestBundle(context, "TestBundleA");
+  auto bundle = InstallTestBundle(context, "TestBundleA");
   bundle->Start();
 
   std::vector<ServiceEvent::Type> events;
@@ -327,9 +327,9 @@ void frameSL05a(const std::shared_ptr<Framework>& framework)
   events.push_back(ServiceEvent::REGISTERED);
   events.push_back(ServiceEvent::UNREGISTERING);
 
-  Bundle* bundle = InstallTestBundle(framework->GetBundleContext(), "TestBundleA");
+  auto bundle = InstallTestBundle(framework->GetBundleContext(), "TestBundleA");
 
-  bool testStatus = runStartStopTest("FrameSL05a", 1, *bundle, framework->GetBundleContext(), events);
+  bool testStatus = runStartStopTest("FrameSL05a", 1, bundle, framework->GetBundleContext(), events);
   US_TEST_CONDITION(testStatus, "FrameSL05a")
 }
 
@@ -339,9 +339,9 @@ void frameSL10a(const std::shared_ptr<Framework>& framework)
   events.push_back(ServiceEvent::REGISTERED);
   events.push_back(ServiceEvent::UNREGISTERING);
 
-  Bundle* bundle = InstallTestBundle(framework->GetBundleContext(), "TestBundleA2");
+  auto bundle = InstallTestBundle(framework->GetBundleContext(), "TestBundleA2");
 
-  bool testStatus = runStartStopTest("FrameSL10a", 1, *bundle, framework->GetBundleContext(), events);
+  bool testStatus = runStartStopTest("FrameSL10a", 1, bundle, framework->GetBundleContext(), events);
   US_TEST_CONDITION(testStatus, "FrameSL10a")
 }
 
@@ -360,9 +360,9 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
     throw;
   }
 
-  Bundle* libSL1 = InstallTestBundle(context, "TestBundleSL1");
-  Bundle* libSL3 = InstallTestBundle(context, "TestBundleSL3");
-  Bundle* libSL4 = InstallTestBundle(context, "TestBundleSL4");
+  auto libSL1 = InstallTestBundle(context, "TestBundleSL1");
+  auto libSL3 = InstallTestBundle(context, "TestBundleSL3");
+  auto libSL4 = InstallTestBundle(context, "TestBundleSL4");
 
   std::vector<ServiceEvent::Type> expectedServiceEventTypes;
 

--- a/core/test/usServiceTemplateTest.cpp
+++ b/core/test/usServiceTemplateTest.cpp
@@ -47,14 +47,14 @@ struct MyFactory1 : public us::ServiceFactory
 {
   std::map<long, std::shared_ptr<MyService1>> m_idToServiceMap;
 
-  virtual us::InterfaceMapConstPtr GetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/)
+  virtual us::InterfaceMapConstPtr GetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/)
   {
     std::shared_ptr<MyService1> s = std::make_shared<MyService1>();
     m_idToServiceMap.insert(std::make_pair(bundle->GetBundleId(), s));
     return us::MakeInterfaceMap<Interface1>(s);
   }
 
-  virtual void UngetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/,
+  virtual void UngetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/,
                             const us::InterfaceMapConstPtr& service)
   {
     std::map<long, std::shared_ptr<MyService1>>::iterator iter = m_idToServiceMap.find(bundle->GetBundleId());
@@ -70,14 +70,14 @@ struct MyFactory2 : public us::ServiceFactory
 {
   std::map<long, std::shared_ptr<MyService2>> m_idToServiceMap;
 
-  virtual us::InterfaceMapConstPtr GetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/)
+  virtual us::InterfaceMapConstPtr GetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/)
   {
     std::shared_ptr<MyService2> s = std::make_shared<MyService2>();
     m_idToServiceMap.insert(std::make_pair(bundle->GetBundleId(), s));
     return us::MakeInterfaceMap<Interface1,Interface2>(s);
   }
 
-  virtual void UngetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/,
+  virtual void UngetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/,
                             const us::InterfaceMapConstPtr& service)
   {
     std::map<long, std::shared_ptr<MyService2>>::iterator iter = m_idToServiceMap.find(bundle->GetBundleId());
@@ -93,14 +93,14 @@ struct MyFactory3 : public us::ServiceFactory
 {
   std::map<long, std::shared_ptr<MyService3>> m_idToServiceMap;
 
-  virtual us::InterfaceMapConstPtr GetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/)
+  virtual us::InterfaceMapConstPtr GetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/)
   {
     std::shared_ptr<MyService3> s = std::make_shared<MyService3>();
     m_idToServiceMap.insert(std::make_pair(bundle->GetBundleId(), s));
     return us::MakeInterfaceMap<Interface1,Interface2,Interface3>(s);
   }
 
-  virtual void UngetService(us::Bundle* bundle, const us::ServiceRegistrationBase& /*registration*/,
+  virtual void UngetService(const std::shared_ptr<us::Bundle>& bundle, const us::ServiceRegistrationBase& /*registration*/,
                             const us::InterfaceMapConstPtr& service)
   {
     std::map<long, std::shared_ptr<MyService3>>::iterator iter = m_idToServiceMap.find(bundle->GetBundleId());

--- a/core/test/usServiceTrackerTest.cpp
+++ b/core/test/usServiceTrackerTest.cpp
@@ -125,7 +125,7 @@ void TestFilterString(us::BundleContext* context)
 
 void TestServiceTracker(us::BundleContext* context)
 {
-  Bundle* bundle = InstallTestBundle(context, "TestBundleS");
+  auto bundle = InstallTestBundle(context, "TestBundleS");
   bundle->Start();
 
   // 1. Create a ServiceTracker with ServiceTrackerCustomizer == null

--- a/core/test/usStaticBundleResourceTest.cpp
+++ b/core/test/usStaticBundleResourceTest.cpp
@@ -56,13 +56,13 @@ struct ResourceComparator {
   }
 };
 
-void testResourceOperators(Bundle* bundle)
+void testResourceOperators(const std::shared_ptr<Bundle>& bundle)
 {
   std::vector<BundleResource> resources = bundle->FindResources("", "res.txt", false);
   US_TEST_CONDITION_REQUIRED(resources.size() == 1, "Check resource count")
 }
 
-void testResourcesWithStaticImport(const std::shared_ptr<Framework>& framework, Bundle* bundle)
+void testResourcesWithStaticImport(const std::shared_ptr<Framework>& framework, const std::shared_ptr<Bundle>& bundle)
 {
   BundleResource resource = bundle->GetResource("res.txt");
   US_TEST_CONDITION_REQUIRED(resource.IsValid(), "Check valid res.txt resource")
@@ -77,8 +77,8 @@ void testResourcesWithStaticImport(const std::shared_ptr<Framework>& framework, 
   resource = bundle->GetResource("static.txt");
   US_TEST_CONDITION_REQUIRED(!resource.IsValid(), "Check in-valid static.txt resource")
 
-  Bundle* importedByBBundle = framework->GetBundleContext()->GetBundle("TestBundleImportedByB");
-  US_TEST_CONDITION_REQUIRED(importedByBBundle != NULL, "Check valid static bundle")
+  auto importedByBBundle = framework->GetBundleContext()->GetBundle("TestBundleImportedByB");
+  US_TEST_CONDITION_REQUIRED(importedByBBundle != nullptr, "Check valid static bundle")
   resource = importedByBBundle->GetResource("static.txt");
   US_TEST_CONDITION_REQUIRED(resource.IsValid(), "Check valid static.txt resource")
   line = GetResourceContent(resource);
@@ -119,19 +119,19 @@ int usStaticBundleResourceTest(int /*argc*/, char* /*argv*/[])
   try
   {
 #if defined (US_BUILD_SHARED_LIBS)
-    Bundle* bundle = framework->GetBundleContext()->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
+    auto bundle = framework->GetBundleContext()->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
 #else
-    Bundle* bundle = framework->GetBundleContext()->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
+    auto bundle = framework->GetBundleContext()->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
 #endif
-    US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle TestBundleImportedByB")
+    US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test installation of bundle TestBundleImportedByB")
   }
   catch (const std::exception& e)
   {
     US_TEST_FAILED_MSG(<< "Install bundle exception: " << e.what())
   }
 
-  Bundle* bundle = framework->GetBundleContext()->GetBundle("TestBundleB");
-  US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test for existing bundle TestBundleB")
+  auto bundle = framework->GetBundleContext()->GetBundle("TestBundleB");
+  US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test for existing bundle TestBundleB")
   US_TEST_CONDITION(bundle->GetName() == "TestBundleB", "Test bundle name")
 
   testResourceOperators(bundle);

--- a/core/test/usStaticBundleTest.cpp
+++ b/core/test/usStaticBundleTest.cpp
@@ -44,24 +44,24 @@ void frame020a(BundleContext* context, TestBundleListener& listener)
 {
   InstallTestBundle(context, "TestBundleB");
 
-  Bundle* bundleB = context->GetBundle("TestBundleB");
+  auto bundleB = context->GetBundle("TestBundleB");
   US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for existing bundle TestBundleB")
 
   try
   {
 #if defined (US_BUILD_SHARED_LIBS)
-    Bundle* bundle = context->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
+    auto bundle = context->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
 #else
-    Bundle* bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
+    auto bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
 #endif
-    US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle TestBundleImportedByB")
+    US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test installation of bundle TestBundleImportedByB")
   }
   catch (const std::exception& e)
   {
     US_TEST_FAILED_MSG(<< "Install bundle exception: " << e.what() << " + in frame020a:FAIL")
   }
 
-  Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
+  auto bundleImportedByB = context->GetBundle("TestBundleImportedByB");
   US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for existing bundle TestBundleImportedByB")
 
   US_TEST_CONDITION(bundleB->GetName() == "TestBundleB", "Test bundle name")
@@ -109,10 +109,10 @@ void frame020a(BundleContext* context, TestBundleListener& listener)
 // Stop libB and check for correct events
 void frame030b(BundleContext* context, TestBundleListener& listener)
 {
-  Bundle* bundleB = context->GetBundle("TestBundleB");
+  auto bundleB = context->GetBundle("TestBundleB");
   US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for non-null bundle")
 
-  Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
+  auto bundleImportedByB = context->GetBundle("TestBundleImportedByB");
   US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for non-null bundle")
 
   std::vector<ServiceReferenceU> refs
@@ -156,10 +156,10 @@ void frame030b(BundleContext* context, TestBundleListener& listener)
 // Uninstall libB and check for correct events
 void frame040c(BundleContext* context, TestBundleListener& listener)
 {
-    Bundle* bundleB = context->GetBundle("TestBundleB");
+    auto bundleB = context->GetBundle("TestBundleB");
     US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for non-null bundle")
 
-    Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
+    auto bundleImportedByB = context->GetBundle("TestBundleImportedByB");
     US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for non-null bundle")
 
     bundleB->Uninstall();

--- a/core/test/usTestUtilBundleListener.cpp
+++ b/core/test/usTestUtilBundleListener.cpp
@@ -65,7 +65,7 @@ ServiceEvent TestBundleListener::GetServiceEvent() const
 bool TestBundleListener::CheckListenerEvents(
     bool pexp, BundleEvent::Type ptype,
     bool sexp, ServiceEvent::Type stype,
-    Bundle* bundleX, ServiceReferenceU* servX)
+    std::shared_ptr<Bundle> bundleX, ServiceReferenceU* servX)
 {
   std::vector<BundleEvent> pEvts;
   std::vector<ServiceEvent> seEvts;

--- a/core/test/usTestUtilBundleListener.h
+++ b/core/test/usTestUtilBundleListener.h
@@ -50,7 +50,7 @@ public:
   bool CheckListenerEvents(
       bool pexp, BundleEvent::Type ptype,
       bool sexp, ServiceEvent::Type stype,
-      Bundle* bundleX, ServiceReferenceU* servX);
+      std::shared_ptr<Bundle> bundleX, ServiceReferenceU* servX);
 
   bool CheckListenerEvents(const std::vector<BundleEvent>& pEvts);
 

--- a/core/test/usTestUtils.cpp
+++ b/core/test/usTestUtils.cpp
@@ -120,9 +120,9 @@ long long HighPrecisionTimer::ElapsedMicro()
 
 #endif
 
-Bundle* InstallTestBundle(BundleContext* frameworkCtx, const std::string& bundleName)
+std::shared_ptr<Bundle> InstallTestBundle(BundleContext* frameworkCtx, const std::string& bundleName)
 {
-    Bundle* bundle = nullptr;
+    std::shared_ptr<Bundle> bundle = nullptr;
     try
     {
 #if defined (US_BUILD_SHARED_LIBS)
@@ -130,7 +130,7 @@ Bundle* InstallTestBundle(BundleContext* frameworkCtx, const std::string& bundle
 #else
         bundle = frameworkCtx->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/" + bundleName);
 #endif
-        US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle " << bundleName)
+        US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Test installation of bundle " << bundleName)
     }
     catch (const std::exception& e)
     {

--- a/core/test/usTestUtils.h
+++ b/core/test/usTestUtils.h
@@ -83,7 +83,7 @@ private:
 // Assumes that test bundles are within the same directory during unit testing.
 // Currently limited to only installing bundles with the same physical filename
 // and logical bundle name (e.g. TestBundleA.dll/TestBundleA).
-Bundle* InstallTestBundle(BundleContext* frameworkCtx, const std::string& bundleName);
+std::shared_ptr<Bundle> InstallTestBundle(BundleContext* frameworkCtx, const std::string& bundleName);
 
 // Copied from usUtils_p.h/usUtils.cpp
 // Place in a different namespace to avoid duplicate symbol errors.

--- a/shellservice/src/usShellService.cpp
+++ b/shellservice/src/usShellService.cpp
@@ -53,9 +53,9 @@ static const int fieldWidth[numFields] = { 4, 26, 10, 12, 40 };
 
 pointer us_bundle_ids(scheme* sc, pointer /*args*/)
 {
-  std::vector<Bundle*> bundles = GetBundleContext()->GetBundles();
+  std::vector<std::shared_ptr<Bundle>> bundles = GetBundleContext()->GetBundles();
   std::set<long> ids;
-  for (std::vector<Bundle*>::iterator iter = bundles.begin(),
+  for (std::vector<std::shared_ptr<Bundle>>::iterator iter = bundles.begin(),
        iterEnd = bundles.end(); iter != iterEnd; ++iter)
   {
     ids.insert((*iter)->GetBundleId());
@@ -87,7 +87,7 @@ pointer us_bundle_info(scheme* sc, pointer args)
   memset(delim, delimChar, 50);
 
   pointer arg = pair_car(args);
-  Bundle* bundle = NULL;
+  auto bundle = std::shared_ptr<Bundle>();
   if (is_string(arg))
   {
     std::string name = sc->vptr->string_value(arg);
@@ -206,7 +206,7 @@ pointer us_bundle_start(scheme* sc, pointer args)
 
   pointer arg = pair_car(args);
 
-  Bundle* bundle = NULL;
+  auto bundle = std::shared_ptr<Bundle>();
   if (is_string(arg))
   {
     std::string name = sc->vptr->string_value(arg);
@@ -244,7 +244,7 @@ pointer us_bundle_stop(scheme* sc, pointer args)
 
   pointer arg = pair_car(args);
 
-  Bundle* bundle = NULL;
+  auto bundle = std::shared_ptr<Bundle>();
   if (is_string(arg))
   {
     std::string name = sc->vptr->string_value(arg);

--- a/tools/shell/usShell.cpp
+++ b/tools/shell/usShell.cpp
@@ -93,14 +93,14 @@ int main(int argc, char** argv)
 
   try
   {
-    std::vector<Bundle*> bundles;
+    std::vector<std::shared_ptr<Bundle>> bundles;
     for (option::Option* opt = options[LOAD_BUNDLE]; opt; opt = opt->next())
     {
       if (opt->arg == nullptr) continue;
       std::cout << "Installing " << opt->arg << std::endl;
       bundles.push_back(context->InstallBundle(opt->arg));
     }
-    for (auto bundle : bundles)
+    for (auto& bundle : bundles)
     {
       bundle->Start();
     }


### PR DESCRIPTION
@CppMicroServices/developers 
I cherry-picked [Sascha's shared_ptr<Bundle> changes](https://github.com/CppMicroServices/CppMicroServices/tree/32-mutex-locking-review) as well as making additional conversions to use ```shared_ptr<Bundle>```.

Convert all instances of Bundle raw pointers to ```shared_ptr<Bundle>```.

Built and tested on Linux, Mac and Windows.

Closes #38

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com