### PR TITLE
Improve ServiceTracker performance

### DIFF
--- a/framework/include/cppmicroservices/ServiceListenerHook.h
+++ b/framework/include/cppmicroservices/ServiceListenerHook.h
@@ -139,7 +139,7 @@ struct US_Framework_EXPORT ServiceListenerHook
 
     ListenerInfo(ListenerInfoData* data);
 
-    ExplicitlySharedDataPointer<ListenerInfoData> d;
+    std::shared_ptr<ListenerInfoData> d;
   };
 
   virtual ~ServiceListenerHook();
@@ -181,7 +181,7 @@ struct US_Framework_EXPORT ServiceListenerHook
 
 US_HASH_FUNCTION_BEGIN(cppmicroservices::ServiceListenerHook::ListenerInfo)
 return hash<const cppmicroservices::ServiceListenerHook::ListenerInfoData*>()(
-  arg.d.Data());
+  arg.d.get());
 US_HASH_FUNCTION_END
 
 #endif // CPPMICROSERVICES_SERVICELISTENERHOOK_H

--- a/framework/include/cppmicroservices/ServiceReference.h
+++ b/framework/include/cppmicroservices/ServiceReference.h
@@ -96,6 +96,10 @@ public:
   }
 
   using ServiceReferenceBase::operator=;
+
+  using ServiceReferenceBase::operator==;
+
+  using ServiceReferenceBase::Hash;
 };
 
 /**
@@ -125,6 +129,10 @@ public:
 
   using ServiceReferenceBase::operator=;
 
+  using ServiceReferenceBase::operator==;
+
+  using ServiceReferenceBase::Hash;
+
   using ServiceType = void;
 };
 /// \endcond
@@ -137,6 +145,17 @@ public:
  * interface identifier.
  */
 using ServiceReferenceU = ServiceReference<void>;
+}
+
+namespace std {
+template<class S>
+struct hash<cppmicroservices::ServiceReference<S>>
+{
+  std::size_t operator()(const cppmicroservices::ServiceReference<S>& arg) const
+  {
+    return arg.Hash();
+  }
+};
 }
 
 #endif // CPPMICROSERVICES_SERVICEREFERENCE_H

--- a/framework/include/cppmicroservices/ServiceTracker.h
+++ b/framework/include/cppmicroservices/ServiceTracker.h
@@ -94,10 +94,10 @@ class ServiceTracker : protected ServiceTrackerCustomizer<S, T>
 {
 public:
   /// The type of the tracked object
-  using TrackedParmType =
-    typename ServiceTrackerCustomizer<S, T>::TrackedParmType;
+  using TrackedParamType =
+    typename ServiceTrackerCustomizer<S, T>::TrackedParamType;
 
-  using TrackingMap = std::map<ServiceReference<S>, std::shared_ptr<TrackedParmType>>;
+  using TrackingMap = std::unordered_map<ServiceReference<S>, std::shared_ptr<TrackedParamType>>;
 
   /**
    * Automatically closes the <code>ServiceTracker</code>
@@ -245,7 +245,7 @@ public:
    *
    * @return The result of GetService().
    */
-  std::shared_ptr<TrackedParmType> WaitForService();
+  std::shared_ptr<TrackedParamType> WaitForService();
 
   /**
    * Wait for at least one service to be tracked by this
@@ -268,7 +268,7 @@ public:
    * @return The result of GetService().
    */
   template<class Rep, class Period>
-  std::shared_ptr<TrackedParmType> WaitForService(
+  std::shared_ptr<TrackedParamType> WaitForService(
     const std::chrono::duration<Rep, Period>& rel_time);
 
   /**
@@ -310,7 +310,7 @@ public:
    *         by the specified <code>ServiceReference</code> is not being
    *         tracked.
    */
-  virtual std::shared_ptr<TrackedParmType> GetService(
+  virtual std::shared_ptr<TrackedParamType> GetService(
     const ServiceReference<S>& reference) const;
 
   /**
@@ -326,7 +326,7 @@ public:
    * @return A list of service objects or an empty list if no services
    *         are being tracked.
    */
-  virtual std::vector<std::shared_ptr<TrackedParmType>> GetServices() const;
+  virtual std::vector<std::shared_ptr<TrackedParamType>> GetServices() const;
 
   /**
    * Returns a service object for one of the services being tracked by this
@@ -339,7 +339,7 @@ public:
    * @return A service object or <code>null</code> if no services are being
    *         tracked.
    */
-  virtual std::shared_ptr<TrackedParmType> GetService() const;
+  virtual std::shared_ptr<TrackedParamType> GetService() const;
 
   /**
    * Remove a service from this <code>ServiceTracker</code>.
@@ -433,7 +433,7 @@ protected:
    *         <code>ServiceReference</code> is invalid (default constructed).
    * @see ServiceTrackerCustomizer::AddingService(const ServiceReference&)
    */
-  std::shared_ptr<TrackedParmType> AddingService(
+  std::shared_ptr<TrackedParamType> AddingService(
     const ServiceReference<S>& reference) override;
 
   /**
@@ -452,7 +452,7 @@ protected:
    * @see ServiceTrackerCustomizer::ModifiedService(const ServiceReference&, TrackedArgType)
    */
   void ModifiedService(const ServiceReference<S>& reference,
-                       const std::shared_ptr<TrackedParmType>& service) override;
+                       const std::shared_ptr<TrackedParamType>& service) override;
 
   /**
    * Default implementation of the
@@ -471,7 +471,7 @@ protected:
    * @see ServiceTrackerCustomizer::RemovedService(const ServiceReferenceType&, TrackedArgType)
    */
   void RemovedService(const ServiceReference<S>& reference,
-                      const std::shared_ptr<TrackedParmType>& service) override;
+                      const std::shared_ptr<TrackedParamType>& service) override;
 
 private:
   using TypeTraits = typename ServiceTrackerCustomizer<S, T>::TypeTraits;

--- a/framework/include/cppmicroservices/ServiceTrackerCustomizer.h
+++ b/framework/include/cppmicroservices/ServiceTrackerCustomizer.h
@@ -66,7 +66,7 @@ struct ServiceTrackerCustomizer
   {
     using ServiceType = S;
     using TrackedType = T;
-    using TrackedParmType = T;
+    using TrackedParamType = T;
 
     static std::shared_ptr<TrackedType> ConvertToTrackedType(
       const std::shared_ptr<S>&)
@@ -76,7 +76,7 @@ struct ServiceTrackerCustomizer
     }
   };
 
-  using TrackedParmType = typename TypeTraits::TrackedParmType;
+  using TrackedParamType = typename TypeTraits::TrackedParamType;
 
   virtual ~ServiceTrackerCustomizer() = default;
 
@@ -98,7 +98,7 @@ struct ServiceTrackerCustomizer
    *         service or <code>0</code> if the specified referenced service
    *         should not be tracked.
    */
-  virtual std::shared_ptr<TrackedParmType> AddingService(
+  virtual std::shared_ptr<TrackedParamType> AddingService(
     const ServiceReference<S>& reference) = 0;
 
   /**
@@ -113,7 +113,7 @@ struct ServiceTrackerCustomizer
    */
   virtual void ModifiedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
 
   /**
    * A service tracked by the <code>ServiceTracker</code> has been removed.
@@ -127,7 +127,7 @@ struct ServiceTrackerCustomizer
    */
   virtual void RemovedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
 };
 
 template<class S>
@@ -138,7 +138,7 @@ struct ServiceTrackerCustomizer<S, S>
   {
     using ServiceType = S;
     using TrackedType = S;
-    using TrackedParmType = S;
+    using TrackedParamType = S;
 
     static std::shared_ptr<S> ConvertToTrackedType(const std::shared_ptr<S>& t)
     {
@@ -146,18 +146,18 @@ struct ServiceTrackerCustomizer<S, S>
     }
   };
 
-  using TrackedParmType = typename TypeTraits::TrackedParmType;
+  using TrackedParamType = typename TypeTraits::TrackedParamType;
 
   virtual ~ServiceTrackerCustomizer() = default;
 
-  virtual std::shared_ptr<TrackedParmType> AddingService(
+  virtual std::shared_ptr<TrackedParamType> AddingService(
     const ServiceReference<S>& reference) = 0;
   virtual void ModifiedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
   virtual void RemovedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
 };
 
 template<class T>
@@ -168,7 +168,7 @@ struct ServiceTrackerCustomizer<void, T>
   {
     using ServiceType = void;
     using TrackedType = T;
-    using TrackedParmType = T;
+    using TrackedParamType = T;
 
     static std::shared_ptr<T> ConvertToTrackedType(const InterfaceMapConstPtr&)
     {
@@ -178,17 +178,17 @@ struct ServiceTrackerCustomizer<void, T>
   };
 
   using S = void;
-  using TrackedParmType = typename TypeTraits::TrackedParmType;
+  using TrackedParamType = typename TypeTraits::TrackedParamType;
 
   virtual ~ServiceTrackerCustomizer() = default;
-  virtual std::shared_ptr<TrackedParmType> AddingService(
+  virtual std::shared_ptr<TrackedParamType> AddingService(
     const ServiceReference<S>& reference) = 0;
   virtual void ModifiedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
   virtual void RemovedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
 };
 
 template<>
@@ -199,10 +199,10 @@ struct ServiceTrackerCustomizer<void, void>
   {
     using ServiceType = void;
     using TrackedType = void;
-    using TrackedParmType = const InterfaceMap;
+    using TrackedParamType = const InterfaceMap;
 
-    static std::shared_ptr<TrackedParmType> ConvertToTrackedType(
-      const std::shared_ptr<TrackedParmType>& t)
+    static std::shared_ptr<TrackedParamType> ConvertToTrackedType(
+      const std::shared_ptr<TrackedParamType>& t)
     {
       return t;
     }
@@ -210,17 +210,17 @@ struct ServiceTrackerCustomizer<void, void>
 
   using S = void;
   using T = void;
-  using TrackedParmType = TypeTraits::TrackedParmType;
+  using TrackedParamType = TypeTraits::TrackedParamType;
 
   virtual ~ServiceTrackerCustomizer() = default;
-  virtual std::shared_ptr<TrackedParmType> AddingService(
+  virtual std::shared_ptr<TrackedParamType> AddingService(
     const ServiceReference<S>& reference) = 0;
   virtual void ModifiedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
   virtual void RemovedService(
     const ServiceReference<S>& reference,
-    const std::shared_ptr<TrackedParmType>& service) = 0;
+    const std::shared_ptr<TrackedParamType>& service) = 0;
 };
 }
 

--- a/framework/include/cppmicroservices/detail/BundleAbstractTracked.h
+++ b/framework/include/cppmicroservices/detail/BundleAbstractTracked.h
@@ -57,9 +57,9 @@ class BundleAbstractTracked
 
 public:
   using T = typename TTT::TrackedType;
-  using TrackedParmType = typename TTT::TrackedParmType;
+  using TrackedParamType = typename TTT::TrackedParamType;
 
-  using TrackingMap = std::map<S, std::shared_ptr<TrackedParmType>>;
+  using TrackingMap = std::unordered_map<S, std::shared_ptr<TrackedParamType>>;
 
   /**
    * BundleAbstractTracked constructor.
@@ -138,7 +138,7 @@ public:
    *
    * @GuardedBy this
    */
-  std::shared_ptr<TrackedParmType> GetCustomizedObject_unlocked(S item) const;
+  std::shared_ptr<TrackedParamType> GetCustomizedObject_unlocked(S item) const;
 
   /**
    * Return the list of tracked items.
@@ -188,7 +188,7 @@ public:
    * @return Customized object for the tracked item or <code>null</code> if
    *         the item is not to be tracked.
    */
-  virtual std::shared_ptr<TrackedParmType> CustomizerAdding(
+  virtual std::shared_ptr<TrackedParamType> CustomizerAdding(
     S item,
     const R& related) = 0;
 
@@ -203,7 +203,7 @@ public:
   virtual void CustomizerModified(
     S item,
     const R& related,
-    const std::shared_ptr<TrackedParmType>& object) = 0;
+    const std::shared_ptr<TrackedParamType>& object) = 0;
 
   /**
    * Call the specific customizer removed method. This method must not be
@@ -216,7 +216,7 @@ public:
   virtual void CustomizerRemoved(
     S item,
     const R& related,
-    const std::shared_ptr<TrackedParmType>& object) = 0;
+    const std::shared_ptr<TrackedParamType>& object) = 0;
 
   /**
    * List of items in the process of being added. This is used to deal with
@@ -287,7 +287,7 @@ private:
   BundleContext* const bc;
 
   bool CustomizerAddingFinal(S item,
-                             const std::shared_ptr<TrackedParmType>& custom);
+                             const std::shared_ptr<TrackedParamType>& custom);
 };
 
 } // namespace detail

--- a/framework/include/cppmicroservices/detail/BundleAbstractTracked.tpp
+++ b/framework/include/cppmicroservices/detail/BundleAbstractTracked.tpp
@@ -110,7 +110,7 @@ void BundleAbstractTracked<S,TTT,R>::Close()
 template<class S, class TTT, class R>
 void BundleAbstractTracked<S,TTT,R>::Track(S item, R related)
 {
-  std::shared_ptr<TrackedParmType> object;
+  std::shared_ptr<TrackedParamType> object;
   {
     auto l = this->Lock(); US_UNUSED(l);
     if (closed)
@@ -153,7 +153,7 @@ void BundleAbstractTracked<S,TTT,R>::Track(S item, R related)
 template<class S, class TTT, class R>
 void BundleAbstractTracked<S,TTT,R>::Untrack(S item, R related)
 {
-  std::shared_ptr<TrackedParmType> object;
+  std::shared_ptr<TrackedParamType> object;
   {
     auto l = this->Lock(); US_UNUSED(l);
     std::size_t initialSize = initial.size();
@@ -214,12 +214,12 @@ bool BundleAbstractTracked<S,TTT,R>::IsEmpty_unlocked() const
 }
 
 template<class S, class TTT, class R>
-std::shared_ptr<typename BundleAbstractTracked<S,TTT,R>::TrackedParmType>
+std::shared_ptr<typename BundleAbstractTracked<S,TTT,R>::TrackedParamType>
 BundleAbstractTracked<S,TTT,R>::GetCustomizedObject_unlocked(S item) const
 {
   typename TrackingMap::const_iterator i = tracked.find(item);
   if (i != tracked.end()) return i->second;
-  return std::shared_ptr<TrackedParmType>();
+  return std::shared_ptr<TrackedParamType>();
 }
 
 template<class S, class TTT, class R>
@@ -252,7 +252,7 @@ void BundleAbstractTracked<S,TTT,R>::CopyEntries_unlocked(TrackingMap& map) cons
 }
 
 template<class S, class TTT, class R>
-bool BundleAbstractTracked<S,TTT,R>::CustomizerAddingFinal(S item, const std::shared_ptr<TrackedParmType>& custom)
+bool BundleAbstractTracked<S,TTT,R>::CustomizerAddingFinal(S item, const std::shared_ptr<TrackedParamType>& custom)
 {
   auto l = this->Lock(); US_UNUSED(l);
   std::size_t addingSize = adding.size();
@@ -281,7 +281,7 @@ template<class S, class TTT, class R>
 void BundleAbstractTracked<S,TTT,R>::TrackAdding(S item, R related)
 {
   DIAG_LOG(*bc->GetLogSink()) << "BundleAbstractTracked::trackAdding:" << item;
-  std::shared_ptr<TrackedParmType> object;
+  std::shared_ptr<TrackedParamType> object;
   bool becameUntracked = false;
   /* Call customizer outside of synchronized region */
   try

--- a/framework/include/cppmicroservices/detail/ServiceTracker.tpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.tpp
@@ -181,7 +181,7 @@ void ServiceTracker<S,T>::Close()
 }
 
 template<class S, class T>
-std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>
+std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>
 ServiceTracker<S,T>::WaitForService()
 {
   return WaitForService(std::chrono::milliseconds::zero());
@@ -189,7 +189,7 @@ ServiceTracker<S,T>::WaitForService()
 
 template<class S, class T>
 template<class Rep, class Period>
-std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>
+std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>
 ServiceTracker<S,T>::WaitForService(const std::chrono::duration<Rep, Period>& rel_time)
 {
   if (rel_time.count() < 0)
@@ -211,7 +211,7 @@ ServiceTracker<S,T>::WaitForService(const std::chrono::duration<Rep, Period>& re
     auto t = d->Tracked();
     if (!t)
     { /* if ServiceTracker is not open */
-      return std::shared_ptr<TrackedParmType>();
+      return std::shared_ptr<TrackedParamType>();
     }
 
     {
@@ -331,21 +331,21 @@ ServiceTracker<S,T>::GetServiceReference() const
 }
 
 template<class S, class T>
-std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>
+std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>
 ServiceTracker<S,T>::GetService(const ServiceReference<S>& reference) const
 {
   auto t = d->Tracked();
   if (!t)
   { /* if ServiceTracker is not open */
-    return std::shared_ptr<TrackedParmType>();
+    return std::shared_ptr<TrackedParamType>();
   }
   return (t->Lock(), t->GetCustomizedObject_unlocked(reference));
 }
 
 template<class S, class T>
-std::vector<std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>> ServiceTracker<S,T>::GetServices() const
+std::vector<std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>> ServiceTracker<S,T>::GetServices() const
 {
-  std::vector<std::shared_ptr<TrackedParmType>> services;
+  std::vector<std::shared_ptr<TrackedParamType>> services;
   auto t = d->Tracked();
   if (!t)
   { /* if ServiceTracker is not open */
@@ -364,7 +364,7 @@ std::vector<std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>> Serv
 }
 
 template<class S, class T>
-std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>
+std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>
 ServiceTracker<S,T>::GetService() const
 {
   auto service = d->cachedService.Load();
@@ -381,7 +381,7 @@ ServiceTracker<S,T>::GetService() const
     auto reference = GetServiceReference();
     if (!reference.GetBundle())
     {
-      return std::shared_ptr<TrackedParmType>();
+      return std::shared_ptr<TrackedParamType>();
     }
     service = GetService(reference);
     d->cachedService.Store(service);
@@ -389,7 +389,7 @@ ServiceTracker<S,T>::GetService() const
   }
   catch (const ServiceException&)
   {
-    return std::shared_ptr<TrackedParmType>();
+    return std::shared_ptr<TrackedParamType>();
   }
 }
 
@@ -449,20 +449,20 @@ bool ServiceTracker<S,T>::IsEmpty() const
 }
 
 template<class S, class T>
-std::shared_ptr<typename ServiceTracker<S,T>::TrackedParmType>
+std::shared_ptr<typename ServiceTracker<S,T>::TrackedParamType>
 ServiceTracker<S,T>::AddingService(const ServiceReference<S>& reference)
 {
   return TypeTraits::ConvertToTrackedType(d->context.GetService(reference));
 }
 
 template<class S, class T>
-void ServiceTracker<S,T>::ModifiedService(const ServiceReference<S>& /*reference*/, const std::shared_ptr<TrackedParmType>& /*service*/)
+void ServiceTracker<S,T>::ModifiedService(const ServiceReference<S>& /*reference*/, const std::shared_ptr<TrackedParamType>& /*service*/)
 {
   /* do nothing */
 }
 
 template<class S, class T>
-void ServiceTracker<S,T>::RemovedService(const ServiceReference<S>& /*reference*/, const std::shared_ptr<TrackedParmType>& /*service*/)
+void ServiceTracker<S,T>::RemovedService(const ServiceReference<S>& /*reference*/, const std::shared_ptr<TrackedParamType>& /*service*/)
 {
   /* do nothing */
 }

--- a/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.h
+++ b/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.h
@@ -41,7 +41,7 @@ class ServiceTrackerPrivate : MultiThreaded<>
 
 public:
   using T = typename TTT::TrackedType;
-  using TrackedParmType = typename TTT::TrackedParmType;
+  using TrackedParamType = typename TTT::TrackedParamType;
 
   ServiceTrackerPrivate(ServiceTracker<S, T>* st,
                         BundleContext  context,
@@ -154,7 +154,7 @@ public:
   /**
    * Cached service object for GetService.
    */
-  mutable Atomic<std::shared_ptr<TrackedParmType>> cachedService;
+  mutable Atomic<std::shared_ptr<TrackedParamType>> cachedService;
 
 private:
   inline ServiceTracker<S, T>* q_func()

--- a/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.tpp
+++ b/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.tpp
@@ -154,7 +154,7 @@ template<class S, class TTT>
 void ServiceTrackerPrivate<S,TTT>::Modified()
 {
   cachedReference.Store(ServiceReference<S>()); /* clear cached value */
-  cachedService.Store(std::shared_ptr<TrackedParmType>()); /* clear cached value */
+  cachedService.Store(std::shared_ptr<TrackedParamType>()); /* clear cached value */
   DIAG_LOG(*context.GetLogSink()) << "ServiceTracker::Modified(): " << filter;
 }
 

--- a/framework/include/cppmicroservices/detail/TrackedService.h
+++ b/framework/include/cppmicroservices/detail/TrackedService.h
@@ -43,7 +43,7 @@ class TrackedService
 
 public:
   using T = typename TTT::TrackedType;
-  using TrackedParmType = typename TTT::TrackedParmType;
+  using TrackedParamType = typename TTT::TrackedParamType;
 
   TrackedService(ServiceTracker<S, T>* serviceTracker,
                  ServiceTrackerCustomizer<S, T>* customizer);
@@ -80,7 +80,7 @@ private:
    * @return Customized object for the tracked item or <code>null</code>
    *         if the item is not to be tracked.
    */
-  std::shared_ptr<TrackedParmType> CustomizerAdding(
+  std::shared_ptr<TrackedParamType> CustomizerAdding(
     ServiceReference<S> item,
     const ServiceEvent& related) override;
 
@@ -94,7 +94,7 @@ private:
    */
   void CustomizerModified(ServiceReference<S> item,
                           const ServiceEvent& related,
-                          const std::shared_ptr<TrackedParmType>& object) override;
+                          const std::shared_ptr<TrackedParamType>& object) override;
 
   /**
    * Call the specific customizer removed method. This method must not be
@@ -106,7 +106,7 @@ private:
    */
   void CustomizerRemoved(ServiceReference<S> item,
                          const ServiceEvent& related,
-                         const std::shared_ptr<TrackedParmType>& object) override;
+                         const std::shared_ptr<TrackedParamType>& object) override;
 };
 
 } // namespace detail

--- a/framework/include/cppmicroservices/detail/TrackedService.tpp
+++ b/framework/include/cppmicroservices/detail/TrackedService.tpp
@@ -106,7 +106,7 @@ void TrackedService<S,TTT>::Modified()
 }
 
 template<class S, class TTT>
-std::shared_ptr<typename TrackedService<S,TTT>::TrackedParmType>
+std::shared_ptr<typename TrackedService<S,TTT>::TrackedParamType>
 TrackedService<S,TTT>::CustomizerAdding(ServiceReference<S> item,
                                         const ServiceEvent& /*related*/)
 {
@@ -116,7 +116,7 @@ TrackedService<S,TTT>::CustomizerAdding(ServiceReference<S> item,
 template<class S, class TTT>
 void TrackedService<S,TTT>::CustomizerModified(ServiceReference<S> item,
                                                const ServiceEvent& /*related*/,
-                                               const std::shared_ptr<TrackedParmType>& object)
+                                               const std::shared_ptr<TrackedParamType>& object)
 {
   customizer->ModifiedService(item, object);
 }
@@ -124,7 +124,7 @@ void TrackedService<S,TTT>::CustomizerModified(ServiceReference<S> item,
 template<class S, class TTT>
 void TrackedService<S,TTT>::CustomizerRemoved(ServiceReference<S> item,
                                               const ServiceEvent& /*related*/,
-                                              const std::shared_ptr<TrackedParmType>& object)
+                                              const std::shared_ptr<TrackedParamType>& object)
 {
   customizer->RemovedService(item, object);
 }

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -128,12 +128,12 @@ ServiceListenerEntry::ServiceListenerEntry(
 
 const LDAPExpr& ServiceListenerEntry::GetLDAPExpr() const
 {
-  return static_cast<ServiceListenerEntryData*>(d.Data())->ldap;
+  return static_cast<ServiceListenerEntryData*>(d.get())->ldap;
 }
 
 LDAPExpr::LocalCache& ServiceListenerEntry::GetLocalCache() const
 {
-  return static_cast<ServiceListenerEntryData*>(d.Data())->local_cache;
+  return static_cast<ServiceListenerEntryData*>(d.get())->local_cache;
 }
 
 void ServiceListenerEntry::CallDelegate(const ServiceEvent& event) const
@@ -174,15 +174,15 @@ std::size_t ServiceListenerEntry::Hash() const
 {
   using namespace std;
 
-  if (static_cast<ServiceListenerEntryData*>(d.Data())->hashValue == 0) {
-    static_cast<ServiceListenerEntryData*>(d.Data())->hashValue =
+  if (static_cast<ServiceListenerEntryData*>(d.get())->hashValue == 0) {
+    static_cast<ServiceListenerEntryData*>(d.get())->hashValue =
       ((hash<BundleContextPrivate*>()(d->context.get()) ^
         (hash<void*>()(d->data) << 1)) >>
        1) ^
       ((hash<ServiceListener>()(d->listener)) ^
        (hash<ListenerTokenId>()(d->tokenId) << 1) << 1);
   }
-  return static_cast<ServiceListenerEntryData*>(d.Data())->hashValue;
+  return static_cast<ServiceListenerEntryData*>(d.get())->hashValue;
 }
 }
 

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -448,14 +448,12 @@ void ServiceListeners::RemoveFromCache_unlocked(const ServiceListenerEntry& sle)
   if (!sle.GetLocalCache().empty()) {
     for (std::size_t i = 0; i < hashedServiceKeys.size(); ++i) {
       CacheType& keymap = cache[i];
-      std::vector<std::string>& l = sle.GetLocalCache()[i];
-      for (std::vector<std::string>::const_iterator it = l.begin();
-           it != l.end();
-           ++it) {
-        std::list<ServiceListenerEntry>& sles = keymap[*it];
+      std::vector<std::string>& filters = sle.GetLocalCache()[i];
+      for (auto const& filter : filters) {
+        std::list<ServiceListenerEntry>& sles = keymap[filter];
         sles.remove(sle);
         if (sles.empty()) {
-          keymap.erase(*it);
+          keymap.erase(filter);
         }
       }
     }

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -214,8 +214,7 @@ std::string ServiceReferenceBase::GetInterfaceId() const
 
 std::size_t ServiceReferenceBase::Hash() const
 {
-  using namespace std;
-  return hash<ServiceRegistrationBasePrivate*>()(this->d.load()->registration);
+  return std::hash<ServiceRegistrationBasePrivate*>()(this->d.load()->registration);
 }
 
 std::ostream& operator<<(std::ostream& os,


### PR DESCRIPTION
Improve performance by using std::unordered_map to track services

Use std::shared_ptr instead of ExplicitlySharedDataPointer

fix typo in type name

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com