### PR TITLE
Changed verbose option from "-v" to "-V" for the resource compiler

### DIFF
--- a/tools/rc/usResourceCompiler.cpp
+++ b/tools/rc/usResourceCompiler.cpp
@@ -356,7 +356,7 @@ const option::Descriptor usage[] =
 {
   {UNKNOWN,          0, "" , ""                 , Custom_Arg::None    , "\nUSAGE: " US_PROG_NAME " [options]\n\n" "Options:" },
   {HELP,             0, "h", "help"             , Custom_Arg::None    , " --help, -h  \tPrint usage and exit." },
-  {VERBOSE,          0, "v", "verbose"          , Custom_Arg::None    , " --verbose, -v  \tRun in verbose mode." },
+  {VERBOSE,          0, "V", "verbose"          , Custom_Arg::None    , " --verbose, -V  \tRun in verbose mode." },
   {BUNDLENAME,       0, "n", "bundle-name"      , Custom_Arg::NonEmpty, " --bundle-name, -n \tThe bundle name as specified in the US_BUNDLE_NAME compile definition."},
   {COMPRESSIONLEVEL, 0, "c", "compression-level", Custom_Arg::Numeric , " --compression-level, -c  \tCompression level used for zip. Value range is 0 to 9. Default value is 6." },
   {OUTFILE,          0, "o", "out-file"         , Custom_Arg::NonEmpty, " --out-file, -o \tPath to output zip file. If the file exists it will be overwritten. If this option is not provided, a temporary zip fie will be created."},


### PR DESCRIPTION
Signed-off-by: The Mathworks, Inc. <Roy.Lurie@mathworks.com>