### PR TITLE
Fix LDAPFilter::ToString seg fault

### DIFF
--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -105,12 +105,12 @@ bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 
 std::string LDAPFilter::ToString() const
 {
-  return d->ldapExpr.ToString();
+  return ((d) ? d->ldapExpr.ToString() : std::string());
 }
 
 bool LDAPFilter::operator==(const LDAPFilter& other) const
 {
-  return d->ldapExpr.ToString() == other.d->ldapExpr.ToString();
+  return (this->ToString() == other.ToString());
 }
 
 LDAPFilter& LDAPFilter::operator=(const LDAPFilter& filter)

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 #-----------------------------------------------------------------------------
 set(_gtest_tests 
   BundleVersionTest.cpp
+  LDAPFilterTest.cpp
 )
 
 add_executable(${us_gtest_test_exe_name} ${_gtest_tests})

--- a/framework/test/gtest/LDAPFilterTest.cpp
+++ b/framework/test/gtest/LDAPFilterTest.cpp
@@ -1,0 +1,52 @@
+/*=============================================================================
+
+Library: CppMicroServices
+
+Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+file at the top-level directory of this distribution and at
+https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=============================================================================*/
+
+#include "cppmicroservices/LDAPFilter.h"
+#include "gtest/gtest.h"
+
+using cppmicroservices::LDAPFilter;
+
+TEST(LDAPFilter, ToString)
+{
+  LDAPFilter filter;
+  ASSERT_NO_THROW(filter.ToString());
+  ASSERT_NO_THROW(std::cout << "Empty LDAPFilter: " << filter << std::endl;);
+}
+
+TEST(LDAPFilter, BooleanOperator)
+{
+  LDAPFilter emptyFilter;
+  ASSERT_FALSE(emptyFilter);
+
+  LDAPFilter validFilter("(cn = Babs Jensen)");
+  ASSERT_TRUE(validFilter);
+}
+
+TEST(LDAPFilter, Comparison)
+{
+  LDAPFilter filter1, filter2;
+  ASSERT_TRUE(filter1 == filter2);
+
+  LDAPFilter filt("(cn = Babs Jensen)");
+  ASSERT_FALSE(filter1 == filt);
+}
+


### PR DESCRIPTION
Fixes #232 

Add test cases to increase code coverage.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com