### PR TITLE
Fix missing forward class declaration

### DIFF
--- a/framework/include/cppmicroservices/BundleImport.h
+++ b/framework/include/cppmicroservices/BundleImport.h
@@ -31,6 +31,7 @@ namespace cppmicroservices {
 
 struct BundleActivator;
 class BundleContext;
+class BundleContextPrivate;
 
 }
 


### PR DESCRIPTION
Building iOS static libraries with a generated .cpp file containing:
```
#include <cppmicroservices/BundleImport.h>
CPPMICROSERVICES_BUNDLE_IMPORT(%BUNDLE_NAME%)
```

produces the following error:

```error: no type named 'BundleContextPrivate' in namespace 'cppmicroservices```


Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com