### PR TITLE
Fix failure caused by permission issues in temp dir

### DIFF
--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -139,7 +139,15 @@ void CoreBundleContext::Init()
 //  {
 //    dataStorage = GetFileStorage(this, "data");
 //  }
-  dataStorage = GetFileStorage(this, "data");
+  try
+  {
+    dataStorage = GetPersistentStoragePath(this, "data", /*create=*/ false);
+  }
+  catch (const std::exception& e)
+  {
+    DIAG_LOG(*sink) << "Ignored runtime exception with message'" << e.what() << "' from the GetPersistentStoragePath function.\n";
+  }
+
 
   systemBundle->InitSystemBundle();
   _us_set_bundle_context_instance_system_bundle(systemBundle->bundleContext.Load().get());

--- a/framework/src/util/Utils.cpp
+++ b/framework/src/util/Utils.cpp
@@ -116,7 +116,7 @@ std::string GetFrameworkDir(CoreBundleContext* ctx)
   return any_cast<std::string>(it->second);
 }
 
-std::string GetFileStorage(CoreBundleContext* ctx, const std::string& name, bool create)
+std::string GetPersistentStoragePath(CoreBundleContext* ctx, const std::string& leafDir, bool create)
 {
   // See if we have a storage directory
   const std::string fwdir(GetFrameworkDir(ctx));
@@ -124,7 +124,7 @@ std::string GetFileStorage(CoreBundleContext* ctx, const std::string& name, bool
   {
     return fwdir;
   }
-  const std::string dir = util::GetAbsolute(fwdir, ctx->workingDir) + util::DIR_SEP + name;
+  const std::string dir = util::GetAbsolute(fwdir, ctx->workingDir) + util::DIR_SEP + leafDir;
   if (!dir.empty())
   {
     if (util::Exists(dir))

--- a/framework/src/util/Utils.h
+++ b/framework/src/util/Utils.h
@@ -50,11 +50,19 @@ extern const std::string FWDIR_DEFAULT;
 std::string GetFrameworkDir(CoreBundleContext* ctx);
 
 /**
- * Check for local file storage directory.
- *
- * @return A directory path or an empty string if no storage is available.
- */
-std::string GetFileStorage(CoreBundleContext* ctx, const std::string& name, bool create = true);
+* Optionally create and get the persistent storage path.
+*
+* @param ctx Pointer to the CoreBundleContext object.
+* @param leafDir The name of the leaf directory in the persistent storage path.
+* @param create Specify if the directory needs to be created if it doesn't already exist.
+*
+* @return A directory path or an empty string if no storage is available.
+*
+* @throw std::runtime_error if the storage directory is inaccessible
+*        or if there exists a file named @c leafDir in that directory
+*        or if the directory cannot be created when @c create is @c true.
+*/
+std::string GetPersistentStoragePath(CoreBundleContext* ctx, const std::string& leafDir, bool create = true);
 
 //-------------------------------------------------------------------
 // Generic utility functions

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -220,9 +220,7 @@ TEST(FrameworkTest, FrameworkStartsWhenFileNamedDataExistsInTempDir)
     ScopedFile(std::string directory, std::string filename) :
       filePath(std::move(directory) + util::DIR_SEP + std::move(filename))
     {
-      std::fstream file(filePath, std::fstream::out);
-      file << "test";
-      file.close();
+      CreateFile();
     }
     ~ScopedFile()
     {
@@ -231,6 +229,13 @@ TEST(FrameworkTest, FrameworkStartsWhenFileNamedDataExistsInTempDir)
       std::remove(filePath.c_str());
     }
   private:
+    void CreateFile()
+    {
+      std::fstream file(filePath, std::fstream::out);
+      ASSERT_FALSE(file.fail()) << "Failbit of the file stream should not be set.";
+      file << "test";
+      file.close();
+    }
     const std::string filePath;
   };
 


### PR DESCRIPTION
Fix #266 by ignoring the exception thrown by the erstwhile
GetFileStorage (renamed to GetPersistentStoragePath)

Disable the creation of the "data" directory under the persistent
storage directory when the framework starts

Make minor refactoring changes

Signed-off-by: The Mathworks Inc <Roy.Lurie@mathworks.com>