### PR TITLE
guard access to the service dependency in test bundles. 

### DIFF
--- a/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
@@ -13,8 +13,8 @@ void ServiceComponentDynamicGreedyMandatoryUnary::Deactivate(const std::shared_p
 
 std::string ServiceComponentDynamicGreedyMandatoryUnary::ExtendedDescription()
 {
-  if(!foo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if(!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result("ServiceComponentDynamicGreedyMandatoryUnary ");
@@ -25,16 +25,16 @@ std::string ServiceComponentDynamicGreedyMandatoryUnary::ExtendedDescription()
 
 void ServiceComponentDynamicGreedyMandatoryUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
 void ServiceComponentDynamicGreedyMandatoryUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSDGMU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDGMU/src/ServiceImpl.hpp
@@ -1,6 +1,8 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
+#include <mutex>
+
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 
@@ -22,6 +24,7 @@ public:
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
 private:
   std::shared_ptr<test::Interface1> foo;
+  std::mutex fooMutex;
 };
 
 } // namespaces

--- a/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
@@ -15,6 +15,7 @@ std::string ServiceComponentDynamicGreedyOptionalUnary::ExtendedDescription()
 {
   std::string result("ServiceComponentDynamicGreedyOptionalUnary ");
   result.append("depends on ");
+  std::lock_guard<std::mutex> lock(fooMutex);
   if (foo) {
     result.append(foo->Description());
   }
@@ -23,16 +24,16 @@ std::string ServiceComponentDynamicGreedyOptionalUnary::ExtendedDescription()
 
 void ServiceComponentDynamicGreedyOptionalUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
 void ServiceComponentDynamicGreedyOptionalUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSDGOU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDGOU/src/ServiceImpl.hpp
@@ -1,6 +1,8 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
+#include <mutex>
+
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 
@@ -22,6 +24,7 @@ public:
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
 private:
   std::shared_ptr<test::Interface1> foo;
+  std::mutex fooMutex;
 };
 
 } // namespaces

--- a/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
@@ -13,8 +13,8 @@ void ServiceComponentDynamicReluctantMandatoryUnary::Deactivate(const std::share
 
 std::string ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription()
 {
-  if(!foo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if(!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result("ServiceComponentDynamicReluctantMandatoryUnary ");
@@ -25,16 +25,16 @@ std::string ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription(
 
 void ServiceComponentDynamicReluctantMandatoryUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
 void ServiceComponentDynamicReluctantMandatoryUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSDRMU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDRMU/src/ServiceImpl.hpp
@@ -1,6 +1,8 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
+#include <mutex>
+
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 
@@ -22,6 +24,7 @@ public:
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
 private:
   std::shared_ptr<test::Interface1> foo;
+  std::mutex fooMutex;
 };
 
 } // namespaces

--- a/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
@@ -15,6 +15,7 @@ std::string ServiceComponentDynamicReluctantOptionalUnary::ExtendedDescription()
 {
   std::string result("ServiceComponentDynamicReluctantOptionalUnary ");
   result.append("depends on ");
+  std::lock_guard<std::mutex> lock(fooMutex);
   if (foo) {
     result.append(foo->Description());
   }
@@ -23,16 +24,16 @@ std::string ServiceComponentDynamicReluctantOptionalUnary::ExtendedDescription()
 
 void ServiceComponentDynamicReluctantOptionalUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
 void ServiceComponentDynamicReluctantOptionalUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  std::lock_guard<std::mutex> lock(fooMutex);
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSDROU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDROU/src/ServiceImpl.hpp
@@ -1,6 +1,8 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
+#include <mutex>
+
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 
@@ -22,6 +24,7 @@ public:
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
 private:
   std::shared_ptr<test::Interface1> foo;
+  std::mutex fooMutex;
 };
 
 } // namespaces

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,1 @@
+race:usResourceCompiler4*


### PR DESCRIPTION
Add TSAN suppression file for usResourceCompiler.  Can be used by setting an environment variable named TSAN_OPTIONS to suppressions="`%path to suppression file%`", where `%path to suppression file%` is an absolute path to a suppression file.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>