### PR TITLE
Use const ref variable to store AnyMap

### DIFF
--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -100,7 +100,7 @@ void SCRActivator::Stop(cppmicroservices::BundleContext context)
 
 void SCRActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
 {
-  auto headers = bundle.GetHeaders();
+  const auto& headers = bundle.GetHeaders();
   // bundle has no "scr" property
   if (headers.count(SERVICE_COMPONENT) == 0u)
   {
@@ -139,7 +139,7 @@ void SCRActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
 
 void SCRActivator::DisposeExtension(const cppmicroservices::Bundle& bundle)
 {
-  auto headers = bundle.GetHeaders();
+  const auto& headers = bundle.GetHeaders();
   // bundle has no scr-component property
   if (headers.count(SERVICE_COMPONENT) == 0u)
   {

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -453,7 +453,7 @@ std::exception_ptr BundlePrivate::Start0()
   coreCtx->listeners.BundleChanged(
     BundleEvent(BundleEvent::BUNDLE_STARTING, thisBundle));
 
-  auto headers = thisBundle.GetHeaders();
+  const auto& headers = thisBundle.GetHeaders();
   Any bundleActivatorVal;
   if (headers.count(Constants::BUNDLE_ACTIVATOR) > 0) {
     bundleActivatorVal = headers.find(Constants::BUNDLE_ACTIVATOR)->second;

--- a/framework/test/bench/AnyMapPerfTest.cpp
+++ b/framework/test/bench/AnyMapPerfTest.cpp
@@ -72,10 +72,10 @@ std::string constructNestedKey(unsigned int depth
 
 BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, HappyPath)(benchmark::State& state)
 {
-  auto         bundleProps = testBundle.GetHeaders();
-  Any&         testData    = bundleProps.at("Test_AtCompoundKey");
+  const auto&  bundleProps = testBundle.GetHeaders();
+  const Any&         testData    = bundleProps.at("Test_AtCompoundKey");
   assert(!testData.Empty());
-  AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
+  const AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
   unsigned int depth       = static_cast<unsigned int>(state.range(0));
   std::string  key(constructNestedKey(depth, "relativelylongkeyname_map", "relativelylongkeyname_element"));
 
@@ -92,10 +92,10 @@ BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, HappyPath)(benchmark::State& state)
 
 BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, ErrorPath)(benchmark::State& state)
 {
-  auto         bundleProps = testBundle.GetHeaders();
-  Any&         testData    = bundleProps.at("Test_AtCompoundKey");
+  const auto&  bundleProps = testBundle.GetHeaders();
+  const Any&         testData    = bundleProps.at("Test_AtCompoundKey");
   assert(!testData.Empty());
-  AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
+  const AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
   unsigned int depth       = static_cast<unsigned int>(state.range(0));
   std::string  key(constructNestedKey(depth, "relativelylongkeyname_map", "relativelylongkeyname_unknown"));
 
@@ -113,10 +113,10 @@ BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, ErrorPath)(benchmark::State& state)
 
 BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, HappyPath_NoThrowOverload)(benchmark::State& state)
 {
-  auto         bundleProps = testBundle.GetHeaders();
-  Any&         testData    = bundleProps.at("Test_AtCompoundKey");
+  const auto&  bundleProps = testBundle.GetHeaders();
+  const Any&         testData    = bundleProps.at("Test_AtCompoundKey");
   assert(!testData.Empty());
-  AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
+  const AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
   unsigned int depth       = static_cast<unsigned int>(state.range(0));
   std::string  key(constructNestedKey(depth, "relativelylongkeyname_map", "relativelylongkeyname_element"));
 
@@ -134,10 +134,10 @@ BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, HappyPath_NoThrowOverload)(benchmark::
 
 BENCHMARK_DEFINE_F(AnyMapPerfTestFixture, ErrorPath_NoThrowOverload)(benchmark::State& state)
 {
-  auto         bundleProps = testBundle.GetHeaders();
-  Any&         testData    = bundleProps.at("Test_AtCompoundKey");
+  const auto&  bundleProps = testBundle.GetHeaders();
+  const Any&         testData    = bundleProps.at("Test_AtCompoundKey");
   assert(!testData.Empty());
-  AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
+  const AnyMap&      testAnyMap  = ref_any_cast<AnyMap>(testData);
   unsigned int depth       = static_cast<unsigned int>(state.range(0));
   std::string  key(constructNestedKey(depth
                                       , "relativelylongkeyname_map"

--- a/framework/test/driver/BundleTest.cpp
+++ b/framework/test/driver/BundleTest.cpp
@@ -144,7 +144,7 @@ public:
     US_TEST_CONDITION_REQUIRED(!sr1, "service from bundle A must not exist yet")
 
     // Check manifest headers
-    auto headers = buA.GetHeaders();
+    const auto& headers = buA.GetHeaders();
     US_TEST_CONDITION_REQUIRED(headers.size() > 0,
                                "One or more manifest header")
     US_TEST_CONDITION(headers.at("bundle.symbolic_name") ==
@@ -248,7 +248,7 @@ public:
     }
 
     // Check manifest headers in stopped state
-    auto headers = buA.GetHeaders();
+    const auto& headers = buA.GetHeaders();
     US_TEST_CONDITION_REQUIRED(headers.size() > 0,
                                "One ore more manifest header")
     US_TEST_CONDITION(headers.at("bundle.symbolic_name") ==

--- a/framework/test/gtest/BundleManifestTest.cpp
+++ b/framework/test/gtest/BundleManifestTest.cpp
@@ -121,7 +121,7 @@ TEST(BundleManifestTest, InstallBundleWithDeepManifest)
   auto framework = FrameworkFactory().NewFramework();
   framework.Start();
   auto bundle = cppmicroservices::testing::InstallLib(framework.GetBundleContext(), "TestBundleWithDeepManifest");
-  auto headers = bundle.GetHeaders();
+  const auto& headers = bundle.GetHeaders();
   ASSERT_THAT(headers.at(Constants::BUNDLE_SYMBOLICNAME).ToString()
               , ::testing::StrEq("TestBundleWithDeepManifest")) << "Bundle symblic name doesn't match.";
 
@@ -143,7 +143,7 @@ TEST(BundleManifestTest, ParseManifest)
   
   ASSERT_TRUE(bundleM) << "Failed to install TestBundleM";
 
-  auto headers = bundleM.GetHeaders();
+  const auto& headers = bundleM.GetHeaders();
   
   EXPECT_THAT(headers.at(Constants::BUNDLE_SYMBOLICNAME).ToString()
               , ::testing::StrEq("TestBundleM"));

--- a/webconsole/src/BundlesPlugin.cpp
+++ b/webconsole/src/BundlesPlugin.cpp
@@ -213,7 +213,7 @@ AbstractWebConsolePlugin::TemplateData BundlesPlugin::GetBundlesData() const
   for (auto& bundle : bundles) {
     TemplateData entry;
 
-    AnyMap headers = bundle.GetHeaders();
+    const AnyMap& headers = bundle.GetHeaders();
 
     entry["id"] = NumToString(bundle.GetBundleId());
     entry["bsn"] = bundle.GetSymbolicName();
@@ -328,7 +328,7 @@ void BundlesPlugin::GetBundleData(long id,
   if (!bundle)
     return;
 
-  auto headers = bundle.GetHeaders();
+  const auto& headers = bundle.GetHeaders();
   SetIfExists(data, "bundle-name", Constants::BUNDLE_NAME, headers);
   data["bundle-bsn"] = bundle.GetSymbolicName();
 


### PR DESCRIPTION
Remove unnecessary AnyMap copying

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com