### PR TITLE
Update library loading error messages

### DIFF
--- a/framework/src/util/SharedLibrary.cpp
+++ b/framework/src/util/SharedLibrary.cpp
@@ -99,9 +99,13 @@ void SharedLibrary::Load(int flags)
 #ifdef US_PLATFORM_POSIX
   d->m_Handle = dlopen(libPath.c_str(), flags);
   if (!d->m_Handle) {
+    std::string err_msg = "Error loading " + libPath + ".";
     const char* err = dlerror();
-    throw std::runtime_error(err ? std::string(err)
-                                 : (std::string("Error loading ") + libPath));
+    if (err) {
+      err_msg += " " + std::string(err);
+    }
+
+    throw std::runtime_error(err_msg);
   }
 #else
   US_UNUSED(flags);
@@ -132,10 +136,13 @@ void SharedLibrary::Unload()
   if (d->m_Handle) {
 #ifdef US_PLATFORM_POSIX
     if (dlclose(d->m_Handle)) {
+      std::string err_msg = "Error unloading " + GetLibraryPath() + ".";
       const char* err = dlerror();
-      throw std::runtime_error(
-        err ? std::string(err)
-            : (std::string("Error unloading ") + GetLibraryPath()));
+      if (err) {
+        err_msg += " " + std::string(err);
+      }
+
+      throw std::runtime_error(err_msg);
     }
 #else
     if (!FreeLibrary(reinterpret_cast<HMODULE>(d->m_Handle))) {


### PR DESCRIPTION
This PR introduces changes to the library loading messages that are returned within the exceptions that are thrown when loading a library/unloading a library goes awry. This PR makes the behavior on Mac/Linux more similar to that of Windows.