### PR TITLE
Improve BundleRegistry::Install() performance

### DIFF
--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -63,24 +63,6 @@ void BundleRegistry::Clear()
 }
 
 /*
-  A struct which contains the necessary objects to utilize condition
-  variables. A thread will wait on this WaitCondition if the waitFlag
-  is set to true.
-*/
-struct WaitCondition
-{
-  std::unique_ptr<std::mutex> m;
-  std::unique_ptr<std::condition_variable> cv;
-  bool waitFlag;
-
-  WaitCondition()
-    : m(std::make_unique<std::mutex>())
-    , cv(std::make_unique<std::condition_variable>())
-    , waitFlag(true)
-  {}
-};
-
-/*
   This function acquires a lock and decrements the reference count
   for the specified bundle. If this decrement causes the count to be
   0, it is erased from the initialBundleInstallMap map.

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -154,7 +154,8 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
       return res;
     }
   } else {
-    // Check to see if another thread is installing the currently uninstalled bundle
+    // Check to see if another thread is currently in the process of installing this
+    // bundle for the first time.
     auto p = initialBundleInstallMap.find(location);
 
     /*

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -201,8 +201,6 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
           lock, [&location, this] {
             return !initialBundleInstallMap[location].second.waitFlag;
           });
-
-        lock.unlock();
       }
 
       l.Lock();

--- a/framework/src/bundle/BundleRegistry.h
+++ b/framework/src/bundle/BundleRegistry.h
@@ -27,6 +27,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -137,6 +138,8 @@ private:
   void CheckIllegalState() const;
 
   CoreBundleContext* coreCtx;
+
+  std::set<std::string> strSet;
 
 using BundleMap = std::multimap<std::string, std::shared_ptr<BundlePrivate>>;
 

--- a/framework/src/bundle/BundleRegistry.h
+++ b/framework/src/bundle/BundleRegistry.h
@@ -136,8 +136,8 @@ private:
   using BundleMap = std::multimap<std::string, std::shared_ptr<BundlePrivate>>;
 
   // don't allow copying the BundleRegistry.
-  BundleRegistry(const BundleRegistry&);
-  BundleRegistry& operator=(const BundleRegistry&);
+  BundleRegistry(const BundleRegistry&) = delete;
+  BundleRegistry& operator=(const BundleRegistry&) = delete;
 
   void CheckIllegalState() const;
 

--- a/framework/src/bundle/BundleRegistry.h
+++ b/framework/src/bundle/BundleRegistry.h
@@ -140,7 +140,7 @@ private:
 
   void CheckIllegalState() const;
 
-  void BundleRegistry::GetAlreadyInstalledBundlesAtLocation(
+  void GetAlreadyInstalledBundlesAtLocation(
     std::pair<BundleMap::iterator, BundleMap::iterator> range,
     std::vector<Bundle>& res,
     std::vector<std::shared_ptr<BundlePrivate>>& alreadyInstalled);

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -104,14 +104,14 @@ protected:
     std::vector<std::future<std::vector<cppmicroservices::Bundle>>> results(numThreads);
     for (auto _ : state) {
       auto start = high_resolution_clock::now();
-      for (int i = 0; i < bundlesToInstallPerThread.size(); i++) {
+      for (uint32_t i = 0; i < bundlesToInstallPerThread.size(); i++) {
         results[i] = std::async(std::launch::async,
                                 ConcurrentInstallHelper,
                                 framework,
                                 bundlesToInstallPerThread[i]);
       }
 
-      for (int i = 0; i < bundlesToInstallPerThread.size(); i++) {
+      for (uint32_t i = 0; i < bundlesToInstallPerThread.size(); i++) {
         results[i].wait();
       }
 

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -24,7 +24,7 @@ public:
   ~BundleInstallFixture() = default;
 
   static std::vector<cppmicroservices::Bundle> ConcurrentInstallHelper(
-    ::cppmicroservices::Framework& framework,
+    cppmicroservices::Framework& framework,
     const std::vector<std::string>& bundlesToInstall)
   {
     using namespace cppmicroservices;
@@ -83,21 +83,19 @@ protected:
     uint32_t currentIndex = 0;
     for (uint32_t i = 0; i < numThreads; i++) {
       std::vector<std::string> tempListOfBundles;
-      if (i == numThreads - 1) {
-        for (uint32_t j = 0; j < str5kBundles.size() / numThreads +
-                                   (str5kBundles.size() % numThreads);
-             j++, currentIndex++) {
-          tempListOfBundles.push_back(str5kBundles[currentIndex]);
-        }
-      } else {
-        for (uint32_t j = 0; j < str5kBundles.size() / numThreads;
-             j++, currentIndex++) {
-          tempListOfBundles.push_back(str5kBundles[currentIndex]);
-        }
+
+      size_t numOfIterations =
+        (i == numThreads - 1 ? str5kBundles.size() / numThreads +
+                                 (str5kBundles.size() % numThreads)
+                             : str5kBundles.size() / numThreads);
+      for (uint32_t j = 0; j < uint32_t(numOfIterations); j++, currentIndex++) {
+        tempListOfBundles.push_back(str5kBundles[currentIndex]);
       }
+
       if (i == numThreads - 1) {
         tempListOfBundles.push_back(str5kBundles[0]);
       }
+
       bundlesToInstallPerThread.push_back(tempListOfBundles);
     }
 

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -132,6 +132,7 @@ BENCHMARK_DEFINE_F(BundleInstallFixture, LargeBundleInstallCppFramework)(benchma
   InstallWithCppFramework(state, "largeBundle");
 }
 
+#if defined(PERFORM_LARGE_CONCURRENCY_TEST)
 BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstall1Thread)
 (benchmark::State& state)
 {
@@ -155,11 +156,14 @@ BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)
 {
   InstallConcurrently(state, std::thread::hardware_concurrency());
 }
+#endif
 
 // Register functions as benchmark
 BENCHMARK_REGISTER_F(BundleInstallFixture, BundleInstallCppFramework)->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, LargeBundleInstallCppFramework)->UseManualTime();
+#if defined(PERFORM_LARGE_CONCURRENCY_TEST)
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall1Thread)->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall2Threads)->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall4Threads)->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)->UseManualTime();
+#endif

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -5,6 +5,7 @@
 #include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/FrameworkFactory.h>
 #include <chrono>
+#include <future>
 
 #include "benchmark/benchmark.h"
 #include "TestUtils.h"
@@ -45,6 +46,83 @@ protected:
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
   }
+
+  static std::vector<cppmicroservices::Bundle> ConcurrentInstallHelper(
+    ::cppmicroservices::Framework& framework,
+    const std::vector<std::string>& bundlesToInstall)
+  {
+    using namespace cppmicroservices;
+    auto fc = framework.GetBundleContext();
+    std::vector<cppmicroservices::Bundle> bundles;
+    for (size_t i = 0; i < bundlesToInstall.size(); i++) {
+      auto bundle = testing::InstallLib(fc, bundlesToInstall[i]);
+      bundles.push_back(bundle);
+    }
+
+    return bundles;
+  }
+
+  void InstallConcurrently(benchmark::State& state, uint32_t numThreads)
+  {
+    using namespace std::chrono;
+
+    std::string bundleBasePath = "bundles\\test_bundle_";
+    auto framework = cppmicroservices::FrameworkFactory().NewFramework();
+    framework.Start();
+
+    // Generate paths to each bundle
+    std::vector<std::string> str5kBundles;
+    for (uint32_t count = 1; count <= 5000; count++) {
+      std::string copiedBundlePath = std::string(bundleBasePath);
+      copiedBundlePath.append(std::to_string(count));
+      str5kBundles.push_back(copiedBundlePath);
+    }
+
+    // Split up bundles per thread
+    std::vector<std::vector<std::string>> bundlesToInstallPerThread;
+    uint32_t currentIndex = 0;
+    for (uint32_t i = 0; i < numThreads; i++) {
+      std::vector<std::string> tempListOfBundles;
+      if (i == numThreads - 1) {
+        for (uint32_t j = 0; j < str5kBundles.size() / numThreads +
+                                   (str5kBundles.size() % numThreads);
+             j++, currentIndex++) {
+          tempListOfBundles.push_back(str5kBundles[currentIndex]);
+        }
+      } else {
+        for (uint32_t j = 0; j < str5kBundles.size() / numThreads;
+             j++, currentIndex++) {
+          tempListOfBundles.push_back(str5kBundles[currentIndex]);
+        }
+      }
+      if (i == numThreads - 1) {
+        tempListOfBundles.push_back(str5kBundles[0]);
+      }
+      bundlesToInstallPerThread.push_back(tempListOfBundles);
+    }
+
+    std::vector<std::future<std::vector<cppmicroservices::Bundle>>> results(numThreads);
+    for (auto _ : state) {
+      auto start = high_resolution_clock::now();
+      for (int i = 0; i < bundlesToInstallPerThread.size(); i++) {
+        results[i] = std::async(std::launch::async,
+                                ConcurrentInstallHelper,
+                                framework,
+                                bundlesToInstallPerThread[i]);
+      }
+
+      for (int i = 0; i < bundlesToInstallPerThread.size(); i++) {
+        results[i].wait();
+      }
+
+      auto end = high_resolution_clock::now();
+      auto elapsed_seconds = duration_cast<duration<double>>(end - start);
+      state.SetIterationTime(elapsed_seconds.count());
+    }
+
+    framework.Stop();
+    framework.WaitForStop(milliseconds::zero());
+  }
 };
 BENCHMARK_DEFINE_F(BundleInstallFixture, BundleInstallCppFramework)(benchmark::State& state)
 {
@@ -56,6 +134,34 @@ BENCHMARK_DEFINE_F(BundleInstallFixture, LargeBundleInstallCppFramework)(benchma
   InstallWithCppFramework(state, "largeBundle");
 }
 
+BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstall1Thread)
+(benchmark::State& state)
+{
+  InstallConcurrently(state, 1);
+}
+
+BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstall2Threads)
+(benchmark::State& state)
+{
+  InstallConcurrently(state, 2);
+}
+
+BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstall4Threads)
+(benchmark::State& state)
+{
+  InstallConcurrently(state, 4);
+}
+
+BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)
+(benchmark::State& state)
+{
+  InstallConcurrently(state, std::thread::hardware_concurrency());
+}
+
 // Register functions as benchmark
 BENCHMARK_REGISTER_F(BundleInstallFixture, BundleInstallCppFramework)->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, LargeBundleInstallCppFramework)->UseManualTime();
+BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall1Thread)->UseManualTime();
+BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall2Threads)->UseManualTime();
+BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall4Threads)->UseManualTime();
+BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)->UseManualTime();

--- a/framework/test/driver/BundleRegistryConcurrencyTest.cpp
+++ b/framework/test/driver/BundleRegistryConcurrencyTest.cpp
@@ -49,12 +49,17 @@ std::unique_lock<std::mutex> io_lock()
 inline void InstallTestBundleNoErrorHandling(BundleContext frameworkCtx,
                                              const std::string& bundleName)
 {
-  frameworkCtx.InstallBundles(testing::LIB_PATH
+  auto bundles = frameworkCtx.InstallBundles(testing::LIB_PATH
                               + util::DIR_SEP
                               + US_LIB_PREFIX
                               + bundleName
                               + US_LIB_POSTFIX
                               + US_LIB_EXT);
+
+  for (auto& b : bundles) {
+    US_TEST_CONDITION(false == !b,
+                      "Test to check if returned bundle is valid.");
+  }
 }
 
 void TestSerial(const Framework& f)
@@ -136,7 +141,7 @@ void TestConcurrent(const Framework& f)
 } // end anonymous namespace
 #endif
 
-int BundleRegistryPerformanceTest(int /*argc*/, char* /*argv*/ [])
+int BundleRegistryConcurrencyTest(int /*argc*/, char* /*argv*/ [])
 {
   US_TEST_BEGIN("BundleRegistryPerformanceTest")
 

--- a/framework/test/driver/BundleRegistryConcurrencyTest.cpp
+++ b/framework/test/driver/BundleRegistryConcurrencyTest.cpp
@@ -143,7 +143,7 @@ void TestConcurrent(const Framework& f)
 
 int BundleRegistryConcurrencyTest(int /*argc*/, char* /*argv*/ [])
 {
-  US_TEST_BEGIN("BundleRegistryPerformanceTest")
+  US_TEST_BEGIN("BundleRegistryConcurrencyTest")
 
   FrameworkFactory factory;
   auto framework = factory.NewFramework();

--- a/framework/test/driver/CMakeLists.txt
+++ b/framework/test/driver/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
 set(_tests
   AnyTest
   AnyMapTest
-  BundleRegistryPerformanceTest
+  BundleRegistryConcurrencyTest
   FrameworkEventTest
   FrameworkListenerTest
   FrameworkFactoryTest


### PR DESCRIPTION
This PR introduces a new method for performing bundle installations which is more friendly to concurrency.

An implementation using maps to keep track of initial bundle installs is presented as a method for avoiding the single race condition (two threads trying to install a bundle that isn't already installed) present within the BundleRegistry::Install() operation. This method improves the amount of code that can be ran concurrently, thus improving the performance of installing bundles in a concurrent fashion.