### PR TITLE
Use consistent catch blocks and exception detail messages.

### DIFF
--- a/core/src/bundle/usBundle.cpp
+++ b/core/src/bundle/usBundle.cpp
@@ -173,7 +173,7 @@ void Bundle::Uninstall()
       if (exception != nullptr)
       {
         try { std::rethrow_exception(exception); }
-        catch (const std::exception& )
+        catch (...)
         {
           d->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, d->shared_from_this(), std::string(), std::current_exception()));
         }
@@ -191,7 +191,7 @@ void Bundle::Uninstall()
           d->WaitOnOperation(d->coreCtx->resolver, l, "Bundle::Uninstall", true);
           d->operation = BundlePrivate::OP_UNINSTALLING;
         }
-        catch (const std::exception& )
+        catch (...)
         {
           // Make sure that bundleContext is invalid
           std::shared_ptr<BundleContextPrivate> ctx;
@@ -234,7 +234,7 @@ void Bundle::Uninstall()
         {
           if (fs::Exists(d->bundleDir)) fs::RemoveDirectoryRecursive(d->bundleDir);
         }
-        catch (const std::exception& )
+        catch (...)
         {
           d->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, 
                                                     d->shared_from_this(), 

--- a/core/src/bundle/usBundleContext.cpp
+++ b/core/src/bundle/usBundleContext.cpp
@@ -220,18 +220,18 @@ struct ServiceHolder
     {
       sref.d.load()->UngetService(b.lock(), true);
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
       // Make sure that we don't crash if the shared_ptr service object outlives
       // the BundlePrivate or CoreBundleContext objects.
       if (!b.expired())
       {
-        DIAG_LOG(*b.lock()->coreCtx->sink) << "UngetService threw an exception. " << ex.what();
+        DIAG_LOG(*b.lock()->coreCtx->sink) << "UngetService threw an exception. " << GetLastExceptionStr();
       }
-	  // don't throw exceptions from the destructor. For an explanation, see:
-	  // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md
-	  // Following this rule means that a FrameworkEvent isn't an option here 
-	  // since it contains an exception object which clients could throw.
+      // don't throw exceptions from the destructor. For an explanation, see:
+      // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md
+      // Following this rule means that a FrameworkEvent isn't an option here
+      // since it contains an exception object which clients could throw.
     }
   }
 };

--- a/core/src/bundle/usBundlePrivate.cpp
+++ b/core/src/bundle/usBundlePrivate.cpp
@@ -131,10 +131,10 @@ std::exception_ptr BundlePrivate::Stop1()
     {
       bactivator->Stop(MakeBundleContext(bundleContext.Load()));
     }
-    catch (const std::exception& e)
+    catch (...)
     {
       res = std::make_exception_ptr(
-            std::runtime_error("Bundle#" + us::ToString(id) + ", BundleActivator::Stop() failed:" + e.what()));
+            std::runtime_error("Bundle#" + us::ToString(id) + ", BundleActivator::Stop() failed: " + GetLastExceptionStr()));
     }
 
     // if stop was aborted (uninstall or timeout), make sure
@@ -305,7 +305,7 @@ Bundle::State BundlePrivate::GetUpdatedState(BundlePrivate* trigger, LockType& l
         }
       }
     }
-    catch (const std::exception& )
+    catch (...)
     {
       resolveFailException = std::current_exception();
       coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR, MakeBundle(this->shared_from_this()), std::string(), std::current_exception()));
@@ -316,7 +316,7 @@ Bundle::State BundlePrivate::GetUpdatedState(BundlePrivate* trigger, LockType& l
         {
           coreCtx->resolverHooks.EndResolve(trigger);
         }
-        catch (const std::exception& )
+        catch (...)
         {
           resolveFailException = std::current_exception();
           coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR, MakeBundle(this->shared_from_this()), std::string(), std::current_exception()));
@@ -527,9 +527,9 @@ std::exception_ptr BundlePrivate::Start0()
     }
 
   }
-  catch (const std::exception& e)
+  catch (...)
   {
-    res = std::make_exception_ptr(std::runtime_error("Bundle#" + us::ToString(id) + " start failed: " + e.what()));
+    res = std::make_exception_ptr(std::runtime_error("Bundle#" + us::ToString(id) + " start failed: " + GetLastExceptionStr()));
   }
 
   // activator.start() done
@@ -712,9 +712,9 @@ BundlePrivate::BundlePrivate(
       {
         bundleManifest.Parse(manifestStream);
       }
-      catch (const std::exception& e)
+      catch (...)
       {
-        throw std::runtime_error(std::string("Parsing of manifest.json for bundle ") + symbolicName + " at " + location + " failed: " + e.what());
+        throw std::runtime_error(std::string("Parsing of manifest.json for bundle ") + symbolicName + " at " + location + " failed: " + GetLastExceptionStr());
       }
     }
   }
@@ -732,9 +732,9 @@ BundlePrivate::BundlePrivate(
     {
       version = BundleVersion(versionAny.ToString());
     }
-    catch (const std::exception& e)
+    catch (...)
     {
-      errMsg = std::string("The version identifier is invalid: ") + e.what();
+      errMsg = std::string("The version identifier is invalid: ") + GetLastExceptionStr();
     }
 
     if (!errMsg.empty())

--- a/core/src/bundle/usBundleRegistry.cpp
+++ b/core/src/bundle/usBundleRegistry.cpp
@@ -147,13 +147,13 @@ std::vector<Bundle> BundleRegistry::Install0(
     }
     return res;
   }
-  catch (const std::exception& e)
+  catch (...)
   {
     for (auto& ba : barchives)
     {
       ba->Purge();
     }
-    throw std::runtime_error("Failed to install bundle library at " + location + ": " + e.what());
+    throw std::runtime_error("Failed to install bundle library at " + location + ": " + GetLastExceptionStr());
   }
 }
 
@@ -256,7 +256,7 @@ void BundleRegistry::Load()
       std::shared_ptr<BundlePrivate> impl(new BundlePrivate(coreCtx, ba));
       bundles.v.insert(std::make_pair(impl->location, impl));
     }
-    catch (const std::exception& )
+    catch (...)
     {
       ba->SetAutostartSetting(-1); // Do not start on launch
       std::string msg("Failed to load bundle " + us::ToString(ba->GetBundleId()) + " (" + ba->GetBundleLocation() + ") ");

--- a/core/src/bundle/usBundleThread.cpp
+++ b/core/src/bundle/usBundleThread.cpp
@@ -117,7 +117,7 @@ void BundleThread::Run()
         break;
       }
     }
-    catch (const std::exception& )
+    catch (...)
     {
       fwCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR, 
                                                             MakeBundle(bundle->shared_from_this()), 

--- a/core/src/service/usServiceHooks.cpp
+++ b/core/src/service/usServiceHooks.cpp
@@ -248,10 +248,10 @@ void ServiceHooks::HandleServiceListenerUnreg(const std::vector<ServiceListenerE
       catch (...)
       {
         std::string message("Failed to call listener hook # " + srIter->GetProperty(Constants::SERVICE_ID).ToString());
-		coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
-            FrameworkEvent::Type::FRAMEWORK_WARNING, 
-            GetBundleContext().GetBundle(), 
-            message, std::current_exception()));
+        coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
+                                                FrameworkEvent::Type::FRAMEWORK_WARNING,
+                                                GetBundleContext().GetBundle(),
+                                                message, std::current_exception()));
       }
     }
   }

--- a/core/src/service/usServiceObjects.cpp
+++ b/core/src/service/usServiceObjects.cpp
@@ -115,18 +115,18 @@ struct UngetHelper
         }
       }
     }
-    catch (const std::exception& ex)
+    catch (...)
     {
       // Make sure that we don't crash if the shared_ptr service object outlives
       // the BundlePrivate or CoreBundleContext objects.
       if (!b.expired())
       {
-        DIAG_LOG(*b.lock()->coreCtx->sink) << "UngetHelper threw an exception. " << ex.what();
+        DIAG_LOG(*b.lock()->coreCtx->sink) << "UngetHelper threw an exception. " << GetLastExceptionStr();
       }
       // don't throw exceptions from the destructor. For an explanation, see:
-	  // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md
-	  // Following this rule means that a FrameworkEvent isn't an option here 
-	  // since it contains an exception object which clients could throw.
+      // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md
+      // Following this rule means that a FrameworkEvent isn't an option here
+      // since it contains an exception object which clients could throw.
     }
   }
 };

--- a/core/src/service/usServiceReferenceBasePrivate.cpp
+++ b/core/src/service/usServiceReferenceBasePrivate.cpp
@@ -195,7 +195,7 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(const std::shared_ptr<Bu
       {
         sf->UngetService(MakeBundle(bundle), ServiceRegistrationBase(registration), service);
       }
-      catch (const std::exception& )
+      catch (...)
       {
         std::string message("ServiceFactory threw an exception");
         registration->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, MakeBundle(bundle->shared_from_this()), message, std::current_exception()));
@@ -268,11 +268,11 @@ bool ServiceReferenceBasePrivate::UngetService(const std::shared_ptr<BundlePriva
     {
       sf->UngetService(MakeBundle(bundle), ServiceRegistrationBase(registration), sfi);
     }
-      catch (const std::exception& )
-      {
-        std::string message("ServiceFactory threw an exception");
-        registration->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, MakeBundle(bundle->shared_from_this()), message, std::current_exception()));
-      }
+    catch (...)
+    {
+      std::string message("ServiceFactory threw an exception");
+      registration->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, MakeBundle(bundle->shared_from_this()), message, std::current_exception()));
+    }
   }
 
   return hadReferences && removeService;

--- a/core/src/service/usServiceRegistrationBase.cpp
+++ b/core/src/service/usServiceRegistrationBase.cpp
@@ -228,7 +228,7 @@ void ServiceRegistrationBase::Unregister()
         {
           serviceFactory->UngetService(MakeBundle(i.first->shared_from_this()), *this, service);
         }
-        catch (const std::exception& )
+        catch (...)
         {
           std::string message("ServiceFactory UngetService implementation threw an exception");
           d->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, MakeBundle(d->bundle->shared_from_this()), message, std::current_exception()));
@@ -243,7 +243,7 @@ void ServiceRegistrationBase::Unregister()
       {
         serviceFactory->UngetService(MakeBundle(i.first->shared_from_this()), *this, i.second);
       }
-      catch (const std::exception& )
+      catch (...)
       {
         std::string message("ServiceFactory UngetService implementation threw an exception");
         d->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING, MakeBundle(d->bundle->shared_from_this()), message, std::current_exception()));

--- a/core/src/util/usFrameworkEvent.cpp
+++ b/core/src/util/usFrameworkEvent.cpp
@@ -24,6 +24,7 @@
 
 #include "usBundle.h"
 #include "usBundlePrivate.h"
+#include "usUtils_p.h"
 
 namespace us {
 
@@ -113,18 +114,7 @@ std::ostream& operator<<(std::ostream& os, const FrameworkEvent& evt)
   std::string exceptionStr("NONE");
   if (evt.GetThrowable())
   {
-    try
-    {
-      std::rethrow_exception(evt.GetThrowable());
-    }
-    catch (const std::exception& e)
-    {
-      exceptionStr = e.what();
-    }
-    catch (...)
-    {
-      exceptionStr = "unknown exception";
-    }
+    exceptionStr = GetExceptionStr(evt.GetThrowable());
   }
 
   os << evt.GetType() << "\n " 

--- a/core/src/util/usUtils.cpp
+++ b/core/src/util/usUtils.cpp
@@ -408,22 +408,7 @@ std::string GetLastErrorStr()
 void TerminateForDebug(const std::exception_ptr ex)
 {
 #if defined(_MSC_VER) && !defined(NDEBUG) && defined(_DEBUG) && defined(_CRT_ERROR)
-    std::string message;
-    if (ex)
-    {
-      try
-      {
-        std::rethrow_exception(ex);
-      }
-      catch (const std::exception& e)
-      {
-        message = e.what();
-      }
-      catch (...)
-      {
-        message = "unknown exception";
-      }
-    }
+    std::string message = GetLastExceptionStr();
 
     // get the current report mode
     int reportMode = _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_WNDW);
@@ -489,6 +474,32 @@ US_Core_EXPORT ::std::string detail::GetDemangledName(const ::std::type_info& ty
   (void)typeInfo;
 #endif
   return result;
+}
+
+std::string GetExceptionStr(const std::exception_ptr& exc)
+{
+  if (!exc)
+  {
+    return std::string();
+  }
+
+  try
+  {
+    std::rethrow_exception(exc);
+  }
+  catch (const std::exception& e)
+  {
+    return e.what();
+  }
+  catch (...)
+  {
+    return "unknown";
+  }
+}
+
+std::string GetLastExceptionStr()
+{
+  return GetExceptionStr(std::current_exception());
 }
 
 } // namespace us

--- a/core/src/util/usUtils_p.h
+++ b/core/src/util/usUtils_p.h
@@ -119,6 +119,9 @@ void TerminateForDebug(const std::exception_ptr ex);
 int GetLastErrorNo();
 std::string GetLastErrorStr();
 
+std::string GetExceptionStr(const std::exception_ptr& exc);
+std::string GetLastExceptionStr();
+
 //-------------------------------------------------------------------
 // Android Compatibility functions
 //-------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #27 which is about consistent exception message handling.