### PR TITLE
Update CMakeLists.txt and fix complier error on Mac

### DIFF
--- a/framework/test/gtest/BundleEventTest.cpp
+++ b/framework/test/gtest/BundleEventTest.cpp
@@ -42,7 +42,7 @@ public:
 
   ~BundleEventTest() override = default;
 
-  virtual void SetUp()
+  void SetUp() override
   {
     f.Start();
 
@@ -55,7 +55,7 @@ public:
 #endif
   }
 
-  virtual void TearDown()
+  void TearDown() override
   {
     f.Stop();
     f.WaitForStop(std::chrono::milliseconds::zero());

--- a/framework/test/gtest/BundleResourceTest.cpp
+++ b/framework/test/gtest/BundleResourceTest.cpp
@@ -41,14 +41,14 @@ public:
   BundleResourceTest() : f(FrameworkFactory().NewFramework()) {}
   ~BundleResourceTest() override = default;
 
-  virtual void SetUp()
+  void SetUp() override
   {
     f.Start();
     auto fCtx = f.GetBundleContext();
     bundleR = cppmicroservices::testing::InstallLib(fCtx, "TestBundleR");
   }
 
-  virtual void TearDown()
+  void TearDown() override
   {
     f.Stop();
     f.WaitForStop(std::chrono::milliseconds::zero());
@@ -65,16 +65,16 @@ TEST(BundleResourceTestNoBundleInstall, operatorEqualTo)
 TEST(BundleResourceTestNoBundleInstall, getChildResourcesFromInvalidBundle)
 {
   BundleResource result;
-  ASSERT_EQ(result.GetChildResources().size(), 0);
+  ASSERT_EQ(result.GetChildResources().size(), static_cast<unsigned int>(0));
 }
 
 TEST_F(BundleResourceTest, getChildResources)
 {
   BundleResource resource = bundleR.GetResource("icons/");
-  ASSERT_EQ(resource.GetChildResources().size(), 0);
+  ASSERT_EQ(resource.GetChildResources().size(), static_cast<unsigned int>(0));
 
   // GetChildResources() should not have a dependency on GetChildren()
   // to return the correct size
   resource.GetChildren();
-  ASSERT_EQ(resource.GetChildResources().size(), 3);
+  ASSERT_EQ(resource.GetChildResources().size(), static_cast<unsigned int>(3));
 }

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -29,6 +29,10 @@ set(_gtest_tests
   ServiceObjectsTest.cpp
   ServiceReferenceTest.cpp
   ServiceFactoryTest.cpp
+  BundleEventTest.cpp
+  BundleResourceTest.cpp
+  BundleStreamOperatorTest.cpp
+  ServiceEventStreamOperatorTest.cpp
 )
 
 set(_additional_srcs


### PR DESCRIPTION
Update CMakeLists.txt to include the following new tests:
BundleEventTest.cpp
BundleResourceTest.cpp
BundleStreamOperatorTest.cpp
ServiceEventStreamOperatorTest.cpp

Fix complier error for setup and teardown in BundleEventTest.cpp and BundleResourceTests.cpp on Mac and Linux.

Fix complier error for unsigned int comparison error in BundleResourceTests.cpp on Mac and Linux.