### PR TITLE
travisci xcode8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
           addons: *valgrind
           compiler: gcc
           env: BUILD_CONFIGURATION=1
-        # latest compiler on OS X
+        # minimum supported compiler on OS X
         - os: osx
           osx_image: xcode7.3
           compiler: clang
@@ -28,15 +28,15 @@ matrix:
           osx_image: xcode7.3
           compiler: clang
           env: BUILD_CONFIGURATION=1 MACOSX_DEPLOYMENT_TARGET=10.11
-        # minimum supported compiler on OS X
+        # latest compiler on OS X
         - os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.2
           compiler: clang
-          env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.10
+          env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.12
         - os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.2
           compiler: clang
-          env: BUILD_CONFIGURATION=1 MACOSX_DEPLOYMENT_TARGET=10.10
+          env: BUILD_CONFIGURATION=1 MACOSX_DEPLOYMENT_TARGET=10.12
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
           env: BUILD_CONFIGURATION=1
         # minimum supported compiler on OS X
         - os: osx
+          osx_image: xcode6.4
+          compiler: clang
+          env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.10
+        - os: osx
           osx_image: xcode7.3
           compiler: clang
           env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.11

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@
 +-------------+-------------------------+--------------------------+
 | Branch      | GCC 4.6                 | Visual Studio 2013       |
 |             +-------------------------+--------------------------+
-|             | XCode 6.4               | Visual Studio 2015       |
+|             | XCode 7.3               | Visual Studio 2015       |
 |             +-------------------------+--------------------------+
-|             | XCode 7.3               | MinGW-w64                |
+|             | XCode 8.2               | MinGW-w64                |
 +=============+=========================+==========================+
 | master      | |Linux Build Status|    | |Windows Build status|   |
 +-------------+-------------------------+--------------------------+
@@ -56,7 +56,7 @@ Minimum required compiler versions:
 
 - GCC 4.6
 - Clang 3.1
-- Clang from XCode 6.4
+- Clang from XCode 7.3
 - Visual Studio 2013
 
 Below is a list of tested compiler/OS combinations:
@@ -64,8 +64,8 @@ Below is a list of tested compiler/OS combinations:
 - GCC 4.6.3 (Ubuntu 12.04) via Travis CI
 - GCC 6.2.1 (Fedora 25)
 - Clang 3.8.0 (Fedora 25)
-- Clang XCode 6.4 (OS X 10.10) via Travis CI
 - Clang XCode 7.3 (OS X 10.11) via Travis CI
+- Clang XCode 8.2 (OS X 10.12) via Travis CI
 - Visual Studio 2013 via Appveyor
 - Visual Studio 2015 via Appveyor
 - Visual Studio 2017 RC (Windows 7)

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,11 @@
 +-------------+-------------------------+--------------------------+
 | Branch      | GCC 4.6                 | Visual Studio 2013       |
 |             +-------------------------+--------------------------+
-|             | Xcode 7.3               | Visual Studio 2015       |
+|             | Xcode 6.4               | Visual Studio 2015       |
 |             +-------------------------+--------------------------+
-|             | Xcode 8.2               | MinGW-w64                |
+|             | Xcode 7.3               | MinGW-w64                |
+|             +-------------------------+--------------------------+
+|             | Xcode 8.2               |                          |
 +=============+=========================+==========================+
 | master      | |Linux Build Status|    | |Windows Build status|   |
 +-------------+-------------------------+--------------------------+
@@ -56,7 +58,7 @@ Minimum required compiler versions:
 
 - GCC 4.6
 - Clang 3.1
-- Clang from Xcode 7.3
+- Clang from Xcode 6.4
 - Visual Studio 2013
 
 Below is a list of tested compiler/OS combinations:
@@ -64,6 +66,7 @@ Below is a list of tested compiler/OS combinations:
 - GCC 4.6.3 (Ubuntu 12.04) via Travis CI
 - GCC 6.2.1 (Fedora 25)
 - Clang 3.8.0 (Fedora 25)
+- Clang Xcode 6.4 (OS X 10.10) via Travis CI
 - Clang Xcode 7.3 (OS X 10.11) via Travis CI
 - Clang Xcode 8.2 (OS X 10.12) via Travis CI
 - Visual Studio 2013 via Appveyor

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@
 +-------------+-------------------------+--------------------------+
 | Branch      | GCC 4.6                 | Visual Studio 2013       |
 |             +-------------------------+--------------------------+
-|             | XCode 7.3               | Visual Studio 2015       |
+|             | Xcode 7.3               | Visual Studio 2015       |
 |             +-------------------------+--------------------------+
-|             | XCode 8.2               | MinGW-w64                |
+|             | Xcode 8.2               | MinGW-w64                |
 +=============+=========================+==========================+
 | master      | |Linux Build Status|    | |Windows Build status|   |
 +-------------+-------------------------+--------------------------+
@@ -56,7 +56,7 @@ Minimum required compiler versions:
 
 - GCC 4.6
 - Clang 3.1
-- Clang from XCode 7.3
+- Clang from Xcode 7.3
 - Visual Studio 2013
 
 Below is a list of tested compiler/OS combinations:
@@ -64,8 +64,8 @@ Below is a list of tested compiler/OS combinations:
 - GCC 4.6.3 (Ubuntu 12.04) via Travis CI
 - GCC 6.2.1 (Fedora 25)
 - Clang 3.8.0 (Fedora 25)
-- Clang XCode 7.3 (OS X 10.11) via Travis CI
-- Clang XCode 8.2 (OS X 10.12) via Travis CI
+- Clang Xcode 7.3 (OS X 10.11) via Travis CI
+- Clang Xcode 8.2 (OS X 10.12) via Travis CI
 - Visual Studio 2013 via Appveyor
 - Visual Studio 2015 via Appveyor
 - Visual Studio 2017 RC (Windows 7)

--- a/third_party/civetweb/civetweb.c
+++ b/third_party/civetweb/civetweb.c
@@ -148,7 +148,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #define CLOCK_REALTIME (2)
 #endif
 
-#if (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
+#if defined(_DARWIN_FEATURE_CLOCK_GETTIME) && (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
 /* clock_gettime is not implemented on OSX */
 int clock_gettime(int clk_id, struct timespec *t);
 
@@ -193,7 +193,7 @@ clock_gettime(int clk_id, struct timespec *t)
 	}
 	return -1; /* EINVAL - Clock ID is unknown */
 }
-#endif // _DARWIN_FEATURE_CLOCK_GETTIME == 0
+#endif // defined(_DARWIN_FEATURE_CLOCK_GETTIME) && (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
 #endif
 
 

--- a/third_party/patches/civetweb_v1.8.patch
+++ b/third_party/patches/civetweb_v1.8.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/civetweb/civetweb.c b/third_party/civetweb/civetweb.c
-index 98130f5..83daace 100644
+index 98130f5..cc25d9d 100644
 --- a/third_party/civetweb/civetweb.c
 +++ b/third_party/civetweb/civetweb.c
 @@ -129,8 +129,11 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
@@ -27,7 +27,7 @@ index 98130f5..83daace 100644
 +#define CLOCK_REALTIME (2)
 +#endif
  
-+#if (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
++#if defined(_DARWIN_FEATURE_CLOCK_GETTIME) && (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
  /* clock_gettime is not implemented on OSX */
  int clock_gettime(int clk_id, struct timespec *t);
  
@@ -35,7 +35,7 @@ index 98130f5..83daace 100644
  	}
  	return -1; /* EINVAL - Clock ID is unknown */
  }
-+#endif // _DARWIN_FEATURE_CLOCK_GETTIME == 0
++#endif // defined(_DARWIN_FEATURE_CLOCK_GETTIME) && (_DARWIN_FEATURE_CLOCK_GETTIME == 0)
  #endif
  
  


### PR DESCRIPTION
add support for xcode8.2 in travis ci and upgrade the minimum supported xcode and Mac OS versions since Apple has released macOS Sierra.