### PR TITLE
Fix Windows static destruction corner case

### DIFF
--- a/framework/include/cppmicroservices/detail/Threads.h
+++ b/framework/include/cppmicroservices/detail/Threads.h
@@ -184,7 +184,7 @@ class Atomic : private MultiThreaded<>
 public:
 
   Atomic()
-    : m_t{}
+    : m_t()
   {}
 
   T Load() const

--- a/framework/src/service/ServiceHooks.cpp
+++ b/framework/src/service/ServiceHooks.cpp
@@ -45,7 +45,6 @@ ServiceHooks::ServiceHooks(CoreBundleContext* coreCtx)
 
 ServiceHooks::~ServiceHooks()
 {
-  this->Close();
 }
 
 std::shared_ptr<ServiceListenerHook> ServiceHooks::AddingService(const ServiceReference<ServiceListenerHook>& reference)

--- a/framework/test/CMakeLists.txt
+++ b/framework/test/CMakeLists.txt
@@ -28,6 +28,12 @@ set(_us_test_bundle_libs "" CACHE INTERNAL "" FORCE)
 add_subdirectory(bundles)
 
 #-----------------------------------------------------------------------------
+# Create non-bundle test libraries
+#-----------------------------------------------------------------------------
+
+add_subdirectory(singletonframework)
+
+#-----------------------------------------------------------------------------
 # Add unit tests
 #-----------------------------------------------------------------------------
 
@@ -96,6 +102,8 @@ if(NOT US_BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(${_test_driver} ${Framework_TARGET})
+
+target_link_libraries(${_test_driver} singletonframework)
 
 # Needed for clock_gettime with glibc < 2.17
 if(UNIX AND NOT APPLE)

--- a/framework/test/FrameworkTest.cpp
+++ b/framework/test/FrameworkTest.cpp
@@ -26,7 +26,7 @@ limitations under the License.
 #include "cppmicroservices/FrameworkFactory.h"
 
 #ifdef US_BUILD_SHARED_LIBS
-#include "singletonframework\singletonframework.h"
+#include "singletonframework/singletonframework.h"
 #endif
 
 #include "TestingConfig.h"

--- a/framework/test/singletonframework/CMakeLists.txt
+++ b/framework/test/singletonframework/CMakeLists.txt
@@ -1,11 +1,17 @@
+# Create a non-bundle shared library for the sole
+# purpose of testing static destruction on Windows.
+#
 project(singletonframework)
 
-find_package(CppMicroServices COMPONENTS Framework REQUIRED)
+find_package(CppMicroServices
+    HINTS ${CppMicroServices_BINARY_DIR}
+    NO_DEFAULT_PATH
+  )
 
 set(_srcs singletonframework.cpp)
 set(_includes singletonframework.h)
 
-include_directories(${US_INCLUDE_DIRS} ${_includes})
+include_directories(${US_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} SHARED ${_srcs} ${_includes})
 target_link_libraries(${PROJECT_NAME} ${US_LIBRARIES})

--- a/framework/test/singletonframework/CMakeLists.txt
+++ b/framework/test/singletonframework/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(singletonframework)
+
+find_package(CppMicroServices COMPONENTS Framework REQUIRED)
+
+set(_srcs singletonframework.cpp)
+set(_includes singletonframework.h)
+
+include_directories(${US_INCLUDE_DIRS} ${_includes})
+
+add_library(${PROJECT_NAME} SHARED ${_srcs} ${_includes})
+target_link_libraries(${PROJECT_NAME} ${US_LIBRARIES})

--- a/framework/test/singletonframework/singletonframework.cpp
+++ b/framework/test/singletonframework/singletonframework.cpp
@@ -7,6 +7,8 @@
 
 namespace singleton { namespace testing {
 
+/// There are no concerns whether or not this API is thread-safe as
+/// its purpose is to test static destruction.
 std::shared_ptr<cppmicroservices::Framework> getFramework()
 {
   static std::shared_ptr<cppmicroservices::Framework> framework = std::make_shared<cppmicroservices::Framework>(cppmicroservices::FrameworkFactory().NewFramework());

--- a/framework/test/singletonframework/singletonframework.cpp
+++ b/framework/test/singletonframework/singletonframework.cpp
@@ -1,0 +1,18 @@
+
+#include "singletonframework.h"
+
+#include <cppmicroservices/Any.h>
+#include <cppmicroservices/FrameworkFactory.h>
+#include <memory>
+
+namespace singleton { namespace testing {
+
+std::shared_ptr<cppmicroservices::Framework> getFramework()
+{
+  static std::shared_ptr<cppmicroservices::Framework> framework = std::make_shared<cppmicroservices::Framework>(cppmicroservices::FrameworkFactory().NewFramework());
+  framework->Start();
+  return framework;
+}
+
+}
+}

--- a/framework/test/singletonframework/singletonframework.h
+++ b/framework/test/singletonframework/singletonframework.h
@@ -1,0 +1,10 @@
+
+#include "cppmicroservices/GlobalConfig.h"
+
+#include <cppmicroservices/Framework.h>
+#include <memory>
+
+namespace singleton { namespace testing {
+  std::shared_ptr<cppmicroservices::Framework> US_ABI_EXPORT getFramework();
+}
+}

--- a/framework/test/singletonframework/singletonframework.h
+++ b/framework/test/singletonframework/singletonframework.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 namespace singleton { namespace testing {
+  /// Returned a started Framework.
   std::shared_ptr<cppmicroservices::Framework> US_ABI_EXPORT getFramework();
 }
 }


### PR DESCRIPTION
It's been observed that when CppMicroServices is used via JNI, during process shutdown, even if the Framework was explicitly shut down, a crash can still occur.  The fix is to remove unnecessary access to thread and synchronizxation objects unless required.  

This also includes a minor fix to resolve a GCC build warning.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com