### PR TITLE
Fix data race in BundleRegistry::Install()

### DIFF
--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -44,12 +44,14 @@
 namespace cppmicroservices {
 
 // Helper class to ensure RAII for InitialBundleMap in case where Install0 throws
-class InitialBundleMapCleanup {
+class InitialBundleMapCleanup
+{
 public:
-  InitialBundleMapCleanup(std::function<void()> cleanupFcn) : _cleanupFcn(std::move(cleanupFcn)) {}
-  ~InitialBundleMapCleanup() {
-	_cleanupFcn();
-  }
+  InitialBundleMapCleanup(std::function<void()> cleanupFcn)
+    : _cleanupFcn(std::move(cleanupFcn))
+  {}
+  ~InitialBundleMapCleanup() { _cleanupFcn(); }
+
 private:
   std::function<void()> _cleanupFcn;
 };
@@ -93,18 +95,22 @@ void BundleRegistry::DecrementInitialBundleMapRef(
 /*
   This function populates the res and alreadyInstalled vectors with the
   appropriate entries so that they can be used by the Install0 call. This was
-  extracted from Install() for convenience.
+  extracted from Install() for convenience. We lock the 'bundles' object to
+  prevent any installs from writing to the map while this operation is occurring.
 */
 void BundleRegistry::GetAlreadyInstalledBundlesAtLocation(
   std::pair<BundleMap::iterator, BundleMap::iterator> foundBundles,
   std::vector<Bundle>& resultingBundles,
   std::vector<std::shared_ptr<BundlePrivate>>& alreadyInstalled)
 {
+  auto l = bundles.Lock();
+  US_UNUSED(l);
   while (foundBundles.first != foundBundles.second) {
     auto installedBundlePrivate = foundBundles.first->second;
     alreadyInstalled.push_back(installedBundlePrivate);
     auto actualBundle = coreCtx->bundleHooks.FilterBundle(
-      MakeBundleContext(installedBundlePrivate->bundleContext.Load()), MakeBundle(installedBundlePrivate));
+      MakeBundleContext(installedBundlePrivate->bundleContext.Load()),
+      MakeBundle(installedBundlePrivate));
     if (actualBundle) {
       resultingBundles.push_back(actualBundle);
     }
@@ -125,7 +131,8 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
   US_UNUSED(l);
 
   // Search the multimap for the current bundle location
-  auto bundlesAtLocationRange = (bundles.Lock(), bundles.v.equal_range(location));
+  auto bundlesAtLocationRange =
+    (bundles.Lock(), bundles.v.equal_range(location));
 
   /*
     If the bundle is already installed, then execute the regular
@@ -133,8 +140,8 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
 
     If the bundle isn't installed, then one of two things can happen: 1) either
     the current thread is the first thread trying to install this bundle or 2) the
-    current thread is trying to install a bundle that is not installed which another
-    thread is currently installing.
+    current thread is trying to install a bundle that is not installed but another
+    thread is currently installing that bundle.
 
     If 1): Create an entry in the initialBundleInstallMap which keeps track of whether
       or not a given bundle is being installed for the first time. After creating this
@@ -151,16 +158,17 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
   */
   if (bundlesAtLocationRange.first != bundlesAtLocationRange.second) {
     l.UnLock();
-
     std::vector<Bundle> resultingBundles;
     std::vector<std::shared_ptr<BundlePrivate>> alreadyInstalled;
     // Populate the res and alreadyInstalled vectors with the appropriate data
     // based on what bundles are already installed
-    GetAlreadyInstalledBundlesAtLocation(bundlesAtLocationRange, resultingBundles, alreadyInstalled);
+    GetAlreadyInstalledBundlesAtLocation(
+      bundlesAtLocationRange, resultingBundles, alreadyInstalled);
 
     // Perform the install
     auto newBundles = Install0(location, alreadyInstalled, caller);
-    resultingBundles.insert(resultingBundles.end(), newBundles.begin(), newBundles.end());
+    resultingBundles.insert(
+      resultingBundles.end(), newBundles.begin(), newBundles.end());
     if (resultingBundles.empty()) {
       throw std::runtime_error("All bundles rejected by a bundle hook");
     } else {
@@ -173,7 +181,7 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
 
     /*
       If no other thread is installing the desired bundle, create a map entry,
-      install the bundle, and notify all other threads wanting to install this bundle
+      install the bundle, and notify all other threads waiting to install this bundle
       that it is safe to do so. If the current thread is not the installing thread, then
       it will increment the reference count in the initialBundleInstallMap so that the map
       entry isn't prematurely deleted, wait to be notified that the install thread is done,
@@ -181,26 +189,29 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
     */
     if (alreadyInstallingIterator == initialBundleInstallMap.end()) {
       // Insert entry into the initialBundleInstallMap to prevent other threads from
-      // trying to install this uninstalled bundle at the same time
+      // trying to install this bundle simultaneously at the same time
       auto pairToInsert = std::make_pair(uint32_t(1), WaitCondition{});
       initialBundleInstallMap.insert(
         std::make_pair(location, std::move(pairToInsert)));
       l.UnLock();
 
       std::vector<Bundle> installedBundles;
-      
       {
         // create instance of clean-up object to ensure RAII
-        InitialBundleMapCleanup cleanup([this, &l, &location](){
+        InitialBundleMapCleanup cleanup([this, &l, &location]() {
           {
+            l.Lock();
+            auto& p = initialBundleInstallMap[location];
+
             // Notify all waiting threads that it is safe to install the bundle
-            std::lock_guard<std::mutex> lock(*(initialBundleInstallMap[location].second.m));
-            initialBundleInstallMap[location].second.waitFlag = false;
-            initialBundleInstallMap[location].second.cv->notify_all();
+            std::lock_guard<std::mutex> lock(*(p.second.m));
+            p.second.waitFlag = false;
+            p.second.cv->notify_all();
+            l.UnLock();
           }
           DecrementInitialBundleMapRef(l, location);
         });
-          
+
         // Perform the install
         installedBundles = Install0(location, {}, caller);
       }
@@ -208,37 +219,39 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
       return installedBundles;
     } else {
       initialBundleInstallMap[location].first++;
-      
       {
         // Wait for the install thread to notify this thread that it is safe
         // to install the current bundle
-        std::unique_lock<std::mutex> lock(
-          *(initialBundleInstallMap[location].second.m));
+        auto& p = initialBundleInstallMap[location];
+        l.UnLock();
+        std::unique_lock<std::mutex> lock(*(p.second.m));
 
         // This while loop exists to prevent a known race condition. If the installing thread notifies before
         // another thread trying to install the same bundle reaches this wait, it will wait indefinitely. To
-        // fix this, a wait_for is used intead (which utilizes a timeout to avoid this race) and the wait statement
+        // fix this, a wait_for is used instead (which utilizes a timeout to avoid this race) and the wait statement
         // as a whole acts as the while statement's predicate; once the timeout is reached, wait_for exits and the
         // statement is re-evaluated since it would have returned false.
-        while (!initialBundleInstallMap[location].second.cv->wait_for(lock, 0.1ms, [&location, this] {
-          return !initialBundleInstallMap[location].second.waitFlag;
-          }));
+        while (!p.second.cv->wait_for(
+          lock, 0.01ms, [&p] { return !p.second.waitFlag; }))
+          ;
       }
-      
+
+      l.Lock();
       // Re-acquire the range because while this thread was waiting, the installing
       // thread made a modification to bundles.v
-      bundlesAtLocationRange = (bundles.Lock(), bundles.v.equal_range(location));
+      bundlesAtLocationRange =
+        (bundles.Lock(), bundles.v.equal_range(location));
       l.UnLock();
 
       std::vector<Bundle> resultingBundles;
       std::vector<std::shared_ptr<BundlePrivate>> alreadyInstalled;
-      GetAlreadyInstalledBundlesAtLocation(bundlesAtLocationRange, resultingBundles, alreadyInstalled);
+      GetAlreadyInstalledBundlesAtLocation(
+        bundlesAtLocationRange, resultingBundles, alreadyInstalled);
 
       std::vector<Bundle> newBundles;
-      
       {
         // create instance of clean-up object to ensure RAII
-        InitialBundleMapCleanup cleanup([this, &l, &location](){
+        InitialBundleMapCleanup cleanup([this, &l, &location]() {
           DecrementInitialBundleMapRef(l, location);
         });
 
@@ -246,7 +259,8 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
         newBundles = Install0(location, alreadyInstalled, caller);
       }
 
-      resultingBundles.insert(resultingBundles.end(), newBundles.begin(), newBundles.end());
+      resultingBundles.insert(
+        resultingBundles.end(), newBundles.begin(), newBundles.end());
       if (resultingBundles.empty()) {
         throw std::runtime_error("All bundles rejected by a bundle hook");
       } else {
@@ -415,7 +429,7 @@ void BundleRegistry::Load()
       ba->SetAutostartSetting(-1); // Do not start on launch
       std::cerr << "Failed to load bundle " << util::ToString(ba->GetBundleId())
                 << " (" + ba->GetBundleLocation() + ") uninstalled it!"
-                << " (execption: "
+                << " (exception: "
                 << util::GetExceptionStr(std::current_exception()) << ")"
                 << std::endl;
     }

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -96,7 +96,9 @@ void BundleRegistry::DecrementInitialBundleMapRef(
   This function populates the res and alreadyInstalled vectors with the
   appropriate entries so that they can be used by the Install0 call. This was
   extracted from Install() for convenience. We lock the 'bundles' object to
-  prevent any installs from writing to the map while this operation is occurring.
+  prevent any installs from writing to the map while this operation is occurring
+  since the map can trigger a re-balancing of the tree nodes and cause some of
+  the iterators to be incorrect.
 */
 void BundleRegistry::GetAlreadyInstalledBundlesAtLocation(
   std::pair<BundleMap::iterator, BundleMap::iterator> foundBundles,

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -189,7 +189,7 @@ std::vector<Bundle> BundleRegistry::Install(const std::string& location,
     */
     if (alreadyInstallingIterator == initialBundleInstallMap.end()) {
       // Insert entry into the initialBundleInstallMap to prevent other threads from
-      // trying to install this bundle simultaneously at the same time
+      // trying to install this bundle simultaneously
       auto pairToInsert = std::make_pair(uint32_t(1), WaitCondition{});
       initialBundleInstallMap.insert(
         std::make_pair(location, std::move(pairToInsert)));

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -69,7 +69,7 @@ protected:
     auto framework = cppmicroservices::FrameworkFactory().NewFramework();
     framework.Start();
 
-    std::vector<std::string> str5kBundles(2048, bundleBasePath);
+    std::vector<std::string> str5kBundles(5000, bundleBasePath);
     //Generate paths to each bundle
     uint32_t count = 1;
     std::transform(str5kBundles.begin(),
@@ -165,7 +165,7 @@ BENCHMARK_DEFINE_F(BundleInstallFixture,
                    ConcurrentBundleInstall1ThreadPerBundle)
 (benchmark::State& state)
 {
-  InstallConcurrently(state, 2048);
+  InstallConcurrently(state, 5000);
 }
 #endif
 

--- a/framework/test/bench/bundleinstall.cpp
+++ b/framework/test/bench/bundleinstall.cpp
@@ -65,22 +65,25 @@ protected:
   {
     using namespace std::chrono;
 
-    std::string bundleBasePath = "bundles\\test_bundle_";
+    std::string bundleBasePath = "bundles\\bundle_";
     auto framework = cppmicroservices::FrameworkFactory().NewFramework();
     framework.Start();
 
-    // Generate paths to each bundle
+    std::vector<std::string> str5kBundles(2048, bundleBasePath);
+    //Generate paths to each bundle
     uint32_t count = 1;
-    std::vector<std::string> str5kBundles(5000, bundleBasePath);
-    std::transform(str5kBundles.begin(), str5kBundles.end(), str5kBundles.begin(),
-      [&count](std::string& s) -> std::string {
-        return s.append(std::to_string(count++));
-      });
+    std::transform(str5kBundles.begin(),
+                   str5kBundles.end(),
+                   str5kBundles.begin(),
+                   [&count](std::string& s) -> std::string {
+                     return s.append(std::to_string(count++));
+                   });
 
     // Split up bundles per thread
     uint32_t numBundlesToInstall = uint32_t(str5kBundles.size()) / numThreads;
     std::vector<std::string>::iterator lowerBound = str5kBundles.begin();
-    std::vector<std::string>::iterator upperBound = str5kBundles.begin() + numBundlesToInstall;
+    std::vector<std::string>::iterator upperBound =
+      str5kBundles.begin() + numBundlesToInstall;
 
     std::vector<std::vector<std::string>> bundlesToInstallPerThread;
     for (uint32_t i = 0; i < numThreads; i++) {
@@ -157,6 +160,13 @@ BENCHMARK_DEFINE_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)
 {
   InstallConcurrently(state, std::thread::hardware_concurrency());
 }
+
+BENCHMARK_DEFINE_F(BundleInstallFixture,
+                   ConcurrentBundleInstall1ThreadPerBundle)
+(benchmark::State& state)
+{
+  InstallConcurrently(state, 2048);
+}
 #endif
 
 // Register functions as benchmark
@@ -172,5 +182,8 @@ BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall2Threads)
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstall4Threads)
   ->UseManualTime();
 BENCHMARK_REGISTER_F(BundleInstallFixture, ConcurrentBundleInstallMaxThreads)
+  ->UseManualTime();
+BENCHMARK_REGISTER_F(BundleInstallFixture,
+                     ConcurrentBundleInstall1ThreadPerBundle)
   ->UseManualTime();
 #endif


### PR DESCRIPTION
This PR addresses the data race currently in BundleRegistry::Install() which causes sporadic crashes (segfaults) when a large number of bundles are being installed at the same time. Performance benefits are exhibited in this change and significantly reduce the amount of time it takes to install all bundles when 2-4 threads are used. There could exist a larger configuration of threads which is faster, but with the input size used to test (~2048 bundles), it appears to be the best.

All benchmarking was performed on a Windows 10, 64bit machine (i7-4790k @ 4.0GHz) with 2048 bundles.

Performance (note: CPU numbers don't mean much, most of the runs during the benchmark had 0 for CPU):
| Benchmark                                                                     | Time (before PR #411, ns) | Time (fix-concurrent-bundle-install, ns) | CPU (before PR #411, ns) | CPU (fix-concurrent-bundle-install, ns) | Iterations |
|-------------------------------------------------------------------------------|--------------------------:|-----------------------------------------:|-------------------------:|----------------------------------------:|-----------:|
| BundleInstallFixture/ConcurrentBundleInstall1Thread/manual_time_mean          |                  12072893 |                                 10665267 |                    12850 |                                   10615 |         64 |
| BundleInstallFixture/ConcurrentBundleInstall2Threads/manual_time_mean         |                   9031489 |                                  4981662 |                    15751 |                                   33203 |         64 |
| BundleInstallFixture/ConcurrentBundleInstall4Threads/manual_time_mean         |                  18439921 |                                  5841105 |                    32552 |                                   58235 |         64 |
| BundleInstallFixture/ConcurrentBundleInstallMaxThreads/manual_time_mean       |                  26885067 |                                 13754601 |                    24414 |                                   44389 |         64 |
| BundleInstallFixture/ConcurrentBundleInstall1ThreadPerBundle/manual_time_mean |                  61213356 |                                 17298247 |                  3662109 |                                 9580870 |         64 |

The existing test suite is incapable of detecting this issue due to the number of bundles being installed is minuscule in comparison to the number of bundles required to see this data race.

To reproduce the issue, a large number of bundles (~2048) were generated and a small program was written to install all of them on many threads at the same time (mimicking the BundleRegistryConcurrencyTest test that we currently have except on a larger scale). When TSAN was turned on, warnings started to appear regarding a data race.

Having a test point to capture this behavior is out of the scope for this PR but I believe it to be valuable when working with this code in the future due to the nature of the issue.