### PR TITLE
Added minimum CMake version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ your build tree. The following are the absolute minimum requirements:
 - Visual Studio 2015 (MSVC++ 14.0)
 
 Recommended minimum required CMake version:
+
 - CMake 3.12.4 
 
 Below is a list of tested compiler/OS combinations:

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,9 @@ your build tree. The following are the absolute minimum requirements:
 - Clang from Xcode 7.3
 - Visual Studio 2015 (MSVC++ 14.0)
 
+Recommended minimum required CMake version:
+- CMake 3.12.4 
+
 Below is a list of tested compiler/OS combinations:
 
 - GCC 5.4 (Ubuntu 14.04) via Travis CI


### PR DESCRIPTION
A minimum CMake version 3.12.4 is required for successful building of project

Signed-off-by: Ameya Patil ameyapatilr@gmail.com