### PR TITLE
Fix for ServiceReferenceBasePrivate race condition

### DIFF
--- a/framework/include/cppmicroservices/ServiceInterface.h
+++ b/framework/include/cppmicroservices/ServiceInterface.h
@@ -317,6 +317,11 @@ std::shared_ptr<Interface> ExtractInterface(const InterfaceMapConstPtr& map)
  */
 inline std::shared_ptr<void> ExtractInterface(const InterfaceMapConstPtr& map, const std::string& interfaceId)
 {
+  if (!map)
+  {
+    return nullptr;
+  }
+
   if (interfaceId.empty() && map && !map->empty())
   {
     return map->begin()->second;

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -299,9 +299,12 @@ InterfaceMapConstPtr BundleContext::GetService(const ServiceReferenceU& referenc
 
   // Although according to the API contract the returned map should not be modified, there is nothing stopping the consumer from
   // using a const_pointer_cast and modifying the map. This copy step is to protect the map stored within the framework.
-  InterfaceMapConstPtr imap_copy = std::make_shared<const InterfaceMap>(
-        *(reference.d.load()->GetServiceInterfaceMap(b))
-        );
+  InterfaceMapConstPtr imap_copy;
+  auto serviceInterfaceMap = reference.d.load()->GetServiceInterfaceMap(b);
+  if (serviceInterfaceMap)
+  {
+    imap_copy = std::make_shared<const InterfaceMap>(*(serviceInterfaceMap));
+  }
   std::shared_ptr<ServiceHolder<const InterfaceMap>> h(new ServiceHolder<const InterfaceMap>(b->shared_from_this(), reference, imap_copy));
   return InterfaceMapConstPtr(h, h->service.get());
 }

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -140,6 +140,13 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(BundleP
       }
       return s;
     }
+
+    if (registration->bundleServiceInstance.end() != registration->bundleServiceInstance.find(bundle))
+    {
+      s = registration->bundleServiceInstance.at(bundle);
+      ++registration->dependents.at(bundle);
+      return s;
+    }
   }
 
   // Calling into a service factory could cause re-entrancy into the

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -130,7 +130,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(BundleP
   if (!serviceFactory)
   {
     auto l = registration->Lock(); US_UNUSED(l);
-          s = registration->service;
+    s = registration->service;
     if (s && !s->empty()) ++registration->dependents[bundle];
   }
   else
@@ -225,7 +225,7 @@ bool ServiceReferenceBasePrivate::UngetService(const std::shared_ptr<BundlePriva
 
   {
     auto l = registration->Lock(); US_UNUSED(l);
-    int count= registration->dependents[bundle.get()];
+    int count = registration->dependents[bundle.get()];
     if (count > 0)
     {
       hadReferences = true;

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -228,6 +228,11 @@ bool ServiceReferenceBasePrivate::UngetService(const std::shared_ptr<BundlePriva
 
   {
     auto l = registration->Lock(); US_UNUSED(l);
+    if (registration->dependents.end() == registration->dependents.find(bundle.get()))
+    {
+      return hadReferences && removeService;
+    }
+
     int count = registration->dependents.at(bundle.get());
     if (count > 0)
     {

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -162,9 +162,22 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceInterfaceMap(BundleP
 
   if (s && !s->empty())
   {
+    // Insert a cached service object instance only if one isn't already cached. If another thread
+    // already inserted a cached service object, discard the service object returned by 
+    // GetServiceFromFactory and return the cached one.
     auto insertResultPair = registration->bundleServiceInstance.insert(std::make_pair(bundle, s));
     s = insertResultPair.first->second;
     ++registration->dependents.at(bundle);
+  }
+  else
+  {
+    // If the service factory returned an invalid service object check the cache and return a valid one
+    // if it exists.
+    if (registration->bundleServiceInstance.end() != registration->bundleServiceInstance.find(bundle))
+    {
+      s = registration->bundleServiceInstance.at(bundle);
+      ++registration->dependents.at(bundle);
+    }
   }
   return s;
 }

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -237,7 +237,7 @@ void ServiceRegistrationBase::Unregister()
       }
     }
 
-    // unget module scope services
+    // unget bundle scope services
     for (auto const& i : bundleServiceInstance)
     {
       try

--- a/framework/test/ServiceFactoryTest.cpp
+++ b/framework/test/ServiceFactoryTest.cpp
@@ -187,7 +187,11 @@ void TestConcurrentServiceFactory()
     worker_threads.push_back(std::thread([framework]()
         {
           auto frameworkCtx = framework.GetBundleContext();
-          US_TEST_CONDITION_REQUIRED(frameworkCtx, "Get framework's bundle context");
+          if (!frameworkCtx)
+          {
+            US_TEST_FAILED_MSG(<< "Failed to get Framework's bundle context. Terminating the thread...");
+            return;
+          }
           
           for (int i = 0; i < 1000; ++i)
           {

--- a/framework/test/ServiceFactoryTest.cpp
+++ b/framework/test/ServiceFactoryTest.cpp
@@ -24,8 +24,11 @@
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
 #include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/GetBundleContext.h"
+#include "cppmicroservices/LDAPProp.h"
+#include "cppmicroservices/ListenerToken.h"
 #include "cppmicroservices/ServiceObjects.h"
 
 #include "TestingConfig.h"
@@ -66,30 +69,34 @@ void TestServiceFactoryBundleScope(BundleContext context)
   bundleH.Start();
 
   std::vector<ServiceReferenceU> registeredRefs = bundleH.GetRegisteredServices();
-  US_TEST_CONDITION_REQUIRED(registeredRefs.size() == 2, "# of registered services")
-  US_TEST_CONDITION(registeredRefs[0].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "service scope")
-  US_TEST_CONDITION(registeredRefs[1].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_PROTOTYPE, "service scope")
+  US_TEST_CONDITION_REQUIRED(registeredRefs.size() == 6, "Test that the # of registered services is six.");
+  US_TEST_CONDITION(registeredRefs[0].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "First service is bundle scope");
+  US_TEST_CONDITION(registeredRefs[1].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "Second service is bundle scope");
+  US_TEST_CONDITION(registeredRefs[2].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "Third service is bundle scope");
+  US_TEST_CONDITION(registeredRefs[3].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "Fourth service is bundle scope");
+  US_TEST_CONDITION(registeredRefs[4].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "Fifth service is bundle scope");
+  US_TEST_CONDITION(registeredRefs[5].GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_PROTOTYPE, "Sixth service is prototype scope");
 
-  // Check that a service reference exist
+  // Check that a service reference exists
   const ServiceReferenceU sr1 = context.GetServiceReference("cppmicroservices::TestBundleH");
-  US_TEST_CONDITION_REQUIRED(sr1, "Service shall be present.")
-  US_TEST_CONDITION(sr1.GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "service scope")
+  US_TEST_CONDITION_REQUIRED(sr1, "A valid service reference was returned.");
+  US_TEST_CONDITION(sr1.GetProperty(Constants::SERVICE_SCOPE).ToString() == Constants::SCOPE_BUNDLE, "service is bundle scope");
 
   InterfaceMapConstPtr service = context.GetService(sr1);
-  US_TEST_CONDITION_REQUIRED(service->size() >= 1, "GetService()")
+  US_TEST_CONDITION_REQUIRED(service->size() >= 1, "Returned at least 1 service object");
   InterfaceMap::const_iterator serviceIter = service->find("cppmicroservices::TestBundleH");
-  US_TEST_CONDITION_REQUIRED(serviceIter != service->end(), "GetService()")
-  US_TEST_CONDITION_REQUIRED(serviceIter->second != nullptr, "GetService()")
+  US_TEST_CONDITION_REQUIRED(serviceIter != service->end(), "Find a service object implementing the 'cppmicroservices::TestBundleH' interface");
+  US_TEST_CONDITION_REQUIRED(serviceIter->second != nullptr, "The service object is valid (i.e. not nullptr)");
 
   InterfaceMapConstPtr service2 = context.GetService(sr1);
-  US_TEST_CONDITION(*(service.get()) == *(service2.get()), "Same service interface maps")
+  US_TEST_CONDITION(*(service.get()) == *(service2.get()), "Two service interface maps are equal");
 
   std::vector<ServiceReferenceU> usedRefs = context.GetBundle().GetServicesInUse();
-  US_TEST_CONDITION_REQUIRED(usedRefs.size() == 1, "services in use")
-  US_TEST_CONDITION(usedRefs[0] == sr1, "service ref in use")
+  US_TEST_CONDITION_REQUIRED(usedRefs.size() == 1, "1 service in use");
+  US_TEST_CONDITION(usedRefs[0] == sr1, "service references are equal");
 
   InterfaceMapConstPtr service3 = bundleH.GetBundleContext().GetService(sr1);
-  US_TEST_CONDITION(service.get() != service3.get(), "Different service pointer")
+  US_TEST_CONDITION(service.get() != service3.get(), "Different service pointer");
 
   // release any service objects before stopping the bundle
   service.reset();
@@ -97,6 +104,77 @@ void TestServiceFactoryBundleScope(BundleContext context)
   service3.reset();
 
   bundleH.Stop();
+}
+
+void TestServiceFactoryBundleScopeErrorConditions()
+{
+  auto framework = FrameworkFactory().NewFramework();
+  framework.Start();
+
+  auto context = framework.GetBundleContext();
+  
+  auto bundle = testing::InstallLib(context, "TestBundleH");
+  US_TEST_CONDITION_REQUIRED(bundle, "Test for existing bundle TestBundleH")
+
+  auto bundleH = testing::GetBundle("TestBundleH", context);
+  US_TEST_CONDITION_REQUIRED(bundleH, "Test for existing bundle TestBundleH")
+
+  bundleH.Start();
+
+  int eventCount(0);
+  auto eventCountListener = [&eventCount](const FrameworkEvent&) { ++eventCount; };
+  auto listenerToken = bundleH.GetBundleContext().AddFrameworkListener(eventCountListener);
+
+ // Test that a service factory which returns a nullptr returns an invalid (nullptr) shared_ptr
+  std::string returnsNullPtrFilter(LDAPProp("returns_nullptr") == std::string("true"));
+  auto serviceRefs(context.GetServiceReferences("cppmicroservices::TestBundleH", returnsNullPtrFilter));
+  US_TEST_CONDITION_REQUIRED(serviceRefs.size() == 1, "Number of service references returned is 1.");
+  US_TEST_CONDITION_REQUIRED("1" == serviceRefs[0].GetProperty(std::string("returns_nullptr")).ToString(), "Test that 'returns_nullptr' service property is 'true'");
+  US_TEST_CONDITION_REQUIRED(nullptr == context.GetService(serviceRefs[0]), "Test that the service object returned is a nullptr");
+  US_TEST_CONDITION_REQUIRED(1 == eventCount, "Test that one FrameworkEvent was sent");
+
+  bundleH.GetBundleContext().RemoveListener(std::move(listenerToken));
+  
+  eventCount = 0;
+  listenerToken = bundleH.GetBundleContext().AddFrameworkListener(eventCountListener);
+
+  // Test getting a service object using an interface which isn't implemented by the service factory
+  std::string returnsWrongInterfaceFilter(LDAPProp("returns_wrong_interface") == std::string("true"));
+  auto svcNoInterfaceRefs(context.GetServiceReferences("cppmicroservices::TestBundleH", returnsWrongInterfaceFilter));
+  US_TEST_CONDITION_REQUIRED(svcNoInterfaceRefs.size() == 1, "Number of service references returned is 1.");
+  US_TEST_CONDITION_REQUIRED("1" == svcNoInterfaceRefs[0].GetProperty(std::string("returns_wrong_interface")).ToString(), "Test that 'returns_wrong_interface' service property is 'true'");
+  US_TEST_CONDITION_REQUIRED(nullptr == context.GetService(svcNoInterfaceRefs[0]), "Test that the service object returned is a nullptr");
+  US_TEST_CONDITION_REQUIRED(1 == eventCount, "Test that one FrameworkEvent was sent");
+
+  bundleH.GetBundleContext().RemoveListener(std::move(listenerToken));
+
+  eventCount = 0;
+  listenerToken = bundleH.GetBundleContext().AddFrameworkListener(eventCountListener);
+
+  // Test getting a service object from a service factory which throws an exception
+  std::string getServiceThrowsFilter(LDAPProp("getservice_exception") == std::string("true"));
+  auto svcGetServiceThrowsRefs(context.GetServiceReferences("cppmicroservices::TestBundleH", getServiceThrowsFilter));
+  US_TEST_CONDITION_REQUIRED(svcGetServiceThrowsRefs.size() == 1, "Number of service references returned is 1.");
+  US_TEST_CONDITION_REQUIRED("1" == svcGetServiceThrowsRefs[0].GetProperty(std::string("getservice_exception")).ToString(), "Test that 'getservice_exception' service property is 'true'");
+  US_TEST_CONDITION_REQUIRED(nullptr == context.GetService(svcGetServiceThrowsRefs[0]), "Test that the service object returned is a nullptr");
+  US_TEST_CONDITION_REQUIRED(1 == eventCount, "Test that one FrameworkEvent was sent");
+
+  bundleH.GetBundleContext().RemoveListener(std::move(listenerToken));
+
+  eventCount = 0;
+  listenerToken = bundleH.GetBundleContext().AddFrameworkListener(eventCountListener);
+
+  std::string unGetServiceThrowsFilter(LDAPProp("ungetservice_exception") == std::string("true"));
+  auto svcUngetServiceThrowsRefs(context.GetServiceReferences("cppmicroservices::TestBundleH", unGetServiceThrowsFilter));
+  US_TEST_CONDITION_REQUIRED(svcUngetServiceThrowsRefs.size() == 1, "Number of service references returned is 1.");
+  US_TEST_CONDITION_REQUIRED("1" == svcUngetServiceThrowsRefs[0].GetProperty(std::string("ungetservice_exception")).ToString(), "Test that 'ungetservice_exception' service property is 'true'");
+  {
+    auto sfUngetServiceThrowSvc = context.GetService(svcUngetServiceThrowsRefs[0]);
+  } // When sfUngetServiceThrowSvc goes out of scope, ServiceFactory::UngetService should be called
+  US_TEST_CONDITION_REQUIRED(1 == eventCount, "Test that one FrameworkEvent was sent");
+
+  framework.Stop();
+  framework.WaitForStop(std::chrono::milliseconds::zero());
 }
 
 void TestServiceFactoryPrototypeScope(BundleContext context)
@@ -223,6 +301,7 @@ int ServiceFactoryTest(int /*argc*/, char* /*argv*/[])
   
   TestServiceFactoryPrototypeScope(framework.GetBundleContext());
   TestServiceFactoryBundleScope(framework.GetBundleContext());
+  TestServiceFactoryBundleScopeErrorConditions();
 
 #ifdef US_ENABLE_THREADING_SUPPORT
   TestConcurrentServiceFactory();

--- a/framework/test/ServiceFactoryTest.cpp
+++ b/framework/test/ServiceFactoryTest.cpp
@@ -271,7 +271,7 @@ void TestConcurrentServiceFactory()
             return;
           }
           
-          for (int i = 0; i < 1000; ++i)
+          for (int i = 0; i < 100; ++i)
           {
             auto ref = frameworkCtx.GetServiceReference<cppmicroservices::TestBundleH2>();
             if (ref)

--- a/framework/test/ServiceFactoryTest.cpp
+++ b/framework/test/ServiceFactoryTest.cpp
@@ -186,18 +186,20 @@ void TestConcurrentServiceFactory()
   {
     worker_threads.push_back(std::thread([framework]()
         {
+          auto frameworkCtx = framework.GetBundleContext();
+          US_TEST_CONDITION_REQUIRED(frameworkCtx, "Get framework's bundle context");
+          
           for (int i = 0; i < 1000; ++i)
           {
-              auto frameworkCtx = framework.GetBundleContext();
-              if (frameworkCtx)
+            auto ref = frameworkCtx.GetServiceReference<cppmicroservices::TestBundleH2>();
+            if (ref)
+            {
+              std::shared_ptr<cppmicroservices::TestBundleH2> svc = frameworkCtx.GetService(ref);
+              if (!svc)
               {
-                auto ref = frameworkCtx.GetServiceReference<cppmicroservices::TestBundleH2>();
-                if (ref)
-                {
-                  std::shared_ptr<cppmicroservices::TestBundleH2> svc = frameworkCtx.GetService(ref);
-                  US_TEST_CONDITION_REQUIRED(svc, "test for valid service object");
-                }
+                US_TEST_FAILED_MSG(<< "Failed to retrieve a valid service object");
               }
+            }
           }
         }));
   }

--- a/framework/test/bundles/libH/TestBundleH.cpp
+++ b/framework/test/bundles/libH/TestBundleH.cpp
@@ -131,7 +131,7 @@ class TestBundleHServiceFactoryGetServiceThrow : public ServiceFactory
 public:
   InterfaceMapConstPtr GetService(const Bundle& /*caller*/, const ServiceRegistrationBase& /*sReg*/)
   {
-    throw std::exception("Test exception thrown from TestBundleHServiceFactoryThrow::GetService");
+    throw std::runtime_error("Test exception thrown from TestBundleHServiceFactoryThrow::GetService");
   }
 
   void UngetService(const Bundle& /*caller*/, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& /*service*/)
@@ -151,7 +151,7 @@ public:
 
   void UngetService(const Bundle& /*caller*/, const ServiceRegistrationBase& /*sReg*/, const InterfaceMapConstPtr& /*service*/)
   {
-    throw std::exception("Test exception thrown from TestBundleHServiceFactoryUngetServiceThrow::UngetService");
+    throw std::runtime_error("Test exception thrown from TestBundleHServiceFactoryUngetServiceThrow::UngetService");
   }
 };
 
@@ -159,7 +159,7 @@ public:
 class TestBundleHServiceFactoryInterfaceNotFound : public ServiceFactory
 {
 public:
-    InterfaceMapConstPtr GetService(const Bundle& caller, const ServiceRegistrationBase& /*sReg*/)
+    InterfaceMapConstPtr GetService(const Bundle& /*caller*/, const ServiceRegistrationBase& /*sReg*/)
     {
       std::shared_ptr<FakeTestProduct> product = std::make_shared<FakeTestProduct>();
       return MakeInterfaceMap<TestBundleH3>(product);

--- a/framework/test/bundles/libH/TestBundleH.cpp
+++ b/framework/test/bundles/libH/TestBundleH.cpp
@@ -71,7 +71,6 @@ public:
 
   InterfaceMapConstPtr GetService(const Bundle& caller, const ServiceRegistrationBase& /*sReg*/)
   {
-    std::cout << "GetService (prototype) in H" << std::endl;
     std::shared_ptr<TestProduct2> product = std::make_shared<TestProduct2>(caller);
     fcbind[caller.GetBundleId()].push_back(product);
     return MakeInterfaceMap<TestBundleH,TestBundleH2>(product);
@@ -92,7 +91,6 @@ public:
 
   InterfaceMapConstPtr GetService(const Bundle& caller, const ServiceRegistrationBase& /*sReg*/)
   {
-    std::cout << "GetService in H" << std::endl;
     std::shared_ptr<TestProduct> product = std::make_shared<TestProduct>(caller);
     fcbind.insert(std::make_pair(caller.GetBundleId(), product));
     return MakeInterfaceMap<TestBundleH>(product);


### PR DESCRIPTION
Fixes #202 

This fixes a race condition involving how ServiceReferenceBasePrivate tracks the cached service instance and the list of dependent bundles.
