### PR TITLE
Consolidate LDAP queries of bundle/service properties using AnyMap

### DIFF
--- a/framework/examples/spellcheckservice/Activator.cpp
+++ b/framework/examples/spellcheckservice/Activator.cpp
@@ -26,7 +26,6 @@
 
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
-#include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/ServiceTracker.h"
 #include "cppmicroservices/ServiceTrackerCustomizer.h"
 

--- a/framework/include/cppmicroservices/LDAPFilter.h
+++ b/framework/include/cppmicroservices/LDAPFilter.h
@@ -23,7 +23,7 @@
 #ifndef CPPMICROSERVICES_LDAPFILTER_H
 #define CPPMICROSERVICES_LDAPFILTER_H
 
-#include "cppmicroservices/ServiceProperties.h"
+#include "cppmicroservices/AnyMap.h"
 #include "cppmicroservices/SharedData.h"
 
 #ifdef _MSC_VER
@@ -136,7 +136,7 @@ public:
    * @return <code>true</code> if the <code>ServiceProperties</code>'s values match this
    *         filter; <code>false</code> otherwise.
    */
-  bool Match(const ServiceProperties& dictionary) const;
+  bool Match(const AnyMap& dictionary) const;
 
   /**
    * Filter using a <code>ServiceProperties</code>. This <code>LDAPFilter</code> is executed using
@@ -148,7 +148,7 @@ public:
    * @return <code>true</code> if the <code>ServiceProperties</code>'s values match this
    *         filter; <code>false</code> otherwise.
    */
-  bool MatchCase(const ServiceProperties& dictionary) const;
+  bool MatchCase(const AnyMap& dictionary) const;
 
   /**
    * Returns this <code>LDAPFilter</code>'s filter string.

--- a/framework/include/cppmicroservices/LDAPFilter.h
+++ b/framework/include/cppmicroservices/LDAPFilter.h
@@ -127,25 +127,25 @@ public:
   bool Match(const Bundle& bundle) const;
   
   /**
-   * Filter using a <code>ServiceProperties</code> object with case insensitive key lookup. This
-   * <code>LDAPFilter</code> is executed using the specified <code>ServiceProperties</code>'s keys
+   * Filter using a <code>AnyMap</code> object with case insensitive key lookup. This
+   * <code>LDAPFilter</code> is executed using the specified <code>AnyMap</code>'s keys
    * and values. The keys are looked up in a case insensitive manner.
    *
-   * @param dictionary The <code>ServiceProperties</code> whose key/value pairs are used
+   * @param dictionary The <code>AnyMap</code> whose key/value pairs are used
    *        in the match.
-   * @return <code>true</code> if the <code>ServiceProperties</code>'s values match this
+   * @return <code>true</code> if the <code>AnyMap</code>'s values match this
    *         filter; <code>false</code> otherwise.
    */
   bool Match(const AnyMap& dictionary) const;
 
   /**
-   * Filter using a <code>ServiceProperties</code>. This <code>LDAPFilter</code> is executed using
-   * the specified <code>ServiceProperties</code>'s keys and values. The keys are looked
+   * Filter using a <code>AnyMap</code>. This <code>LDAPFilter</code> is executed using
+   * the specified <code>AnyMap</code>'s keys and values. The keys are looked
    * up in a normal manner respecting case.
    *
-   * @param dictionary The <code>ServiceProperties</code> whose key/value pairs are used
+   * @param dictionary The <code>AnyMap</code> whose key/value pairs are used
    *        in the match.
-   * @return <code>true</code> if the <code>ServiceProperties</code>'s values match this
+   * @return <code>true</code> if the <code>AnyMap</code>'s values match this
    *         filter; <code>false</code> otherwise.
    */
   bool MatchCase(const AnyMap& dictionary) const;

--- a/framework/include/cppmicroservices/ServiceObjects.h
+++ b/framework/include/cppmicroservices/ServiceObjects.h
@@ -27,7 +27,6 @@
 #include "cppmicroservices/FrameworkExport.h"
 #include "cppmicroservices/PrototypeServiceFactory.h"
 #include "cppmicroservices/ServiceReference.h"
-#include "cppmicroservices/ServiceProperties.h"
 
 namespace cppmicroservices {
 

--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -36,6 +36,8 @@ namespace cppmicroservices {
  * A hash table with std::string as the key type and Any as the value
  * type. It is typically used for passing service properties to
  * BundleContext::RegisterService.
+ *
+ * Deprecated. Use AnyMap instead.
  */
 typedef std::unordered_map<std::string, Any> ServiceProperties;
 

--- a/framework/src/service/ServiceEvent.cpp
+++ b/framework/src/service/ServiceEvent.cpp
@@ -23,7 +23,6 @@
 #include "cppmicroservices/ServiceEvent.h"
 
 #include "cppmicroservices/Constants.h"
-#include "cppmicroservices/ServiceProperties.h"
 
 namespace cppmicroservices {
 

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -90,15 +90,15 @@ bool LDAPFilter::Match(const ServiceReferenceBase& reference) const
     
 bool LDAPFilter::Match(const Bundle& bundle) const
 {
-  return d->ldapExpr.Evaluate(PropertiesHandle(Properties(bundle.GetProperties()), false), false);
+  return d->ldapExpr.Evaluate(PropertiesHandle(Properties(bundle.GetHeaders()), false), false);
 }
 
-bool LDAPFilter::Match(const ServiceProperties& dictionary) const
+bool LDAPFilter::Match(const AnyMap& dictionary) const
 {
   return d->ldapExpr.Evaluate(PropertiesHandle(Properties(dictionary), false), false);
 }
 
-bool LDAPFilter::MatchCase(const ServiceProperties& dictionary) const
+bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 {
   return d->ldapExpr.Evaluate(PropertiesHandle(Properties(dictionary), false), true);
 }

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -36,8 +36,7 @@ namespace cppmicroservices {
 
 const Any Properties::emptyAny;
 
-template <typename T>
-void Properties::ConstructProperties(const T& p)
+Properties::Properties(const AnyMap& p)
 {
   if (p.size() > static_cast<std::size_t>(std::numeric_limits<int>::max()))
   {
@@ -58,16 +57,6 @@ void Properties::ConstructProperties(const T& p)
     keys.push_back(iter.first);
     values.push_back(iter.second);
   }
-}
-
-Properties::Properties(const ServiceProperties& p)
-{
-  ConstructProperties(p);
-}
-    
-Properties::Properties(const std::map<std::string, Any>& p)
-{
-  ConstructProperties(p);
 }
 
 Properties::Properties(Properties&& o)

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -24,10 +24,9 @@
 #define CPPMICROSERVICES_PROPERTIES_H
 
 #include "cppmicroservices/Any.h"
-#include "cppmicroservices/ServiceProperties.h"
+#include "cppmicroservices/AnyMap.h"
 #include "cppmicroservices/detail/Threads.h"
 
-#include <map>
 #include <string>
 #include <vector>
 
@@ -38,8 +37,7 @@ class Properties : public detail::MultiThreaded<>
 
 public:
 
-  explicit Properties(const ServiceProperties& props);
-  Properties(const std::map<std::string, Any>& p);
+  explicit Properties(const AnyMap& props);
 
   Properties(Properties&& o);
   Properties& operator=(Properties&& o);
@@ -60,10 +58,6 @@ private:
   std::vector<Any> values;
 
   static const Any emptyAny;
-
-  template <typename T>
-  void ConstructProperties(const T& p);
-
 };
 
 class PropertiesHandle

--- a/framework/test/LDAPFilterTest.cpp
+++ b/framework/test/LDAPFilterTest.cpp
@@ -24,6 +24,7 @@
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/LDAPFilter.h"
 #include "cppmicroservices/LDAPProp.h"
+#include "cppmicroservices/ServiceProperties.h"
 
 #include "TestingMacros.h"
 

--- a/framework/test/LDAPFilterTest.cpp
+++ b/framework/test/LDAPFilterTest.cpp
@@ -24,7 +24,6 @@
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/LDAPFilter.h"
 #include "cppmicroservices/LDAPProp.h"
-#include "cppmicroservices/ServiceProperties.h"
 
 #include "TestingMacros.h"
 
@@ -74,7 +73,7 @@ int TestEvaluate()
   {
     // Make sure Match's key look-up is case-insensitive
     LDAPFilter ldap( "(Cn=Babs Jensen)" );
-    ServiceProperties props;
+    AnyMap props(AnyMap::UNORDERED_MAP);
     bool eval = false;
 
     // Several values


### PR DESCRIPTION
With the AnyMap class available to work with ordered and unordered maps, LDAP query users can now work with both types of maps with a single LDAP query API.
