### PR TITLE
fix macos codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,11 @@ matrix:
         env: BUILD_CONFIGURATION=3 MACOSX_DEPLOYMENT_TARGET=10.15
 
 # To generate codecov reports
+# pin xcode version back to 10.3 since 11.6 appears to break code coverage
       - os: osx
-        osx_image: xcode11.6
+        osx_image: xcode10.3
         compiler: clang
-        env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.15 WITH_COVERAGE=1
+        env: BUILD_CONFIGURATION=0 MACOSX_DEPLOYMENT_TARGET=10.14 WITH_COVERAGE=1
 
 cache:
   directories:


### PR DESCRIPTION
pin back the version of xcode to 10.3 which was the last known version of xcode that doesn't break code coverage.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>