### PR TITLE
Clean header dependencies

### DIFF
--- a/core/doc/snippets/uServices-bundlecontext/main.cpp
+++ b/core/doc/snippets/uServices-bundlecontext/main.cpp
@@ -1,10 +1,11 @@
 #include <usBundleActivator.h>
 
 //! [GetBundleContext]
-#include <iostream>
 #include <usGetBundleContext.h>
 #include <usBundle.h>
 #include <usBundleContext.h>
+
+#include <iostream>
 
 using namespace us;
 

--- a/core/doc/snippets/uServices-resources/main.cpp
+++ b/core/doc/snippets/uServices-resources/main.cpp
@@ -1,10 +1,11 @@
-#include <iostream>
 
 #include <usGetBundleContext.h>
 #include <usBundleContext.h>
 #include <usBundleResource.h>
 #include <usBundle.h>
 #include <usBundleResourceStream.h>
+
+#include <iostream>
 
 using namespace us;
 

--- a/core/doc/snippets/uServices-singleton/SingletonOne.cpp
+++ b/core/doc/snippets/uServices-singleton/SingletonOne.cpp
@@ -2,11 +2,12 @@
 
 #include "SingletonTwo.h"
 
-#include <iostream>
-#include <cassert>
 
 #include <usGetBundleContext.h>
 #include <usBundleContext.h>
+
+#include <iostream>
+#include <cassert>
 
 using namespace us;
 

--- a/core/examples/dictionaryclient/Activator.cpp
+++ b/core/examples/dictionaryclient/Activator.cpp
@@ -21,12 +21,13 @@
 =============================================================================*/
 
 //! [Activator]
-#include <iostream>
 
 #include "IDictionaryService.h"
 
 #include <usBundleActivator.h>
 #include <usBundleContext.h>
+
+#include <iostream>
 
 using namespace us;
 

--- a/core/examples/dictionaryclient2/Activator.cpp
+++ b/core/examples/dictionaryclient2/Activator.cpp
@@ -21,13 +21,14 @@
 =============================================================================*/
 
 //! [Activator]
-#include <iostream>
 
 #include "IDictionaryService.h"
 
 #include <usBundleActivator.h>
 #include <usBundleContext.h>
 #include <usServiceEvent.h>
+
+#include <iostream>
 
 using namespace us;
 

--- a/core/examples/eventlistener/Activator.cpp
+++ b/core/examples/eventlistener/Activator.cpp
@@ -21,10 +21,11 @@
 =============================================================================*/
 
 //! [Activator]
-#include <iostream>
 #include <usBundleActivator.h>
 #include <usBundleContext.h>
 #include <usServiceEvent.h>
+
+#include <iostream>
 
 using namespace us;
 

--- a/core/src/service/usServiceListeners.cpp
+++ b/core/src/service/usServiceListeners.cpp
@@ -24,9 +24,11 @@
 
 US_MSVC_PUSH_DISABLE_WARNING(4180) // qualifier applied to function type has no meaning; ignored
 
-#include "usUtils_p.h"
 
 #include "usServiceListeners_p.h"
+
+#include "usUtils_p.h"
+
 #include "usServiceReferenceBasePrivate.h"
 
 #include "usCoreBundleContext_p.h"

--- a/core/src/service/usServiceRegistry.cpp
+++ b/core/src/service/usServiceRegistry.cpp
@@ -20,17 +20,19 @@
 
 =============================================================================*/
 
-#include <iterator>
-#include <stdexcept>
-#include <cassert>
 
 #include "usServiceRegistry_p.h"
+
 #include "usServiceFactory.h"
 #include "usPrototypeServiceFactory.h"
 #include "usServiceRegistry_p.h"
 #include "usServiceRegistrationBasePrivate.h"
 #include "usBundlePrivate.h"
 #include "usCoreBundleContext_p.h"
+
+#include <iterator>
+#include <stdexcept>
+#include <cassert>
 
 
 namespace us {

--- a/httpservice/src/usServletConfig_p.h
+++ b/httpservice/src/usServletConfig_p.h
@@ -24,6 +24,8 @@
 
 #include "usSharedData.h"
 
+#include <string>
+
 namespace us {
 
 class ServletContext;

--- a/shellservice/include/usShellService.h
+++ b/shellservice/include/usShellService.h
@@ -19,6 +19,9 @@
 
 =============================================================================*/
 
+#ifndef USSHELLSERVICE_H
+#define USSHELLSERVICE_H
+
 #include <usGlobalConfig.h>
 
 #include <usShellServiceExport.h>
@@ -53,3 +56,5 @@ private:
 };
 
 }
+
+#endif // USSHELLSERVICE_H

--- a/webconsole/src/usAbstractWebConsolePlugin.cpp
+++ b/webconsole/src/usAbstractWebConsolePlugin.cpp
@@ -19,8 +19,6 @@
 
 =============================================================================*/
 
-#include <iostream>
-
 #include "usAbstractWebConsolePlugin.h"
 
 #include "usWebConsoleConstants.h"
@@ -33,6 +31,9 @@
 #include "usHttpServletRequest.h"
 #include "usServletContext.h"
 #include "usWebConsoleDefaultVariableResolver.h"
+
+#include <iostream>
+
 
 namespace us {
 


### PR DESCRIPTION
In support of early detection for violations of clean header
dependencies, move counterpart header files to be the first include,
and move system header includes to after component header includes.
Also fix two minor violations: a missing <string> include in
usServletConfig_p.h, and missing include guard in usShellService.h.