### PR TITLE
Remove unnecessary object copying

### DIFF
--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -216,7 +216,7 @@ public:
    *
    * @param other The Any to move
    */
-  Any(Any&& other)
+  Any(Any&& other) noexcept
     : _content(std::move(other._content))
   {}
 

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -247,6 +247,27 @@ public:
   mapped_type& operator[](key_type&& key);
 
   std::pair<iterator, bool> insert(const value_type& value);
+
+  template< class... Args >
+  std::pair<iterator, bool> emplace(Args&&... args)
+  {
+    switch (type) {
+      case map_type::ORDERED_MAP: {
+        return o_m().emplace(std::forward<Args>(args)...);
+      }
+      case map_type::UNORDERED_MAP: {
+        auto p = uo_m().emplace(std::forward<Args>(args)...);
+        return { iterator(std::move(p.first), iterator::UNORDERED), p.second };
+      }
+      case map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS: {
+        auto p = uoci_m().emplace(std::forward<Args>(args)...);
+        return { iterator(std::move(p.first), iterator::UNORDERED_CI), p.second };
+      }
+      default:
+        throw std::logic_error("invalid map type");
+    }
+  }
+  
   const_iterator find(const key_type& key) const;
 
 protected:

--- a/framework/src/bundle/BundleManifest.cpp
+++ b/framework/src/bundle/BundleManifest.cpp
@@ -82,7 +82,7 @@ void ParseJsonObject(const Json::Value& jsonObject, AnyOrderedMap& anyMap)
     const Json::Value& jsonValue = *it;
     Any anyValue = ParseJsonValue(jsonValue, false);
     if (!anyValue.Empty()) {
-      anyMap.insert(std::make_pair(it.name(), anyValue));
+      anyMap.emplace(it.name(), std::move(anyValue));
     }
   }
 }
@@ -95,7 +95,7 @@ void ParseJsonObject(const Json::Value& jsonObject, AnyMap& anyMap)
     const Json::Value& jsonValue = *it;
     Any anyValue = ParseJsonValue(jsonValue, true);
     if (!anyValue.Empty()) {
-      anyMap.insert(std::make_pair(it.name(), anyValue));
+      anyMap.emplace(it.name(), std::move(anyValue));
     }
   }
 }
@@ -105,7 +105,7 @@ void ParseJsonArray(const Json::Value& jsonArray, AnyVector& anyVector, bool ci)
   for (const auto & jsonValue : jsonArray) {
     Any anyValue = ParseJsonValue(jsonValue, ci);
     if (!anyValue.Empty()) {
-      anyVector.push_back(anyValue);
+      anyVector.emplace_back(std::move(anyValue));
     }
   }
 }


### PR DESCRIPTION
Reduce the number of objects copied while parsing the ```manifest.json``` data.

This reduces the heap memory used in an application installing many bundles with non-trivial ```manifest.json``` data.