### PR TITLE
Improve performance of bundleobj on macOS

### DIFF
--- a/framework/test/gtest/BundleObjFileTest.cpp
+++ b/framework/test/gtest/BundleObjFileTest.cpp
@@ -25,6 +25,8 @@
 
 #include "cppmicroservices/util/FileSystem.h"
 
+#include "cppmicroservices/util/MappedFile.h"
+
 #include "TestUtils.h"
 #include "TestingConfig.h"
 
@@ -76,3 +78,28 @@ TEST(BundleObjFile, GetRawBundleResourceContainer)
 #endif
 }
 
+#if defined (US_BUILD_SHARED_LIBS)
+#if defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
+TEST(BundleObjFile, MappedFile)
+{
+  int fileDesc = open(testBundlePath.c_str(), O_RDONLY);
+  struct stat sb;
+  fstat(fileDesc, &sb);
+  off_t offset{0};
+  off_t pa_offset = offset & ~(sysconf(_SC_PAGE_SIZE) - 1);
+  /* offset for mmap() must be page aligned */
+  size_t length = sb.st_size - offset;
+  close(fileDesc);
+
+  cppmicroservices::MappedFile mappedBundleFile(testBundlePath, length, pa_offset);
+  ASSERT_TRUE(mappedBundleFile.GetData());
+  ASSERT_GT(mappedBundleFile.GetSize(), 0u);
+
+  ASSERT_NO_THROW({
+      cppmicroservices::MappedFile mappedBundleFile("/does/not/exist/bogus.bundle", 0, 0);
+      ASSERT_EQ(mappedBundleFile.GetData(), nullptr);
+      ASSERT_EQ(mappedBundleFile.GetSize(), 0u);
+  });
+}
+#endif // defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
+#endif // defined (US_BUILD_SHARED_LIBS)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(util OBJECT
   include/cppmicroservices/util/BundleObjFactory.h
   include/cppmicroservices/util/BundleObjFile.h
   include/cppmicroservices/util/BundlePEFile.h
+  include/cppmicroservices/util/DataContainer.h
   include/cppmicroservices/util/Error.h
   include/cppmicroservices/util/FileSystem.h
   include/cppmicroservices/util/MappedFile.h

--- a/util/include/cppmicroservices/util/BundleElfFile.h
+++ b/util/include/cppmicroservices/util/BundleElfFile.h
@@ -104,7 +104,6 @@ public:
 
   BundleElfFile(std::ifstream& fs, std::size_t fileSize, const std::string& fileName)
     : m_rawData()
-    , m_mappedZipData()
   {
     if (fileSize < sizeof(Ehdr)) {
       throw InvalidElfException("Missing ELF header");
@@ -147,8 +146,7 @@ public:
           if (0 < zipContentSize) {
             off_t pa_offset = (sectionHeaders[i].sh_offset) & ~(sysconf(_SC_PAGESIZE) - 1);
             size_t mappedLength = zipContentSize + (sectionHeaders[i].sh_offset) - pa_offset;
-            m_mappedZipData = std::make_unique<MappedFile>(fileName, mappedLength, pa_offset);
-            m_rawData = std::make_shared<RawBundleResources>(m_mappedZipData->GetMappedAddress(), m_mappedZipData->GetSize());
+            m_rawData = std::make_shared<RawBundleResources>(std::make_unique<MappedFile>(fileName, mappedLength, pa_offset));
             break;
           }
         }
@@ -160,7 +158,6 @@ public:
 
 private:
   std::shared_ptr<RawBundleResources> m_rawData;
-  std::unique_ptr<MappedFile> m_mappedZipData;
 };
 
 std::unique_ptr<BundleObjFile> CreateBundleElfFile(const std::string& fileName)

--- a/util/include/cppmicroservices/util/BundlePEFile.h
+++ b/util/include/cppmicroservices/util/BundlePEFile.h
@@ -23,6 +23,7 @@
 #if defined (US_PLATFORM_WINDOWS)
 
 #include "BundleObjFile.h"
+#include "DataContainer.h"
 #include "Error.h"
 #include "cppmicroservices_pe.h"
 
@@ -50,6 +51,32 @@ struct hModuleDeleter
   }
 };
 
+// A DataContainer which scopes the lifetimes of the
+// Windows DLL and the data within it together.
+class ResDataContainer : public DataContainer
+{
+public:
+  ResDataContainer(std::unique_ptr<HMODULE, hModuleDeleter> moduleHandle,
+                   LPVOID data,
+                   DWORD dataSize)
+    : m_ModuleHandle(std::move(moduleHandle))
+    , m_Data(data)
+    , m_DataSize(dataSize)
+  {}
+  ~ResDataContainer() = default;
+
+  ResDataContainer(const ResDataContainer&) = delete;
+  ResDataContainer& operator=(const ResDataContainer&) = delete;
+
+  void* GetData() const override { return m_Data; }
+  std::size_t GetSize() const override { return m_DataSize; }
+
+private:
+  std::unique_ptr<HMODULE, hModuleDeleter> m_ModuleHandle;
+  LPVOID m_Data;
+  DWORD m_DataSize;
+};
+
 struct InvalidPEException : public InvalidObjFileException
 {
   InvalidPEException(std::string what, int errorNumber = 0)
@@ -61,19 +88,18 @@ class BundlePEFile : public BundleObjFile
 {
 public:
   BundlePEFile(std::string location)
-    : m_LoadLibraryHandle(nullptr)
-    , m_rawData(nullptr)
+    : m_rawData(nullptr)
   {
     HMODULE hBundleResources = LoadLibraryEx(location.c_str(), nullptr, LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
     if (hBundleResources) {
       // RAII - automatically free the library handle on object destruction
-      m_LoadLibraryHandle = std::unique_ptr<HMODULE, hModuleDeleter>(hBundleResources, hModuleDeleter{});
+      auto loadLibraryHandle = std::unique_ptr<HMODULE, hModuleDeleter>(hBundleResources, hModuleDeleter{});
       HRSRC hResource = FindResource(hBundleResources, "US_RESOURCES", MAKEINTRESOURCE(300));
       HGLOBAL hRes = LoadResource(hBundleResources, hResource);
       const LPVOID res = LockResource(hRes);
       const DWORD zipSizeInBytes = SizeofResource(hBundleResources, hResource);
       if (0 < zipSizeInBytes) {
-        m_rawData = std::make_shared<RawBundleResources>(res, zipSizeInBytes);
+        m_rawData = std::make_shared<RawBundleResources>(std::make_unique<ResDataContainer>(std::move(loadLibraryHandle), res, zipSizeInBytes));
       }
     }
     else {
@@ -88,7 +114,6 @@ public:
   }
 
 private:
-  std::unique_ptr<HMODULE, hModuleDeleter> m_LoadLibraryHandle;
   std::shared_ptr<RawBundleResources> m_rawData;
 };
 

--- a/util/include/cppmicroservices/util/BundlePEFile.h
+++ b/util/include/cppmicroservices/util/BundlePEFile.h
@@ -53,7 +53,7 @@ struct hModuleDeleter
 
 // A DataContainer which scopes the lifetimes of the
 // Windows DLL and the data within it together.
-class ResDataContainer : public DataContainer
+class ResDataContainer final : public DataContainer
 {
 public:
   ResDataContainer(std::unique_ptr<HMODULE, hModuleDeleter> moduleHandle,
@@ -64,9 +64,6 @@ public:
     , m_DataSize(dataSize)
   {}
   ~ResDataContainer() = default;
-
-  ResDataContainer(const ResDataContainer&) = delete;
-  ResDataContainer& operator=(const ResDataContainer&) = delete;
 
   void* GetData() const override { return m_Data; }
   std::size_t GetSize() const override { return m_DataSize; }

--- a/util/include/cppmicroservices/util/DataContainer.h
+++ b/util/include/cppmicroservices/util/DataContainer.h
@@ -38,11 +38,15 @@ class DataContainer
 {
 public:
   virtual ~DataContainer() = default;
+  DataContainer(DataContainer&&) = default;
+  DataContainer& operator=(DataContainer&&) = default;
   virtual void* GetData() const = 0;
   virtual std::size_t GetSize() const = 0;
+protected:
+  DataContainer() = default;
 };
 
-class RawDataContainer : public DataContainer
+class RawDataContainer final : public DataContainer
 {
 public:
   RawDataContainer(std::unique_ptr<void, void(*)(void*)> data, std::size_t dataSize)
@@ -50,9 +54,6 @@ public:
     , m_DataSize(dataSize)
     { }
   ~RawDataContainer() = default;
-  
-  RawDataContainer(const RawDataContainer&) = delete;
-  RawDataContainer& operator=(const RawDataContainer&) = delete;
     
   void* GetData() const override { return m_Data.get(); }
   std::size_t GetSize() const override { return m_DataSize; }

--- a/util/include/cppmicroservices/util/DataContainer.h
+++ b/util/include/cppmicroservices/util/DataContainer.h
@@ -20,12 +20,10 @@
 
 =============================================================================*/
 
-#ifndef CPPMICROSERVICES_BUNDLEOBJFILE_H
-#define CPPMICROSERVICES_BUNDLEOBJFILE_H
+#ifndef CPPMICROSERVICES_DATACONTAINER_H
+#define CPPMICROSERVICES_DATACONTAINER_H
 
 #include "cppmicroservices/GlobalConfig.h"
-
-#include "DataContainer.h"
 
 #include <cstring>
 #include <memory>
@@ -34,47 +32,36 @@
 
 namespace cppmicroservices {
 
-struct InvalidObjFileException : public std::exception
-{
-  ~InvalidObjFileException() throw() {}
-  InvalidObjFileException(std::string  what, int errorNumber = 0);
-
-  virtual const char* what() const throw();
-private:
-  std::string m_What;
-};
-
-// Represents the raw bundle resource data.
-// The data buffer contains the bits representing a zip file.
-// The data size is the zip file's size in bytes.
-class RawBundleResources
+// A generic abstract base class to store
+// and retrieve raw data bytes
+class DataContainer
 {
 public:
-  RawBundleResources(std::unique_ptr<DataContainer> data)
+  virtual ~DataContainer() = default;
+  virtual void* GetData() const = 0;
+  virtual std::size_t GetSize() const = 0;
+};
+
+class RawDataContainer : public DataContainer
+{
+public:
+  RawDataContainer(std::unique_ptr<void, void(*)(void*)> data, std::size_t dataSize)
     : m_Data(std::move(data))
-  { }
-
-  operator bool() const
-  {
-    return m_Data && m_Data->GetData() && (m_Data->GetSize() > 0);
-  }
-
-  void* GetData() const { return m_Data->GetData(); }
-  std::size_t GetSize() const { return m_Data->GetSize(); }
+    , m_DataSize(dataSize)
+    { }
+  ~RawDataContainer() = default;
+  
+  RawDataContainer(const RawDataContainer&) = delete;
+  RawDataContainer& operator=(const RawDataContainer&) = delete;
     
+  void* GetData() const override { return m_Data.get(); }
+  std::size_t GetSize() const override { return m_DataSize; }
+  
 private:
-  std::unique_ptr<DataContainer> m_Data;
+  std::unique_ptr<void, void(*)(void*)> m_Data;
+  std::size_t m_DataSize;
 };
 
-class BundleObjFile
-{
-public:
-
-  virtual ~BundleObjFile() {}
-
-  /// Return the raw bundle resource container bits.
-  virtual std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer() const = 0;
-};
 
 }
 

--- a/util/include/cppmicroservices/util/MappedFile.h
+++ b/util/include/cppmicroservices/util/MappedFile.h
@@ -25,6 +25,8 @@
 #ifndef CPPMICROSERVICES_MAPPEDFILE_H
 #define CPPMICROSERVICES_MAPPEDFILE_H
 
+#include "DataContainer.h"
+
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -32,7 +34,7 @@
 
 namespace cppmicroservices {
 
-class MappedFile
+class MappedFile : public DataContainer
 {
 public:
   MappedFile()
@@ -66,9 +68,10 @@ public:
 
   MappedFile(const MappedFile&) = delete;
   MappedFile& operator=(const MappedFile&) = delete;
-    
-  size_t GetSize() const { return mapSize; }
-  void* GetMappedAddress() const { return mappedAddress; }
+  
+  void* GetData() const override { return mappedAddress; }
+  std::size_t GetSize() const override { return mapSize; }
+
 private:
   int fileDesc;
   void* mappedAddress;

--- a/util/include/cppmicroservices/util/MappedFile.h
+++ b/util/include/cppmicroservices/util/MappedFile.h
@@ -34,7 +34,7 @@
 
 namespace cppmicroservices {
 
-class MappedFile : public DataContainer
+class MappedFile final : public DataContainer
 {
 public:
   MappedFile()
@@ -65,9 +65,6 @@ public:
       close(fileDesc);
     }
   }
-
-  MappedFile(const MappedFile&) = delete;
-  MappedFile& operator=(const MappedFile&) = delete;
   
   void* GetData() const override { return mappedAddress; }
   std::size_t GetSize() const override { return mapSize; }


### PR DESCRIPTION
It was observed that using ```mmap``` was slower on macOS than on Linux. Some research was done to find out why ```mmap``` is slower. After measuring the time it took to read a file with ```mmap``` versus ```std::ifstream::read``` it was found that on macOS, mmap only becomes faster than ```std::ifstream::read``` if the file is larger than about 10mb.

This code change attempts to be smart about when to use mmap on macOS.


snippets of the google benchmark code used to measure the time:

```
void MemoryMapFile(benchmark::State& state, const std::string& filePath) {
        for (auto _ : state)
        {
            MappedFile memorymappedfile(filePath);
        }
    }

    void FReadFile(benchmark::State& state, const std::string& filePath) {
        for (auto _ : state)
        {
            std::ifstream bundleStream(filePath.c_str(), std::ios_base::binary);
            bundleStream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
            bundleStream.seekg(0, std::ios_base::end);
            auto fileSize = bundleStream.tellg();
            bundleStream.seekg(0);
            auto data = malloc(fileSize * sizeof(char));
            bundleStream.read(reinterpret_cast<char*>(data), fileSize);
            std::unique_ptr<void, void(*)(void*)> scopedData(data, ::free);
            bundleStream.close();
        }
    }

    void IsolateMemoryMap(benchmark::State& state, const std::string& filePath) {
        for (auto _ : state)
        {
            int fileDesc = open(filePath.c_str(), O_RDONLY);
            
            struct stat sb;
            fstat(fileDesc, &sb);

            off_t offset{0};
            off_t pa_offset = offset & ~(sysconf(_SC_PAGE_SIZE) - 1);
            /* offset for mmap() must be page aligned */
            size_t length = sb.st_size - offset;

            auto start = std::chrono::high_resolution_clock::now();
            
            void* mappedAddress = nullptr;
            if(fileDesc >= 0) {
              mappedAddress = mmap(0, length, PROT_READ, MAP_PRIVATE, fileDesc, offset);
              if (MAP_FAILED == mappedAddress) {
                state.SkipWithError("Failed to map file!");
              }
            }

            if(mappedAddress && length) {
              munmap(mappedAddress, length);
            }
            auto end = std::chrono::high_resolution_clock::now();
            auto elapsed_seconds =
              std::chrono::duration_cast<std::chrono::duration<double>>(
                end - start);

            state.SetIterationTime(elapsed_seconds.count());

            if(0 <= fileDesc) {
              close(fileDesc);
            }
        }
    }

    void IsolateRead(benchmark::State& state, const std::string& filePath) {
        for (auto _ : state)
        {
            std::ifstream bundleStream(filePath.c_str(), std::ios_base::binary);
            bundleStream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
            bundleStream.seekg(0, std::ios_base::end);
            auto fileSize = bundleStream.tellg();
            bundleStream.seekg(0);
            auto data = malloc(fileSize * sizeof(char));

            auto start = std::chrono::high_resolution_clock::now();

            bundleStream.read(reinterpret_cast<char*>(data), fileSize);

            auto end = std::chrono::high_resolution_clock::now();
            auto elapsed_seconds =
              std::chrono::duration_cast<std::chrono::duration<double>>(
                end - start);

            state.SetIterationTime(elapsed_seconds.count());

            std::unique_ptr<void, void(*)(void*)> scopedData(data, ::free);
            bundleStream.close();
        }
    }
```

the timing results from google benchmark:

Run on (8 X 2300 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
-------------------------------------------------------------------------------------
Benchmark                                              Time           CPU Iterations
-------------------------------------------------------------------------------------
FileIOFixture/FReadFile/0                         408016 ns      79828 ns       8644
FileIOFixture/FReadFile/1                         418365 ns      81823 ns       8571
FileIOFixture/FReadFile/2                         423681 ns      88277 ns       7929
FileIOFixture/FReadFile/3                         434320 ns      95990 ns       6588
FileIOFixture/FReadFile/4                         491474 ns     166589 ns       4540
FileIOFixture/FReadFile/5                         524465 ns     198553 ns       3132
FileIOFixture/FReadFile/6                         405936 ns      79423 ns       8596
FileIOFixture/FReadFile/7                         435413 ns     118961 ns       6073
FileIOFixture/FReadFile/8                         548582 ns     218082 ns       3103
FileIOFixture/FReadFile/9                         647160 ns     322221 ns       2011
FileIOFixture/FReadFile/10                       6696334 ns    6296017 ns        118
FileIOFixture/FReadFile/11                      30354164 ns   29934833 ns         24
FileIOFixture/FReadFile/12                      64359132 ns   63641083 ns         12
FileIOFixture/FReadFile/13                    6002772074 ns 1171125000 ns          1
FileIOFixture/FReadFile/14                    8944470608 ns 1673996000 ns          1
FileIOFixture/FReadFile/15                    12150668117 ns 2299456000 ns          1
FileIOFixture/FReadFile/16                    48674792321 ns 9236919000 ns          1
FileIOFixture/MemoryMapFile/0                     951124 ns     111327 ns       6320
FileIOFixture/MemoryMapFile/1                     941801 ns     111282 ns       6226
FileIOFixture/MemoryMapFile/2                     950863 ns     112533 ns       6208
FileIOFixture/MemoryMapFile/3                     974491 ns     111641 ns       6207
FileIOFixture/MemoryMapFile/4                     966651 ns     111996 ns       6275
FileIOFixture/MemoryMapFile/5                     871866 ns     112690 ns       6168
FileIOFixture/MemoryMapFile/6                     812214 ns     108258 ns       6333
FileIOFixture/MemoryMapFile/7                     844462 ns     109448 ns       6429
FileIOFixture/MemoryMapFile/8                     824895 ns     109679 ns       6479
FileIOFixture/MemoryMapFile/9                     810887 ns     108078 ns       6411
FileIOFixture/MemoryMapFile/10                    841485 ns     111062 ns       6200
FileIOFixture/MemoryMapFile/11                    830902 ns     129080 ns       5476
FileIOFixture/MemoryMapFile/12                    877875 ns     149427 ns       4719
FileIOFixture/MemoryMapFile/13                   1009767 ns     304669 ns       2302
FileIOFixture/MemoryMapFile/14                   1150945 ns     410274 ns       1749
FileIOFixture/MemoryMapFile/15                   1377125 ns     531830 ns       1292
FileIOFixture/MemoryMapFile/16                 205021749 ns  204105333 ns          3
FileIOFixture/IsolateMemoryMap/0/manual_time      469785 ns     103843 ns       1487
FileIOFixture/IsolateMemoryMap/1/manual_time      551109 ns     110597 ns       1000
FileIOFixture/IsolateMemoryMap/2/manual_time      454282 ns      91566 ns       1457
FileIOFixture/IsolateMemoryMap/3/manual_time      457621 ns     101853 ns       1699
FileIOFixture/IsolateMemoryMap/4/manual_time      861070 ns     103408 ns       1000
FileIOFixture/IsolateMemoryMap/5/manual_time      490613 ns      97945 ns       1482
FileIOFixture/IsolateMemoryMap/6/manual_time      508297 ns      95259 ns       1338
FileIOFixture/IsolateMemoryMap/7/manual_time      499201 ns      89814 ns       1369
FileIOFixture/IsolateMemoryMap/8/manual_time      508284 ns      92088 ns       1403
FileIOFixture/IsolateMemoryMap/9/manual_time      495657 ns      98841 ns       1413
FileIOFixture/IsolateMemoryMap/10/manual_time     491669 ns      90454 ns       1391
FileIOFixture/IsolateMemoryMap/11/manual_time     513975 ns     114287 ns       1382
FileIOFixture/IsolateMemoryMap/12/manual_time     564176 ns     150363 ns       1285
FileIOFixture/IsolateMemoryMap/13/manual_time     729606 ns     321209 ns        892
FileIOFixture/IsolateMemoryMap/14/manual_time     846895 ns     398970 ns        867
FileIOFixture/IsolateMemoryMap/15/manual_time     883909 ns     560902 ns        738
FileIOFixture/IsolateMemoryMap/16/manual_time    2259048 ns    1949187 ns        305
FileIOFixture/IsolateRead/0/manual_time             2681 ns      80753 ns     243569
FileIOFixture/IsolateRead/1/manual_time             3214 ns      82370 ns     214478
FileIOFixture/IsolateRead/2/manual_time             5290 ns      89000 ns     131523
FileIOFixture/IsolateRead/3/manual_time             7818 ns      95668 ns      88742
FileIOFixture/IsolateRead/4/manual_time            60981 ns     154341 ns      11422
FileIOFixture/IsolateRead/5/manual_time            90540 ns     184274 ns       7740
FileIOFixture/IsolateRead/6/manual_time             2658 ns      81450 ns     262398
FileIOFixture/IsolateRead/7/manual_time            27011 ns     114374 ns      25942
FileIOFixture/IsolateRead/8/manual_time           120337 ns     211952 ns       5785
FileIOFixture/IsolateRead/9/manual_time           246100 ns     322912 ns       2845
FileIOFixture/IsolateRead/10/manual_time         4541022 ns    6307255 ns        157
FileIOFixture/IsolateRead/11/manual_time       583601640 ns  109475000 ns          1
FileIOFixture/IsolateRead/12/manual_time      1174147212 ns  215710000 ns          1
FileIOFixture/IsolateRead/13/manual_time      5937747736 ns 1139932000 ns          1
FileIOFixture/IsolateRead/14/manual_time      9086865995 ns 1697740000 ns          1
FileIOFixture/IsolateRead/15/manual_time      12194451349 ns 2336007000 ns          1
FileIOFixture/IsolateRead/16/manual_time      48621447825 ns 9323229000 ns          1