### PR TITLE
Remove unary_function from GlobalConfig.h

### DIFF
--- a/cmake/GlobalConfig.h.in
+++ b/cmake/GlobalConfig.h.in
@@ -145,7 +145,7 @@ US_MSVC_DISABLE_WARNING(4996)
 #define US_HASH_FUNCTION_BEGIN(type)                         \
 namespace std {                                              \
 template<>                                                   \
-struct hash<type> : std::unary_function<type, std::size_t> { \
+struct hash<type> { \
 std::size_t operator()(const type& arg) const {
 
 #define US_HASH_FUNCTION_END } }; }

--- a/framework/include/cppmicroservices/BundleResource.h
+++ b/framework/include/cppmicroservices/BundleResource.h
@@ -23,6 +23,7 @@
 #ifndef CPPMICROSERVICES_BUNDLERESOURCE_H
 #define CPPMICROSERVICES_BUNDLERESOURCE_H
 
+#include <functional>
 #include "cppmicroservices/FrameworkExport.h"
 
 #include <cstdint>

--- a/framework/include/cppmicroservices/ServiceListenerHook.h
+++ b/framework/include/cppmicroservices/ServiceListenerHook.h
@@ -23,6 +23,7 @@
 #ifndef CPPMICROSERVICES_SERVICELISTENERHOOK_H
 #define CPPMICROSERVICES_SERVICELISTENERHOOK_H
 
+#include <functional>
 #include "cppmicroservices/ServiceInterface.h"
 #include "cppmicroservices/SharedData.h"
 #include "cppmicroservices/ShrinkableVector.h"

--- a/framework/include/cppmicroservices/ServiceReferenceBase.h
+++ b/framework/include/cppmicroservices/ServiceReferenceBase.h
@@ -23,6 +23,7 @@
 #ifndef CPPMICROSERVICES_SERVICEREFERENCEBASE_H
 #define CPPMICROSERVICES_SERVICEREFERENCEBASE_H
 
+#include <functional>
 #include "cppmicroservices/Any.h"
 
 #include <atomic>

--- a/framework/include/cppmicroservices/ServiceRegistrationBase.h
+++ b/framework/include/cppmicroservices/ServiceRegistrationBase.h
@@ -23,6 +23,7 @@
 #ifndef CPPMICROSERVICES_SERVICEREGISTRATIONBASE_H
 #define CPPMICROSERVICES_SERVICEREGISTRATIONBASE_H
 
+#include <functional>
 #include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/ServiceReference.h"
 


### PR DESCRIPTION
Fixes #457 
Remove unary_function to make the headers compatible with C++17 code.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com