### PR TITLE
Migrate BundleActivatorTest to gtest

### DIFF
--- a/framework/test/driver/CMakeLists.txt
+++ b/framework/test/driver/CMakeLists.txt
@@ -38,7 +38,6 @@ set(_tests
   LDAPFilterTest
   LDAPQueryTest
   LogTest
-  BundleActivatorTest
   BundleEventTest
   BundleHooksTest
   BundleTest

--- a/framework/test/gtest/BundleActivatorTest.cpp
+++ b/framework/test/gtest/BundleActivatorTest.cpp
@@ -37,7 +37,7 @@ using namespace cppmicroservices;
 class BundleActivatorTest : public ::testing::Test
 {
 protected:
-  static void SetUpTestSuite()
+  void SetUp() override
   {
     f = std::make_shared<cppmicroservices::Framework>(
       FrameworkFactory().NewFramework());
@@ -47,20 +47,15 @@ protected:
                       f->GetBundleContext()));
   }
 
-  static void TearDownTestSuite()
+  void TearDown() override
   {
     f->Stop();
     f->WaitForStop(std::chrono::milliseconds::zero());
-    f = nullptr;
-    ctx = nullptr;
   }
 
-  static std::shared_ptr<cppmicroservices::Framework> f;
-  static std::shared_ptr<cppmicroservices::BundleContext> ctx;
+  std::shared_ptr<cppmicroservices::Framework> f;
+  std::shared_ptr<cppmicroservices::BundleContext> ctx;
 };
-
-std::shared_ptr<cppmicroservices::Framework> BundleActivatorTest::f;
-std::shared_ptr<cppmicroservices::BundleContext> BundleActivatorTest::ctx;
 
 // bundle.activator property not specified in the manifest and bundle has no activator class
 TEST_F(BundleActivatorTest, NoPropertyNoClass)

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 #-----------------------------------------------------------------------------
 set(_gtest_tests 
   AnyMapTest.cpp
+  BundleActivatorTest.cpp
   BundleManifestTest.cpp
   BundleVersionTest.cpp
   InvalidBundleTest.cpp


### PR DESCRIPTION
This PR migrates BundleActivatorTest from the test driver to gtest.