### PR TITLE
Update Activator.cpp

### DIFF
--- a/examples/eventlistener/Activator.cpp
+++ b/examples/eventlistener/Activator.cpp
@@ -69,7 +69,7 @@ private:
    */
   void ServiceChanged(const ServiceEvent event)
   {
-    std::string objectClass = ref_any_cast<std::list<std::string> >(event.GetServiceReference().GetProperty(ServiceConstants::OBJECTCLASS())).front();
+    std::string objectClass = ref_any_cast<std::vector<std::string> >(event.GetServiceReference().GetProperty(ServiceConstants::OBJECTCLASS())).front();
 
     if (event.GetType() == ServiceEvent::REGISTERED)
     {


### PR DESCRIPTION
std::string objectClass = ref_any_cast<std::list<std::string> >(event.GetServiceReference().GetProperty(ServiceConstants::OBJECTCLASS())).front();

throw an exception：In us::ServiceListeners::ServiceChanged at ..\..\src\service\usServiceListeners.cpp:185 : Service listener threw an exception!

See：
class ServicePropertiesImpl
{
  ... ...
private:
  std::vector<std::string> keys;
  ... ...
};

Not std::list, is std::vector.

Edit:
std::string objectClass = ref_any_cast<std::list<std::string> >(event.GetServiceReference().GetProperty(ServiceConstants::OBJECTCLASS())).front();

std::list -> std::vector