### PR TITLE
Fix Xcode 11 build failure (TestBundleRA)

### DIFF
--- a/cmake/usFunctionEmbedResources.cmake
+++ b/cmake/usFunctionEmbedResources.cmake
@@ -235,6 +235,13 @@ function(usFunctionEmbedResources)
       COMMENT "Appending zipped resources to ${US_RESOURCE_TARGET}"
       VERBATIM
     )
+    
+    # Disable code-signing on macOS if appending resources.
+	if(APPLE)
+	  set_target_properties(${US_RESOURCE_TARGET} PROPERTIES
+		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+	endif()
+	
   endif()
 
 endfunction()

--- a/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
+++ b/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
@@ -12,6 +12,3 @@ usFunctionCreateTestBundleWithResources(TestBundleRA
   APPEND_RESOURCES
 )
 
-if(APPLE)
-	set_target_properties(TestBundleRA PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
-endif()

--- a/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
+++ b/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
@@ -12,6 +12,6 @@ usFunctionCreateTestBundleWithResources(TestBundleRA
   APPEND_RESOURCES
 )
 
-set_target_properties(TestBundleRA PROPERTIES
-	XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-)
+if(APPLE)
+	set_target_properties(TestBundleRA PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+endif()

--- a/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
+++ b/framework/test/bundles/libRWithAppendedResources/CMakeLists.txt
@@ -12,3 +12,6 @@ usFunctionCreateTestBundleWithResources(TestBundleRA
   APPEND_RESOURCES
 )
 
+set_target_properties(TestBundleRA PROPERTIES
+	XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+)


### PR DESCRIPTION
TestBundleRA fail to build in Xcode 11 with the following message:
`"main executable failed strict validation"`

This is the behavior described in the following Apple documentation regarding codesign:
https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG309

Appending a resources zip at the end of a dylib is not a supported workflow; and starting with Xcode 11, codesign step fails. 

I added an Apple-only CMake property to disable codesigning TestBundleRA.