### PR TITLE
Use correct objcopy in all cases

### DIFF
--- a/cmake/usFunctionEmbedResources.cmake
+++ b/cmake/usFunctionEmbedResources.cmake
@@ -199,7 +199,7 @@ function(usFunctionEmbedResources)
       add_custom_command(
         OUTPUT ${_source_output}
         COMMAND ${CMAKE_LINKER} -r -b binary -o ${_source_output} ${_zip_archive_name}
-        COMMAND objcopy --rename-section .data=.us_resources,alloc,load,readonly,data,contents ${_source_output} ${_source_output}
+        COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.us_resources,alloc,load,readonly,data,contents ${_source_output} ${_source_output}
         DEPENDS ${_zip_archive}
         WORKING_DIRECTORY ${_zip_archive_path}
         COMMENT "Linking resources zip file for ${US_RESOURCE_TARGET}"


### PR DESCRIPTION
Resource embedding using the linker will fail when cross compiling. Use the cross build chain's objcopy instead of the host build tools' objcopy.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com