### PR TITLE
Addition of new benchmark test point for ServiceTrackers with LDAPFilters

### DIFF
--- a/framework/test/bench/ServiceTrackerTest.cpp
+++ b/framework/test/bench/ServiceTrackerTest.cpp
@@ -138,6 +138,7 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultiplieImplOneInterfaceServiceTracke
 
   int64_t maxServices{ state.range(0) };
   std::vector<std::shared_ptr<FooImpl>> impls;
+  impls.reserve(maxServices);
   for (int64_t i = 0; i < maxServices; ++i) {
     impls.emplace_back(std::make_shared<FooImpl>());
   }

--- a/framework/test/bench/ServiceTrackerTest.cpp
+++ b/framework/test/bench/ServiceTrackerTest.cpp
@@ -138,7 +138,7 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTracker
 
   int64_t maxServices{ state.range(0) };
   std::vector<std::shared_ptr<FooImpl>> impls;
-  impls.reserve((size_t)maxServices);
+  impls.reserve(static_cast<size_t>(maxServices));
   for (int64_t i = 0; i < maxServices; ++i) {
     impls.emplace_back(std::make_shared<FooImpl>());
   }
@@ -147,7 +147,7 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTracker
 
   for (auto _ : state) {
     for (int64_t i = 0; i < maxServices; ++i) {
-      fc.RegisterService<Foo>(impls[i]);
+      fc.RegisterService<Foo>(impls[static_cast<size_t>(i)]);
     }
   }
 

--- a/framework/test/bench/ServiceTrackerTest.cpp
+++ b/framework/test/bench/ServiceTrackerTest.cpp
@@ -129,7 +129,7 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalability)(benchmark::
 }
 
 /// Benchmark service tracker scalability (use case: one ServiceTracker, multiple service impls)
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultiplieImplOneInterfaceServiceTrackerScalability)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTrackerScalability)(benchmark::State& state)
 {
   using namespace benchmark::test;
   using namespace cppmicroservices;
@@ -138,7 +138,7 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultiplieImplOneInterfaceServiceTracke
 
   int64_t maxServices{ state.range(0) };
   std::vector<std::shared_ptr<FooImpl>> impls;
-  impls.reserve(maxServices);
+  impls.reserve((size_t)maxServices);
   for (int64_t i = 0; i < maxServices; ++i) {
     impls.emplace_back(std::make_shared<FooImpl>());
   }
@@ -189,9 +189,9 @@ BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalability)->Arg(1)
                                                                       ->Arg(4000)
                                                                       ->Arg(10000);
 BENCHMARK_REGISTER_F(ServiceTrackerFixture,
-                     MultiplieImplOneInterfaceServiceTrackerScalability)->Arg(1)
-                                                                        ->Arg(4000)
-                                                                        ->Arg(10000);
+                     MultipleImplOneInterfaceServiceTrackerScalability)->Arg(1)
+                                                                       ->Arg(4000)
+                                                                       ->Arg(10000);
 BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalabilityWithLDAPFilter)->Arg(1)
                                                                                     ->Arg(4000)
                                                                                     ->Arg(10000);


### PR DESCRIPTION
Added a new benchmark test point to the ServiceTrackerTest suite to test the performance of creating multiple ServiceTrackers which track specific services based upon a specified LDAPFilter.

This added test helps with profiling the performance of this type of operation.