### PR TITLE
Update BundleVersionTest and InvalidBundleTest to improve code coverage

### DIFF
--- a/framework/test/gtest/BundleVersionTest.cpp
+++ b/framework/test/gtest/BundleVersionTest.cpp
@@ -34,6 +34,7 @@ TEST(BundleVersion, EmptyVersion)
   ASSERT_EQ(zero, empty.GetMicro());
   ASSERT_EQ(std::string(), empty.GetQualifier());
   ASSERT_FALSE(empty.IsUndefined());
+  ASSERT_NO_THROW(BundleVersion stEmpty(std::string("")));
 }
 
 TEST(BundleVersion, UndefinedVersion)
@@ -138,6 +139,10 @@ TEST(BundleVersion, Comparison)
   ASSERT_TRUE(zeroVersion == BundleVersion::EmptyVersion());
   ASSERT_FALSE(zeroVersion == alphaVersion);
   ASSERT_FALSE(alphaVersion == betaVersion);
+  ASSERT_TRUE(BundleVersion::UndefinedVersion() ==
+              BundleVersion::UndefinedVersion());
+  ASSERT_THROW(BundleVersion::UndefinedVersion() == zeroVersion, 
+	           std::logic_error);
 }
 
 TEST(BundleVersion, ParseVersion)

--- a/framework/test/gtest/InvalidBundleTest.cpp
+++ b/framework/test/gtest/InvalidBundleTest.cpp
@@ -130,3 +130,15 @@ TEST(InvalidBundle, GetLastModifiedFromInvalidBundle)
   Bundle b;
   EXPECT_THROW(b.GetLastModified(), std::invalid_argument);
 }
+
+TEST(InvalidBundle, GetBundleIdFromInvalidState)
+{
+  Bundle b;
+  EXPECT_THROW(b.GetState(), std::invalid_argument);
+}
+
+TEST(InvalidBundle, GetBundleIdFromInvalidGetVersion)
+{
+  Bundle b;
+  EXPECT_THROW(b.GetVersion(), std::invalid_argument);
+}


### PR DESCRIPTION
Update tests for BundleVersionTest to hit lines 112, 220 and 222 for
BundleVersion to have 100% coverage.

Add missing testpoints for InvalidBundleTest.