### PR TITLE
Fix codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,22 +89,28 @@ matrix:
       - os: osx
         osx_image: xcode10.3
         compiler: clang
+        env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.14
+
+      - os: osx
+        osx_image: xcode10.3
+        compiler: clang
+        env: BUILD_CONFIGURATION=1 MACOSX_DEPLOYMENT_TARGET=10.14
+
+      - os: osx
+        osx_image: xcode10.3
+        compiler: clang
+        env: BUILD_CONFIGURATION=2 MACOSX_DEPLOYMENT_TARGET=10.14
+
+      - os: osx
+        osx_image: xcode10.3
+        compiler: clang
+        env: BUILD_CONFIGURATION=3 MACOSX_DEPLOYMENT_TARGET=10.14
+
+# To generate codecov reports
+      - os: osx
+        osx_image: xcode10.3
+        compiler: clang
         env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.14 WITH_COVERAGE=1
-
-      - os: osx
-        osx_image: xcode10.3
-        compiler: clang
-        env: BUILD_CONFIGURATION=1 MACOSX_DEPLOYMENT_TARGET=10.14 WITH_COVERAGE=1
-
-      - os: osx
-        osx_image: xcode10.3
-        compiler: clang
-        env: BUILD_CONFIGURATION=2 MACOSX_DEPLOYMENT_TARGET=10.14 WITH_COVERAGE=1
-
-      - os: osx
-        osx_image: xcode10.3
-        compiler: clang
-        env: BUILD_CONFIGURATION=3 MACOSX_DEPLOYMENT_TARGET=10.14 WITH_COVERAGE=1
 
 cache:
   directories:

--- a/cmake/usCTestScript.cmake
+++ b/cmake/usCTestScript.cmake
@@ -91,7 +91,7 @@ set(config2     1       0     )
 set(config3     0       0     )
 
 if(NOT US_CMAKE_GENERATOR)
-  if(APPLE)
+  if(APPLE AND NOT WITH_COVERAGE)
     set(US_CMAKE_GENERATOR "Xcode")
   else()
     set(US_CMAKE_GENERATOR "Unix Makefiles")


### PR DESCRIPTION
Issue: Code coverage was not getting generated for macOS when built with xcode.

Cause: gcov was unable to find any object file as Xcode generates those files in a different path than what gcov expects. Due to this mismatch in paths codecov reports were not generated. 

Solution: Stitching the path was not feasible as it would disturb the relative paths in code coverage report. Therefore, to generate code coverage, added a new osX configuration with cmake generator = 'Unix Makefiles'. This generates the code coverage report and also makes it easy to conserve the relative path.

Signed-off-by: The MathWorks, Inc. Roy.Lurie@mathworks.com