### PR TITLE
Make existing code c++17 compliant for future upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endforeach()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # Since version 3.1, CMake pulls in implicit link libraries when compiling
 # source files in C mode. Because we mix C and C++ code in the test driver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endforeach()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 
 # Since version 3.1, CMake pulls in implicit link libraries when compiling
 # source files in C mode. Because we mix C and C++ code in the test driver

--- a/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <vector>
 #include <memory>
+#include <random>
 #include "gmock/gmock.h"
 #include <cppmicroservices/Framework.h>
 #include <cppmicroservices/FrameworkFactory.h>
@@ -47,7 +48,9 @@ std::string GenRandomString()
 {
   static const std::string name("com::servicecomponentimpl.testcompname");
   std::string tempName = name;
-  std::random_shuffle(tempName.begin(), tempName.end());
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(tempName.begin(), tempName.end(), g);
   return tempName;
 }
 

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -34,7 +34,7 @@ US_MSVC_PUSH_DISABLE_WARNING(
 namespace cppmicroservices {
 
 struct ServiceListenerCompare
-  : std::binary_function<ServiceListener, ServiceListener, bool>
+  : std::function<bool(ServiceListener, ServiceListener)>
 {
   bool operator()(const ServiceListener& f1, const ServiceListener& f2) const
   {


### PR DESCRIPTION
When compiling the project with -std=c++17, there are a few sections of the code which cause problems due to deprecation of certain APIs. This PR aims to fix these while still remaining the current c++ standard version (14) until a decision has been made to upgrade it.

In one instance, our code was using std::random_shuffle (which was deprecated), and in another, we were using std::binary_function (which was also deprecated). For the first issue, the usage of this API had to be updated; instead of using std::random_shuffle, we now use std;:shuffle and pass in the std::mt19937 as a UniformRandomBitGenerator. For the latter issue, switching this to use std::function<bool(ServiceListener, ServiceListener)> is sufficient.

All changes were built and tested on all platforms.