### PR TITLE
Fix codecov uploader issue on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -250,9 +250,11 @@ after_test:
 - if [%WITH_COVERAGE%]==[1] python %APPVEYOR_BUILD_FOLDER%/fixcoveragefilepaths.py -i coverage.xml -s %APPVEYOR_BUILD_FOLDER% -o coverage_pathsfixed.xml
 # use codecov bash script. Requires powershell and bash to be installed, which both are on the AppVeyor machine image
 - ps: |
-    $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
-    Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-    bash codecov.sh -f "./coverage_pathsfixed.xml"
+    if($env:WITH_COVERAGE -eq 1){
+      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+      bash codecov.sh -f "./coverage_pathsfixed.xml" -U "-s" -A "-s"
+    }
 
 test_script:
 - cd %APPVEYOR_BUILD_FOLDER%/build


### PR DESCRIPTION
Issue: Codecov bash uploader was throwing an error on appveyor causing the build to fail.

Solution:
Appending codecov flags to fix codecov uploader issue on appveyor.
Also, wrapping the code in condition to make it run only when code coverage is needed.