### PR TITLE
Fixed #217, Updates framework exception severity levels and uses ServiceExceptions

### DIFF
--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -412,7 +412,7 @@ void BundlePrivate::Uninstall()
             std::rethrow_exception(exception);
           } catch (...) {
             coreCtx->listeners.SendFrameworkEvent(
-              FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+              FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                              MakeBundle(shared_from_this()),
                              std::string(),
                              std::current_exception()));

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -435,7 +435,7 @@ void BundlePrivate::Uninstall()
             }
             operation = BundlePrivate::OP_UNINSTALLING;
             coreCtx->listeners.SendFrameworkEvent(
-              FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+              FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                              MakeBundle(shared_from_this()),
                              std::string(),
                              std::current_exception()));

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -107,7 +107,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
       FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                      MakeBundle(bundle->shared_from_this()),
                      message,
-                     std::make_exception_ptr(ServiceException(message.c_str(),
+                     std::make_exception_ptr(ServiceException(message,
                        ServiceException::Type::FACTORY_EXCEPTION))));
   }
   return s;

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -76,7 +76,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
           FrameworkEvent::Type::FRAMEWORK_ERROR,
           MakeBundle(bundle->shared_from_this()),
           message,
-          std::make_exception_ptr(ServiceException(message.c_str(), 
+          std::make_exception_ptr(ServiceException(message, 
             ServiceException::Type::FACTORY_ERROR)
           )));
       return smap;
@@ -100,14 +100,14 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
       }
     }
     s = smap;
-  } catch (...) {
+  } catch (std::exception& ex) {
     s.reset();
     std::string message = "ServiceFactory threw an unknown exception.";
     registration->bundle->coreCtx->listeners.SendFrameworkEvent(
       FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                      MakeBundle(bundle->shared_from_this()),
                      message,
-                     std::make_exception_ptr(ServiceException(message,
+                     std::make_exception_ptr(ServiceException(ex.what(),
                        ServiceException::Type::FACTORY_EXCEPTION))));
   }
   return s;
@@ -279,13 +279,13 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(
       try {
         sf->UngetService(
           MakeBundle(bundle), ServiceRegistrationBase(registration), service);
-      } catch (...) {
+      } catch (std::exception& ex) {
         std::string message("ServiceFactory threw an exception");
         registration->bundle->coreCtx->listeners.SendFrameworkEvent(
           FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                          MakeBundle(bundle->shared_from_this()),
                          message,
-                         std::make_exception_ptr(ServiceException(message,
+                         std::make_exception_ptr(ServiceException(ex.what(),
                            ServiceException::Type::FACTORY_EXCEPTION))));
       }
 
@@ -360,13 +360,13 @@ bool ServiceReferenceBasePrivate::UngetService(
     try {
       sf->UngetService(
         MakeBundle(bundle), ServiceRegistrationBase(registration), sfi);
-    } catch (...) {
+    } catch (std::exception& ex) {
       std::string message("ServiceFactory threw an exception");
       registration->bundle->coreCtx->listeners.SendFrameworkEvent(
         FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                        MakeBundle(bundle->shared_from_this()),
                        message,
-                       std::make_exception_ptr(ServiceException(message, 
+                       std::make_exception_ptr(ServiceException(ex.what(), 
                          ServiceException::Type::FACTORY_EXCEPTION))));
     }
   }

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -278,7 +278,7 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(
       } catch (...) {
         std::string message("ServiceFactory threw an exception");
         registration->bundle->coreCtx->listeners.SendFrameworkEvent(
-          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                          MakeBundle(bundle->shared_from_this()),
                          message,
                          std::current_exception()));
@@ -358,7 +358,7 @@ bool ServiceReferenceBasePrivate::UngetService(
     } catch (...) {
       std::string message("ServiceFactory threw an exception");
       registration->bundle->coreCtx->listeners.SendFrameworkEvent(
-        FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+        FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                        MakeBundle(bundle->shared_from_this()),
                        message,
                        std::current_exception()));

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -100,7 +100,7 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
       }
     }
     s = smap;
-  } catch (std::exception& ex) {
+  } catch (const std::exception& ex) {
     s.reset();
     std::string message = "ServiceFactory threw an unknown exception.";
     registration->bundle->coreCtx->listeners.SendFrameworkEvent(
@@ -279,7 +279,7 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(
       try {
         sf->UngetService(
           MakeBundle(bundle), ServiceRegistrationBase(registration), service);
-      } catch (std::exception& ex) {
+      } catch (const std::exception& ex) {
         std::string message("ServiceFactory threw an exception");
         registration->bundle->coreCtx->listeners.SendFrameworkEvent(
           FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
@@ -360,7 +360,7 @@ bool ServiceReferenceBasePrivate::UngetService(
     try {
       sf->UngetService(
         MakeBundle(bundle), ServiceRegistrationBase(registration), sfi);
-    } catch (std::exception& ex) {
+    } catch (const std::exception& ex) {
       std::string message("ServiceFactory threw an exception");
       registration->bundle->coreCtx->listeners.SendFrameworkEvent(
         FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -256,7 +256,7 @@ void ServiceRegistrationBase::Unregister()
           std::string message(
             "ServiceFactory UngetService implementation threw an exception");
           d->bundle->coreCtx->listeners.SendFrameworkEvent(
-            FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+            FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                            MakeBundle(d->bundle->shared_from_this()),
                            message,
                            std::current_exception()));
@@ -273,7 +273,7 @@ void ServiceRegistrationBase::Unregister()
         std::string message(
           "ServiceFactory UngetService implementation threw an exception");
         d->bundle->coreCtx->listeners.SendFrameworkEvent(
-          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
+          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                          MakeBundle(d->bundle->shared_from_this()),
                          message,
                          std::current_exception()));

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -252,14 +252,14 @@ void ServiceRegistrationBase::Unregister()
         try {
           serviceFactory->UngetService(
             MakeBundle(i.first->shared_from_this()), *this, service);
-        } catch (...) {
+        } catch (std::exception& ex) {
           std::string message(
             "ServiceFactory UngetService implementation threw an exception");
           d->bundle->coreCtx->listeners.SendFrameworkEvent(
             FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                            MakeBundle(d->bundle->shared_from_this()),
                            message,
-                           std::make_exception_ptr(ServiceException(message, 
+                           std::make_exception_ptr(ServiceException(ex.what(), 
                              ServiceException::Type::FACTORY_EXCEPTION))));
         }
       }
@@ -270,14 +270,14 @@ void ServiceRegistrationBase::Unregister()
       try {
         serviceFactory->UngetService(
           MakeBundle(i.first->shared_from_this()), *this, i.second);
-      } catch (...) {
+      } catch (std::exception& ex) {
         std::string message(
           "ServiceFactory UngetService implementation threw an exception");
         d->bundle->coreCtx->listeners.SendFrameworkEvent(
           FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                          MakeBundle(d->bundle->shared_from_this()),
                          message,
-                         std::make_exception_ptr(ServiceException(message, 
+                         std::make_exception_ptr(ServiceException(ex.what(), 
                            ServiceException::Type::FACTORY_EXCEPTION))));
       }
     }

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -259,7 +259,8 @@ void ServiceRegistrationBase::Unregister()
             FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                            MakeBundle(d->bundle->shared_from_this()),
                            message,
-                           std::current_exception()));
+                           std::make_exception_ptr(ServiceException(message, 
+                             ServiceException::Type::FACTORY_EXCEPTION))));
         }
       }
     }
@@ -276,7 +277,8 @@ void ServiceRegistrationBase::Unregister()
           FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                          MakeBundle(d->bundle->shared_from_this()),
                          message,
-                         std::current_exception()));
+                         std::make_exception_ptr(ServiceException(message, 
+                           ServiceException::Type::FACTORY_EXCEPTION))));
       }
     }
   }

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -252,7 +252,7 @@ void ServiceRegistrationBase::Unregister()
         try {
           serviceFactory->UngetService(
             MakeBundle(i.first->shared_from_this()), *this, service);
-        } catch (std::exception& ex) {
+        } catch (const std::exception& ex) {
           std::string message(
             "ServiceFactory UngetService implementation threw an exception");
           d->bundle->coreCtx->listeners.SendFrameworkEvent(
@@ -270,7 +270,7 @@ void ServiceRegistrationBase::Unregister()
       try {
         serviceFactory->UngetService(
           MakeBundle(i.first->shared_from_this()), *this, i.second);
-      } catch (std::exception& ex) {
+      } catch (const std::exception& ex) {
         std::string message(
           "ServiceFactory UngetService implementation threw an exception");
         d->bundle->coreCtx->listeners.SendFrameworkEvent(

--- a/framework/test/driver/BundleTest.cpp
+++ b/framework/test/driver/BundleTest.cpp
@@ -1154,7 +1154,7 @@ void TestBundleActivatorFailures()
                     "Test that one FrameworkEvent was received.");
   US_TEST_CONDITION(
     listener.CheckEvents(std::vector<FrameworkEvent>{ FrameworkEvent{
-      FrameworkEvent::Type::FRAMEWORK_WARNING,
+      FrameworkEvent::Type::FRAMEWORK_ERROR,
       bundleStopFail,
       std::string(),
       std::make_exception_ptr(std::runtime_error("whoopsie!")) } }),

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -122,7 +122,7 @@ TEST_F(ServiceFactoryTest, TestGetServiceThrows)
 {
   auto context = framework.GetBundleContext();
   auto sf = std::make_shared<MockFactory>();
-  std::string exceptionMsg("Exception in user code");
+  std::string exceptionMsg("ServiceFactory threw an unknown exception.");
   EXPECT_CALL(*sf, GetService(testing::_, testing::_))
     .Times(1)
     .WillRepeatedly(testing::Throw(std::runtime_error(exceptionMsg)));
@@ -169,7 +169,7 @@ TEST_F(ServiceFactoryTest, TestGetServiceReturnsNull)
   ASSERT_TRUE(static_cast<bool>(sref));
   auto lToken = context.AddFrameworkListener(
     [](const cppmicroservices::FrameworkEvent& evt) {
-      ASSERT_EQ(evt.GetType(), FrameworkEvent::FRAMEWORK_WARNING);
+      ASSERT_EQ(evt.GetType(), FrameworkEvent::FRAMEWORK_ERROR);
     });
   ASSERT_EQ(context.GetService<ITestServiceA>(sref), nullptr);
   context.RemoveListener(std::move(lToken));


### PR DESCRIPTION
This PR addresses issue #217 which requested a review of framework exception severity and usage of the already-existing ServiceException class in lieu of std::logic_error as stated by the spec.

By looking through the docs for OSGi, I identified the proper exception types and modified the currently used exceptions in the code. The same was done for std::logic_errors in the correct areas to better match the spec as well.

Two tests (BundleTest and ServiceFactoryTest) had to be updated to reflect the newly introduced state into the software's internal logic. For both tests, it was a matter of updating the type of exceptions or expected exception messages so that they matched the source code changes made.