### PR TITLE
Introduce code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,3 +133,18 @@ Use your real name (sorry, no pseudonyms or anonymous contributions).
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+### Code of Conduct
+
+CppMicroServices.org welcomes developers with different backgrounds and a broad range of 
+experience. A diverse and inclusive community will create more great ideas, provide more unique 
+perspectives, and produce more outstanding code. Our aim is to make the CppMicroServices community 
+welcoming to everyone.
+
+To provide clarity of what is expected of our members, CppMicroServices has adopted the code 
+of conduct defined by [contributor-covenant.org][contributor-covenant.org]. This document is used 
+across many open  source communities, and we believe it articulates our values well. 
+
+The full text is on [Code of Conduct](./CodeOfConduct.md).
+
+[contributor-covenant.org]: http://contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,6 @@ To provide clarity of what is expected of our members, CppMicroServices has adop
 of conduct defined by [contributor-covenant.org][contributor-covenant.org]. This document is used 
 across many open  source communities, and we believe it articulates our values well. 
 
-The full text is on [Code of Conduct](./CodeOfConduct.md).
+Please refer to the [Code of Conduct](./CodeOfConduct.md) for further details.
 
 [contributor-covenant.org]: http://contributor-covenant.org

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at sascha.zelzer@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at sascha.zelzer@gmail.com. All
+reported by contacting the project team at info@cppmicroservices.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ directory for detailed copyright information.
 
 This project is licensed under the [Apache License v2.0][apache_license].
 
+Code of Conduct
+---------------
+
+CppMicroServices.org welcomes developers with different backgrounds and a broad range of 
+experience. A diverse and inclusive community will create more great ideas, provide more unique 
+perspectives, and produce more outstanding code. Our aim is to make the CppMicroServices community 
+welcoming to everyone.
+
+To provide clarity of what is expected of our members, CppMicroServices has adopted the code 
+of conduct defined by [contributor-covenant.org][contributor-covenant.org]. This document is used
+across many open source communities, and we believe it articulates our values well. 
+
+The full text is on [Code of Conduct](./CodeOfConduct.md).
+
 Quick Start
 -----------
 
@@ -116,3 +130,5 @@ Please visit the [Build Instructions][bi_master] page online.
 
 [bi_master]: http://cppmicroservices.org/doc_latest/BuildInstructions.html
 [apache_license]: http://www.apache.org/licenses/LICENSE-2.0
+[contributor-covenant.org]: http://contributor-covenant.org
+[code_of_conduct]: http://www.github.org/CppMicroServices/CppMicroServices/CodeOfConduct.md

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To provide clarity of what is expected of our members, CppMicroServices has adop
 of conduct defined by [contributor-covenant.org][contributor-covenant.org]. This document is used
 across many open source communities, and we believe it articulates our values well. 
 
-The full text is on [Code of Conduct](./CodeOfConduct.md).
+Please refer to the [Code of Conduct](./CodeOfConduct.md) for further details.
 
 Quick Start
 -----------


### PR DESCRIPTION
Based on contributor-covenant.org version 1.4.

The only edited part is under enforcement the e-mail address:

> Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at sascha.zelzer@gmail.com.
