### PR TITLE
ConfigAdmin Extra Tests

### DIFF
--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(_configurationadmin_tests
   TestCMActivator.cpp
   TestCMBundleExtension.cpp
   TestCMLogger.cpp
+  TestConfigAdmin.cpp
   TestConfigurationAdminImpl.cpp
   TestConfigurationImpl.cpp
   TestMetadataParserFactory.cpp
@@ -107,17 +108,25 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
     )
 endif()
 
+set(_test_bundles
+  ManagedServiceAndFactoryBundle
+  )
+
 target_link_libraries(${us_configurationadmin_test_exe_name} 
   PRIVATE
   ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_BOTH_LIBRARIES}
   ${${PROJECT_NAME}_LINK_LIBRARIES}
   CppMicroServices
+  cm
   ConfigurationAdminObjs
+  usTestInterfaces
   usLogService
+  usServiceComponent
   gtest
   gmock
   util
+  ${_test_bundles}
 )
 
 # Needed for clock_gettime with glibc < 2.17

--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -140,6 +140,7 @@ add_test(NAME ${us_configurationadmin_test_exe_name}
   WORKING_DIRECTORY ${CppMicroServices_BINARY_DIR}
 )
 set_property(TEST ${us_configurationadmin_test_exe_name} PROPERTY LABELS regular)
+set_tests_properties(${us_configurationadmin_test_exe_name} PROPERTIES TIMEOUT 1200)
 
 # Run the GTest EXE from valgrind
 if(US_MEMCHECK_COMMAND)

--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -112,7 +112,7 @@ set(_test_bundles
   ManagedServiceAndFactoryBundle
   )
 
-target_link_libraries(${us_configurationadmin_test_exe_name} 
+target_link_libraries(${us_configurationadmin_test_exe_name}
   PRIVATE
   ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_BOTH_LIBRARIES}
@@ -149,6 +149,10 @@ if(US_MEMCHECK_COMMAND)
     WORKING_DIRECTORY ${CppMicroServices_BINARY_DIR}
     )
   set_property(TEST memcheck_${us_configurationadmin_test_exe_name} PROPERTY LABELS valgrind memcheck)
+  # The test, when ran with Valgrind, executes extremely slow and doesn't allow for ConfigAdmin
+  # notifications to properly be received so a higher timeout in the code is necessary. Due to this,
+  # the test times out and we need to increase the timeout time.
+  set_tests_properties(memcheck_${us_configurationadmin_test_exe_name} PROPERTIES TIMEOUT 1200)
 endif()
 
 # Enable code coverage for GTest tests
@@ -176,23 +180,23 @@ if (WIN32 AND US_USE_SYSTEM_GTEST)
     set(dll_file "${dir}/${name_no_ext}${CMAKE_SHARED_LIBRARY_SUFFIX}")
     add_custom_command(TARGET ${us_configurationadmin_test_exe_name} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${dll_file}"
-        $<TARGET_FILE_DIR:${us_configurationadmin_test_exe_name}>)
+	"${dll_file}"
+	$<TARGET_FILE_DIR:${us_configurationadmin_test_exe_name}>)
   endforeach(lib_fullpath)
 endif()
 
 #-----------------------------------------------------------------------------
-# Add dependencies on test bundles if building shared libraries or 
+# Add dependencies on test bundles if building shared libraries or
 # link them if building static libraries
 #-----------------------------------------------------------------------------
 
 if(BUILD_SHARED_LIBS)
   # Add resources
   usFunctionEmbedResources(TARGET ${us_configurationadmin_test_exe_name}
-                           FILES manifest.json)
+			   FILES manifest.json)
 else()
   # Add resources
   usFunctionEmbedResources(TARGET ${us_configurationadmin_test_exe_name}
-                           FILES manifest.json
-                           ZIP_ARCHIVES ${Framework_TARGET})
+			   FILES manifest.json
+			   ZIP_ARCHIVES ${Framework_TARGET})
 endif()

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -1,0 +1,522 @@
+#include "ConfigurationAdminTestingConfig.h"
+
+#include <gtest/gtest.h>
+
+#include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
+#include <cppmicroservices/cm/ConfigurationAdmin.hpp>
+#include <cppmicroservices/util/FileSystem.h>
+
+#include "TestInterfaces/Interfaces.hpp"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#ifdef US_PLATFORM_WINDOWS
+const char DIR_SEP = cppmicroservices::util::DIR_SEP_WIN32;
+#else
+const char DIR_SEP = cppmicroservices::util::DIR_SEP_POSIX;
+#endif
+
+namespace cm = cppmicroservices::service::cm;
+
+namespace {
+
+auto const DEFAULT_POLL_PERIOD = std::chrono::milliseconds(2000);
+
+size_t installAndStartTestBundles(cppmicroservices::BundleContext& ctx,
+                                        const std::string& bundleName)
+{
+  std::string path = US_LIBRARY_OUTPUT_DIRECTORY;
+  path += DIR_SEP;
+  path += US_LIB_PREFIX;
+  path += bundleName;
+  path += US_LIB_POSTFIX;
+  path += US_LIB_EXT;
+  auto bundles = ctx.InstallBundles(path);
+  for (auto& b : bundles) {
+      b.Start();
+  }
+
+  return bundles.size();
+}
+
+std::shared_ptr<::test::TestManagedServiceInterface> getManagedService(
+  cppmicroservices::BundleContext& ctx)
+{
+  auto sr = ctx.GetServiceReference<::test::TestManagedServiceInterface>();
+  return ctx.GetService<::test::TestManagedServiceInterface>(sr);
+}
+
+std::shared_ptr<::test::TestManagedServiceFactory> getManagedServiceFactory(
+  cppmicroservices::BundleContext& ctx)
+{
+  auto sr = ctx.GetServiceReference<::test::TestManagedServiceFactory>();
+  return ctx.GetService<::test::TestManagedServiceFactory>(sr);
+}
+
+enum class PollingCondition
+{
+  GT,
+  GE,
+  EQ,
+  LE,
+  LT
+};
+std::ostream& operator<<(std::ostream& out, PollingCondition condition)
+{
+  if (condition == PollingCondition::GT) {
+    out << "greater than";
+  } else if (condition == PollingCondition::GE) {
+    out << "greater than or equal to";
+  } else if (condition == PollingCondition::EQ) {
+    out << "equal to";
+  } else if (condition == PollingCondition::LE) {
+    out << "less than or equal to";
+  } else if (condition == PollingCondition::LT) {
+    out << "less than";
+  }
+  return out;
+}
+
+template<PollingCondition condition, typename Func>
+std::pair<bool, std::string> pollOnCondition(
+  Func&& func,
+  int compareTo,
+  std::chrono::milliseconds const& timeout = DEFAULT_POLL_PERIOD)
+{
+
+  std::function<bool()> pollingFunc;
+  if (condition == PollingCondition::GT) {
+    pollingFunc = [&func, compareTo]() { return func() > compareTo; };
+  } else if (condition == PollingCondition::GE) {
+    pollingFunc = [&func, compareTo]() { return func() >= compareTo; };
+  } else if (condition == PollingCondition::EQ) {
+    pollingFunc = [&func, compareTo]() { return func() == compareTo; };
+  } else if (condition == PollingCondition::LE) {
+    pollingFunc = [&func, compareTo]() { return func() <= compareTo; };
+  } else if (condition == PollingCondition::LT) {
+    pollingFunc = [&func, compareTo]() { return func() < compareTo; };
+  }
+
+  auto const startTime = std::chrono::steady_clock::now();
+  auto result = pollingFunc();
+
+  while (!result &&
+         std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now() - startTime) <= timeout) {
+    result = pollingFunc();
+  }
+  std::string diagnostic("");
+  if (!result) {
+    std::stringstream ss;
+    ss << "Expected polling function to be " << condition << " the value "
+       << std::to_string(compareTo) << ", but was " << std::to_string(func());
+    diagnostic = ss.str();
+  }
+
+  return { result, diagnostic };
+}
+
+} // namespace
+
+class ConfigAdminTests : public ::testing::Test
+{
+public:
+  ConfigAdminTests()
+    : m_framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
+
+  void SetUp() override
+  {
+    // Ensure the CppMicroServices framework is started. This should
+    // install and start compendium services, including ConfigAdmin.
+    m_framework.Start();
+    auto bc = m_framework.GetBundleContext();
+
+    installAndStartTestBundles(bc, "DeclarativeServices");
+    installAndStartTestBundles(bc, "ConfigurationAdmin");
+    auto const numBundles =
+      installAndStartTestBundles(bc, "ManagedServiceAndFactoryBundle");
+
+    auto sr = bc.GetServiceReference<cppmicroservices::service::cm::ConfigurationAdmin>();
+    m_configAdmin = bc.GetService<cm::ConfigurationAdmin>(sr);
+
+    ASSERT_EQ(numBundles, 1);
+  }
+
+  void TearDown() override
+  {
+    m_configAdmin.reset();
+
+    // Shut down the framework, so it's restarted in the next testpoint.
+    m_framework.Stop();
+    m_framework.WaitForStop(std::chrono::milliseconds::zero());
+  }
+
+  cppmicroservices::Framework& GetFramework() { return m_framework; }
+
+protected:
+  std::shared_ptr<cm::ConfigurationAdmin> m_configAdmin;
+
+private:
+  cppmicroservices::Framework m_framework;
+};
+
+TEST_F(ConfigAdminTests, testInstallAndStart)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const service = getManagedService(ctx);
+  EXPECT_NE(service, nullptr)
+    << "Couldn't obtain test managed service implementation";
+
+  auto const factory = getManagedServiceFactory(ctx);
+  EXPECT_NE(factory, nullptr)
+    << "Couldn't obtain test managed service factory implementation";
+}
+
+TEST_F(ConfigAdminTests, testServiceUpdated)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const service = getManagedService(ctx);
+  ASSERT_NE(service, nullptr);
+
+  // We should get at least one Updated() call with the initial configuration from
+  // the test bundle's manifest.json file (anInt=2). The asynchronous nature of
+  // ConfigAdmin means that we may get more than one call to Updated(). This is also
+  // why we check the counter is >= 1: we may get an initial Updated() call with empty
+  // properties if the service is configured before the initial configuration has loaded.
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::GE>(
+      [&service] { return service->getCounter(); }, 1);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+
+  auto const initConfiguredCount = service->getCounter();
+  auto expectedCount = initConfiguredCount;
+
+  auto configuration = m_configAdmin->GetConfiguration("cm.testservice");
+  EXPECT_EQ(configuration->GetPid(), "cm.testservice");
+  EXPECT_FALSE(configuration->GetProperties().empty());
+
+  auto const newIncrement{ 5 };
+  cppmicroservices::AnyMap props(
+    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  props["anInt"] = newIncrement;
+  expectedCount += newIncrement;
+
+  // props differs from the initial configuration (anInt = 2) of the pid in the manifest file,
+  // so the service should get an Updated() notification.
+  configuration->UpdateIfDifferent(props);
+
+  // Poll on the service having been updated with the new configuration. The asynchronous
+  // nature of configuration admin means that we may get an additional Updated() call, which
+  // could have either anInt=2 or anInt=5 depending on relative thread timings.
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::GE>(
+      [&service] { return service->getCounter(); }, expectedCount);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+
+  // Wait for long enough for any superfluous Updated() calls to wash out
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  // At most, Updated() should have been called three times (one "excess"). If the excess
+  // call were made with the updated properties, this would give us a maximum counter value
+  // of 2 + 2*newIncrement. Update expectedCount to the current value of the counter.
+  EXPECT_LE(service->getCounter(), expectedCount + newIncrement);
+  expectedCount = service->getCounter();
+
+  // UpdateIfDifferent with the same properties shouldn't call Updated()
+  configuration->UpdateIfDifferent(props);
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  EXPECT_EQ(service->getCounter(), expectedCount);
+
+  // Update should call Updated() even if the properties are unchanged
+  configuration->Update(props);
+  expectedCount += newIncrement;
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&service] { return service->getCounter(); }, expectedCount);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+}
+
+TEST_F(ConfigAdminTests, testServiceRemoved)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const service = getManagedService(ctx);
+  ASSERT_NE(service, nullptr);
+
+  // Sleep rather than poll to allow superfluous Updated() calls to flush through
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  EXPECT_GE(service->getCounter(), 1);
+
+  auto const initConfiguredCount = service->getCounter();
+  auto expectedCount = initConfiguredCount;
+
+  auto configuration = m_configAdmin->GetConfiguration("cm.testservice");
+
+  configuration->Remove();
+  expectedCount -= 1;
+
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&service] { return service->getCounter(); }, expectedCount);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+
+  // Should create a new configuration and call Updated()
+  configuration = m_configAdmin->GetConfiguration("cm.testservice");
+  EXPECT_TRUE(configuration->GetProperties().empty());
+  expectedCount -= 1;
+
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&service] { return service->getCounter(); }, expectedCount);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+
+  auto const newIncrement{ 5 };
+  cppmicroservices::AnyMap props(
+    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  props["anInt"] = newIncrement;
+  expectedCount += newIncrement;
+
+  // props differs from the latest configuration for the recreated configuration, which is empty.
+  // The service should therefore get an Updated() notification.
+  configuration->UpdateIfDifferent(props);
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&service] { return service->getCounter(); }, expectedCount);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+}
+
+/*
+ * Managed service factory tests
+ */
+TEST_F(ConfigAdminTests, testServiceFactoryUpdated)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const serviceFactory = getManagedServiceFactory(ctx);
+  ASSERT_NE(serviceFactory, nullptr);
+
+  // Sleep rather than poll to allow superfluous Updated() calls to flush through
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  auto const initConfiguredCount_config1 =
+    serviceFactory->getUpdatedCounter("cm.testfactory~config1");
+  EXPECT_GE(initConfiguredCount_config1, 1);
+  auto expectedCount_config1 = initConfiguredCount_config1;
+
+  auto const initConfiguredCount_config2 =
+    serviceFactory->getUpdatedCounter("cm.testfactory~config2");
+  EXPECT_GE(initConfiguredCount_config1, 1);
+  auto expectedCount_config2 = initConfiguredCount_config2;
+
+  // Create services using the factory
+  auto const svc1_before = serviceFactory->create("cm.testfactory~config1");
+  EXPECT_EQ(svc1_before->getValue(), initConfiguredCount_config1);
+  auto const svc2_before = serviceFactory->create("cm.testfactory~config2");
+  EXPECT_EQ(svc2_before->getValue(), initConfiguredCount_config2);
+
+  // Check the configuration config1 has the right properties
+  auto configuration_config1 =
+    m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config1");
+  EXPECT_EQ(configuration_config1->GetFactoryPid(), "cm.testfactory");
+  EXPECT_EQ(configuration_config1->GetPid(), "cm.testfactory~config1");
+  EXPECT_FALSE(configuration_config1->GetProperties().empty());
+
+  // Update config1
+  auto const newIncrement{ 5 };
+  cppmicroservices::AnyMap props(
+    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  props["anInt"] = newIncrement;
+
+  expectedCount_config1 += newIncrement;
+
+  // props differs from the initial configuration (anInt = 2) of the pid in the manifest file,
+  // so the service should get an Updated() notification.
+  configuration_config1->UpdateIfDifferent(props);
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&serviceFactory] {
+        return serviceFactory->getUpdatedCounter("cm.testfactory~config1");
+      },
+      expectedCount_config1);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config2"),
+            expectedCount_config2);
+
+  // UpdateIfDifferent with the same properties shouldn't call Updated()
+  configuration_config1->UpdateIfDifferent(props);
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config1"),
+            expectedCount_config1);
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config2"),
+            expectedCount_config2);
+
+  // Update should call Updated() even if the properties are unchanged
+  configuration_config1->Update(props);
+  expectedCount_config1 += newIncrement;
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&serviceFactory] {
+        return serviceFactory->getUpdatedCounter("cm.testfactory~config1");
+      },
+      expectedCount_config1);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config2"),
+            expectedCount_config2);
+
+  // Update config 2 now.
+  auto configuration_config2 =
+    m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config2");
+  configuration_config2->UpdateIfDifferent(props);
+  expectedCount_config2 += newIncrement;
+
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&serviceFactory] {
+        return serviceFactory->getUpdatedCounter("cm.testfactory~config2");
+      },
+      expectedCount_config2);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config1"),
+            expectedCount_config1);
+
+  // Get new services from the factory. Check that subsequent updates to the
+  // factory configuration doesn't affect already-created services.
+  auto const svc1_after = serviceFactory->create("cm.testfactory~config1");
+  EXPECT_EQ(svc1_after->getValue(), expectedCount_config1);
+  auto const svc2_after = serviceFactory->create("cm.testfactory~config2");
+  EXPECT_EQ(svc2_after->getValue(), expectedCount_config2);
+
+  EXPECT_EQ(svc1_before->getValue(), initConfiguredCount_config1);
+  EXPECT_EQ(svc2_before->getValue(), initConfiguredCount_config2);
+}
+
+TEST_F(ConfigAdminTests, testCreateFactoryConfiguration)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const serviceFactory = getManagedServiceFactory(ctx);
+  ASSERT_NE(serviceFactory, nullptr);
+
+  auto configuration =
+    m_configAdmin->CreateFactoryConfiguration("cm.testfactory");
+  EXPECT_EQ(configuration->GetFactoryPid(), "cm.testfactory");
+
+  auto const newConfigPid = configuration->GetPid();
+  EXPECT_FALSE(newConfigPid.empty());
+  EXPECT_NE(newConfigPid.find("cm.testfactory"), std::string::npos);
+
+  EXPECT_TRUE(configuration->GetProperties().empty());
+
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::LT>(
+      [&serviceFactory, &newConfigPid]() {
+        return serviceFactory->getUpdatedCounter(newConfigPid);
+      },
+      0);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+
+  auto const service = serviceFactory->create(newConfigPid);
+  ASSERT_NE(service, nullptr);
+  EXPECT_LT(service->getValue(), 0);
+}
+
+TEST_F(ConfigAdminTests, testRemoveFactoryConfiguration)
+{
+  auto f = GetFramework();
+  auto ctx = f.GetBundleContext();
+
+  auto const serviceFactory = getManagedServiceFactory(ctx);
+  ASSERT_NE(serviceFactory, nullptr);
+
+  // Sleep rather than poll to allow superfluous Updated() calls to flush through
+  std::this_thread::sleep_for(DEFAULT_POLL_PERIOD);
+  auto const initConfiguredCount_config1 =
+    serviceFactory->getUpdatedCounter("cm.testfactory~config1");
+  EXPECT_GE(initConfiguredCount_config1, 1);
+  auto expectedCount_config1 = initConfiguredCount_config1;
+
+  auto const initConfiguredCount_config2 =
+    serviceFactory->getUpdatedCounter("cm.testfactory~config2");
+  EXPECT_GE(initConfiguredCount_config1, 1);
+  auto expectedCount_config2 = initConfiguredCount_config2;
+
+  auto configuration_config1 =
+    m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config1");
+
+  configuration_config1->Remove();
+
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&serviceFactory] {
+        return serviceFactory->getRemovedCounter("cm.testfactory~config1");
+      },
+      1);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+  EXPECT_EQ(serviceFactory->getRemovedCounter("cm.testfactory~config2"), 0);
+
+  // Should create a new configuration
+  configuration_config1 =
+    m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config1");
+  --expectedCount_config1;
+
+  EXPECT_TRUE(configuration_config1->GetProperties().empty());
+  {
+    bool result = false;
+    std::string diagnostic;
+    std::tie(result, diagnostic) = pollOnCondition<PollingCondition::EQ>(
+      [&serviceFactory] {
+        return serviceFactory->getUpdatedCounter("cm.testfactory~config1");
+      },
+      expectedCount_config1);
+    EXPECT_TRUE(result) << diagnostic;
+  }
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config2"),
+            expectedCount_config2);
+}

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -18,12 +18,6 @@
 
 #include "ConfigurationAdminTestingConfig.h"
 
-#ifdef US_PLATFORM_WINDOWS
-const char DIR_SEP = cppmicroservices::util::DIR_SEP_WIN32;
-#else
-const char DIR_SEP = cppmicroservices::util::DIR_SEP_POSIX;
-#endif
-
 namespace cm = cppmicroservices::service::cm;
 
 namespace {

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -22,7 +22,7 @@ namespace cm = cppmicroservices::service::cm;
 
 namespace {
 
-auto const DEFAULT_POLL_PERIOD = std::chrono::milliseconds(60000);
+auto const DEFAULT_POLL_PERIOD = std::chrono::milliseconds(90000);
 
 std::string PathToLib(const std::string& libName)
 {

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -246,13 +246,13 @@ TEST_F(ConfigAdminTests, testServiceUpdated)
   }
 
   auto const initConfiguredCount = service->getCounter();
-  auto expectedCount = initConfiguredCount;
+  int expectedCount = initConfiguredCount;
 
   auto configuration = m_configAdmin->GetConfiguration("cm.testservice");
   EXPECT_EQ(configuration->GetPid(), "cm.testservice");
   EXPECT_FALSE(configuration->GetProperties().empty());
 
-  auto const newIncrement{ 5 };
+  const int newIncrement{ 5 };
   cppmicroservices::AnyMap props(
     cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
   props["anInt"] = newIncrement;
@@ -311,7 +311,7 @@ TEST_F(ConfigAdminTests, testServiceRemoved)
   EXPECT_GE(service->getCounter(), 1);
 
   auto const initConfiguredCount = service->getCounter();
-  auto expectedCount = initConfiguredCount;
+  int expectedCount = initConfiguredCount;
 
   auto configuration = m_configAdmin->GetConfiguration("cm.testservice");
 
@@ -339,7 +339,7 @@ TEST_F(ConfigAdminTests, testServiceRemoved)
     EXPECT_TRUE(result) << diagnostic;
   }
 
-  auto const newIncrement{ 5 };
+  const int newIncrement{ 5 };
   cppmicroservices::AnyMap props(
     cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
   props["anInt"] = newIncrement;
@@ -373,12 +373,12 @@ TEST_F(ConfigAdminTests, testServiceFactoryUpdated)
   auto const initConfiguredCount_config1 =
     serviceFactory->getUpdatedCounter("cm.testfactory~config1");
   EXPECT_GE(initConfiguredCount_config1, 1);
-  auto expectedCount_config1 = initConfiguredCount_config1;
+  int expectedCount_config1 = initConfiguredCount_config1;
 
   auto const initConfiguredCount_config2 =
     serviceFactory->getUpdatedCounter("cm.testfactory~config2");
   EXPECT_GE(initConfiguredCount_config1, 1);
-  auto expectedCount_config2 = initConfiguredCount_config2;
+  int expectedCount_config2 = initConfiguredCount_config2;
 
   // Create services using the factory
   auto const svc1_before = serviceFactory->create("cm.testfactory~config1");
@@ -394,7 +394,7 @@ TEST_F(ConfigAdminTests, testServiceFactoryUpdated)
   EXPECT_FALSE(configuration_config1->GetProperties().empty());
 
   // Update config1
-  auto const newIncrement{ 5 };
+  const int newIncrement{ 5 };
   cppmicroservices::AnyMap props(
     cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
   props["anInt"] = newIncrement;

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -22,7 +22,7 @@ namespace cm = cppmicroservices::service::cm;
 
 namespace {
 
-auto const DEFAULT_POLL_PERIOD = std::chrono::milliseconds(2000);
+auto const DEFAULT_POLL_PERIOD = std::chrono::milliseconds(60000);
 
 std::string PathToLib(const std::string& libName)
 {

--- a/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
+++ b/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
@@ -159,9 +159,17 @@ namespace {
     : manifestName(std::move(manifest))
     , errorOutput(std::move(errorOut))
     {}
-
+ 
     std::string manifestName;
     std::string errorOutput;
+ 
+    friend std::ostream& operator<<(std::ostream& os,
+                                  const MetadataInvalidManifestState& obj)
+    {
+      return os << "Manifest Name: " << obj.manifestName
+                << " error output: " << obj.errorOutput
+                << "\n";
+    }
   };
 
   // Test failure modes where the exceptions are thrown

--- a/compendium/test_bundles/CMakeLists.txt
+++ b/compendium/test_bundles/CMakeLists.txt
@@ -35,3 +35,5 @@ add_subdirectory(TestBundleDSDROU)
 add_subdirectory(TestBundleDSDGMU)
 add_subdirectory(TestBundleDSDGOU)
 add_subdirectory(TestBindUnbindThrows)
+
+add_subdirectory(ManagedServiceAndFactoryBundle)

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/CMakeLists.txt
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/CMakeLists.txt
@@ -1,0 +1,7 @@
+usFunctionCreateDSTestBundle(ManagedServiceAndFactoryBundle)
+
+usFunctionCreateTestBundleWithResources(ManagedServiceAndFactoryBundle
+  SOURCES src/ManagedServiceFactoryImpl.cpp src/ManagedServiceFactoryServiceImpl.cpp src/ManagedServiceImpl.cpp ${_glue_file}
+  RESOURCES manifest.json
+  BUNDLE_SYMBOLIC_NAME ManagedServiceAndFactoryBundle
+  OTHER_LIBRARIES usTestInterfaces usServiceComponent cm)

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/resources/manifest.json
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/resources/manifest.json
@@ -1,0 +1,57 @@
+{
+  "bundle.symbolic_name": "ManagedServiceAndFactoryBundle",
+  "bundle.name": "ManagedServiceAndFactoryBundle",
+  "bundle.activator": false,
+  "scr": {
+    "version": 1,
+    "components": [
+      {
+        "name": "cppmicroservices::service::cm::test::TestManagedServiceImpl",
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceImpl",
+        "properties" : {
+          "service.pid" : "cm.testservice"
+        },
+        "service": {
+          "interfaces": [
+             "test::TestManagedServiceInterface", "cppmicroservices::service::cm::ManagedService"
+          ]
+        }
+      },
+      {
+        "name": "cppmicroservices::service::cm::test::TestManagedServiceFactoryImpl",
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceFactoryImpl",
+        "properties" : {
+          "service.pid" : "cm.testfactory"
+        },
+        "service": {
+          "interfaces": [
+            "test::TestManagedServiceFactory", "cppmicroservices::service::cm::ManagedServiceFactory"
+          ]
+        }
+      }
+    ]
+  },
+  "cm": {
+    "version": 1,
+    "configurations": [
+      {
+        "pid": "cm.testservice",
+        "properties": {
+          "anInt": 2
+        }
+      },
+      {
+        "pid": "cm.testfactory~config1",
+        "properties": {
+          "anInt": 2
+        }
+      },
+      {
+        "pid": "cm.testfactory~config2",
+        "properties": {
+          "anInt": 2
+        }
+      }
+    ]
+  }
+}

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
@@ -12,19 +12,15 @@ TestManagedServiceFactoryImpl::~TestManagedServiceFactoryImpl() = default;
 void TestManagedServiceFactoryImpl::Updated(std::string const& pid, AnyMap const& properties) {
     std::lock_guard<std::mutex> lk(m_updatedMtx);
     if (properties.empty()) {
-        std::cout << "    Updated called for pid \"" << pid << "\" with empty properties" << std::endl;
         m_updatedCallCount[pid] -= 1;
     } else {
         auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
-        std::cout << "    Updated called for pid \"" << pid
-                  << "\" with value: " << std::to_string(incrementBy) << std::endl;
         m_updatedCallCount[pid] += incrementBy;
     }
 }
 
 void TestManagedServiceFactoryImpl::Removed(std::string const& pid) {
     std::lock_guard<std::mutex> lk(m_removedMtx);
-    std::cout << "    Removed called for pid \"" << pid << "\" with empty properties" << std::endl;
     ++m_removedCallCount[pid];
 }
 

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
@@ -1,0 +1,55 @@
+#include "ManagedServiceFactoryImpl.hpp"
+
+#include <iostream>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryImpl::~TestManagedServiceFactoryImpl() = default;
+
+void TestManagedServiceFactoryImpl::Updated(std::string const& pid, AnyMap const& properties) {
+    std::lock_guard<std::mutex> lk(m_updatedMtx);
+    if (properties.empty()) {
+        std::cout << "    Updated called for pid \"" << pid << "\" with empty properties" << std::endl;
+        m_updatedCallCount[pid] -= 1;
+    } else {
+        auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
+        std::cout << "    Updated called for pid \"" << pid
+                  << "\" with value: " << std::to_string(incrementBy) << std::endl;
+        m_updatedCallCount[pid] += incrementBy;
+    }
+}
+
+void TestManagedServiceFactoryImpl::Removed(std::string const& pid) {
+    std::lock_guard<std::mutex> lk(m_removedMtx);
+    std::cout << "    Removed called for pid \"" << pid << "\" with empty properties" << std::endl;
+    ++m_removedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl::getUpdatedCounter(std::string const& pid) {
+    std::lock_guard<std::mutex> lk(m_updatedMtx);
+    return m_updatedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl::getRemovedCounter(std::string const& pid) {
+    std::lock_guard<std::mutex> lk(m_removedMtx);
+    return m_removedCallCount[pid];
+}
+
+std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> TestManagedServiceFactoryImpl::create(
+    std::string const& config) {
+
+    std::lock_guard<std::mutex> lk(m_updatedMtx);
+    try {
+        return std::make_shared<TestManagedServiceFactoryServiceImpl>(m_updatedCallCount.at(config));
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.hpp
@@ -1,0 +1,43 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+#include "ManagedServiceFactoryServiceImpl.hpp"
+#include <cppmicroservices/cm/ManagedServiceFactory.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryImpl
+    : public ::test::TestManagedServiceFactory,
+      public ::cppmicroservices::service::cm::ManagedServiceFactory {
+
+  public:
+    virtual ~TestManagedServiceFactoryImpl();
+
+    void Updated(std::string const& pid, AnyMap const& properties) override;
+
+    void Removed(std::string const& pid) override;
+
+    int getUpdatedCounter(std::string const& pid) override;
+
+    int getRemovedCounter(std::string const& pid) override;
+
+    std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> create(std::string const& config) override;
+
+  private:
+    std::map<std::string, int> m_updatedCallCount;
+    std::map<std::string, int> m_removedCallCount;
+
+    std::mutex m_updatedMtx;
+    std::mutex m_removedMtx;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
@@ -1,0 +1,20 @@
+#include "ManagedServiceFactoryServiceImpl.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryServiceImpl::TestManagedServiceFactoryServiceImpl(int initialValue)
+    : value{initialValue} {}
+
+TestManagedServiceFactoryServiceImpl::~TestManagedServiceFactoryServiceImpl() = default;
+
+int TestManagedServiceFactoryServiceImpl::getValue() {
+    return value;
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.hpp
@@ -1,0 +1,22 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryServiceImpl : public ::test::TestManagedServiceFactoryServiceInterface {
+  public:
+    TestManagedServiceFactoryServiceImpl(int initialValue);
+    ~TestManagedServiceFactoryServiceImpl();
+
+    int getValue() override;
+
+  private:
+    int value;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
@@ -1,0 +1,39 @@
+#include "ManagedServiceImpl.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceImpl::TestManagedServiceImpl()
+    : m_counter{0} {
+}
+
+TestManagedServiceImpl::~TestManagedServiceImpl() = default;
+
+void TestManagedServiceImpl::Updated(AnyMap const& properties) {
+    std::lock_guard<std::mutex> lk(m_counterMtx);
+    if (properties.empty()) {
+        // Usually corresponds to the configuration being removed
+        std::cout << "    Updated called with empty properties" << std::endl;
+        m_counter -= 1;
+    }
+    else {
+        auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
+        std::cout << "    Updated called with value: " << std::to_string(incrementBy) << std::endl;
+        m_counter += incrementBy;
+    }
+}
+
+int TestManagedServiceImpl::getCounter() {
+    std::lock_guard<std::mutex> lk(m_counterMtx);
+    return m_counter;
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
@@ -18,12 +18,10 @@ void TestManagedServiceImpl::Updated(AnyMap const& properties) {
     std::lock_guard<std::mutex> lk(m_counterMtx);
     if (properties.empty()) {
         // Usually corresponds to the configuration being removed
-        std::cout << "    Updated called with empty properties" << std::endl;
         m_counter -= 1;
     }
     else {
         auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
-        std::cout << "    Updated called with value: " << std::to_string(incrementBy) << std::endl;
         m_counter += incrementBy;
     }
 }

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.hpp
@@ -1,0 +1,31 @@
+#include <cppmicroservices/cm/ManagedService.hpp>
+#include <cppmicroservices/AnyMap.h>
+
+#include "TestInterfaces/Interfaces.hpp"
+
+#include <mutex>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceImpl : public ::test::TestManagedServiceInterface, public cppmicroservices::service::cm::ManagedService {
+  public:
+    TestManagedServiceImpl();
+
+    virtual ~TestManagedServiceImpl();
+
+    void Updated(AnyMap const& properties) override;
+
+    int getCounter() override;
+
+  private:
+    int m_counter;
+    std::mutex m_counterMtx;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ServiceComponents.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ServiceComponents.hpp
@@ -1,0 +1,7 @@
+#ifndef ServiceComponents_hpp
+#define ServiceComponents_hpp
+
+#include "ManagedServiceFactoryImpl.hpp"
+#include "ManagedServiceImpl.hpp"
+
+#endif /* ServiceComponents_hpp */

--- a/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
+++ b/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
@@ -48,6 +48,20 @@ namespace test
       virtual std::string ExtendedDescription() = 0;
       virtual ~Interface2();
     };
+
+    class US_TestInterfaces_EXPORT TestManagedServiceInterface {
+      public:
+        virtual ~TestManagedServiceInterface() = default;
+
+        virtual int getCounter() = 0;
+    };
+
+    class US_TestInterfaces_EXPORT TestManagedServiceFactoryServiceInterface {
+      public:
+        virtual ~TestManagedServiceFactoryServiceInterface() = default;
+
+        virtual int getValue() = 0;
+    };
     
     // Interfaces for declarative services dependency graph resolution benchmarks. The
     // implentations of these interfaces have dependencies that form a complete 3 level tree:
@@ -111,6 +125,18 @@ namespace test
       virtual bool IsActivated() = 0;
       virtual bool IsDeactivated() = 0;
       virtual ~LifeCycleValidation();
+    };
+
+    class US_TestInterfaces_EXPORT TestManagedServiceFactory {
+      public:
+        TestManagedServiceFactory() = default;
+        virtual ~TestManagedServiceFactory() = default;
+
+        virtual int getUpdatedCounter(std::string const& pid) = 0;
+
+        virtual int getRemovedCounter(std::string const& pid) = 0;
+
+        virtual std::shared_ptr<TestManagedServiceFactoryServiceInterface> create(std::string const& config) = 0;
     };
 }
 

--- a/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
+++ b/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
@@ -62,6 +62,18 @@ namespace test
 
         virtual int getValue() = 0;
     };
+
+    class US_TestInterfaces_EXPORT TestManagedServiceFactory {
+      public:
+        TestManagedServiceFactory() = default;
+        virtual ~TestManagedServiceFactory() = default;
+
+        virtual int getUpdatedCounter(std::string const& pid) = 0;
+
+        virtual int getRemovedCounter(std::string const& pid) = 0;
+
+        virtual std::shared_ptr<TestManagedServiceFactoryServiceInterface> create(std::string const& config) = 0;
+    };
     
     // Interfaces for declarative services dependency graph resolution benchmarks. The
     // implentations of these interfaces have dependencies that form a complete 3 level tree:
@@ -125,18 +137,6 @@ namespace test
       virtual bool IsActivated() = 0;
       virtual bool IsDeactivated() = 0;
       virtual ~LifeCycleValidation();
-    };
-
-    class US_TestInterfaces_EXPORT TestManagedServiceFactory {
-      public:
-        TestManagedServiceFactory() = default;
-        virtual ~TestManagedServiceFactory() = default;
-
-        virtual int getUpdatedCounter(std::string const& pid) = 0;
-
-        virtual int getRemovedCounter(std::string const& pid) = 0;
-
-        virtual std::shared_ptr<TestManagedServiceFactoryServiceInterface> create(std::string const& config) = 0;
     };
 }
 


### PR DESCRIPTION
This PR introduces another ConfigAdmin test and makes it open source.

Additionally, it fixes a Valgrind error which was present in TestMetadataParserImplV1.cpp