### PR TITLE
Bug fixes for tests and error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: cpp
 env:
   global:
     - PATH=$HOME/cache/bin/:$PATH
-    - TMPDIR=$TRAVIS_BUILD_DIR/tmp
     - secure: "g2dT1rLVDXAR7uFkhgKlm7rUqCPHwl+o4CFSqEo5w9H/M5xuuQLP597J8qwhgkWutJABM4G4zLF9yzb5rTbUH1BSdGTzmdUkvJGvLOFq09xwLQP5PAKlq6s1dpVr7J9Ciy49cEVDD2leaikMf9zK3ty9Fv5F2mL3Itd6a/U5M5o="
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: cpp
 env:
   global:
     - PATH=$HOME/cache/bin/:$PATH
+    - TMPDIR=$TRAVIS_BUILD_DIR/tmp
     - secure: "g2dT1rLVDXAR7uFkhgKlm7rUqCPHwl+o4CFSqEo5w9H/M5xuuQLP597J8qwhgkWutJABM4G4zLF9yzb5rTbUH1BSdGTzmdUkvJGvLOFq09xwLQP5PAKlq6s1dpVr7J9Ciy49cEVDD2leaikMf9zK3ty9Fv5F2mL3Itd6a/U5M5o="
 
 matrix:

--- a/framework/src/util/Utils.cpp
+++ b/framework/src/util/Utils.cpp
@@ -392,7 +392,8 @@ int GetLastErrorNo()
 std::string GetLastErrorStr()
 {
 #ifdef US_PLATFORM_POSIX
-  return std::string(strerror(errno));
+  char* errorString = strerror(errno);
+  return std::string(((errorString == nullptr)?"":errorString));
 #else
   // Retrieve the system error message for the last-error code
   LPVOID lpMsgBuf;

--- a/framework/test/TestUtils.cpp
+++ b/framework/test/TestUtils.cpp
@@ -163,7 +163,8 @@ std::string GetTempDirectory()
   if (buffer) CoTaskMemFree(static_cast<void*>(buffer));
   return std::string(temp_dir.cbegin(), temp_dir.cend());
 #else
-  return std::string("/tmp");
+    char* tempdir = getenv("TMPDIR");
+  return std::string(((tempdir == nullptr)?"":tempdir));
 #endif
 }
 

--- a/framework/test/TestUtils.cpp
+++ b/framework/test/TestUtils.cpp
@@ -164,7 +164,7 @@ std::string GetTempDirectory()
   return std::string(temp_dir.cbegin(), temp_dir.cend());
 #else
   char* tempdir = getenv("TMPDIR");
-  return std::string(((tempdir == nullptr)?"":tempdir));
+  return std::string(((tempdir == nullptr)?"/tmp":tempdir));
 #endif
 }
 

--- a/framework/test/TestUtils.cpp
+++ b/framework/test/TestUtils.cpp
@@ -163,7 +163,7 @@ std::string GetTempDirectory()
   if (buffer) CoTaskMemFree(static_cast<void*>(buffer));
   return std::string(temp_dir.cbegin(), temp_dir.cend());
 #else
-    char* tempdir = getenv("TMPDIR");
+  char* tempdir = getenv("TMPDIR");
   return std::string(((tempdir == nullptr)?"":tempdir));
 #endif
 }


### PR DESCRIPTION
In our build environment (i.e. not travis ci), using a hard coded ```/tmp``` during tests occasionally produced a "permission denied" error while creating the persistent framework storage area. This lead to sporadic build failures. Changes were made to use ```TMPDIR``` instead which should always be a write-able location. ```/tmp``` was left in to satisfy travis ci. 

While making the above change, it was noticed that ```strerror``` in ```Utils.cpp``` could return a ```nullptr```. Fixed this as well to avoid constructing a ```std::string``` with a ```nullptr```.
