### PR TITLE
Rename mc to context

### DIFF
--- a/core/src/bundle/usBundleHooks.cpp
+++ b/core/src/bundle/usBundleHooks.cpp
@@ -36,7 +36,7 @@ BundleHooks::BundleHooks(CoreBundleContext* ctx)
 {
 }
 
-Bundle* BundleHooks::FilterBundle(const BundleContext* mc, Bundle* bundle) const
+Bundle* BundleHooks::FilterBundle(const BundleContext* context, Bundle* bundle) const
 {
   if(bundle == NULL)
   {
@@ -53,12 +53,12 @@ Bundle* BundleHooks::FilterBundle(const BundleContext* mc, Bundle* bundle) const
   {
     std::vector<Bundle*> ml;
     ml.push_back(bundle);
-    this->FilterBundles(mc, ml);
+    this->FilterBundles(context, ml);
     return ml.empty() ? NULL : bundle;
   }
 }
 
-void BundleHooks::FilterBundles(const BundleContext* mc, std::vector<Bundle*>& bundles) const
+void BundleHooks::FilterBundles(const BundleContext* context, std::vector<Bundle*>& bundles) const
 {
   std::vector<ServiceRegistrationBase> srl;
   coreCtx->services.Get(us_service_interface_iid<BundleFindHook>(), srl);
@@ -74,7 +74,7 @@ void BundleHooks::FilterBundles(const BundleContext* mc, std::vector<Bundle*>& b
     {
       try
       {
-        fh->Find(mc, filtered);
+        fh->Find(context, filtered);
       }
       catch (const std::exception& e)
       {

--- a/core/src/bundle/usBundleHooks_p.h
+++ b/core/src/bundle/usBundleHooks_p.h
@@ -45,9 +45,9 @@ public:
 
   BundleHooks(CoreBundleContext* ctx);
 
-  Bundle* FilterBundle(const BundleContext* mc, Bundle* bundle) const;
+  Bundle* FilterBundle(const BundleContext* context, Bundle* bundle) const;
 
-  void FilterBundles(const BundleContext* mc, std::vector<Bundle*>& bundles) const;
+  void FilterBundles(const BundleContext* context, std::vector<Bundle*>& bundles) const;
 
   void FilterBundleEventReceivers(const BundleEvent& evt,
                                   ServiceListeners::BundleListenerMap& bundleListeners);

--- a/core/src/bundle/usCoreBundleActivator.cpp
+++ b/core/src/bundle/usCoreBundleActivator.cpp
@@ -31,14 +31,14 @@ namespace us {
 class CoreBundleActivator : public BundleActivator
 {
 
-  void Start(BundleContext* mc)
+  void Start(BundleContext* context)
   {
-    mc->GetBundle()->d->coreCtx->Init();
+    context->GetBundle()->d->coreCtx->Init();
   }
 
-  void Stop(BundleContext* /*mc*/)
+  void Stop(BundleContext* /*context*/)
   {
-    //mc->GetBundle()->d->coreCtx->Uninit();
+    //context->GetBundle()->d->coreCtx->Uninit();
   }
 
 };

--- a/core/src/service/usServiceHooks.cpp
+++ b/core/src/service/usServiceHooks.cpp
@@ -103,7 +103,7 @@ bool ServiceHooks::IsOpen() const
   return bOpen;
 }
 
-void ServiceHooks::FilterServiceReferences(BundleContext* mc, const std::string& service,
+void ServiceHooks::FilterServiceReferences(BundleContext* context, const std::string& service,
                                            const std::string& filter, std::vector<ServiceReferenceBase>& refs)
 {
   std::vector<ServiceRegistrationBase> srl;
@@ -122,7 +122,7 @@ void ServiceHooks::FilterServiceReferences(BundleContext* mc, const std::string&
       {
         try
         {
-          fh->Find(mc, service, filter, filtered);
+          fh->Find(context, service, filter, filtered);
         }
         catch (const std::exception& e)
         {

--- a/core/src/service/usServiceHooks_p.h
+++ b/core/src/service/usServiceHooks_p.h
@@ -56,7 +56,7 @@ public:
 
   bool IsOpen() const;
 
-  void FilterServiceReferences(BundleContext* mc, const std::string& service,
+  void FilterServiceReferences(BundleContext* context, const std::string& service,
                                const std::string& filter, std::vector<ServiceReferenceBase>& refs);
 
   void FilterServiceEventReceivers(const ServiceEvent& evt,

--- a/core/src/service/usServiceListenerEntry.cpp
+++ b/core/src/service/usServiceListenerEntry.cpp
@@ -47,9 +47,9 @@ public:
   ServiceListenerEntryData(const ServiceListenerEntryData&) = delete;
   ServiceListenerEntryData& operator=(const ServiceListenerEntryData&) = delete;
 
-  ServiceListenerEntryData(BundleContext* mc, const ServiceListener& l,
+  ServiceListenerEntryData(BundleContext* context, const ServiceListener& l,
                            void* data, const std::string& filter)
-    : ServiceListenerHook::ListenerInfoData(mc, l, data, filter)
+    : ServiceListenerHook::ListenerInfoData(context, l, data, filter)
     , ldap()
     , hashValue(0)
   {
@@ -116,9 +116,9 @@ void ServiceListenerEntry::SetRemoved(bool removed) const
   d->bRemoved = removed;
 }
 
-ServiceListenerEntry::ServiceListenerEntry(BundleContext* mc, const ServiceListener& l,
+ServiceListenerEntry::ServiceListenerEntry(BundleContext* context, const ServiceListener& l,
                                            void* data, const std::string& filter)
-  : ServiceListenerHook::ListenerInfo(new ServiceListenerEntryData(mc, l, data, filter))
+  : ServiceListenerHook::ListenerInfo(new ServiceListenerEntryData(context, l, data, filter))
 {
 }
 
@@ -139,7 +139,7 @@ void ServiceListenerEntry::CallDelegate(const ServiceEvent& event) const
 
 bool ServiceListenerEntry::operator==(const ServiceListenerEntry& other) const
 {
-  return ((d->mc == NULL || other.d->mc == NULL) || d->mc == other.d->mc) &&
+  return ((d->context == NULL || other.d->context == NULL) || d->context == other.d->context) &&
       (d->data == other.d->data) && ServiceListenerCompare()(d->listener, other.d->listener);
 }
 
@@ -150,7 +150,7 @@ std::size_t ServiceListenerEntry::Hash() const
   if (static_cast<ServiceListenerEntryData*>(d.Data())->hashValue == 0)
   {
     static_cast<ServiceListenerEntryData*>(d.Data())->hashValue =
-        ((hash<BundleContext*>()(d->mc) ^ (hash<void*>()(d->data) << 1)) >> 1) ^
+        ((hash<BundleContext*>()(d->context) ^ (hash<void*>()(d->data) << 1)) >> 1) ^
         (hash<ServiceListener>()(d->listener) << 1);
   }
   return static_cast<ServiceListenerEntryData*>(d.Data())->hashValue;

--- a/core/src/service/usServiceListenerEntry_p.h
+++ b/core/src/service/usServiceListenerEntry_p.h
@@ -53,7 +53,7 @@ public:
 
   void SetRemoved(bool removed) const;
 
-  ServiceListenerEntry(BundleContext* mc, const ServiceListener& l, void* data, const std::string& filter = "");
+  ServiceListenerEntry(BundleContext* context, const ServiceListener& l, void* data, const std::string& filter = "");
 
   const LDAPExpr& GetLDAPExpr() const;
 

--- a/core/src/service/usServiceListenerHook.cpp
+++ b/core/src/service/usServiceListenerHook.cpp
@@ -30,9 +30,9 @@ ServiceListenerHook::~ServiceListenerHook()
 }
 
 ServiceListenerHook::ListenerInfoData::ListenerInfoData(
-    BundleContext* mc, const ServiceListener& l,
+    BundleContext* context, const ServiceListener& l,
     void* data, const std::string& filter)
-  : mc(mc)
+  : context(context)
   , listener(l)
   , data(data)
   , filter(filter)
@@ -76,7 +76,7 @@ bool ServiceListenerHook::ListenerInfo::IsNull() const
 
 BundleContext* ServiceListenerHook::ListenerInfo::GetBundleContext() const
 {
-  return d->mc;
+  return d->context;
 }
 
 std::string ServiceListenerHook::ListenerInfo::GetFilter() const

--- a/core/src/service/usServiceListenerHook_p.h
+++ b/core/src/service/usServiceListenerHook_p.h
@@ -32,12 +32,12 @@ namespace us {
 class ServiceListenerHook::ListenerInfoData : public SharedData
 {
 public:
-  ListenerInfoData(BundleContext* mc, const ServiceListener& l,
+  ListenerInfoData(BundleContext* context, const ServiceListener& l,
                    void* data, const std::string& filter);
 
   virtual ~ListenerInfoData();
 
-  BundleContext* const mc;
+  BundleContext* const context;
   ServiceListener listener;
   void* data;
   std::string filter;

--- a/core/src/service/usServiceListeners_p.h
+++ b/core/src/service/usServiceListeners_p.h
@@ -82,14 +82,14 @@ public:
    * Add a new service listener. If an old one exists, and it has the
    * same owning bundle, the old listener is removed first.
    *
-   * @param mc The bundle context adding this listener.
+   * @param context The bundle context adding this listener.
    * @param listener The service listener to add.
    * @param data Additional data to distinguish ServiceListener objects.
    * @param filter An LDAP filter string to check when a service is modified.
    * @exception org.osgi.framework.InvalidSyntaxException
    * If the filter is not a correct LDAP expression.
    */
-  void AddServiceListener(BundleContext* mc, const ServiceListener& listener,
+  void AddServiceListener(BundleContext* context, const ServiceListener& listener,
                           void* data, const std::string& filter);
 
   /**
@@ -97,47 +97,47 @@ public:
    * if listener doesn't exist. If listener is registered more than
    * once remove all instances.
    *
-   * @param mc The bundle context who wants to remove listener.
+   * @param context The bundle context who wants to remove listener.
    * @param listener Object to remove.
    * @param data Additional data to distinguish ServiceListener objects.
    */
-  void RemoveServiceListener(BundleContext* mc, const ServiceListener& listener,
+  void RemoveServiceListener(BundleContext* context, const ServiceListener& listener,
                              void* data);
 
   /**
    * Add a new bundle listener.
    *
-   * @param mc The bundle context adding this listener.
+   * @param context The bundle context adding this listener.
    * @param listener The bundle listener to add.
    * @param data Additional data to distinguish BundleListener objects.
    */
-  void AddBundleListener(BundleContext* mc, const BundleListener& listener, void* data);
+  void AddBundleListener(BundleContext* context, const BundleListener& listener, void* data);
 
   /**
    * Remove bundle listener from current framework. Silently ignore
    * if listener doesn't exist.
    *
-   * @param mc The bundle context who wants to remove listener.
+   * @param context The bundle context who wants to remove listener.
    * @param listener Object to remove.
    * @param data Additional data to distinguish BundleListener objects.
    */
-  void RemoveBundleListener(BundleContext* mc, const BundleListener& listener, void* data);
+  void RemoveBundleListener(BundleContext* context, const BundleListener& listener, void* data);
 
   void BundleChanged(const BundleEvent& evt);
 
   /**
    * Remove all listener registered by a bundle in the current framework.
    *
-   * @param mc Bundle context which listeners we want to remove.
+   * @param context Bundle context which listeners we want to remove.
    */
-  void RemoveAllListeners(BundleContext* mc);
+  void RemoveAllListeners(BundleContext* context);
 
   /**
    * Notify hooks that a bundle is about to be stopped
    *
-   * @param mc Bundle context which listeners are about to be removed.
+   * @param context Bundle context which listeners are about to be removed.
    */
-  void HooksBundleStopped(BundleContext* mc);
+  void HooksBundleStopped(BundleContext* context);
 
   /**
    * Receive notification that a service has had a change occur in its lifecycle.

--- a/core/test/bundles/libH/usTestBundleH.cpp
+++ b/core/test/bundles/libH/usTestBundleH.cpp
@@ -112,7 +112,7 @@ class TestBundleHActivator : public BundleActivator
   std::string thisServiceName;
   ServiceRegistration<TestBundleH> factoryService;
   ServiceRegistration<TestBundleH,TestBundleH2> prototypeFactoryService;
-  BundleContext* mc;
+  BundleContext* context;
   std::shared_ptr<ServiceFactory> factoryObj;
   std::shared_ptr<TestBundleHPrototypeServiceFactory> prototypeFactoryObj;
 
@@ -120,20 +120,20 @@ public:
 
   TestBundleHActivator()
     : thisServiceName(us_service_interface_iid<TestBundleH>())
-    , mc(NULL)
+    , context(NULL)
   {}
 
-  void Start(BundleContext* mc)
+  void Start(BundleContext* context)
   {
     std::cout << "start in H" << std::endl;
-    this->mc = mc;
+    this->context = context;
     factoryObj = std::make_shared<TestBundleHServiceFactory>();
-    factoryService = mc->RegisterService<TestBundleH>(ToFactory(factoryObj));
+    factoryService = context->RegisterService<TestBundleH>(ToFactory(factoryObj));
     prototypeFactoryObj = std::make_shared<TestBundleHPrototypeServiceFactory>();
-    prototypeFactoryService = mc->RegisterService<TestBundleH,TestBundleH2>(ToFactory(prototypeFactoryObj));
+    prototypeFactoryService = context->RegisterService<TestBundleH,TestBundleH2>(ToFactory(prototypeFactoryObj));
   }
 
-  void Stop(BundleContext* /*mc*/)
+  void Stop(BundleContext* /*context*/)
   {
     factoryService.Unregister();
   }

--- a/core/test/bundles/libS/usTestBundleS.cpp
+++ b/core/test/bundles/libS/usTestBundleS.cpp
@@ -44,8 +44,8 @@ class TestBundleS : public ServiceControlInterface,
 
 public:
 
-  TestBundleS(BundleContext* mc)
-    : mc(mc)
+  TestBundleS(BundleContext* context)
+    : context(context)
   {
     for(int i = 0; i <= 3; ++i)
     {
@@ -72,7 +72,7 @@ public:
           ifm->insert(std::make_pair(servicename.str(), shared_from_this()));
           ServiceProperties props;
           props.insert(std::make_pair(ServiceConstants::SERVICE_RANKING(), Any(ranking)));
-          servregs[offset] = mc->RegisterService(ifm, props);
+          servregs[offset] = context->RegisterService(ifm, props);
         }
       }
       if (operation == "unregister")
@@ -91,7 +91,7 @@ private:
 
   static const std::string SERVICE; // = "us::TestBundleSService"
 
-  BundleContext* mc;
+  BundleContext* context;
   std::vector<ServiceRegistrationU> servregs;
 };
 

--- a/core/test/usBundleAutoLoadTest.cpp
+++ b/core/test/usBundleAutoLoadTest.cpp
@@ -41,15 +41,15 @@ namespace {
 
 void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framework>& framework)
 {
-  BundleContext* mc = framework->GetBundleContext();
-  assert(mc);
+  BundleContext* context = framework->GetBundleContext();
+  assert(context);
   TestBundleListener listener;
 
-  BundleListenerRegistrationHelper<TestBundleListener> listenerReg(mc, &listener, &TestBundleListener::BundleChanged);
+  BundleListenerRegistrationHelper<TestBundleListener> listenerReg(context, &listener, &TestBundleListener::BundleChanged);
 
-  InstallTestBundle(mc, "TestBundleAL");
+  InstallTestBundle(context, "TestBundleAL");
 
-  Bundle* bundleAL = mc->GetBundle("TestBundleAL");
+  Bundle* bundleAL = context->GetBundle("TestBundleAL");
   US_TEST_CONDITION_REQUIRED(bundleAL != NULL, "Test for existing bundle TestBundleAL")
 
   US_TEST_CONDITION(bundleAL->GetName() == "TestBundleAL", "Test bundle name")
@@ -57,7 +57,7 @@ void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framewo
   bundleAL->Start();
 
   Any installedBundles = bundleAL->GetProperty(Bundle::PROP_AUTOINSTALLED_BUNDLES);
-  Bundle* bundleAL_1 = mc->GetBundle("TestBundleAL_1");
+  Bundle* bundleAL_1 = context->GetBundle("TestBundleAL_1");
 
   // check the listeners for events
   std::vector<BundleEvent> pEvts;
@@ -93,20 +93,20 @@ void testDefaultAutoLoadPath(bool autoLoadEnabled, const std::shared_ptr<Framewo
 
   US_TEST_CONDITION(listener.CheckListenerEvents(pEvts), "Test for unexpected events");
 
-  mc->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
+  context->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
 
   bundleAL->Stop();
 }
 
 void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
 {
-  BundleContext* mc = framework->GetBundleContext();
-  assert(mc);
+  BundleContext* context = framework->GetBundleContext();
+  assert(context);
   TestBundleListener listener;
 
   try
   {
-    mc->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
+    context->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -114,16 +114,16 @@ void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
     throw;
   }
 
-  InstallTestBundle(mc, "TestBundleAL2");
+  InstallTestBundle(context, "TestBundleAL2");
 
-  Bundle* bundleAL2 = mc->GetBundle("TestBundleAL2");
+  Bundle* bundleAL2 = context->GetBundle("TestBundleAL2");
   US_TEST_CONDITION_REQUIRED(bundleAL2 != NULL, "Test for existing bundle TestBundleAL2")
 
   US_TEST_CONDITION(bundleAL2->GetName() == "TestBundleAL2", "Test bundle name")
 
   bundleAL2->Start();
 
-  Bundle* bundleAL2_1 = mc->GetBundle("TestBundleAL2_1");
+  Bundle* bundleAL2_1 = context->GetBundle("TestBundleAL2_1");
 
   // check the listeners for events
   std::vector<BundleEvent> pEvts;
@@ -148,7 +148,7 @@ void testCustomAutoLoadPath(const std::shared_ptr<Framework>& framework)
 
   US_TEST_CONDITION(listener.CheckListenerEvents(pEvts), "Test for unexpected events");
 
-  mc->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
+  context->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
 
   bundleAL2->Stop();
 }

--- a/core/test/usBundleResourceTest.cpp
+++ b/core/test/usBundleResourceTest.cpp
@@ -396,11 +396,11 @@ void testResourceFromExecutable(Bundle* bundle)
   US_TEST_CONDITION(line == "meant to be compiled into the test driver", "Check executable resource content")
 }
 
-void testResourcesFrom(const std::string& bundleName, BundleContext* mc)
+void testResourcesFrom(const std::string& bundleName, BundleContext* context)
 {
-  InstallTestBundle(mc, bundleName);
+  InstallTestBundle(context, bundleName);
 
-  Bundle* bundleR = mc->GetBundle(bundleName);
+  Bundle* bundleR = context->GetBundle(bundleName);
   US_TEST_CONDITION_REQUIRED(bundleR != NULL, "Test for existing bundle")
 
   US_TEST_CONDITION(bundleR->GetName() == bundleName, "Test bundle name")
@@ -420,12 +420,12 @@ int usBundleResourceTest(int /*argc*/, char* /*argv*/[])
   std::shared_ptr<Framework> framework = factory.NewFramework(std::map<std::string, std::string>());
   framework->Start();
 
-  BundleContext* mc = framework->GetBundleContext();
-  assert(mc);
+  BundleContext* context = framework->GetBundleContext();
+  assert(context);
 
-  InstallTestBundle(mc, "TestBundleR");
+  InstallTestBundle(context, "TestBundleR");
 
-  Bundle* bundleR = mc->GetBundle("TestBundleR");
+  Bundle* bundleR = context->GetBundle("TestBundleR");
   US_TEST_CONDITION_REQUIRED(bundleR != NULL, "Test for existing bundle TestBundleR")
 
   US_TEST_CONDITION(bundleR->GetName() == "TestBundleR", "Test bundle name")
@@ -435,7 +435,7 @@ int usBundleResourceTest(int /*argc*/, char* /*argv*/[])
   Bundle* executableBundle = nullptr;
   try
   {
-    executableBundle = mc->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
+    executableBundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
     US_TEST_CONDITION_REQUIRED(executableBundle != NULL, "Test installation of bundle main")
   }
   catch (const std::exception& e)

--- a/core/test/usBundleTest.cpp
+++ b/core/test/usBundleTest.cpp
@@ -43,11 +43,11 @@ using namespace us;
 namespace {
 
 // Check that the executable's activator was started and called
-void frame01(BundleContext* mc)
+void frame01(BundleContext* context)
 {
   try
   {
-    Bundle* bundle = mc->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
+    Bundle* bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
     US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle main")
 
     bundle->Start();
@@ -62,17 +62,17 @@ void frame01(BundleContext* mc)
 
 // Verify that the same member function pointers registered as listeners
 // with different receivers works.
-void frame02a(BundleContext* mc)
+void frame02a(BundleContext* context)
 {
   TestBundleListener listener1;
   TestBundleListener listener2;
 
   try
   {
-    mc->RemoveBundleListener(&listener1, &TestBundleListener::BundleChanged);
-    mc->AddBundleListener(&listener1, &TestBundleListener::BundleChanged);
-    mc->RemoveBundleListener(&listener2, &TestBundleListener::BundleChanged);
-    mc->AddBundleListener(&listener2, &TestBundleListener::BundleChanged);
+    context->RemoveBundleListener(&listener1, &TestBundleListener::BundleChanged);
+    context->AddBundleListener(&listener1, &TestBundleListener::BundleChanged);
+    context->RemoveBundleListener(&listener2, &TestBundleListener::BundleChanged);
+    context->AddBundleListener(&listener2, &TestBundleListener::BundleChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -80,9 +80,9 @@ void frame02a(BundleContext* mc)
                         << " : frameSL02a:FAIL" );
   }
 
-  InstallTestBundle(mc, "TestBundleA");
+  InstallTestBundle(context, "TestBundleA");
 
-  Bundle* bundleA = mc->GetBundle("TestBundleA");
+  Bundle* bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
 
   bundleA->Start();
@@ -97,28 +97,28 @@ void frame02a(BundleContext* mc)
   US_TEST_CONDITION(listener1.CheckListenerEvents(pEvts, seEvts), "Check first bundle listener")
   US_TEST_CONDITION(listener2.CheckListenerEvents(pEvts, seEvts), "Check second bundle listener")
 
-  mc->RemoveBundleListener(&listener1, &TestBundleListener::BundleChanged);
-  mc->RemoveBundleListener(&listener2, &TestBundleListener::BundleChanged);
+  context->RemoveBundleListener(&listener1, &TestBundleListener::BundleChanged);
+  context->RemoveBundleListener(&listener2, &TestBundleListener::BundleChanged);
 
   bundleA->Stop();
 
 }
 
 // Verify information from the BundleInfo struct
-void frame005a(BundleContext* mc)
+void frame005a(BundleContext* context)
 {
-  Bundle* m = mc->GetBundle();
+  Bundle* m = context->GetBundle();
   long systemId = 0;
   // check expected meta-data
   US_TEST_CONDITION("main" == m->GetName(), "Test bundle name")
   US_TEST_CONDITION(BundleVersion(0,1,0) == m->GetVersion(), "Test test driver bundle version")
-  US_TEST_CONDITION(BundleVersion(CppMicroServices_MAJOR_VERSION, CppMicroServices_MINOR_VERSION, CppMicroServices_PATCH_VERSION) == mc->GetBundle(systemId)->GetVersion(), "Test CppMicroServices version")
+  US_TEST_CONDITION(BundleVersion(CppMicroServices_MAJOR_VERSION, CppMicroServices_MINOR_VERSION, CppMicroServices_PATCH_VERSION) == context->GetBundle(systemId)->GetVersion(), "Test CppMicroServices version")
 }
 
 // Get context id, location, persistent storage and status of the bundle
-void frame010a(const std::shared_ptr<Framework>& framework, BundleContext* mc)
+void frame010a(const std::shared_ptr<Framework>& framework, BundleContext* context)
 {
-  Bundle* m = mc->GetBundle();
+  Bundle* m = context->GetBundle();
 
   long int contextid = m->GetBundleId();
   US_DEBUG << "CONTEXT ID:" << contextid;
@@ -144,11 +144,11 @@ void frame010a(const std::shared_ptr<Framework>& framework, BundleContext* mc)
 
 //----------------------------------------------------------------------------
 //Test result of GetService(ServiceReference()). Should throw std::invalid_argument
-void frame018a(BundleContext* mc)
+void frame018a(BundleContext* context)
 {
   try
   {
-    mc->GetService(ServiceReferenceU());
+    context->GetService(ServiceReferenceU());
     US_DEBUG << "Got service object, expected std::invalid_argument exception";
     US_TEST_FAILED_MSG(<< "Got service object, excpected std::invalid_argument exception")
   }
@@ -164,9 +164,9 @@ void frame018a(BundleContext* mc)
 // also check that the expected events occur
 void frame020a(const std::shared_ptr<Framework>& framework, TestBundleListener& listener)
 {
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
-  Bundle* bundleA = mc->GetBundle("TestBundleA");
+  Bundle* bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
 
   US_TEST_CONDITION(bundleA->GetName() == "TestBundleA", "Test bundle name")
@@ -176,8 +176,8 @@ void frame020a(const std::shared_ptr<Framework>& framework, TestBundleListener& 
   // Check if libA registered the expected service
   try
   {
-    ServiceReferenceU sr1 = mc->GetServiceReference("us::TestBundleAService");
-    InterfaceMapConstPtr o1 = mc->GetService(sr1);
+    ServiceReferenceU sr1 = context->GetServiceReference("us::TestBundleAService");
+    InterfaceMapConstPtr o1 = context->GetService(sr1);
     US_TEST_CONDITION(o1 && !o1->empty(), "Test if service object found");
 
     // check the listeners for events
@@ -203,11 +203,11 @@ void frame020a(const std::shared_ptr<Framework>& framework, TestBundleListener& 
 // Start libA and check that it exists and that the storage paths are correct
 void frame02b(const std::shared_ptr<Framework>& framework)
 {
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
   US_TEST_CONDITION(framework->GetProperty(Framework::PROP_STORAGE_LOCATION).ToString() == "/tmp", "Test for valid base storage path")
 
-  Bundle* bundleA = mc->GetBundle("TestBundleA");
+  Bundle* bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for existing bundle TestBundleA")
   // launching properties should be accessible through any bundle
   US_TEST_CONDITION(bundleA->GetProperty(Framework::PROP_STORAGE_LOCATION).ToString() == "/tmp", "Test for valid base storage path")
@@ -227,13 +227,13 @@ void frame02b(const std::shared_ptr<Framework>& framework)
 
 
 // Stop libA and check for correct events
-void frame030b(BundleContext* mc, TestBundleListener& listener)
+void frame030b(BundleContext* context, TestBundleListener& listener)
 {
-  Bundle* bundleA = mc->GetBundle("TestBundleA");
+  Bundle* bundleA = context->GetBundle("TestBundleA");
   US_TEST_CONDITION_REQUIRED(bundleA != nullptr, "Test for non-null bundle")
 
   ServiceReferenceU sr1
-      = mc->GetServiceReference("us::TestBundleAService");
+      = context->GetServiceReference("us::TestBundleAService");
   US_TEST_CONDITION(sr1, "Test for valid service reference")
 
   try
@@ -262,14 +262,14 @@ struct LocalListener {
 };
 
 // Add a service listener with a broken LDAP filter to Get an exception
-void frame045a(BundleContext* mc)
+void frame045a(BundleContext* context)
 {
   LocalListener sListen1;
   std::string brokenFilter = "A broken LDAP filter";
 
   try
   {
-    mc->AddServiceListener(&sListen1, &LocalListener::ServiceChanged, brokenFilter);
+    context->AddServiceListener(&sListen1, &LocalListener::ServiceChanged, brokenFilter);
     US_TEST_FAILED_MSG(<< "test bundle, no exception on broken LDAP filter:");
   }
   catch (const std::invalid_argument& /*ia*/)
@@ -435,15 +435,15 @@ int usBundleTest(int /*argc*/, char* /*argv*/[])
     std::cout << "----- " << (*iter)->GetName() << std::endl;
   }
 
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
   TestBundleListener listener;
 
-  frame01(mc);
-  frame02a(mc);
+  frame01(context);
+  frame02a(context);
 
   try
   {
-    mc->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
+    context->AddBundleListener(&listener, &TestBundleListener::BundleChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -453,7 +453,7 @@ int usBundleTest(int /*argc*/, char* /*argv*/[])
 
   try
   {
-    mc->AddServiceListener(&listener, &TestBundleListener::ServiceChanged);
+    context->AddServiceListener(&listener, &TestBundleListener::ServiceChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -461,17 +461,17 @@ int usBundleTest(int /*argc*/, char* /*argv*/[])
     throw;
   }
 
-  frame005a(mc->GetBundle("main")->GetBundleContext());
-  frame010a(framework, mc);
-  frame018a(mc);
+  frame005a(context->GetBundle("main")->GetBundleContext());
+  frame010a(framework, context);
+  frame018a(context);
 
   frame020a(framework, listener);
-  frame030b(mc, listener);
+  frame030b(context, listener);
 
-  frame045a(mc);
+  frame045a(context);
 
-  mc->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
-  mc->RemoveServiceListener(&listener, &TestBundleListener::ServiceChanged);
+  context->RemoveBundleListener(&listener, &TestBundleListener::BundleChanged);
+  context->RemoveServiceListener(&listener, &TestBundleListener::ServiceChanged);
 
   framework->Stop();
 

--- a/core/test/usServiceFactoryTest.cpp
+++ b/core/test/usServiceFactoryTest.cpp
@@ -48,15 +48,15 @@ struct TestBundleH2
 }
 
 
-void TestServiceFactoryBundleScope(BundleContext* mc)
+void TestServiceFactoryBundleScope(BundleContext* context)
 {
 
   // Install and start test bundle H, a service factory and test that the methods
   // in that interface works.
 
-  InstallTestBundle(mc, "TestBundleH");
+  InstallTestBundle(context, "TestBundleH");
 
-  Bundle* bundleH = mc->GetBundle("TestBundleH");
+  Bundle* bundleH = context->GetBundle("TestBundleH");
   US_TEST_CONDITION_REQUIRED(bundleH != nullptr, "Test for existing bundle TestBundleH")
 
   bundleH->Start();
@@ -67,20 +67,20 @@ void TestServiceFactoryBundleScope(BundleContext* mc)
   US_TEST_CONDITION(registeredRefs[1].GetProperty(ServiceConstants::SERVICE_SCOPE()).ToString() == ServiceConstants::SCOPE_PROTOTYPE(), "service scope")
 
   // Check that a service reference exist
-  const ServiceReferenceU sr1 = mc->GetServiceReference("us::TestBundleH");
+  const ServiceReferenceU sr1 = context->GetServiceReference("us::TestBundleH");
   US_TEST_CONDITION_REQUIRED(sr1, "Service shall be present.")
   US_TEST_CONDITION(sr1.GetProperty(ServiceConstants::SERVICE_SCOPE()).ToString() == ServiceConstants::SCOPE_BUNDLE(), "service scope")
 
-  InterfaceMapConstPtr service = mc->GetService(sr1);
+  InterfaceMapConstPtr service = context->GetService(sr1);
   US_TEST_CONDITION_REQUIRED(service->size() >= 1, "GetService()")
   InterfaceMap::const_iterator serviceIter = service->find("us::TestBundleH");
   US_TEST_CONDITION_REQUIRED(serviceIter != service->end(), "GetService()")
   US_TEST_CONDITION_REQUIRED(serviceIter->second, "GetService()")
 
-  InterfaceMapConstPtr service2 = mc->GetService(sr1);
+  InterfaceMapConstPtr service2 = context->GetService(sr1);
   US_TEST_CONDITION(*(service.get()) == *(service2.get()), "Same service interface maps")
 
-  std::vector<ServiceReferenceU> usedRefs = mc->GetBundle()->GetServicesInUse();
+  std::vector<ServiceReferenceU> usedRefs = context->GetBundle()->GetServicesInUse();
   US_TEST_CONDITION_REQUIRED(usedRefs.size() == 1, "services in use")
   US_TEST_CONDITION(usedRefs[0] == sr1, "service ref in use")
 
@@ -95,67 +95,67 @@ void TestServiceFactoryBundleScope(BundleContext* mc)
   bundleH->Stop();
 }
 
-void TestServiceFactoryPrototypeScope(BundleContext* mc)
+void TestServiceFactoryPrototypeScope(BundleContext* context)
 {
 
   // Install and start test bundle H, a service factory and test that the methods
   // in that interface works.
 
-  InstallTestBundle(mc, "TestBundleH");
+  InstallTestBundle(context, "TestBundleH");
 
-  Bundle* bundleH = mc->GetBundle("TestBundleH");
+  Bundle* bundleH = context->GetBundle("TestBundleH");
   US_TEST_CONDITION_REQUIRED(bundleH != nullptr, "Test for existing bundle TestBundleH")
 
   bundleH->Start();
 
   // Check that a service reference exist
-  const ServiceReference<TestBundleH2> sr1 = mc->GetServiceReference<TestBundleH2>();
+  const ServiceReference<TestBundleH2> sr1 = context->GetServiceReference<TestBundleH2>();
   US_TEST_CONDITION_REQUIRED(sr1, "Service shall be present.")
   US_TEST_CONDITION(sr1.GetProperty(ServiceConstants::SERVICE_SCOPE()).ToString() == ServiceConstants::SCOPE_PROTOTYPE(), "service scope")
 
-  ServiceObjects<TestBundleH2> svcObjects = mc->GetServiceObjects(sr1);
+  ServiceObjects<TestBundleH2> svcObjects = context->GetServiceObjects(sr1);
   std::shared_ptr<TestBundleH2> prototypeServiceH2 = svcObjects.GetService();
 
-  const ServiceReferenceU sr1void = mc->GetServiceReference(us_service_interface_iid<TestBundleH2>());
-  ServiceObjects<void> svcObjectsVoid = mc->GetServiceObjects(sr1void);
+  const ServiceReferenceU sr1void = context->GetServiceReference(us_service_interface_iid<TestBundleH2>());
+  ServiceObjects<void> svcObjectsVoid = context->GetServiceObjects(sr1void);
   InterfaceMapConstPtr prototypeServiceH2Void = svcObjectsVoid.GetService();
   US_TEST_CONDITION_REQUIRED(prototypeServiceH2Void->find(us_service_interface_iid<TestBundleH2>()) != prototypeServiceH2Void->end(),
                              "ServiceObjects<void>::GetService()")
 
 #ifdef US_BUILD_SHARED_LIBS
   // There should be only one service in use
-  US_TEST_CONDITION_REQUIRED(mc->GetBundle()->GetServicesInUse().size() == 1, "services in use")
+  US_TEST_CONDITION_REQUIRED(context->GetBundle()->GetServicesInUse().size() == 1, "services in use")
 #endif
 
-  std::shared_ptr<TestBundleH2> bundleScopeService = mc->GetService(sr1);
+  std::shared_ptr<TestBundleH2> bundleScopeService = context->GetService(sr1);
   US_TEST_CONDITION_REQUIRED(bundleScopeService && bundleScopeService != prototypeServiceH2, "GetService()")
 
   US_TEST_CONDITION_REQUIRED(prototypeServiceH2 != prototypeServiceH2Void->find(us_service_interface_iid<TestBundleH2>())->second,
                              "GetService()")
 
-  std::shared_ptr<TestBundleH2> bundleScopeService2 = mc->GetService(sr1);
+  std::shared_ptr<TestBundleH2> bundleScopeService2 = context->GetService(sr1);
   US_TEST_CONDITION(bundleScopeService == bundleScopeService2, "Same service pointer")
 
 #ifdef US_BUILD_SHARED_LIBS
-  std::vector<ServiceReferenceU> usedRefs = mc->GetBundle()->GetServicesInUse();
+  std::vector<ServiceReferenceU> usedRefs = context->GetBundle()->GetServicesInUse();
   US_TEST_CONDITION_REQUIRED(usedRefs.size() == 1, "services in use")
   US_TEST_CONDITION(usedRefs[0] == sr1, "service ref in use")
 #endif
 
   std::string filter = "(" + ServiceConstants::SERVICE_ID() + "=" + sr1.GetProperty(ServiceConstants::SERVICE_ID()).ToString() + ")";
-  const ServiceReference<TestBundleH> sr2 = mc->GetServiceReferences<TestBundleH>(filter).front();
+  const ServiceReference<TestBundleH> sr2 = context->GetServiceReferences<TestBundleH>(filter).front();
   US_TEST_CONDITION_REQUIRED(sr2, "Service shall be present.")
   US_TEST_CONDITION(sr2.GetProperty(ServiceConstants::SERVICE_SCOPE()).ToString() == ServiceConstants::SCOPE_PROTOTYPE(), "service scope")
   US_TEST_CONDITION(any_cast<long>(sr2.GetProperty(ServiceConstants::SERVICE_ID())) == any_cast<long>(sr1.GetProperty(ServiceConstants::SERVICE_ID())), "same service id")
 
 #ifdef US_BUILD_SHARED_LIBS
   // There should still be only one service in use
-  usedRefs = mc->GetBundle()->GetServicesInUse();
+  usedRefs = context->GetBundle()->GetServicesInUse();
   US_TEST_CONDITION_REQUIRED(usedRefs.size() == 1, "services in use")
 #endif
 
   ServiceObjects<TestBundleH2> svcObjects2 = svcObjects;
-  ServiceObjects<TestBundleH2> svcObjects3 = mc->GetServiceObjects(sr1);
+  ServiceObjects<TestBundleH2> svcObjects3 = context->GetServiceObjects(sr1);
 
   prototypeServiceH2 = svcObjects2.GetService();
   std::shared_ptr<TestBundleH2> prototypeServiceH2_2 = svcObjects3.GetService();

--- a/core/test/usServiceHooksTest.cpp
+++ b/core/test/usServiceHooksTest.cpp
@@ -63,9 +63,9 @@ private:
 
 public:
 
-  TestServiceEventListenerHook(int id, BundleContext* mc)
+  TestServiceEventListenerHook(int id, BundleContext* context)
   : id(id),
-    bundleCtx(mc)
+    bundleCtx(context)
   {
   }
 
@@ -146,9 +146,9 @@ private:
 
 public:
 
-  TestServiceFindHook(int id, BundleContext* mc)
+  TestServiceFindHook(int id, BundleContext* context)
     : id(id),
-      bundleCtx(mc)
+      bundleCtx(context)
   {
   }
 
@@ -174,9 +174,9 @@ private:
 
 public:
 
-  TestServiceListenerHook(int id,BundleContext* mc)
+  TestServiceListenerHook(int id,BundleContext* context)
     : id(id),
-      bundleCtx(mc)
+      bundleCtx(context)
   {
   }
 

--- a/core/test/usServiceListenerTest.cpp
+++ b/core/test/usServiceListenerTest.cpp
@@ -43,7 +43,7 @@ class TestServiceListener
 private:
 
   friend bool runStartStopTest(const std::string&, int cnt, Bundle&,
-                                BundleContext* mc,
+                                BundleContext* context,
                                 const std::vector<ServiceEvent::Type>&);
 
   const bool checkUsingBundles;
@@ -51,12 +51,12 @@ private:
 
   bool teststatus;
 
-  BundleContext* mc;
+  BundleContext* context;
 
 public:
 
-  TestServiceListener(BundleContext* mc, bool checkUsingBundles = true)
-    : checkUsingBundles(checkUsingBundles), events(), teststatus(true), mc(mc)
+  TestServiceListener(BundleContext* context, bool checkUsingBundles = true)
+    : checkUsingBundles(checkUsingBundles), events(), teststatus(true), context(context)
   {}
 
   bool getTestStatus() const
@@ -106,7 +106,7 @@ public:
       }
 
       // Check if the service can be fetched
-      InterfaceMapConstPtr service = mc->GetService(sr);
+      InterfaceMapConstPtr service = context->GetService(sr);
       sr.GetUsingBundles(usingBundles);
       // if (UNREGISTERSERVICE_VALID_DURING_UNREGISTERING) {
       // In this mode the service shall be obtainable during
@@ -155,7 +155,7 @@ public:
         long sid = any_cast<long>(sr.GetProperty(ServiceConstants::SERVICE_ID()));
         std::stringstream ss;
         ss << "(" << ServiceConstants::SERVICE_ID() << "=" << sid << ")";
-        std::vector<ServiceReferenceU> srs = mc->GetServiceReferences("", ss.str());
+        std::vector<ServiceReferenceU> srs = context->GetServiceReferences("", ss.str());
         if (srs.empty())
         {
           US_TEST_OUTPUT( << "ServiceReference for UNREGISTERING service is not"
@@ -219,18 +219,18 @@ public:
 }; // end of class ServiceListener
 
 bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
-                       BundleContext* mc,
+                       BundleContext* context,
                        const std::vector<ServiceEvent::Type>& events)
 {
   bool teststatus = true;
 
   for (int i = 0; i < cnt && teststatus; ++i)
   {
-    TestServiceListener sListen(mc);
+    TestServiceListener sListen(context);
     try
     {
-      mc->AddServiceListener(&sListen, &TestServiceListener::serviceChanged);
-      //mc->AddServiceListener(MessageDelegate1<ServiceListener, const ServiceEvent&>(&sListen, &ServiceListener::serviceChanged));
+      context->AddServiceListener(&sListen, &TestServiceListener::serviceChanged);
+      //context->AddServiceListener(MessageDelegate1<ServiceListener, const ServiceEvent&>(&sListen, &ServiceListener::serviceChanged));
     }
     catch (const std::logic_error& ise)
     {
@@ -272,7 +272,7 @@ bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
 
     try
     {
-      mc->RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
+      context->RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
       teststatus &= sListen.teststatus;
       sListen.clearEvents();
     }
@@ -288,17 +288,17 @@ bool runStartStopTest(const std::string& name, int cnt, Bundle& bundle,
 
 void frameSL02a(const std::shared_ptr<Framework>& framework)
 {
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
-  TestServiceListener listener1(mc);
-  TestServiceListener listener2(mc);
+  TestServiceListener listener1(context);
+  TestServiceListener listener2(context);
 
   try
   {
-    mc->RemoveServiceListener(&listener1, &TestServiceListener::serviceChanged);
-    mc->AddServiceListener(&listener1, &TestServiceListener::serviceChanged);
-    mc->RemoveServiceListener(&listener2, &TestServiceListener::serviceChanged);
-    mc->AddServiceListener(&listener2, &TestServiceListener::serviceChanged);
+    context->RemoveServiceListener(&listener1, &TestServiceListener::serviceChanged);
+    context->AddServiceListener(&listener1, &TestServiceListener::serviceChanged);
+    context->RemoveServiceListener(&listener2, &TestServiceListener::serviceChanged);
+    context->AddServiceListener(&listener2, &TestServiceListener::serviceChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -306,7 +306,7 @@ void frameSL02a(const std::shared_ptr<Framework>& framework)
                         << " : frameSL02a:FAIL" );
   }
 
-  Bundle* bundle = InstallTestBundle(mc, "TestBundleA");
+  Bundle* bundle = InstallTestBundle(context, "TestBundleA");
   bundle->Start();
 
   std::vector<ServiceEvent::Type> events;
@@ -315,8 +315,8 @@ void frameSL02a(const std::shared_ptr<Framework>& framework)
   US_TEST_CONDITION(listener1.checkEvents(events), "Check first service listener")
   US_TEST_CONDITION(listener2.checkEvents(events), "Check second service listener")
 
-  mc->RemoveServiceListener(&listener1, &TestServiceListener::serviceChanged);
-  mc->RemoveServiceListener(&listener2, &TestServiceListener::serviceChanged);
+  context->RemoveServiceListener(&listener1, &TestServiceListener::serviceChanged);
+  context->RemoveServiceListener(&listener2, &TestServiceListener::serviceChanged);
 
   bundle->Stop();
 }
@@ -347,12 +347,12 @@ void frameSL10a(const std::shared_ptr<Framework>& framework)
 
 void frameSL25a(const std::shared_ptr<Framework>& framework)
 {
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
-  TestServiceListener sListen(mc, false);
+  TestServiceListener sListen(context, false);
   try
   {
-    mc->AddServiceListener(&sListen, &TestServiceListener::serviceChanged);
+    context->AddServiceListener(&sListen, &TestServiceListener::serviceChanged);
   }
   catch (const std::logic_error& ise)
   {
@@ -360,9 +360,9 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
     throw;
   }
 
-  Bundle* libSL1 = InstallTestBundle(mc, "TestBundleSL1");
-  Bundle* libSL3 = InstallTestBundle(mc, "TestBundleSL3");
-  Bundle* libSL4 = InstallTestBundle(mc, "TestBundleSL4");
+  Bundle* libSL1 = InstallTestBundle(context, "TestBundleSL1");
+  Bundle* libSL3 = InstallTestBundle(context, "TestBundleSL3");
+  Bundle* libSL4 = InstallTestBundle(context, "TestBundleSL4");
 
   std::vector<ServiceEvent::Type> expectedServiceEventTypes;
 
@@ -421,12 +421,12 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
   US_TEST_OUTPUT( << "Check that FooService is added to service tracker in libSL3" );
   try
   {
-    ServiceReferenceU libSL3SR = mc->GetServiceReference("ActivatorSL3");
-    InterfaceMapConstPtr libSL3Activator = mc->GetService(libSL3SR);
+    ServiceReferenceU libSL3SR = context->GetServiceReference("ActivatorSL3");
+    InterfaceMapConstPtr libSL3Activator = context->GetService(libSL3SR);
     US_TEST_CONDITION_REQUIRED(libSL3Activator && !libSL3Activator->empty(), "ActivatorSL3 service != 0");
 
     ServiceReference<BundlePropsInterface> libSL3PropsI(libSL3SR);
-    std::shared_ptr<BundlePropsInterface> propsInterface = mc->GetService(libSL3PropsI);
+    std::shared_ptr<BundlePropsInterface> propsInterface = context->GetService(libSL3PropsI);
     US_TEST_CONDITION_REQUIRED(propsInterface, "BundlePropsInterface != 0");
 
     BundlePropsInterface::Properties::const_iterator i = propsInterface->GetProperties().find("serviceAdded");
@@ -444,12 +444,12 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
   US_TEST_OUTPUT( << "Check that FooService is added to service tracker in libSL1" );
   try
   {
-    ServiceReferenceU libSL1SR = mc->GetServiceReference("ActivatorSL1");
-    InterfaceMapConstPtr libSL1Activator = mc->GetService(libSL1SR);
+    ServiceReferenceU libSL1SR = context->GetServiceReference("ActivatorSL1");
+    InterfaceMapConstPtr libSL1Activator = context->GetService(libSL1SR);
     US_TEST_CONDITION_REQUIRED(libSL1Activator && !libSL1Activator->empty(), "ActivatorSL1 service != 0");
 
     ServiceReference<BundlePropsInterface> libSL1PropsI(libSL1SR);
-    std::shared_ptr<BundlePropsInterface> propsInterface = mc->GetService(libSL1PropsI);
+    std::shared_ptr<BundlePropsInterface> propsInterface = context->GetService(libSL1PropsI);
     US_TEST_CONDITION_REQUIRED(propsInterface, "Cast to BundlePropsInterface");
 
     BundlePropsInterface::Properties::const_iterator i = propsInterface->GetProperties().find("serviceAdded");
@@ -479,12 +479,12 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
   US_TEST_OUTPUT( << "Check that FooService is removed from service tracker in libSL3" );
   try
   {
-    ServiceReferenceU libSL3SR = mc->GetServiceReference("ActivatorSL3");
-    InterfaceMapConstPtr libSL3Activator = mc->GetService(libSL3SR);
+    ServiceReferenceU libSL3SR = context->GetServiceReference("ActivatorSL3");
+    InterfaceMapConstPtr libSL3Activator = context->GetService(libSL3SR);
     US_TEST_CONDITION_REQUIRED(libSL3Activator && !libSL3Activator->empty(), "ActivatorSL3 service != 0");
 
     ServiceReference<BundlePropsInterface> libSL3PropsI(libSL3SR);
-    std::shared_ptr<BundlePropsInterface> propsInterface = mc->GetService(libSL3PropsI);
+    std::shared_ptr<BundlePropsInterface> propsInterface = context->GetService(libSL3PropsI);
     US_TEST_CONDITION_REQUIRED(propsInterface, "Cast to BundlePropsInterface");
 
     BundlePropsInterface::Properties::const_iterator i = propsInterface->GetProperties().find("serviceRemoved");
@@ -533,7 +533,7 @@ void frameSL25a(const std::shared_ptr<Framework>& framework)
   US_TEST_CONDITION_REQUIRED(sListen.getTestStatus(), "Service listener checks");
   try
   {
-    mc->RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
+    context->RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
     sListen.clearEvents();
   }
   catch (const std::logic_error& ise)

--- a/core/test/usServiceRegistryPerformanceTest.cpp
+++ b/core/test/usServiceRegistryPerformanceTest.cpp
@@ -49,7 +49,7 @@ private:
 
   friend class MyServiceListener;
 
-  BundleContext* mc;
+  BundleContext* context;
 
   int nListeners;
   int nServices;
@@ -124,7 +124,7 @@ public:
 
 
 ServiceRegistryPerformanceTest::ServiceRegistryPerformanceTest(BundleContext* context)
-  : mc(context)
+  : context(context)
   , nListeners(100)
   , nServices(1000)
   , nRegistered(0)
@@ -151,7 +151,7 @@ void ServiceRegistryPerformanceTest::CleanupTestCase()
     try
     {
       MyServiceListener* l = listeners[i];
-      mc->RemoveServiceListener(l, &MyServiceListener::ServiceChanged);
+      context->RemoveServiceListener(l, &MyServiceListener::ServiceChanged);
       delete l;
     }
     catch (const std::exception& e)
@@ -176,7 +176,7 @@ void ServiceRegistryPerformanceTest::AddListeners(int n)
     try
     {
       listeners.push_back(l);
-      mc->AddServiceListener(l, &MyServiceListener::ServiceChanged, "(perf.service.value>=0)");
+      context->AddServiceListener(l, &MyServiceListener::ServiceChanged, "(perf.service.value>=0)");
     }
     catch (const std::exception& e)
     {
@@ -221,7 +221,7 @@ void ServiceRegistryPerformanceTest::RegisterServices(int n)
     std::shared_ptr<PerfTestService> service = std::make_shared<PerfTestService>();
     services.push_back(service);
     ServiceRegistration<IPerfTestService> reg =
-        mc->RegisterService<IPerfTestService>(service, props);
+        context->RegisterService<IPerfTestService>(service, props);
     regs.push_back(reg);
   }
 }

--- a/core/test/usServiceRegistryTest.cpp
+++ b/core/test/usServiceRegistryTest.cpp
@@ -52,13 +52,11 @@ void TestServiceInterfaceId()
   US_TEST_CONDITION(us_service_interface_iid<ITestServiceB>() == "com.mycompany.ITestService/1.0", "Service interface id com.mycompany.ITestService/1.0")
 }
 
-void TestMultipleServiceRegistrations(BundleContext* mc)
+void TestMultipleServiceRegistrations(BundleContext* context)
 {
   struct TestServiceA : public ITestServiceA
   {
   };
-
-  BundleContext* context = mc;
 
   std::shared_ptr<TestServiceA> s1 = std::make_shared<TestServiceA>();
   std::shared_ptr<TestServiceA> s2 = std::make_shared<TestServiceA>();
@@ -81,13 +79,11 @@ void TestMultipleServiceRegistrations(BundleContext* mc)
   US_TEST_CONDITION_REQUIRED(!ref, "Testing for invalid service reference")
 }
 
-void TestServicePropertiesUpdate(BundleContext* mc)
+void TestServicePropertiesUpdate(BundleContext* context)
 {
   struct TestServiceA : public ITestServiceA
   {
   };
-
-  BundleContext* context = mc;
 
   std::shared_ptr<TestServiceA> s1 = std::make_shared<TestServiceA>();
   ServiceProperties props;
@@ -146,11 +142,11 @@ int usServiceRegistryTest(int /*argc*/, char* /*argv*/[])
   std::shared_ptr<Framework> framework = factory.NewFramework(std::map<std::string, std::string>());
   framework->Start();
 
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
   TestServiceInterfaceId();
-  TestMultipleServiceRegistrations(mc);
-  TestServicePropertiesUpdate(mc);
+  TestMultipleServiceRegistrations(context);
+  TestServicePropertiesUpdate(context);
 
   US_TEST_END()
 }

--- a/core/test/usServiceTemplateTest.cpp
+++ b/core/test/usServiceTemplateTest.cpp
@@ -123,83 +123,83 @@ int usServiceTemplateTest(int /*argc*/, char* /*argv*/[])
   std::shared_ptr<Framework> framework = factory.NewFramework(std::map<std::string, std::string>());
   framework->Start();
 
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
   // Register compile tests
   std::shared_ptr<MyService1> s1 = std::make_shared<MyService1>();
   std::shared_ptr<MyService2> s2 = std::make_shared<MyService2>();
   std::shared_ptr<MyService3> s3 = std::make_shared<MyService3>();
 
-  us::ServiceRegistration<Interface1> sr1 = mc->RegisterService<Interface1>(s1);
-  us::ServiceRegistration<Interface1,Interface2> sr2 = mc->RegisterService<Interface1,Interface2>(s2);
-  us::ServiceRegistration<Interface1,Interface2,Interface3> sr3 = mc->RegisterService<Interface1,Interface2,Interface3>(s3);
+  us::ServiceRegistration<Interface1> sr1 = context->RegisterService<Interface1>(s1);
+  us::ServiceRegistration<Interface1,Interface2> sr2 = context->RegisterService<Interface1,Interface2>(s2);
+  us::ServiceRegistration<Interface1,Interface2,Interface3> sr3 = context->RegisterService<Interface1,Interface2,Interface3>(s3);
 
   std::shared_ptr<MyFactory1> f1 = std::make_shared<MyFactory1>();
-  us::ServiceRegistration<Interface1> sfr1 = mc->RegisterService<Interface1>(ToFactory(f1));
+  us::ServiceRegistration<Interface1> sfr1 = context->RegisterService<Interface1>(ToFactory(f1));
 
   std::shared_ptr<MyFactory2> f2 = std::make_shared<MyFactory2>();
-  us::ServiceRegistration<Interface1,Interface2> sfr2 = mc->RegisterService<Interface1,Interface2>(ToFactory(f2));
+  us::ServiceRegistration<Interface1,Interface2> sfr2 = context->RegisterService<Interface1,Interface2>(ToFactory(f2));
 
   std::shared_ptr<MyFactory3> f3 = std::make_shared<MyFactory3>();
-  us::ServiceRegistration<Interface1,Interface2,Interface3> sfr3 = mc->RegisterService<Interface1,Interface2,Interface3>(ToFactory(f3));
+  us::ServiceRegistration<Interface1,Interface2,Interface3> sfr3 = context->RegisterService<Interface1,Interface2,Interface3>(ToFactory(f3));
 
 #ifdef US_BUILD_SHARED_LIBS
-  US_TEST_CONDITION(mc->GetBundle()->GetRegisteredServices().size() == 6, "# of reg services")
+  US_TEST_CONDITION(context->GetBundle()->GetRegisteredServices().size() == 6, "# of reg services")
 #endif
 
-  std::vector<us::ServiceReference<Interface1> > s1refs = mc->GetServiceReferences<Interface1>();
+  std::vector<us::ServiceReference<Interface1> > s1refs = context->GetServiceReferences<Interface1>();
   US_TEST_CONDITION(s1refs.size() == 6, "# of interface1 regs")
-  std::vector<us::ServiceReference<Interface2> > s2refs = mc->GetServiceReferences<Interface2>();
+  std::vector<us::ServiceReference<Interface2> > s2refs = context->GetServiceReferences<Interface2>();
   US_TEST_CONDITION(s2refs.size() == 4, "# of interface2 regs")
-  std::vector<us::ServiceReference<Interface3> > s3refs = mc->GetServiceReferences<Interface3>();
+  std::vector<us::ServiceReference<Interface3> > s3refs = context->GetServiceReferences<Interface3>();
   US_TEST_CONDITION(s3refs.size() == 2, "# of interface3 regs")
 
-  std::shared_ptr<Interface1> i1 = mc->GetService(sr1.GetReference());
+  std::shared_ptr<Interface1> i1 = context->GetService(sr1.GetReference());
   US_TEST_CONDITION(i1 == s1, "interface1 ptr")
   i1.reset();
   
-  i1 = mc->GetService(sfr1.GetReference());
-  US_TEST_CONDITION(i1 == f1->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface1 factory ptr")
+  i1 = context->GetService(sfr1.GetReference());
+  US_TEST_CONDITION(i1 == f1->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface1 factory ptr")
   i1.reset();
 
-  i1 = mc->GetService(sr2.GetReference<Interface1>());
+  i1 = context->GetService(sr2.GetReference<Interface1>());
   US_TEST_CONDITION(i1 == s2, "interface1 ptr")
   i1.reset();
   
-  i1 = mc->GetService(sfr2.GetReference<Interface1>());
-  US_TEST_CONDITION(i1 == f2->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface1 factory ptr")
+  i1 = context->GetService(sfr2.GetReference<Interface1>());
+  US_TEST_CONDITION(i1 == f2->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface1 factory ptr")
   i1.reset();
   
-  std::shared_ptr<Interface2> i2 = mc->GetService(sr2.GetReference<Interface2>());
+  std::shared_ptr<Interface2> i2 = context->GetService(sr2.GetReference<Interface2>());
   US_TEST_CONDITION(i2 == s2, "interface2 ptr")
   i2.reset();
   
-  i2 = mc->GetService(sfr2.GetReference<Interface2>());
-  US_TEST_CONDITION(i2 == f2->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface2 factory ptr")
+  i2 = context->GetService(sfr2.GetReference<Interface2>());
+  US_TEST_CONDITION(i2 == f2->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface2 factory ptr")
   i2.reset();
 
-  i1 = mc->GetService(sr3.GetReference<Interface1>());
+  i1 = context->GetService(sr3.GetReference<Interface1>());
   US_TEST_CONDITION(i1 == s3, "interface1 ptr")
   i1.reset();
   
-  i1 = mc->GetService(sfr3.GetReference<Interface1>());
-  US_TEST_CONDITION(i1 == f3->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface1 factory ptr")
+  i1 = context->GetService(sfr3.GetReference<Interface1>());
+  US_TEST_CONDITION(i1 == f3->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface1 factory ptr")
   i1.reset();
   
-  i2 = mc->GetService(sr3.GetReference<Interface2>());
+  i2 = context->GetService(sr3.GetReference<Interface2>());
   US_TEST_CONDITION(i2 == s3, "interface2 ptr")
   i2.reset();
   
-  i2 = mc->GetService(sfr3.GetReference<Interface2>());
-  US_TEST_CONDITION(i2 == f3->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface2 factory ptr")
+  i2 = context->GetService(sfr3.GetReference<Interface2>());
+  US_TEST_CONDITION(i2 == f3->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface2 factory ptr")
   i2.reset();
 
-    std::shared_ptr<Interface3> i3 = mc->GetService(sr3.GetReference<Interface3>());
+    std::shared_ptr<Interface3> i3 = context->GetService(sr3.GetReference<Interface3>());
   US_TEST_CONDITION(i3 == s3, "interface3 ptr")
   i3.reset();
 
-  i3 = mc->GetService(sfr3.GetReference<Interface3>());
-  US_TEST_CONDITION(i3 == f3->m_idToServiceMap[mc->GetBundle()->GetBundleId()], "interface3 factory ptr")
+  i3 = context->GetService(sfr3.GetReference<Interface3>());
+  US_TEST_CONDITION(i3 == f3->m_idToServiceMap[context->GetBundle()->GetBundleId()], "interface3 factory ptr")
   i3.reset();
 
   sr1.Unregister();

--- a/core/test/usServiceTrackerTest.cpp
+++ b/core/test/usServiceTrackerTest.cpp
@@ -125,25 +125,23 @@ void TestFilterString(us::BundleContext* context)
 
 void TestServiceTracker(us::BundleContext* context)
 {
-  BundleContext* mc = context;
-
-  Bundle* bundle = InstallTestBundle(mc, "TestBundleS");
+  Bundle* bundle = InstallTestBundle(context, "TestBundleS");
   bundle->Start();
 
   // 1. Create a ServiceTracker with ServiceTrackerCustomizer == null
 
   std::string s1("us::TestBundleSService");
-  ServiceReferenceU servref = mc->GetServiceReference(s1 + "0");
+  ServiceReferenceU servref = context->GetServiceReference(s1 + "0");
 
   US_TEST_CONDITION_REQUIRED(servref != nullptr, "Test if registered service of id us::TestBundleSService0");
 
-  ServiceReference<ServiceControlInterface> servCtrlRef = mc->GetServiceReference<ServiceControlInterface>();
+  ServiceReference<ServiceControlInterface> servCtrlRef = context->GetServiceReference<ServiceControlInterface>();
   US_TEST_CONDITION_REQUIRED(servCtrlRef != nullptr, "Test if constrol service was registered");
 
-  std::shared_ptr<ServiceControlInterface> serviceController = mc->GetService(servCtrlRef);
+  std::shared_ptr<ServiceControlInterface> serviceController = context->GetService(servCtrlRef);
   US_TEST_CONDITION_REQUIRED(serviceController.get() != nullptr, "Test valid service controller");
 
-  std::unique_ptr<ServiceTracker<void> > st1(new ServiceTracker<void>(mc, servref));
+  std::unique_ptr<ServiceTracker<void> > st1(new ServiceTracker<void>(context, servref));
 
   // 2. Check the size method with an unopened service tracker
 
@@ -172,7 +170,7 @@ void TestServiceTracker(us::BundleContext* context)
   // 8. A new Servicetracker, this time with a filter for the object
   std::string fs = std::string("(") + ServiceConstants::OBJECTCLASS() + "=" + s1 + "*" + ")";
   LDAPFilter f1(fs);
-  st1.reset(new ServiceTracker<void>(mc, f1));
+  st1.reset(new ServiceTracker<void>(context, f1));
   // add a service
   serviceController->ServiceControl(1, "register", 7);
 

--- a/core/test/usStaticBundleTest.cpp
+++ b/core/test/usStaticBundleTest.cpp
@@ -40,19 +40,19 @@ namespace {
 
 // Install and start libTestBundleB and check that it exists and that the service it registers exists,
 // also check that the expected events occur
-void frame020a(BundleContext* mc, TestBundleListener& listener)
+void frame020a(BundleContext* context, TestBundleListener& listener)
 {
-  InstallTestBundle(mc, "TestBundleB");
+  InstallTestBundle(context, "TestBundleB");
 
-  Bundle* bundleB = mc->GetBundle("TestBundleB");
+  Bundle* bundleB = context->GetBundle("TestBundleB");
   US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for existing bundle TestBundleB")
 
   try
   {
 #if defined (US_BUILD_SHARED_LIBS)
-    Bundle* bundle = mc->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
+    Bundle* bundle = context->InstallBundle(LIB_PATH + DIR_SEP + LIB_PREFIX + "TestBundleB" + LIB_EXT + "/TestBundleImportedByB");
 #else
-    Bundle* bundle = mc->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
+    Bundle* bundle = context->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/TestBundleImportedByB");
 #endif
     US_TEST_CONDITION_REQUIRED(bundle != NULL, "Test installation of bundle TestBundleImportedByB")
   }
@@ -61,7 +61,7 @@ void frame020a(BundleContext* mc, TestBundleListener& listener)
     US_TEST_FAILED_MSG(<< "Install bundle exception: " << e.what() << " + in frame020a:FAIL")
   }
 
-  Bundle* bundleImportedByB = mc->GetBundle("TestBundleImportedByB");
+  Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
   US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for existing bundle TestBundleImportedByB")
 
   US_TEST_CONDITION(bundleB->GetName() == "TestBundleB", "Test bundle name")
@@ -72,13 +72,13 @@ void frame020a(BundleContext* mc, TestBundleListener& listener)
   // Check if libB registered the expected service
   try
   {
-    std::vector<ServiceReferenceU> refs = mc->GetServiceReferences("us::TestBundleBService");
+    std::vector<ServiceReferenceU> refs = context->GetServiceReferences("us::TestBundleBService");
     US_TEST_CONDITION_REQUIRED(refs.size() == 2, "Test that both the service from the shared and imported library are regsitered");
 
-    InterfaceMapConstPtr o1 = mc->GetService(refs.front());
+    InterfaceMapConstPtr o1 = context->GetService(refs.front());
     US_TEST_CONDITION(o1 && !o1->empty(), "Test if first service object found");
 
-    InterfaceMapConstPtr o2 = mc->GetService(refs.back());
+    InterfaceMapConstPtr o2 = context->GetService(refs.back());
     US_TEST_CONDITION(o1 && !o2->empty(), "Test if second service object found");
 
     // check the listeners for events
@@ -107,16 +107,16 @@ void frame020a(BundleContext* mc, TestBundleListener& listener)
 
 
 // Stop libB and check for correct events
-void frame030b(BundleContext* mc, TestBundleListener& listener)
+void frame030b(BundleContext* context, TestBundleListener& listener)
 {
-  Bundle* bundleB = mc->GetBundle("TestBundleB");
+  Bundle* bundleB = context->GetBundle("TestBundleB");
   US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for non-null bundle")
 
-  Bundle* bundleImportedByB = mc->GetBundle("TestBundleImportedByB");
+  Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
   US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for non-null bundle")
 
   std::vector<ServiceReferenceU> refs
-      = mc->GetServiceReferences("us::TestBundleBService");
+      = context->GetServiceReferences("us::TestBundleBService");
   US_TEST_CONDITION(refs.front(), "Test for first valid service reference")
   US_TEST_CONDITION(refs.back(), "Test for second valid service reference")
 
@@ -154,18 +154,18 @@ void frame030b(BundleContext* mc, TestBundleListener& listener)
 }
 
 // Uninstall libB and check for correct events
-void frame040c(BundleContext* mc, TestBundleListener& listener)
+void frame040c(BundleContext* context, TestBundleListener& listener)
 {
-    Bundle* bundleB = mc->GetBundle("TestBundleB");
+    Bundle* bundleB = context->GetBundle("TestBundleB");
     US_TEST_CONDITION_REQUIRED(bundleB != nullptr, "Test for non-null bundle")
 
-    Bundle* bundleImportedByB = mc->GetBundle("TestBundleImportedByB");
+    Bundle* bundleImportedByB = context->GetBundle("TestBundleImportedByB");
     US_TEST_CONDITION_REQUIRED(bundleImportedByB != nullptr, "Test for non-null bundle")
 
     bundleB->Uninstall();
-    US_TEST_CONDITION(mc->GetBundles().size() == 2, "Test for uninstall of TestBundleB")
+    US_TEST_CONDITION(context->GetBundles().size() == 2, "Test for uninstall of TestBundleB")
     bundleImportedByB->Uninstall();
-    US_TEST_CONDITION(mc->GetBundles().size() == 1, "Test for uninstall of TestBundleImportedByB")
+    US_TEST_CONDITION(context->GetBundles().size() == 1, "Test for uninstall of TestBundleImportedByB")
 
     std::vector<BundleEvent> pEvts;
     pEvts.push_back(BundleEvent(BundleEvent::UNINSTALLED, bundleB));
@@ -184,7 +184,7 @@ int usStaticBundleTest(int /*argc*/, char* /*argv*/[])
   std::shared_ptr<Framework> framework = factory.NewFramework(std::map<std::string, std::string>());
   framework->Start();
 
-  BundleContext* mc = framework->GetBundleContext();
+  BundleContext* context = framework->GetBundleContext();
 
   { // scope the use of the listener so its destructor is
     // called before we destroy the framework's bundle context.
@@ -192,12 +192,12 @@ int usStaticBundleTest(int /*argc*/, char* /*argv*/[])
     // the framework is still active.
     TestBundleListener listener;
 
-    BundleListenerRegistrationHelper<TestBundleListener> ml(mc, &listener, &TestBundleListener::BundleChanged);
-    ServiceListenerRegistrationHelper<TestBundleListener> sl(mc, &listener, &TestBundleListener::ServiceChanged);
+    BundleListenerRegistrationHelper<TestBundleListener> ml(context, &listener, &TestBundleListener::BundleChanged);
+    ServiceListenerRegistrationHelper<TestBundleListener> sl(context, &listener, &TestBundleListener::ServiceChanged);
 
-    frame020a(mc, listener);
-    frame030b(mc, listener);
-    frame040c(mc, listener);
+    frame020a(context, listener);
+    frame030b(context, listener);
+    frame040c(context, listener);
   }
 
   US_TEST_END()


### PR DESCRIPTION
After the conversion from ModuleContext to BundleContext, the variable
names became in need of updating from “mc”. Chose “context” to match
the terminology in the OSGi reference implementation.
Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com