### PR TITLE
Update Util.hpp

### DIFF
--- a/compendium/tools/SCRCodeGen/Util.hpp
+++ b/compendium/tools/SCRCodeGen/Util.hpp
@@ -52,7 +52,7 @@ public:
     , msg("Invalid value for the name '" + jsonName + "'. Expected ")
   {
     jsonVal = data[jsonName.c_str()];
-    if (Json::Value::null == jsonVal) {
+    if (Json::Value::nullRef == jsonVal) {
       std::string msg =
         "Mandatory name '" + jsonName + "' missing from the manifest";
       throw std::runtime_error(msg);
@@ -77,7 +77,7 @@ public:
     static_assert(S > 0, "Choices cannot be empty!");
 
     jsonVal = data[jsonName.c_str()];
-    if (Json::Value::null == jsonVal) {
+    if (Json::Value::nullRef == jsonVal) {
       jsonVal = choices.front();
       return;
     }


### PR DESCRIPTION
This occurs when building on RPi, when changes from #401 are taken, there are still errors in `CppMicroServices/compendium/tools/SCRCodeGen/Util.hpp:55` and `CppMicroServices/compendium/tools/SCRCodeGen/Util.hpp:80` while building. Changing `Json::Value::null` `Json::Value::nullRef` solves the issue.