### PR TITLE
Minimum version of CMake set to 3.13.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ install:
       CMAKE_OS="Darwin";
     fi
   - CMAKE_VER_DIR="v3.13"
-  - CMAKE_VER="3.13.2"
+  - CMAKE_VER="3.13.4"
   - CMAKE_DIR="cmake-${CMAKE_VER}-${CMAKE_OS}-x86_64"
   - CMAKE_FILE="${CMAKE_DIR}.tar.gz"
   - CMAKE_SHA_FILE="cmake-${CMAKE_VER}-SHA-256.txt"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Extract the current version from the VERSION file
 file(STRINGS VERSION _version LIMIT_COUNT 1)
 
-set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.2)
+set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.13.4)
 
 cmake_minimum_required(VERSION ${US_CMAKE_MINIMUM_REQUIRED_VERSION})
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ your build tree. The following are the absolute minimum requirements:
 
 Recommended minimum required CMake version:
 
-- CMake 3.12.4 
+- CMake 3.13.4 
 
 Below is a list of tested compiler/OS combinations:
 

--- a/doc/src/build_instructions.rst
+++ b/doc/src/build_instructions.rst
@@ -11,7 +11,7 @@ project or *Make* files.
 Prerequisites
 -------------
 
--  `CMake <http://www.cmake.org>`_ 3.2 (users of the latest Visual Studio
+-  `CMake <http://www.cmake.org>`_ 3.13.4 (users of the latest Visual Studio
    should typically also use the latest CMake version available)
 
 Configuration
@@ -31,7 +31,7 @@ configuration options at hand.
    .. note::
 
       In version 3.0 and 3.1 this option only supported the *ON* value.
-      The *OFF* configuration is supported again in version 3.2 and later.
+      The *OFF* configuration is supported again in version 3.2 and above and later.
 
  - **BUILD_SHARED_LIBS** Specify if the library should be build
    shared or static. See :any:`concept-static-bundles`


### PR DESCRIPTION
This is with reference to issue #445. The minimum version in docs was 3.2 (do not interpret 3.2 as 3.20), whereas some CMake Commands require the latest CMake version. I checked it on Raspbian OS with CMake version 3.13.4 and the CppMicroservices built successfully.

Singing off: Ameya Patil (ameyapatilr@gmail.com)