### PR TITLE
Service ctor exception crash

### DIFF
--- a/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
@@ -25,7 +25,6 @@
 #include "TestUtils.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 #include "cppmicroservices/ServiceEvent.h"
-#include "cppmicroservices/ServiceObjects.h"
 
 namespace sc  = cppmicroservices::service::component;
 namespace scr = cppmicroservices::service::component::runtime;
@@ -74,11 +73,7 @@ TEST_F(tServiceComponent, testThrowingLifeCycleHooks) //DS_TOI_9
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI9");
   auto ctxt = framework.GetBundleContext();
-  auto const refs = ctxt.GetServiceReferences<test::LifeCycleValidation>();
   auto sRef = ctxt.GetServiceReference<test::LifeCycleValidation>();
-  auto serviceObjects = ctxt.GetServiceObjects<test::LifeCycleValidation>(sRef);
-  (void)serviceObjects.GetService();
-  (void)serviceObjects.GetServiceReference();
   ASSERT_TRUE(static_cast<bool>(sRef));
   auto service = ctxt.GetService<test::LifeCycleValidation>(sRef);
   EXPECT_EQ(service, nullptr) << "Service object must be nullptr since the service component should have thrown an exception when activated";

--- a/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
@@ -25,6 +25,7 @@
 #include "TestUtils.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 #include "cppmicroservices/ServiceEvent.h"
+#include "cppmicroservices/ServiceObjects.h"
 
 namespace sc  = cppmicroservices::service::component;
 namespace scr = cppmicroservices::service::component::runtime;
@@ -73,11 +74,14 @@ TEST_F(tServiceComponent, testThrowingLifeCycleHooks) //DS_TOI_9
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI9");
   auto ctxt = framework.GetBundleContext();
+  auto const refs = ctxt.GetServiceReferences<test::LifeCycleValidation>();
   auto sRef = ctxt.GetServiceReference<test::LifeCycleValidation>();
+  auto serviceObjects = ctxt.GetServiceObjects<test::LifeCycleValidation>(sRef);
+  (void)serviceObjects.GetService();
+  (void)serviceObjects.GetServiceReference();
   ASSERT_TRUE(static_cast<bool>(sRef));
   auto service = ctxt.GetService<test::LifeCycleValidation>(sRef);
   EXPECT_EQ(service, nullptr) << "Service object must be nullptr since the service component should have thrown an exception when activated";
-
   auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent9");
   auto compConfigs = dsRuntimeService->GetComponentConfigurationDTOs(compDesc);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";

--- a/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.cpp
@@ -1,15 +1,26 @@
 #include "ServiceImpl.hpp"
 
+#include <iostream>
+#include <exception>
+
 namespace sample {
-  void ServiceComponent9::Activate(const std::shared_ptr<ComponentContext>&)
-  {
-    activated = true;
-    throw std::runtime_error("Exception thrown from user code");
-  };
-  void ServiceComponent9::Deactivate(const std::shared_ptr<ComponentContext>&)
-  {
-    deactivated = true;
-    throw std::runtime_error("Exception thrown from user code");
-  };
-  ServiceComponent9::~ServiceComponent9() {};
+
+ServiceComponent9::ServiceComponent9()
+  : test::LifeCycleValidation()
+{
+  throw std::exception {};
 }
+
+void ServiceComponent9::Activate(const std::shared_ptr<ComponentContext>&)
+{
+  activated = true;
+  throw std::runtime_error("Exception thrown from user code");
+};
+void ServiceComponent9::Deactivate(const std::shared_ptr<ComponentContext>&)
+{
+  deactivated = true;
+  throw std::runtime_error("Exception thrown from user code");
+};
+ServiceComponent9::~ServiceComponent9() {};
+
+} // namespaces

--- a/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.cpp
@@ -1,15 +1,6 @@
 #include "ServiceImpl.hpp"
 
-#include <iostream>
-#include <exception>
-
 namespace sample {
-
-ServiceComponent9::ServiceComponent9()
-  : test::LifeCycleValidation()
-{
-  throw std::exception {};
-}
 
 void ServiceComponent9::Activate(const std::shared_ptr<ComponentContext>&)
 {
@@ -21,6 +12,5 @@ void ServiceComponent9::Deactivate(const std::shared_ptr<ComponentContext>&)
   deactivated = true;
   throw std::runtime_error("Exception thrown from user code");
 };
-ServiceComponent9::~ServiceComponent9() {};
 
 } // namespaces

--- a/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
@@ -9,8 +9,8 @@ using ComponentContext = cppmicroservices::service::component::ComponentContext;
 namespace sample {
   class ServiceComponent9 : public test::LifeCycleValidation {
   public:
-    ServiceComponent9();
-    ~ServiceComponent9() override;
+    ServiceComponent9() = default;
+    ~ServiceComponent9() override = default;
     void Activate(const std::shared_ptr<ComponentContext>& context);
     void Deactivate(const std::shared_ptr<ComponentContext>& context);
     bool IsActivated() override { return activated; };

--- a/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
@@ -9,7 +9,7 @@ using ComponentContext = cppmicroservices::service::component::ComponentContext;
 namespace sample {
   class ServiceComponent9 : public test::LifeCycleValidation {
   public:
-    ServiceComponent9() = default;
+    ServiceComponent9();
     ~ServiceComponent9() override;
     void Activate(const std::shared_ptr<ComponentContext>& context);
     void Deactivate(const std::shared_ptr<ComponentContext>& context);

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -139,8 +139,8 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
   }
 
   auto interfaceMap = d->GetServiceInterfaceMap();
-  // g2113391: interfaceMap can be null under certain circumstance e.g. if a constructor
-  // is thrown in the service implementation.  In that case, we bail out early.
+  // interfaceMap can be null under certain circumstance e.g. if a constructor is thrown
+  // in the service implementation.  In that case, we bail out early.
   if (!interfaceMap) {
     return nullptr;
   }

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -149,9 +149,7 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
   auto h = std::make_shared<UngetHelper>(interfaceMap
                                          , d->m_reference
                                          , d->m_context->bundle->shared_from_this());
-  auto deleter = h->interfaceMap
-                  ->find(d->m_reference.GetInterfaceId())
-                  ->second.get();
+  auto deleter = h->interfaceMap->find(d->m_reference.GetInterfaceId())->second.get();
   return std::shared_ptr<void>(h, deleter);
 }
 

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -151,7 +151,7 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
                                          , d->m_context->bundle->shared_from_this());
   auto deleter = h->interfaceMap
                   ->find(d->m_reference.GetInterfaceId())
-                  ->second.get()
+                  ->second.get();
   return std::shared_ptr<void>(h, deleter);
 }
 

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -139,8 +139,8 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
   }
 
   auto interfaceMap = d->GetServiceInterfaceMap();
-  // interfaceMap can be null under certain circumstance e.g. if a constructor is thrown
-  // in the service implementation.  In that case, we bail out early.
+  // interfaceMap can be null under certain circumstance e.g. if a constructor throws an
+  // exception in the service implementation.  In that case, we bail out early.
   if (!interfaceMap) {
     return nullptr;
   }

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -138,12 +138,21 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
     return nullptr;
   }
 
-  std::shared_ptr<UngetHelper> h(
-    new UngetHelper(d->GetServiceInterfaceMap(),
-                    d->m_reference,
-                    d->m_context->bundle->shared_from_this()));
-  return std::shared_ptr<void>(
-    h, (h->interfaceMap->find(d->m_reference.GetInterfaceId()))->second.get());
+  // interfaceMap can be null under certain circumstance
+  // e.g. if a constructor is thrown in the service implementation.
+  // In that case, we bail out early.
+  auto interfaceMap = d->GetServiceInterfaceMap();
+  if (!interfaceMap) {
+    return nullptr;
+  }
+  
+  auto h = std::make_shared<UngetHelper>(interfaceMap
+                                         , d->m_reference
+                                         , d->m_context->bundle->shared_from_this());
+  auto deleter = h->interfaceMap
+                  ->find(d->m_reference.GetInterfaceId())
+                  ->second.get()
+  return std::shared_ptr<void>(h, deleter);
 }
 
 InterfaceMapConstPtr ServiceObjectsBase::GetServiceInterfaceMap() const

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -138,10 +138,9 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
     return nullptr;
   }
 
-  // interfaceMap can be null under certain circumstance
-  // e.g. if a constructor is thrown in the service implementation.
-  // In that case, we bail out early.
   auto interfaceMap = d->GetServiceInterfaceMap();
+  // g2113391: interfaceMap can be null under certain circumstance e.g. if a constructor
+  // is thrown in the service implementation.  In that case, we bail out early.
   if (!interfaceMap) {
     return nullptr;
   }

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -181,16 +181,17 @@ TEST_F(ServiceFactoryTest, TestGetServiceObjectThrows)
     .WillRepeatedly(testing::Throw(std::runtime_error(exceptionMsg)));
   EXPECT_CALL(*sf, UngetService(testing::_, testing::_, testing::_)).Times(0);
 
-  auto reg1 = context.RegisterService<ITestServiceA>(ToFactory(sf)
-                                                     , {{
-                                                         Constants::SERVICE_SCOPE
-                                                         , Any(Constants::SCOPE_PROTOTYPE)
-                                                       }});
+  (void)context.RegisterService<ITestServiceA>(ToFactory(sf)
+                                               , {{
+                                                   Constants::SERVICE_SCOPE
+                                                   , Any(Constants::SCOPE_PROTOTYPE)
+                                                 }});
 
   auto sref = context.GetServiceReference<ITestServiceA>();
   auto serviceObjects = context.GetServiceObjects<ITestServiceA>(sref);
+
+  // Without a fix for g2113391 this next line crashes
   (void)serviceObjects.GetService();
-  (void)serviceObjects.GetServiceReference();
 }
 
 // Tests the return type and FrameworkEvent generated when a

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -176,7 +176,7 @@ TEST_F(ServiceFactoryTest, TestGetServiceObjectThrows)
 
   // Next line used to crash if a service implementation threw an exception in the
   // constructor. This test case checks to make sure that the fix is in place.
-  (void)serviceObjects.GetService();
+  EXPECT_NO_THROW((void)serviceObjects.GetService());
 }
 
 // Tests the return type and FrameworkEvent generated when a

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -62,22 +62,6 @@ public:
                     const InterfaceMapConstPtr&));
 };
 
-class ThrowingFactory
-  : public ServiceFactory
-{
-public:
-  InterfaceMapConstPtr GetService(const Bundle&
-                                  , const ServiceRegistrationBase&)
-  {
-    throw std::runtime_error("Exception thrown from user code");
-  }
-  
-  MOCK_METHOD3(UngetService,
-               void(const Bundle&,
-                    const ServiceRegistrationBase&,
-                    const InterfaceMapConstPtr&));
-};
-
 }
 
 class ServiceFactoryTest : public ::testing::Test

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -44,21 +44,40 @@ struct ITestServiceB
 };
 
 // Service implementations
-struct TestServiceAImpl : public ITestServiceA
+struct TestServiceAImpl
+  : public ITestServiceA
 {};
 
 // Mocks
-class MockFactory : public ServiceFactory
+class MockFactory
+  : public ServiceFactory
 {
 public:
   MOCK_METHOD2(GetService,
-               InterfaceMapConstPtr(const Bundle&,
-                                    const ServiceRegistrationBase&));
+               InterfaceMapConstPtr(const Bundle&
+                                    , const ServiceRegistrationBase&));
   MOCK_METHOD3(UngetService,
                void(const Bundle&,
                     const ServiceRegistrationBase&,
                     const InterfaceMapConstPtr&));
 };
+
+class ThrowingFactory
+  : public ServiceFactory
+{
+public:
+  InterfaceMapConstPtr GetService(const Bundle&
+                                  , const ServiceRegistrationBase&)
+  {
+    throw std::runtime_error("Exception thrown from user code");
+  }
+  
+  MOCK_METHOD3(UngetService,
+               void(const Bundle&,
+                    const ServiceRegistrationBase&,
+                    const InterfaceMapConstPtr&));
+};
+
 }
 
 class ServiceFactoryTest : public ::testing::Test
@@ -140,13 +159,38 @@ TEST_F(ServiceFactoryTest, TestGetServiceThrows)
       ASSERT_EQ(evt.GetType(), FrameworkEvent::FRAMEWORK_ERROR);
       ASSERT_NE(evt.GetThrowable(), nullptr);
       EXPECT_NO_THROW(try {
-        std::rethrow_exception(evt.GetThrowable());
-      } catch (const std::runtime_error& err) {
-        ASSERT_STREQ(err.what(), exceptionMsg.c_str());
-      });
+          std::rethrow_exception(evt.GetThrowable());
+        } catch (const std::runtime_error& err) {
+          ASSERT_STREQ(err.what(), exceptionMsg.c_str());
+        });
     });
   ASSERT_EQ(context.GetService<ITestServiceA>(sref), nullptr);
   context.RemoveListener(std::move(lToken));
+}
+
+// Tests the return type and FrameworkEvent generated when a
+// ServiceFactory instance throws an exception in it's GetService
+// callback
+TEST_F(ServiceFactoryTest, TestGetServiceObjectThrows)
+{
+  auto context = framework.GetBundleContext();
+  auto sf = std::make_shared<MockFactory>();
+  std::string exceptionMsg("ServiceFactory threw an unknown exception.");
+  EXPECT_CALL(*sf, GetService(testing::_, testing::_))
+    .Times(1)
+    .WillRepeatedly(testing::Throw(std::runtime_error(exceptionMsg)));
+  EXPECT_CALL(*sf, UngetService(testing::_, testing::_, testing::_)).Times(0);
+
+  auto reg1 = context.RegisterService<ITestServiceA>(ToFactory(sf)
+                                                     , {{
+                                                         Constants::SERVICE_SCOPE
+                                                         , Any(Constants::SCOPE_PROTOTYPE)
+                                                       }});
+
+  auto sref = context.GetServiceReference<ITestServiceA>();
+  auto serviceObjects = context.GetServiceObjects<ITestServiceA>(sref);
+  (void)serviceObjects.GetService();
+  (void)serviceObjects.GetServiceReference();
 }
 
 // Tests the return type and FrameworkEvent generated when a

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -190,7 +190,8 @@ TEST_F(ServiceFactoryTest, TestGetServiceObjectThrows)
   auto sref = context.GetServiceReference<ITestServiceA>();
   auto serviceObjects = context.GetServiceObjects<ITestServiceA>(sref);
 
-  // Without a fix for g2113391 this next line crashes
+  // Next line used to crash if a service implementation threw an exception in the
+  // constructor. This test case checks to make sure that the fix is in place.
   (void)serviceObjects.GetService();
 }
 


### PR DESCRIPTION
If for some reason an exception is thrown in the constructor of a service implementation, a later call to ServiceObjectsBase::GetService() would throw an exception because the ServiceInterfaceMap is not populated for this service. Added a null check against the interfacemap to avoid this exception.