### PR TITLE
performance: reduce the # of open file handles

### DIFF
--- a/framework/src/bundle/BundleArchive.cpp
+++ b/framework/src/bundle/BundleArchive.cpp
@@ -41,7 +41,7 @@ BundleArchive::BundleArchive()
 BundleArchive::BundleArchive(
   BundleStorage* storage,
   std::unique_ptr<Data>&& data,
-  const std::shared_ptr<const BundleResourceContainer>& resourceContainer,
+  const std::shared_ptr<BundleResourceContainer>& resourceContainer,
   const std::string& resourcePrefix,
   const std::string& location)
   : storage(storage)
@@ -135,7 +135,7 @@ void BundleArchive::SetAutostartSetting(int32_t setting)
   data->autostartSetting = setting;
 }
 
-std::shared_ptr<const BundleResourceContainer>
+std::shared_ptr<BundleResourceContainer>
 BundleArchive::GetResourceContainer() const
 {
   return resourceContainer;

--- a/framework/src/bundle/BundleArchive.h
+++ b/framework/src/bundle/BundleArchive.h
@@ -58,7 +58,7 @@ struct BundleArchive : std::enable_shared_from_this<BundleArchive>
   BundleArchive(
     BundleStorage* storage,
     std::unique_ptr<Data>&& data,
-    const std::shared_ptr<const BundleResourceContainer>& resourceContainer,
+    const std::shared_ptr<BundleResourceContainer>& resourceContainer,
     const std::string& resourcePrefix,
     const std::string& location);
 
@@ -157,12 +157,12 @@ struct BundleArchive : std::enable_shared_from_this<BundleArchive>
    */
   void SetAutostartSetting(int32_t setting);
 
-  std::shared_ptr<const BundleResourceContainer> GetResourceContainer() const;
+  std::shared_ptr<BundleResourceContainer> GetResourceContainer() const;
 
 private:
   BundleStorage* const storage;
   const std::unique_ptr<Data> data;
-  const std::shared_ptr<const BundleResourceContainer> resourceContainer;
+  const std::shared_ptr<BundleResourceContainer> resourceContainer;
   const std::string resourcePrefix;
   const std::string location;
 };

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -825,6 +825,13 @@ BundlePrivate::BundlePrivate(CoreBundleContext* coreCtx,
           " at " + location + " failed: " + util::GetLastExceptionStr());
       }
     }
+    // It is unlikely that clients will access bundle resources
+    // if the only resource is the manifest file. On this assumption,
+    // close the open file handle to the zip file to improve performance
+    // and avoid exceeding OS open file handle limits.
+    if (OnlyContainsManifest(location)) {
+      barchive->GetResourceContainer()->CloseContainer();
+    }
   }
 
   // Check if we got version information and validate the version identifier

--- a/framework/src/bundle/BundleResourceContainer.cpp
+++ b/framework/src/bundle/BundleResourceContainer.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <climits>
 #include <cstring>
+#include <exception>
 #include <sstream>
 #include <stdexcept>
 
@@ -60,7 +61,7 @@ BundleResourceContainer::~BundleResourceContainer()
 {
   try {
     CloseContainer();
-  } catch(...) {}
+  } catch(const std::exception&) {}
 }
 
 std::string BundleResourceContainer::GetLocation() const

--- a/framework/src/bundle/BundleResourceContainer.h
+++ b/framework/src/bundle/BundleResourceContainer.h
@@ -25,7 +25,6 @@
 
 #include "miniz.h"
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/framework/src/bundle/BundleStorage.h
+++ b/framework/src/bundle/BundleStorage.h
@@ -58,7 +58,7 @@ struct BundleStorage
    * @return A list of BundleArchive instances representing the installed bundles.
    */
   virtual std::vector<std::shared_ptr<BundleArchive>> InsertArchives(
-    const std::shared_ptr<const BundleResourceContainer>& resCont,
+    const std::shared_ptr<BundleResourceContainer>& resCont,
     const std::vector<std::string>& topLevelEntries) = 0;
 
   /**

--- a/framework/src/bundle/BundleStorageFile.cpp
+++ b/framework/src/bundle/BundleStorageFile.cpp
@@ -57,7 +57,7 @@ std::vector<std::shared_ptr<BundleArchive>> BundleStorageFile::InsertBundleLib(
 }
 
 std::vector<std::shared_ptr<BundleArchive>> BundleStorageFile::InsertArchives(
-  const std::shared_ptr<const BundleResourceContainer>& /*resCont*/,
+  const std::shared_ptr<BundleResourceContainer>& /*resCont*/,
   const std::vector<std::string>& /*topLevelEntries*/)
 {
   throw std::logic_error("not implemented");

--- a/framework/src/bundle/BundleStorageFile.h
+++ b/framework/src/bundle/BundleStorageFile.h
@@ -37,7 +37,7 @@ public:
     const std::string& location);
 
   std::vector<std::shared_ptr<BundleArchive>> InsertArchives(
-    const std::shared_ptr<const BundleResourceContainer>& resCont,
+    const std::shared_ptr<BundleResourceContainer>& resCont,
     const std::vector<std::string>& topLevelEntries);
 
   bool RemoveArchive(const BundleArchive* ba);

--- a/framework/src/bundle/BundleStorageMemory.cpp
+++ b/framework/src/bundle/BundleStorageMemory.cpp
@@ -41,7 +41,7 @@ BundleStorageMemory::InsertBundleLib(const std::string& location)
 }
 
 std::vector<std::shared_ptr<BundleArchive>> BundleStorageMemory::InsertArchives(
-  const std::shared_ptr<const BundleResourceContainer>& resCont,
+  const std::shared_ptr<BundleResourceContainer>& resCont,
   const std::vector<std::string>& topLevelEntries)
 {
   std::vector<std::shared_ptr<BundleArchive>> res;

--- a/framework/src/bundle/BundleStorageMemory.h
+++ b/framework/src/bundle/BundleStorageMemory.h
@@ -42,7 +42,7 @@ public:
     const std::string& location);
 
   std::vector<std::shared_ptr<BundleArchive>> InsertArchives(
-    const std::shared_ptr<const BundleResourceContainer>& resCont,
+    const std::shared_ptr<BundleResourceContainer>& resCont,
     const std::vector<std::string>& topLevelEntries);
 
   bool RemoveArchive(const BundleArchive* ba);

--- a/framework/src/util/Utils.cpp
+++ b/framework/src/util/Utils.cpp
@@ -98,6 +98,31 @@ bool IsBundleFile(const std::string& location)
   }
 }
 
+bool OnlyContainsManifest(const std::string& location)
+{
+  if (location.empty()) {
+    throw std::runtime_error("Invalid (empty) location provided.");
+  }
+
+  BundleResourceContainer resContainer(location);
+  auto topLevelDirs = resContainer.GetTopLevelDirs();
+  return std::all_of(
+      topLevelDirs.begin(),
+      topLevelDirs.end(),
+      [&resContainer](const std::string& dir) -> bool {
+        std::vector<std::string> names;
+        std::vector<uint32_t> indices;
+
+        resContainer.GetChildren(dir + "/", true, names, indices);
+        return std::all_of(names.begin(),
+                           names.end(),
+                           [](const std::string& resourceName) -> bool {
+                             return resourceName ==
+                                    std::string("manifest.json");
+                           });
+      });
+}
+
 //-------------------------------------------------------------------
 // Framework storage
 //-------------------------------------------------------------------

--- a/framework/src/util/Utils.h
+++ b/framework/src/util/Utils.h
@@ -37,6 +37,19 @@ bool IsSharedLibrary(const std::string& location);
 
 bool IsBundleFile(const std::string& location);
 
+/**
+ * Return true if the bundle's zip file only contains a 
+ * manifest file, false otherwise.
+ *
+ * @param location The bundle file path
+ *
+ * @return true if the bundle's zip file only contains a 
+ *         manifest file, false otherwise.
+ * @throw std::runtime_error if the bundle location is empty or
+ *        the bundle manifest cannot be read.
+ */
+bool OnlyContainsManifest(const std::string& location);
+
 //-------------------------------------------------------------------
 // Framework storage
 //-------------------------------------------------------------------

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_gtest_tests
   GlobalServiceTrackerTest.cpp
   LDAPExprTest.cpp
   LDAPFilterTest.cpp
+  OpenFileHandleTest.cpp
   UtilsTest.cpp
   FrameworkTest.cpp
   ServiceExceptionTest.cpp

--- a/framework/test/gtest/OpenFileHandleTest.cpp
+++ b/framework/test/gtest/OpenFileHandleTest.cpp
@@ -1,0 +1,100 @@
+/*=============================================================================
+
+Library: CppMicroServices
+
+Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+file at the top-level directory of this distribution and at
+https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=============================================================================*/
+
+#include <chrono>
+
+#include "TestUtilBundleListener.h"
+#include "TestUtils.h"
+#include "cppmicroservices/Bundle.h"
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/BundleEvent.h"
+#include "cppmicroservices/Constants.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/util/FileSystem.h"
+#include "gtest/gtest.h"
+
+#if defined(US_PLATFORM_WINDOWS)
+#include "windows.h"
+#elif defined(US_PLATFORM_POSIX)
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+using namespace cppmicroservices;
+
+static unsigned long GetHandleCountForCurrentProcess()
+{
+#if defined(US_PLATFORM_WINDOWS)
+  auto processHandle = GetCurrentProcess();
+  unsigned long handleCount{ 0 };
+  if (!GetProcessHandleCount(processHandle, &handleCount)) {
+      throw std::runtime_error("GetProcessHandleCount failed to retrieve the number of open handles.");
+  }
+  return handleCount;
+#elif defined(US_PLATFORM_POSIX)
+  auto pid_t = getpid();
+  std::string command("lsof -p " + std::to_string(pid_t) + " | wc -l");
+  FILE* fd = popen(command.c_str(), "r");
+  if (nullptr == fd) {
+      throw std::runtime_error("popen failed.");
+  }
+  std::string result;
+  char buf[PATH_MAX];
+  while (nullptr != fgets(buf, PATH_MAX, fd)) {
+      result += buf;
+  }
+  if (-1 == pclose(fd)) {
+      throw std::runtime_error("pclose failed.");
+  }
+  return stoul(result);
+#else
+  throw std::runtime_error("unsupported platform - can't get handle count for current process.")
+#endif
+}
+
+// Test that the file handle count doesn't change after installing a bundle.
+// Installing a bundle should not hold the file open.
+TEST(OpenFileHandleTest, InstallBundle)
+{
+  auto f = FrameworkFactory().NewFramework();
+  ASSERT_TRUE(f);
+  f.Start();
+
+  auto handleCountBefore = GetHandleCountForCurrentProcess();
+  
+#if defined(US_BUILD_SHARED_LIBS)
+  auto bundle =
+    cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA");
+#else
+  auto bundle =
+    cppmicroservices::testing::GetBundle("TestBundleA", f.GetBundleContext());
+#endif
+
+  auto handleCountAfter = GetHandleCountForCurrentProcess();
+  ASSERT_EQ(handleCountBefore, handleCountAfter) << "The handle counts before and after installing a bundle should not differ.";
+
+  f.Stop();
+  f.WaitForStop(std::chrono::seconds::zero());
+}

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -203,7 +203,7 @@ void validateManifestInArchive(mz_zip_archive* zipArchive,
 /* 
  * @brief Validate manifest files in an archive.
  * @param archiveFile archive file path
- * @throw std::InvalidManifest on the first invalid manifest found.
+ * @throw InvalidManifest on the first invalid manifest found.
  * @throw runtime_error on the first manifest file which could not be read from the archive.
  */
 void validateManifestsInArchive(const std::string& archiveFile)


### PR DESCRIPTION
Installing thousands of bundles within a process can cause undefined behavior if the OS open file limit has been reached. In our use case, we reached this open file limit on Windows.

In order to resolve the issue on Windows and to allow thousands of bundles to be installed into an applications, this solution will close the file handle for the bundle if it only contains a manifest file. The idea is that with only a manifest.json file, clients are unlikely to use another CppMicroServices resource API to read meta-data from the .zip file. If the resource API is used after the bundle is installed, the file will remain open until the bundle is uninstalled.

There are most likely more improvements that can be made to manage the # of file handles CppMicroServices keeps open and this is a small step towards getting to that state.
