### PR TITLE
Improve performance of ServiceTrackers and LDAP

### DIFF
--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -143,10 +143,12 @@ void ServiceListenerEntry::CallDelegate(const ServiceEvent& event) const
 
 bool ServiceListenerEntry::operator==(const ServiceListenerEntry& other) const
 {
-  return (d->data == other.d->data) && (d->tokenId == other.d->tokenId) &&
-         ServiceListenerCompare()(d->listener, other.d->listener) &&
-         ((d->context == nullptr || other.d->context == nullptr) ||
-          d->context == other.d->context);
+  return (d->data == other.d->data)
+         && (d->tokenId == other.d->tokenId)
+         && ServiceListenerCompare()(d->listener, other.d->listener)
+         && ((d->context == nullptr
+              || other.d->context == nullptr)
+            || d->context == other.d->context);
 }
 
 bool ServiceListenerEntry::operator<(const ServiceListenerEntry& other) const 

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -143,10 +143,15 @@ void ServiceListenerEntry::CallDelegate(const ServiceEvent& event) const
 
 bool ServiceListenerEntry::operator==(const ServiceListenerEntry& other) const
 {
-  return ((d->context == nullptr || other.d->context == nullptr) ||
-          d->context == other.d->context) &&
-         (d->data == other.d->data) && (d->tokenId == other.d->tokenId) &&
-         ServiceListenerCompare()(d->listener, other.d->listener);
+  return (d->data == other.d->data) && (d->tokenId == other.d->tokenId) &&
+         ServiceListenerCompare()(d->listener, other.d->listener) &&
+         ((d->context == nullptr || other.d->context == nullptr) ||
+          d->context == other.d->context);
+}
+
+bool ServiceListenerEntry::operator<(const ServiceListenerEntry& other) const 
+{
+  return d->tokenId < other.d->tokenId;
 }
 
 bool ServiceListenerEntry::Contains(

--- a/framework/src/service/ServiceListenerEntry.h
+++ b/framework/src/service/ServiceListenerEntry.h
@@ -66,6 +66,7 @@ public:
   void CallDelegate(const ServiceEvent& event) const;
 
   bool operator==(const ServiceListenerEntry& other) const;
+  bool operator<(const ServiceListenerEntry& other) const;
 
   bool Contains(const std::shared_ptr<BundleContextPrivate>& context,
                 ListenerTokenId tokenId) const;

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -501,12 +501,9 @@ void ServiceListeners::AddToSet_unlocked(
 {
   std::set<ServiceListenerEntry>& l = cache[cache_ix][val];
   if (!l.empty()) {
-
-    for (std::set<ServiceListenerEntry>::const_iterator entry = l.begin();
-         entry != l.end();
-         ++entry) {
-      if (receivers.count(*entry)) {
-        set.insert(*entry);
+    for (const ServiceListenerEntry& entry : l) {
+      if (receivers.count(entry)) {
+        set.insert(entry);
       }
     }
   }

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -458,8 +458,8 @@ void ServiceListeners::RemoveFromCache_unlocked(const ServiceListenerEntry& sle)
       CacheType& keymap = cache[i];
       std::vector<std::string>& filters = sle.GetLocalCache()[i];
       for (auto const& filter : filters) {
-        std::list<ServiceListenerEntry>& sles = keymap[filter];
-        sles.remove(sle);
+        std::set<ServiceListenerEntry>& sles = keymap[filter];
+        sles.erase(sle);
         if (sles.empty()) {
           keymap.erase(filter);
         }
@@ -483,8 +483,8 @@ void ServiceListeners::CheckSimple_unlocked(const ServiceListenerEntry& sle)
                local_cache[i].begin();
              it != local_cache[i].end();
              ++it) {
-          std::list<ServiceListenerEntry>& sles = cache[i][*it];
-          sles.push_back(sle);
+          std::set<ServiceListenerEntry>& sles = cache[i][*it];
+          sles.insert(sle);
         }
       }
     } else {
@@ -499,10 +499,10 @@ void ServiceListeners::AddToSet_unlocked(
   int cache_ix,
   const std::string& val)
 {
-  std::list<ServiceListenerEntry>& l = cache[cache_ix][val];
+  std::set<ServiceListenerEntry>& l = cache[cache_ix][val];
   if (!l.empty()) {
 
-    for (std::list<ServiceListenerEntry>::const_iterator entry = l.begin();
+    for (std::set<ServiceListenerEntry>::const_iterator entry = l.begin();
          entry != l.end();
          ++entry) {
       if (receivers.count(*entry)) {

--- a/framework/src/service/ServiceListeners.h
+++ b/framework/src/service/ServiceListeners.h
@@ -58,7 +58,7 @@ public:
     BundleListenerMap value;
   } bundleListenerMap;
 
-  using CacheType = std::unordered_map<std::string, std::list<ServiceListenerEntry>>;
+  using CacheType = std::unordered_map<std::string, std::set<ServiceListenerEntry>>;
   using ServiceListenerEntries = std::unordered_set<ServiceListenerEntry>;
 
   using FrameworkListenerEntry = std::tuple<FrameworkListener, void*>;


### PR DESCRIPTION
This PR accomplishes the task of improving the performance of ServiceTracker objects and LDAP. Through a combination of switching up one of the data structures currently utilized and the re-ordering of a conditional to help with short circuiting, a noticeable speedup is exhibited. The last benchmark test does not exhibit as large as a speedup as the others documented here; a reason for this is that there are a wide variety of smaller areas of improvement throughout the code which contribute to this slowdown. Each of these tests were profiled and I decided to tackle the most egregious offenders when it came to performance (hence the speedup with respect to common use cases and a smaller speedup with respect to a more niche use case).

As an added benefit, all changes with respect to the implementation are "internal" in the sense that customers of the library will not need to make any changes for this to work properly; this was a main concern when trying to accomplish this task and it proved to be doable.

All times below are in nanoseconds (ns). Benchmarking was done on an Intel i7-4790K @ 4.0 GHz

| Benchmark | Time (development) | Time (ldap-service-tracker-performance) | CPU (development) | CPU (ldap-service-tracker-performance) | Iterations |
| :------------ |----------------------: | --------------------------------------------: | ---------------------: | ----------------------------------------------: | ----------: |
| ServiceTrackerFixture/ServiceTrackerScalability/1_mean | 28024 | 20201 | 27169 | 20207 | 32 |
| ServiceTrackerFixture/ServiceTrackerScalability/4000_mean | 21803450 | 12617028 | 20943307 | 12581961 | 32 |
| ServiceTrackerFixture/ServiceTrackerScalability/10000_mean | 54738354 | 35153763 | 52685547 | 35130551 | 32 |

| Benchmark | Time (development) | Time (ldap-service-tracker-performance) | CPU (development) | CPU (ldap-service-tracker-performance) | Iterations |
| :------------ |----------------------: | --------------------------------------------: | ---------------------: | ----------------------------------------------: | ----------: |
| ServiceTrackerFixture/ServiceTrackerScalabilityWithLDAPFilter/1_mean | 18605 | 17241 | 18561 | 17225 | 32 |
| ServiceTrackerFixture/ServiceTrackerScalabilityWithLDAPFilter/4000_mean | 1106599 | 773077 | 1099396 | 772749 | 32 |
| ServiceTrackerFixture/ServiceTrackerScalabilityWithLDAPFilter/10000_mean | 5590129 | 2942335 | 5537109 | 2944170 | 32 |

| Benchmark | Time (development) | Time (ldap-service-tracker-performance) | CPU (development) | CPU (ldap-service-tracker-performance) | Iterations |
| :------------ |----------------------: | --------------------------------------------: | ---------------------: | ----------------------------------------------: | ----------: |
| ServiceTrackerFixture/MultiplieImplOneInterfaceServiceTrackerScalability/1_mean | 21891 | 21070 | 21848 | 20979 | 32 |
| ServiceTrackerFixture/MultiplieImplOneInterfaceServiceTrackerScalability/4000_mean | 85944123 | 83312018 | 85666233 | 83333333 | 32 |
| ServiceTrackerFixture/MultiplieImplOneInterfaceServiceTrackerScalability/10000_mean | 207529861 | 206484694 | 206380208 | 206420898 | 32 |