### PR TITLE
Support constructing long LDAP expressions using concise C++

### DIFF
--- a/framework/include/cppmicroservices/LDAPProp.h
+++ b/framework/include/cppmicroservices/LDAPProp.h
@@ -37,7 +37,7 @@ namespace cppmicroservices {
 class US_Framework_EXPORT LDAPPropExpr
 {
 public:
-
+  LDAPPropExpr();
   explicit LDAPPropExpr(const std::string& expr);
 
   LDAPPropExpr& operator!();
@@ -46,9 +46,55 @@ public:
 
   bool IsNull() const;
 
-private:
-
   LDAPPropExpr& operator=(const LDAPPropExpr&);
+
+  /**
+  * Convenience operator for LDAP logical or '|'.
+  *
+  * Writing either
+  * \code
+  * LDAPPropExpr expr(LDAPProp("key1") == "value1");
+  * expr = expr || LDAPProp("key2") == "value2";
+  * \endcode
+  * or
+  * \code
+  * LDAPPropExpr expr(LDAPProp("key1") == "value1");
+  * expr |= LDAPProp("key2") == "value2";
+  * \endcode
+  * leads to the same string "(|(key1=value1) (key2=value2))".
+  *
+  * @param right A LDAP expression object.
+  * @return A LDAP expression object.
+  *
+  * @{
+  */
+  LDAPPropExpr& operator|=(const LDAPPropExpr& right);
+  /// @}
+
+  /**
+  * Convenience operator for LDAP logical and '&'.
+  *
+  * Writing either
+  * \code
+  * LDAPPropExpr expr(LDAPProp("key1") == "value1");
+  * expr = expr && LDAPProp("key2") == "value2";
+  * \endcode
+  * or
+  * \code
+  * LDAPPropExpr expr(LDAPProp("key1") == "value1");
+  * expr &= LDAPProp("key2") == "value2";
+  * \endcode
+  * leads to the same string "(&(key1=value1) (key2=value2))".
+  *
+  * @param right A LDAP expression object.
+  * @return A LDAP expression object.
+  *
+  * @{
+  */
+  LDAPPropExpr& operator&=(const LDAPPropExpr& right);
+  /// @}
+
+private:
 
   std::string m_ldapExpr;
 };

--- a/framework/src/util/LDAPProp.cpp
+++ b/framework/src/util/LDAPProp.cpp
@@ -26,6 +26,11 @@
 
 namespace cppmicroservices {
 
+LDAPPropExpr::LDAPPropExpr()
+    : m_ldapExpr()
+{
+}
+
 LDAPPropExpr::LDAPPropExpr(const std::string& expr)
   : m_ldapExpr(expr)
 {}
@@ -48,6 +53,26 @@ bool LDAPPropExpr::IsNull() const
   return m_ldapExpr.empty();
 }
 
+LDAPPropExpr& LDAPPropExpr::operator=(const LDAPPropExpr& expr)
+{
+  if(this != &expr)
+  {
+    m_ldapExpr = expr.m_ldapExpr;
+  }
+  return *this;
+}
+
+LDAPPropExpr& LDAPPropExpr::operator|=(const LDAPPropExpr& right)
+{
+  m_ldapExpr = (*this || right).m_ldapExpr;
+  return *this;
+}
+
+LDAPPropExpr& LDAPPropExpr::operator&=(const LDAPPropExpr& right)
+{
+  m_ldapExpr = (*this && right).m_ldapExpr;
+  return *this;
+}
 
 LDAPProp::LDAPProp(const std::string& property)
   : m_property(property)

--- a/framework/test/gtest/LDAPExprTest.cpp
+++ b/framework/test/gtest/LDAPExprTest.cpp
@@ -20,11 +20,12 @@ limitations under the License.
 
 =============================================================================*/
 
-#include "cppmicroservices/LDAPFilter.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/Framework.h"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/LDAPFilter.h"
+#include "cppmicroservices/LDAPProp.h"
 #include "cppmicroservices/ServiceEvent.h"
 #include "cppmicroservices/ServiceTracker.h"
 
@@ -241,4 +242,51 @@ TEST(LDAPExprTest, ParseExceptions)
   EXPECT_THROW(LDAPFilter("(name=abra"), std::invalid_argument);
   // Testing '\\' case in LDAPExpr::ParseState::getAttributeValue()
   ASSERT_EQ(LDAPFilter("(name=ab\\a)"), LDAPFilter("(name=aba)"));
+}
+
+TEST(LDAPExprTest, BitWiseOperatorOr)
+{
+  LDAPPropExpr checkedExpr((LDAPProp("key1") == "value1") || (LDAPProp("key2") == "value2"));
+
+  LDAPPropExpr expr(LDAPProp("key1") == "value1");
+
+  expr |= LDAPProp("key2") == "value2";
+  ASSERT_EQ(expr.operator std::string(), checkedExpr.operator std::string());
+ 
+}
+
+TEST(LDAPExprTest, BitWiseOperatorAnd)
+{
+  LDAPPropExpr checkedExpr((LDAPProp("key1") == "value1") && (LDAPProp("key2") == "value2"));
+
+  LDAPPropExpr expr(LDAPProp("key1") == "value1");
+
+  expr &= LDAPProp("key2") == "value2";
+
+  ASSERT_EQ(expr.operator std::string(), checkedExpr.operator std::string());
+}
+
+TEST(LDAPExprTest, OperatorAssignment)
+{
+  LDAPPropExpr checkedExpr((LDAPProp("key1") == "value1") || (LDAPProp("key2") == "value2"));
+  LDAPPropExpr expr(LDAPProp("key1") == "value1");
+
+  expr = expr || LDAPProp("key2") == "value2";
+  
+  ASSERT_EQ(expr.operator std::string(), checkedExpr.operator std::string());
+}
+
+TEST(LDAPExprTest, AssignToDefaultConstructed)
+{
+  LDAPPropExpr checkedExpr((LDAPProp("key2") == "value2"));
+
+  LDAPPropExpr defaultConstructed;
+  ASSERT_TRUE(defaultConstructed.IsNull());
+
+  defaultConstructed |= LDAPProp("key2") == "value2";
+  ASSERT_EQ(defaultConstructed.operator std::string(), checkedExpr.operator std::string());
+
+  LDAPPropExpr expr(LDAPProp("key2") == "value2");
+  expr |= LDAPPropExpr();
+  ASSERT_EQ(expr.operator std::string(), checkedExpr.operator std::string());
 }


### PR DESCRIPTION
Fixes #246

This change is based on feedback from a user who wants to construct long LDAP expressions based on conditions in their code. See #246 for details.

Signed-off-by: The Mathworks Inc. <Roy.Lurie@mathworks.com>