### PR TITLE
88 find activator inside executable bundles

### DIFF
--- a/core/src/bundle/usBundleUtils.cpp
+++ b/core/src/bundle/usBundleUtils.cpp
@@ -192,7 +192,7 @@ std::string GetLibraryPath_impl(void *symbol)
   }
 
   char bundlePath[512];
-  if (GetModuleFileNameA(handle, bundlePath, 512))
+  if (GetModuleFileName(handle, bundlePath, 512))
   {
     return bundlePath;
   }
@@ -204,7 +204,7 @@ std::string GetLibraryPath_impl(void *symbol)
 std::string GetExecutablePath()
 {
   char pathBuf[1024]; // assuming this is a large enough buffer.
-  if (GetModuleFileNameA(nullptr, pathBuf, sizeof(pathBuf)) == 0 || GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+  if (GetModuleFileName(nullptr, pathBuf, sizeof(pathBuf)) == 0 || GetLastError() == ERROR_INSUFFICIENT_BUFFER)
   {
     US_DEBUG << "GetModuleFileName failed" << GetLastErrorStr();
     pathBuf[0] = '\0';
@@ -224,7 +224,7 @@ struct FileInfo {
   {
     if(!path.empty())
     {
-      HANDLE hFile = CreateFileA(path.c_str(),
+      HANDLE hFile = CreateFile(path.c_str(),
                                  0,
                                  0,
                                  NULL,
@@ -264,11 +264,11 @@ void* GetSymbol_impl(const BundleInfo& bundleInfo, const char* symbol)
   
   if (IsCurrentExecutable(bundleInfo.location))
   {
-    handle = GetModuleHandleA(nullptr);
+    handle = GetModuleHandle(nullptr);
   }
   else
   {
-    handle = GetModuleHandleA(bundleInfo.location.c_str());
+    handle = GetModuleHandle(bundleInfo.location.c_str());
   }
   
   if (!handle)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(_tests
   usBundleRegistryPerformanceTest
   usFrameworkTest
   usFrameworkFactoryTest
+  usExecutableBundleTest
   usHelgrindTest
   usLDAPFilterTest
   usLDAPQueryTest

--- a/core/test/bundles/CMakeLists.txt
+++ b/core/test/bundles/CMakeLists.txt
@@ -18,3 +18,5 @@ add_subdirectory(libRWithLinkedResources)
 if(US_ENABLE_THREADING_SUPPORT)
   add_subdirectory(libC1)
 endif()
+
+add_subdirectory(execWithStaticBundle)

--- a/core/test/bundles/execWithStaticBundle/CMakeLists.txt
+++ b/core/test/bundles/execWithStaticBundle/CMakeLists.txt
@@ -1,0 +1,38 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# This test is only applicable when build mode is shared libraries. 
+# The test point usExecutableBundleTest in usCoreDriver is sufficeint for static library builds.
+if(US_BUILD_SHARED_LIBS)
+
+set(BUILD_SHARED_LIBS 0)
+usFunctionCreateTestBundleWithResources(TestStaticBundle
+  SOURCES usTestStaticBundle.cpp
+  RESOURCES manifest.json
+  RESOURCES_ROOT resources_static
+  SKIP_BUNDLE_LIST)
+
+set(BUILD_SHARED_LIBS ${US_BUILD_SHARED_LIBS})
+
+add_executable(usTestExecutableWithStaticBundle main.cpp)
+
+#MESSAGE( STATUS "CppMicroServices_LIBRARIES:         " ${Core_TARGET})
+target_link_libraries(usTestExecutableWithStaticBundle ${Core_TARGET} TestStaticBundle)
+
+
+add_custom_command(
+      TARGET usTestExecutableWithStaticBundle
+      POST_BUILD
+      COMMAND ${US_RCC_EXECUTABLE_NAME} -b $<TARGET_FILE:usTestExecutableWithStaticBundle> -z $<TARGET_FILE:TestStaticBundle>
+      WORKING_DIRECTORY ${US_RESOURCE_WORKING_DIRECTORY}
+      COMMENT "Appending zipped resources to usTestExecutableWithStaticBundle"
+      VERBATIM
+    )
+
+if(US_BUILD_TESTING)
+  enable_testing()
+  add_test(NAME usTestExecutableWithStaticBundle
+      WORKING_DIRECTORY ${CppMicroServices_BINARY_DIR}
+      COMMAND usTestExecutableWithStaticBundle)
+endif()
+
+endif()

--- a/core/test/bundles/execWithStaticBundle/CMakeLists.txt
+++ b/core/test/bundles/execWithStaticBundle/CMakeLists.txt
@@ -15,7 +15,6 @@ set(BUILD_SHARED_LIBS ${US_BUILD_SHARED_LIBS})
 
 add_executable(usTestExecutableWithStaticBundle main.cpp)
 
-#MESSAGE( STATUS "CppMicroServices_LIBRARIES:         " ${Core_TARGET})
 target_link_libraries(usTestExecutableWithStaticBundle ${Core_TARGET} TestStaticBundle)
 
 

--- a/core/test/bundles/execWithStaticBundle/main.cpp
+++ b/core/test/bundles/execWithStaticBundle/main.cpp
@@ -10,6 +10,7 @@
 
 #include "usTestingMacros.h"
 #include "usTestingConfig.h"
+#include "usTestBundleService.h"
 
 using namespace us;
 
@@ -28,6 +29,13 @@ int main(int ac, char **av)
 		  throw std::runtime_error("Static bundle not found in the executable");
 	  if (bundle->GetName() != "TestStaticBundle")
 		  throw std::runtime_error("Check bundle name failed - " + bundle->GetName());
+    bundle->Start();
+    // Make sure the activator is called
+    auto service = bundle->GetBundleContext()->GetServiceReference<TestBundleService>();
+    if (!service)
+    {
+      throw std::runtime_error("Could not find service from the statically linked bundle");
+    }
   }
   catch (const std::exception& ex)
   {

--- a/core/test/bundles/execWithStaticBundle/main.cpp
+++ b/core/test/bundles/execWithStaticBundle/main.cpp
@@ -17,7 +17,7 @@ using namespace us;
 /**
  * Test point to ensure the statically linked bundle is installed properly.
  */
-int main(int ac, char **av)
+int main(int , char **)
 {
   auto framework = FrameworkFactory().NewFramework();
   framework->Start();
@@ -25,10 +25,10 @@ int main(int ac, char **av)
   auto bundle = frameworkCtx->InstallBundle(BIN_PATH + DIR_SEP + "usTestExecutableWithStaticBundle" + EXE_EXT + "/TestStaticBundle");
   try 
   {
-	  if (bundle == nullptr)
-		  throw std::runtime_error("Static bundle not found in the executable");
-	  if (bundle->GetName() != "TestStaticBundle")
-		  throw std::runtime_error("Check bundle name failed - " + bundle->GetName());
+    if (bundle == nullptr)
+      throw std::runtime_error("Static bundle not found in the executable");
+    if (bundle->GetName() != "TestStaticBundle")
+      throw std::runtime_error("Check bundle name failed - " + bundle->GetName());
     bundle->Start();
     // Make sure the activator is called
     auto service = bundle->GetBundleContext()->GetServiceReference<TestBundleService>();
@@ -39,12 +39,10 @@ int main(int ac, char **av)
   }
   catch (const std::exception& ex)
   {
-	  std::cerr << ex.what() << std::endl;
-	  return -1;
+    std::cerr << ex.what() << std::endl;
+    return -1;
   }
   framework->Stop();
-  (void)ac;
-  (void)av;
   return 0;
 }
 

--- a/core/test/bundles/execWithStaticBundle/main.cpp
+++ b/core/test/bundles/execWithStaticBundle/main.cpp
@@ -1,0 +1,43 @@
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <cassert>
+
+#include "usFrameworkFactory.h"
+#include "usFramework.h"
+#include "usBundleContext.h"
+#include "usBundleImport.h"
+
+#include "usTestingMacros.h"
+#include "usTestingConfig.h"
+
+using namespace us;
+
+/**
+ * Test point to ensure the statically linked bundle is installed properly.
+ */
+int main(int ac, char **av)
+{
+  auto framework = FrameworkFactory().NewFramework();
+  framework->Start();
+  BundleContext* frameworkCtx = framework->GetBundleContext();
+  auto bundle = frameworkCtx->InstallBundle(BIN_PATH + DIR_SEP + "usTestExecutableWithStaticBundle" + EXE_EXT + "/TestStaticBundle");
+  try 
+  {
+	  if (bundle == nullptr)
+		  throw std::runtime_error("Static bundle not found in the executable");
+	  if (bundle->GetName() != "TestStaticBundle")
+		  throw std::runtime_error("Check bundle name failed - " + bundle->GetName());
+  }
+  catch (const std::exception& ex)
+  {
+	  std::cerr << ex.what() << std::endl;
+	  return -1;
+  }
+  framework->Stop();
+  (void)ac;
+  (void)av;
+  return 0;
+}
+
+US_IMPORT_BUNDLE(TestStaticBundle)

--- a/core/test/bundles/execWithStaticBundle/resources_static/manifest.json
+++ b/core/test/bundles/execWithStaticBundle/resources_static/manifest.json
@@ -1,0 +1,3 @@
+{
+  "bundle.name" : "TestStaticBundle"
+}

--- a/core/test/bundles/execWithStaticBundle/usTestBundleService.h
+++ b/core/test/bundles/execWithStaticBundle/usTestBundleService.h
@@ -1,0 +1,39 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/saschazelzer/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=============================================================================*/
+
+
+#ifndef USTESTBUNDLEBSERVICE_H
+#define USTESTBUNDLEBSERVICE_H
+
+#include <usGlobalConfig.h>
+#include <usServiceInterface.h>
+
+namespace us {
+
+struct TestBundleService
+{
+  virtual ~TestBundleService() {}
+};
+
+}
+
+#endif // USTESTBUNDLEASERVICE_H

--- a/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
+++ b/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
@@ -57,7 +57,7 @@ public:
 
 private:
   std::shared_ptr<TestBundleImportedByExec> s;
-  ServiceRegistration<TestBundleImportedByExec> sr;
+  ServiceRegistration<TestBundleService> sr;
 };
 
 }

--- a/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
+++ b/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
@@ -1,0 +1,65 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/saschazelzer/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=============================================================================*/
+
+#include "usTestBundleService.h"
+
+#include <usBundleActivator.h>
+#include <usBundleContext.h>
+#include <usLog.h>
+
+namespace us {
+
+struct TestBundleImportedByExec : public TestBundleService
+{
+
+  TestBundleImportedByExec() {}
+  virtual ~TestBundleImportedByExec() {}
+
+};
+
+class TestBundleImportedByExecActivator : public BundleActivator
+{
+public:
+
+  TestBundleImportedByExecActivator() {}
+  ~TestBundleImportedByExecActivator() {}
+
+  void Start(BundleContext* context)
+  {
+    s = std::make_shared<TestBundleImportedByExec>();
+    US_INFO << "Registering TestBundleImportedByExec";
+    sr = context->RegisterService<TestBundleImportedByExec>(s);
+  }
+
+  void Stop(BundleContext*)
+  {
+    sr.Unregister();
+  }
+
+private:
+  std::shared_ptr<TestBundleImportedByExec> s;
+  ServiceRegistration<TestBundleImportedByExec> sr;
+};
+
+}
+
+US_EXPORT_BUNDLE_ACTIVATOR(us::TestBundleImportedByExecActivator)

--- a/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
+++ b/core/test/bundles/execWithStaticBundle/usTestStaticBundle.cpp
@@ -47,7 +47,7 @@ public:
   {
     s = std::make_shared<TestBundleImportedByExec>();
     US_INFO << "Registering TestBundleImportedByExec";
-    sr = context->RegisterService<TestBundleImportedByExec>(s);
+    sr = context->RegisterService<TestBundleService>(s);
   }
 
   void Stop(BundleContext*)

--- a/core/test/usExecutableBundleTest.cpp
+++ b/core/test/usExecutableBundleTest.cpp
@@ -1,0 +1,50 @@
+/*=============================================================================
+ 
+ Library: CppMicroServices
+ 
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/saschazelzer/CppMicroServices/COPYRIGHT .
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ =============================================================================*/
+
+#include "usTestingMacros.h"
+#include <usFrameworkFactory.h>
+#include <usFramework.h>
+#include <usBundle.h>
+#include <usBundleContext.h>
+#include "usTestingConfig.h"
+
+#include <string>
+
+using namespace us;
+
+/**
+ * Test point to ensure the executable bundle is installed properly.
+ */
+int usExecutableBundleTest(int /*argc*/, char* /*argv*/[])
+{
+  US_TEST_BEGIN("ExecutableBundleTest");
+  
+  auto framework = FrameworkFactory().NewFramework();
+  framework->Start();
+  BundleContext* frameworkCtx = framework->GetBundleContext();
+  auto bundle = frameworkCtx->InstallBundle(BIN_PATH + DIR_SEP + "usCoreTestDriver" + EXE_EXT + "/main");
+  US_TEST_CONDITION_REQUIRED(bundle != nullptr, "Bundle found in current executable");
+  US_TEST_CONDITION_REQUIRED(bundle->GetName() == "main", "Check bundle name");
+  US_TEST_CONDITION_REQUIRED(bundle->GetProperty(Bundle::PROP_VERSION).ToString() == "0.1.0", "Check bundle version");
+  
+  US_TEST_END()
+}


### PR DESCRIPTION
Remove the requirement that bundle inside an executable has to be named "main".
