### PR TITLE
Support parentheses in LDAP query attribute value

### DIFF
--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -709,14 +709,23 @@ std::string LDAPExpr::ParseState::getAttributeName()
 
 std::string LDAPExpr::ParseState::getAttributeValue()
 {
+  int num_parens = 0;
   std::string sb;
   bool exit = false;
   while (!exit) {
     Byte c = peek();
     switch (c) {
       case '(':
+        num_parens+=1;
+        sb.append(1, c);
+        break;
       case ')':
-        exit = true;
+        if (num_parens > 0) {
+          num_parens-=1;
+          sb.append(1, c);
+        } else {
+          exit = true;
+        }
         break;
       case '*':
         sb.append(1, LDAPExprConstants::WILDCARD());

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -716,12 +716,12 @@ std::string LDAPExpr::ParseState::getAttributeValue()
     Byte c = peek();
     switch (c) {
       case '(':
-        num_parens+=1;
+        ++num_parens;
         sb.append(1, c);
         break;
       case ')':
         if (num_parens > 0) {
-          num_parens-=1;
+          --num_parens;
           sb.append(1, c);
         } else {
           exit = true;

--- a/framework/test/driver/LDAPFilterTest.cpp
+++ b/framework/test/driver/LDAPFilterTest.cpp
@@ -46,6 +46,10 @@ int TestParsing()
                       "=Person)(|(sn=Jensen)(cn=Babs J*)))");
     US_TEST_OUTPUT(<< "Parsing (o=univ*of*mich*)")
     ldap = LDAPFilter("(o=univ*of*mich*)");
+    US_TEST_OUTPUT(<< "Parsing (prop=foo(bar))")
+    ldap = LDAPFilter("(prop=foo(bar))");
+    US_TEST_OUTPUT(<< "Parsing (&(one=two(2))(three=four(4)))")
+    ldap = LDAPFilter("(&(one=two(2))(three=four(4)))");
   } catch (const std::invalid_argument& e) {
     US_TEST_OUTPUT(<< e.what());
     return EXIT_FAILURE;
@@ -122,6 +126,17 @@ int TestEvaluate()
     if (eval) {
       return EXIT_FAILURE;
     }
+    
+    // parentheses
+    ldap = LDAPFilter("(prop=foo(bar))");
+    props.clear();
+    props["prop"] = std::string("foo(bar)");
+    US_TEST_OUTPUT(<< "Evaluating prop value with parentheses: " << ldap.ToString())
+    eval = ldap.Match(props);
+    if (!eval) {
+      return EXIT_FAILURE;
+    }
+    
   } catch (const std::invalid_argument& e) {
     US_TEST_OUTPUT(<< e.what())
     return EXIT_FAILURE;

--- a/framework/test/driver/LDAPFilterTest.cpp
+++ b/framework/test/driver/LDAPFilterTest.cpp
@@ -48,6 +48,8 @@ int TestParsing()
     ldap = LDAPFilter("(o=univ*of*mich*)");
     US_TEST_OUTPUT(<< "Parsing (prop=foo(bar))")
     ldap = LDAPFilter("(prop=foo(bar))");
+    US_TEST_OUTPUT(<< "Parsing (prop=(foo)(bar))")
+    ldap = LDAPFilter("(prop=(foo)(bar))");
     US_TEST_OUTPUT(<< "Parsing (&(one=two(2))(three=four(4)))")
     ldap = LDAPFilter("(&(one=two(2))(three=four(4)))");
   } catch (const std::invalid_argument& e) {

--- a/framework/test/gtest/LDAPExprTest.cpp
+++ b/framework/test/gtest/LDAPExprTest.cpp
@@ -227,6 +227,9 @@ TEST(LDAPExprTest, ParseExceptions)
   // Test various exceptions thrown.
   // Test error condition in LDAPExpr::LDAPExpr()
   EXPECT_THROW(LDAPFilter("(name=abra)zxdzx"), std::invalid_argument);
+  EXPECT_THROW(LDAPFilter("(name=abra(foo)))"), std::invalid_argument);
+  EXPECT_THROW(LDAPFilter("(name=abra"), std::invalid_argument);
+  EXPECT_THROW(LDAPFilter("(name=abra((foo))"), std::invalid_argument);
   // Test error condition in LDAPExpr::ParseExpr()
   EXPECT_THROW(LDAPFilter("(!(name=abra)(name=beta))"), std::invalid_argument);
   // Test attribute name empty error condition in


### PR DESCRIPTION
- changed LDAPExpr implementation to account for parentheses in attribute value
- added test cases

Signed-off-by: Kevin Lee <kevinlee@mathworks.com>

fixes #496 