### PR TITLE
Added new framework working dir property.

### DIFF
--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -247,10 +247,10 @@ public:
    * \returns \c true if this Any contains value \c val, \c false otherwise.
    */
   template <typename ValueType>
-  bool operator==(const ValueType& val)
+  bool operator==(const ValueType& val) const
   {
     if (Type() != typeid(ValueType)) return false;
-    return *any_cast<ValueType>(this) == val;
+    return *any_cast<const ValueType>(this) == val;
   }
 
   /**
@@ -265,7 +265,7 @@ public:
    * \returns \c true if this Any does not contain value \c val, \c false otherwise.
    */
   template <typename ValueType>
-  bool operator!=(const ValueType& val)
+  bool operator!=(const ValueType& val) const
   {
     return !operator==(val);
   }

--- a/framework/include/cppmicroservices/Constants.h
+++ b/framework/include/cppmicroservices/Constants.h
@@ -297,6 +297,13 @@ US_Framework_EXPORT extern const std::string FRAMEWORK_LOG; // = "org.cppmicrose
  */
 US_Framework_EXPORT extern const std::string FRAMEWORK_UUID; // = "org.cppmicroservices.framework.uuid";
 
+/**
+ * Framework launching property specifying the working directory used for
+ * resolving relative path names. If not set, the framework will use the process
+ * current working directory as set during static initialization of the
+ * framework library.
+ */
+US_Framework_EXPORT extern const std::string FRAMEWORK_WORKING_DIR; // = "org.cppmicroservices.framework.working.dir";
 
 /*
  * Service properties.

--- a/framework/include/cppmicroservices/FrameworkFactory.h
+++ b/framework/include/cppmicroservices/FrameworkFactory.h
@@ -25,8 +25,11 @@
 
 #include "cppmicroservices/FrameworkConfig.h"
 
+#include "cppmicroservices/Any.h"
+
 #include <iostream>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 
@@ -35,6 +38,8 @@ namespace cppmicroservices {
 class Any;
 
 class Framework;
+
+typedef std::unordered_map<std::string, Any> FrameworkConfiguration;
 
 /**
  * \ingroup MicroServices
@@ -56,7 +61,26 @@ public:
      *
      * @return A new, configured Framework instance.
      */
-    Framework NewFramework(const std::map<std::string, Any>& configuration = std::map<std::string, Any>(), std::ostream* logger = nullptr);
+    Framework NewFramework(const FrameworkConfiguration& configuration, std::ostream* logger = nullptr);
+
+    /**
+     * Create a new Framework instance.
+     *
+     * This is the same as calling \code NewFramework(FrameworkConfiguration()) \endcode.
+     *
+     * @return A new, configured Framework instance.
+     */
+    Framework NewFramework();
+
+    /**
+     * Create a new Framework instance.
+     *
+     * @deprecated Since 3.1, use NewFramework() or NewFramework(const FramworkConfiguration&, std::ostream*)
+     * instead.
+     *
+     * @return A new, configured Framework instance.
+     */
+    US_DEPRECATED Framework NewFramework(const std::map<std::string, Any>& configuration, std::ostream* logger = nullptr);
 
 };
 

--- a/framework/src/bundle/Constants.cpp
+++ b/framework/src/bundle/Constants.cpp
@@ -53,7 +53,7 @@ const std::string FRAMEWORK_THREADING_SINGLE          = "single";
 const std::string FRAMEWORK_THREADING_MULTI           = "multi";
 const std::string FRAMEWORK_LOG                       = "org.cppmicroservices.framework.log";
 const std::string FRAMEWORK_UUID                      = "org.cppmicroservices.framework.uuid";
-
+const std::string FRAMEWORK_WORKING_DIR               = "org.cppmicroservices.framework.working.dir";
 const std::string OBJECTCLASS                         = "objectclass";
 const std::string SERVICE_ID                          = "service.id";
 const std::string SERVICE_PID                         = "service.pid";

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -34,7 +34,7 @@ US_MSVC_DISABLE_WARNING(4355)
 #include "BundleThread.h"
 #include "BundleUtils.h"
 #include "FrameworkPrivate.h"
-#include "Utils.h" // cppmicroservices::ToString()
+#include "Utils.h"
 
 #include <iomanip>
 
@@ -44,7 +44,7 @@ namespace cppmicroservices {
 
 std::atomic<int> CoreBundleContext::globalId{0};
 
-std::map<std::string, Any> InitProperties(std::map<std::string, Any> configuration)
+std::unordered_map<std::string, Any> InitProperties(std::unordered_map<std::string, Any> configuration)
 {
   // Framework internal diagnostic logging is off by default
   configuration.insert(std::make_pair(Constants::FRAMEWORK_LOG, Any(false)));
@@ -57,6 +57,15 @@ std::map<std::string, Any> InitProperties(std::map<std::string, Any> configurati
   configuration[Constants::FRAMEWORK_THREADING_SUPPORT] = std::string("single");
 #endif
 
+  if (configuration.find(Constants::FRAMEWORK_WORKING_DIR) == configuration.end())
+  {
+    configuration.insert(std::make_pair(
+                           Constants::FRAMEWORK_WORKING_DIR,
+                           fs::GetCurrentWorkingDirectory()
+                           )
+                         );
+  }
+
   configuration.insert(std::make_pair(Constants::FRAMEWORK_STORAGE, Any(FWDIR_DEFAULT)));
 
   configuration[Constants::FRAMEWORK_VERSION] = std::string(CppMicroServices_VERSION_STR);
@@ -65,9 +74,10 @@ std::map<std::string, Any> InitProperties(std::map<std::string, Any> configurati
   return configuration;
 }
 
-CoreBundleContext::CoreBundleContext(const std::map<std::string, Any>& props, std::ostream* logger)
+CoreBundleContext::CoreBundleContext(const std::unordered_map<std::string, Any>& props, std::ostream* logger)
   : id(globalId++)
   , frameworkProperties(InitProperties(props))
+  , workingDir(ref_any_cast<std::string>(frameworkProperties.at(Constants::FRAMEWORK_WORKING_DIR)))
   , listeners(this)
   , services(this)
   , serviceHooks(this)

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -99,7 +99,9 @@ public:
   * Note: CppMicroServices currently has no concept
   * of "system properties".
   */
-  std::map<std::string, Any> frameworkProperties;
+  std::unordered_map<std::string, Any> frameworkProperties;
+
+  const std::string& workingDir;
 
  /**
   * The diagnostic logging sink
@@ -204,7 +206,7 @@ private:
    * Construct a core context
    *
    */
-  CoreBundleContext(const std::map<std::string, Any>& props, std::ostream* logger);
+  CoreBundleContext(const std::unordered_map<std::string, Any>& props, std::ostream* logger);
 
   struct : detail::MultiThreaded<> { std::weak_ptr<CoreBundleContext> v; } self;
 

--- a/framework/src/util/FrameworkFactory.cpp
+++ b/framework/src/util/FrameworkFactory.cpp
@@ -61,13 +61,29 @@ struct CoreBundleContextHolder
   std::unique_ptr<CoreBundleContext> ctx;
 };
 
-Framework FrameworkFactory::NewFramework(const std::map<std::string, Any>& configuration, std::ostream* logger)
+Framework FrameworkFactory::NewFramework(const FrameworkConfiguration& configuration, std::ostream* logger)
 {
   std::unique_ptr<CoreBundleContext> ctx(new CoreBundleContext(configuration, logger));
   auto fwCtx = ctx.get();
   std::shared_ptr<CoreBundleContext> holder(std::make_shared<CoreBundleContextHolder>(std::move(ctx)), fwCtx);
   holder->SetThis(holder);
   return Framework(holder->systemBundle);
+}
+
+Framework FrameworkFactory::NewFramework()
+{
+  return NewFramework(FrameworkConfiguration());
+}
+
+Framework FrameworkFactory::NewFramework(const std::map<std::string, Any>& configuration, std::ostream* logger)
+{
+  FrameworkConfiguration fwConfig;
+  for (auto& c : configuration)
+  {
+    fwConfig.insert(c);
+  }
+
+  return NewFramework(fwConfig, logger);
 }
 
 }

--- a/framework/src/util/Utils.h
+++ b/framework/src/util/Utils.h
@@ -62,7 +62,7 @@ bool IsDirectory(const std::string& path);
 bool IsFile(const std::string& path);
 bool IsRelative(const std::string& path);
 
-std::string GetAbsolute(const std::string& path);
+std::string GetAbsolute(const std::string& path, const std::string& base);
 
 void MakePath(const std::string& path);
 
@@ -105,10 +105,6 @@ template<typename T> std::shared_ptr<T> make_shared_array(std::size_t size)
 {
   return std::shared_ptr<T>(new T[size], std::default_delete<T[]>());
 }
-
-// Platform agnostic way to get the current working directory.
-// Supports Linux, Mac, and Windows.
-std::string GetCurrentWorkingDirectory();
 
 void TerminateForDebug(const std::exception_ptr ex);
 

--- a/framework/test/BundleTest.cpp
+++ b/framework/test/BundleTest.cpp
@@ -398,7 +398,7 @@ void TestBundleStates()
     std::vector<BundleEvent> bundleEvents;
     FrameworkFactory factory;
 
-    std::map<std::string, Any> frameworkConfig;
+    FrameworkConfiguration frameworkConfig;
     auto framework = factory.NewFramework(frameworkConfig);
     framework.Start();
 
@@ -602,7 +602,7 @@ void TestAutoInstallEmbeddedBundles()
   // There are atleast 2 bundles, maybe more depending on how the executable is created
   US_TEST_CONDITION(2 <= frameworkCtx.GetBundles().size(), "Test # of installed bundles")
 #endif
-  
+
   auto bundles = frameworkCtx.GetBundles();
   auto bundleIter = std::find_if(bundles.begin(), bundles.end(),
                                   [](const Bundle& b)
@@ -617,7 +617,7 @@ void TestAutoInstallEmbeddedBundles()
 
   auto b = frameworkCtx.GetBundle(0);
   US_TEST_FOR_EXCEPTION(std::runtime_error, b.Uninstall());
-  
+
   f.Stop();
 }
 
@@ -639,8 +639,8 @@ void TestNonStandardBundleExtension()
 
   // Test the non-standard file extension bundle's lifecycle
   auto bundles = frameworkCtx.GetBundles();
-  auto bundleIter = std::find_if(bundles.begin(), bundles.end(), 
-                                  [](const Bundle& b) 
+  auto bundleIter = std::find_if(bundles.begin(), bundles.end(),
+                                  [](const Bundle& b)
                                   {
                                         return (std::string("TestBundleExt") == b.GetSymbolicName());
                                   }
@@ -689,7 +689,7 @@ int BundleTest(int /*argc*/, char* /*argv*/[])
 
   // test a non-default framework instance using a different persistent storage location.
   {
-    std::map<std::string, Any> frameworkConfig;
+    FrameworkConfiguration frameworkConfig;
     frameworkConfig[Constants::FRAMEWORK_STORAGE] = testing::GetTempDirectory();
     auto framework = FrameworkFactory().NewFramework(frameworkConfig);
     framework.Start();

--- a/framework/test/FrameworkFactoryTest.cpp
+++ b/framework/test/FrameworkFactoryTest.cpp
@@ -45,7 +45,7 @@ int FrameworkFactoryTest(int /*argc*/, char* /*argv*/[])
 
     US_TEST_CONDITION(f != f1, "Test unique Framework instantiation");
 
-    std::map < std::string, Any > configuration;
+    FrameworkConfiguration configuration;
     configuration["org.osgi.framework.security"] = std::string("osgi");
     configuration["org.osgi.framework.startlevel.beginning"] = 0;
     configuration["org.osgi.framework.bsnversion"] = std::string("single");
@@ -56,9 +56,9 @@ int FrameworkFactoryTest(int /*argc*/, char* /*argv*/[])
 
     US_TEST_CONDITION(f2, "Test Framework instantiation with configuration");
 
-	auto f3 = FrameworkFactory().NewFramework(std::map<std::string, cppmicroservices::Any>(), &std::clog);
+    auto f3 = FrameworkFactory().NewFramework(std::unordered_map<std::string, cppmicroservices::Any>(), &std::clog);
 
-	US_TEST_CONDITION(f3, "Test Framework instantiation with default configuration and custom logger");
+    US_TEST_CONDITION(f3, "Test Framework instantiation with default configuration and custom logger");
 
     US_TEST_END()
 }

--- a/framework/test/FrameworkTest.cpp
+++ b/framework/test/FrameworkTest.cpp
@@ -40,7 +40,7 @@ namespace
     void TestDefaultConfig()
     {
         auto f = FrameworkFactory().NewFramework();
-    US_TEST_CONDITION(f, "Test Framework instantiation");
+        US_TEST_CONDITION(f, "Test Framework instantiation");
 
         f.Start();
 
@@ -59,11 +59,12 @@ namespace
         US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_STORAGE) == std::string("fwdir"), "Test for default base storage property")
         US_TEST_CONDITION(any_cast<bool>(ctx.GetProperty(Constants::FRAMEWORK_LOG)) == false, "Test default diagnostic logging")
 
+        US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_WORKING_DIR) == testing::GetCurrentWorkingDirectory(), "Test for default working directory")
     }
 
     void TestCustomConfig()
     {
-        std::map < std::string, Any > configuration;
+        FrameworkConfiguration configuration;
         configuration["org.osgi.framework.security"] = std::string("osgi");
         configuration["org.osgi.framework.startlevel.beginning"] = 0;
         configuration["org.osgi.framework.bsnversion"] = std::string("single");
@@ -71,6 +72,7 @@ namespace
         configuration["org.osgi.framework.custom2"] = std::string("bar");
         configuration[Constants::FRAMEWORK_LOG] = true;
         configuration[Constants::FRAMEWORK_STORAGE] = testing::GetTempDirectory();
+        configuration[Constants::FRAMEWORK_WORKING_DIR] = testing::GetTempDirectory();
 
         // the threading model framework property is set at compile time and read-only at runtime. Test that this
         // is always the case.
@@ -81,7 +83,7 @@ namespace
 #endif
 
         auto f = FrameworkFactory().NewFramework(configuration);
-    US_TEST_CONDITION(f, "Test Framework instantiation with custom configuration");
+        US_TEST_CONDITION(f, "Test Framework instantiation with custom configuration");
 
         try
         {
@@ -104,7 +106,8 @@ namespace
         US_TEST_CONDITION("foo" == any_cast<std::string>(ctx.GetProperty("org.osgi.framework.custom1")), "Test Framework custom launch properties");
         US_TEST_CONDITION("bar" == any_cast<std::string>(ctx.GetProperty("org.osgi.framework.custom2")), "Test Framework custom launch properties");
         US_TEST_CONDITION(any_cast<bool>(ctx.GetProperty(Constants::FRAMEWORK_LOG)) == true, "Test for enabled diagnostic logging");
-    US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_STORAGE).ToString() == testing::GetTempDirectory(), "Test for custom base storage path");
+        US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_STORAGE).ToString() == testing::GetTempDirectory(), "Test for custom base storage path");
+        US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_WORKING_DIR) == testing::GetTempDirectory(), "Test for custom working directory");
 
 #ifdef US_ENABLE_THREADING_SUPPORT
         US_TEST_CONDITION(ctx.GetProperty(Constants::FRAMEWORK_THREADING_SUPPORT).ToString() == "multi", "Test for attempt to change threading option")
@@ -115,7 +118,7 @@ namespace
 
     void TestDefaultLogSink()
     {
-        std::map<std::string, Any> configuration;
+        FrameworkConfiguration configuration;
         // turn on diagnostic logging
         configuration[Constants::FRAMEWORK_LOG] = true;
 
@@ -143,7 +146,7 @@ namespace
 
   void TestCustomLogSink()
   {
-    std::map<std::string, Any> configuration;
+    FrameworkConfiguration configuration;
     // turn on diagnostic logging
     configuration[Constants::FRAMEWORK_LOG] = true;
 

--- a/framework/test/StaticBundleTest.cpp
+++ b/framework/test/StaticBundleTest.cpp
@@ -210,7 +210,7 @@ int StaticBundleTest(int /*argc*/, char* /*argv*/[])
   US_TEST_BEGIN("StaticBundleTest");
 
   FrameworkFactory factory;
-  std::map<std::string, Any> frameworkConfig;
+  FrameworkConfiguration frameworkConfig;
   auto framework = factory.NewFramework(frameworkConfig);
   framework.Start();
 
@@ -227,7 +227,7 @@ int StaticBundleTest(int /*argc*/, char* /*argv*/[])
 
     frame020a(context, listener);
     frame030b(context, listener);
-#ifdef US_BUILD_SHARED_LIBS 
+#ifdef US_BUILD_SHARED_LIBS
     // bundles in the executable are auto-installed.
     // install and uninstall on embedded bundles is not allowed.
     frame040c(context, listener);


### PR DESCRIPTION
This fixes #209 by adding a new framework launch property for setting the current working directory. The unsafe working directory related OS functions are only called once during static initialization.

As a side effect, changed the framework properties map from `std::map` to `std::unordered_map`. The ordered map is a legacy from our pre-C++11 development.