### PR TITLE
Add sysroot to fix Makefile build on OS X #81

### DIFF
--- a/cmake/usFunctionEmbedResources.cmake
+++ b/cmake/usFunctionEmbedResources.cmake
@@ -137,7 +137,7 @@ function(usFunctionEmbedResources)
     if(APPLE)
       add_custom_command(
         OUTPUT ${_source_output}
-        COMMAND ${CMAKE_CXX_COMPILER} -c ${US_CMAKE_RESOURCE_DEPENDENCIES_CPP} -o stub.o
+        COMMAND ${CMAKE_CXX_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT} -c ${US_CMAKE_RESOURCE_DEPENDENCIES_CPP} -o stub.o
         COMMAND ${CMAKE_LINKER} -r -sectcreate __TEXT us_resources ${_zip_archive_name} stub.o -o ${_source_output}
         DEPENDS ${_zip_archive}
         WORKING_DIRECTORY ${_zip_archive_path}


### PR DESCRIPTION
Implemented the solution described in issue #81. With this and the commit made to resolve #107, I can build and run unit tests using Makefile infrastructure on OS X. 