### PR TITLE
Patch jsoncpp for GCC 7 implicit-fallthrough warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ else()
   foreach(_cxxflag  -Werror -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align
                     -Wwrite-strings -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast
                     -Wstrict-null-sentinel -Wsign-promo -fdiagnostics-show-option
-                    -fstack-protector-all -Wimplicit-fallthrough=0)
+                    -fstack-protector-all)
     usFunctionCheckCompilerFlags(${_cxxflag} US_CXX_FLAGS)
   endforeach()
 

--- a/third_party/README
+++ b/third_party/README
@@ -29,7 +29,11 @@ MIT License or Public Domain
 
 https://github.com/open-source-parsers/jsoncpp
 (formerly http://jsoncpp.sourceforge.net)
-0.6.0-rc2
+0.10.6
+
+Patches
+
+ * Suppress -Wimplicit-fallthrough warning in GCC 7
 
 miniz
 -----

--- a/third_party/jsoncpp.cpp
+++ b/third_party/jsoncpp.cpp
@@ -1307,7 +1307,7 @@ bool OurReader::readToken(Token& token) {
     token.type_ = tokenString;
     ok = readStringSingleQuote();
     break;
-    } // else continue
+    } // else fall through
   case '/':
     token.type_ = tokenComment;
     ok = readComment();

--- a/third_party/patches/jsoncpp_0.10.6.patch
+++ b/third_party/patches/jsoncpp_0.10.6.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/jsoncpp.cpp b/third_party/jsoncpp.cpp
+index 60c7a44..d827863 100644
+--- a/third_party/jsoncpp.cpp
++++ b/third_party/jsoncpp.cpp
+@@ -1307,7 +1307,7 @@ bool OurReader::readToken(Token& token) {
+     token.type_ = tokenString;
+     ok = readStringSingleQuote();
+     break;
+-    } // else continue
++    } // else fall through
+   case '/':
+     token.type_ = tokenComment;
+     ok = readComment();


### PR DESCRIPTION
Suppress the warning in jsoncpp.cpp instead of turning it off entirely.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com