### PR TITLE
Fix build failures on Linux and MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ else()
   foreach(_cxxflag  -Werror -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align
                     -Wwrite-strings -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast
                     -Wstrict-null-sentinel -Wsign-promo -fdiagnostics-show-option
-                    -fstack-protector-all)
+                    -fstack-protector-all -Wimplicit-fallthrough=0)
     usFunctionCheckCompilerFlags(${_cxxflag} US_CXX_FLAGS)
   endforeach()
 
@@ -524,7 +524,7 @@ endif()
 # Currently the default C++ library for gcc < 4.9 doesn't
 # fully support c++11 regex.
 # Generalize the detection of regex and make its availability
-# conditional of wether the compiler's C++ library supports it
+# conditional of whether the compiler's C++ library supports it
 # or not.
 # This can be removed once the minimum supported gcc version is 4.9
 if(NOT US_HAVE_REGEX AND US_BUILD_TESTING)

--- a/framework/test/driver/ResourceCompilerTest.cpp
+++ b/framework/test/driver/ResourceCompilerTest.cpp
@@ -58,8 +58,13 @@ int runExecutable(const std::string& executable)
 #if defined US_PLATFORM_WINDOWS
 #define WEXITSTATUS 
 #endif
+
   int ret = std::system(executable.c_str());
+
+  // WEXITSTATUS uses an old c-sytle cast
+US_GCC_PUSH_DISABLE_WARNING(old-style-cast)
   return WEXITSTATUS(ret);
+US_GCC_POP_WARNING
 }
 
 /*

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -576,7 +576,8 @@ struct Custom_Arg : public option::Arg
       // the return value of strtol is misleading since 0 indicates failure and
       // we support 0 as a valid command line option argument. Checking errno
       // is the correct way to determine if the argument is valid.
-      strtol(option.arg, &endptr, 10);
+      long ret = strtol(option.arg, &endptr, 10);
+      (void)ret;
       if (errno != ERANGE)
       {
         errno = 0;

--- a/valgrind_suppressions.txt
+++ b/valgrind_suppressions.txt
@@ -247,6 +247,18 @@
 {
    <miniz-uninitialized_values>
    Memcheck:Cond
+   fun:tdefl_compress
+   fun:tdefl_compress_buffer
+   fun:mz_zip_writer_add_mem_ex
+   fun:mz_zip_writer_add_mem
+   ...
+   fun:main
+}
+
+
+{
+   <miniz-uninitialized_values>
+   Memcheck:Cond
    fun:tdefl_compress_normal
    ...
    fun:mz_zip_writer_add_mem


### PR DESCRIPTION
Turn off new GCC 7 -Wimplicit-fallthrough warning, jsoncpp.cpp is tripping over this warning.

Fix ```warn_unused_result``` error from use of strtol

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com