### PR TITLE
Removed GetChildren() dependency of GetChildResources()

### DIFF
--- a/framework/include/cppmicroservices/BundleResource.h
+++ b/framework/include/cppmicroservices/BundleResource.h
@@ -303,6 +303,10 @@ private:
   BundleResource(int index,
                  const std::shared_ptr<const BundleArchive>& archive);
 
+  /// Helper function which initializes the childNodes member in BundleResourcePrivate;
+  /// this is called during BundleResource construction.
+  void InitializeChildren();
+
   friend struct BundleArchive;
   friend class BundleResourceContainer;
   friend class BundleResourceStream;

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -113,6 +113,8 @@ BundleResource::BundleResource(
   d->stat.filePath = d->archive->GetResourcePrefix() + d->path + d->fileName;
 
   d->archive->GetResourceContainer()->GetStat(d->stat);
+
+  InitializeChildren();
 }
 
 BundleResource::BundleResource(
@@ -123,6 +125,16 @@ BundleResource::BundleResource(
   d->archive->GetResourceContainer()->GetStat(index, d->stat);
   d->InitFilePath(
     d->stat.filePath.substr(d->archive->GetResourcePrefix().size()));
+
+  InitializeChildren();
+}
+
+void BundleResource::InitializeChildren()
+{
+  if (d->children.empty()) {
+    d->archive->GetResourceContainer()->GetChildren(
+      d->stat.filePath, true, d->children, d->childNodes);
+  }
 }
 
 BundleResource::~BundleResource()
@@ -230,10 +242,6 @@ std::vector<std::string> BundleResource::GetChildren() const
   if (!IsValid() || !IsDir())
     return d->children;
 
-  if (d->children.empty()) {
-    d->archive->GetResourceContainer()->GetChildren(
-      d->stat.filePath, true, d->children, d->childNodes);
-  }
   return d->children;
 }
 
@@ -243,11 +251,6 @@ std::vector<BundleResource> BundleResource::GetChildResources() const
 
   if (!IsValid() || !IsDir())
     return childResources;
-
-  if (d->childNodes.empty()) {
-    d->archive->GetResourceContainer()->GetChildren(
-      this->GetResourcePath(), true, d->children, d->childNodes);
-  }
 
   for (std::vector<uint32_t>::const_iterator iter = d->childNodes.begin(),
                                              iterEnd = d->childNodes.end();

--- a/framework/src/bundle/BundleResourceContainer.cpp
+++ b/framework/src/bundle/BundleResourceContainer.cpp
@@ -58,6 +58,7 @@ BundleResourceContainer::BundleResourceContainer(const std::string& location)
     throw std::runtime_error("Invalid zip archive layout for bundle at " +
                              m_Location);
   }
+
   m_IsContainerOpen = true;
 }
 

--- a/framework/test/gtest/BundleResourceTest.cpp
+++ b/framework/test/gtest/BundleResourceTest.cpp
@@ -71,9 +71,6 @@ TEST(BundleResourceTestNoBundleInstall, getChildResourcesFromInvalidBundle)
 TEST_F(BundleResourceTest, getChildResources)
 {
   BundleResource resource = bundleR.GetResource("icons/");
-  // Demonstrate that call to GetChildren() is not required to get the actual
-  // count of children resources
-  ASSERT_NE(resource.GetChildResources().size(), static_cast<unsigned int>(0));
 
   // Confirm that GetChildResources() returns the correct number
   ASSERT_EQ(resource.GetChildResources().size(), static_cast<unsigned int>(3));

--- a/framework/test/gtest/BundleResourceTest.cpp
+++ b/framework/test/gtest/BundleResourceTest.cpp
@@ -71,10 +71,10 @@ TEST(BundleResourceTestNoBundleInstall, getChildResourcesFromInvalidBundle)
 TEST_F(BundleResourceTest, getChildResources)
 {
   BundleResource resource = bundleR.GetResource("icons/");
-  ASSERT_EQ(resource.GetChildResources().size(), static_cast<unsigned int>(0));
+  // Demonstrate that call to GetChildren() is not required to get the actual
+  // count of children resources
+  ASSERT_NE(resource.GetChildResources().size(), static_cast<unsigned int>(0));
 
-  // GetChildResources() should not have a dependency on GetChildren()
-  // to return the correct size
-  resource.GetChildren();
+  // Confirm that GetChildResources() returns the correct number
   ASSERT_EQ(resource.GetChildResources().size(), static_cast<unsigned int>(3));
 }


### PR DESCRIPTION
This PR removes the need for calling GetChildren() before GetChildResources() to get the correct number of children resources. The operation of populating the childrenNodes vector is moved to the private constructors of BundleResource, thus eliminating the necessity to call GetChildren() before GetChildResources().

Fixes #397 