### PR TITLE
Explicit use of ASCII or Unicode versions of Windows APIs

### DIFF
--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -60,7 +60,7 @@ static std::string get_error_str()
                    NULL,
                    dw,
                    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                   reinterpret_cast<LPTSTR>(&lpMsgBuf),
+                   reinterpret_cast<LPSTR>(&lpMsgBuf),
                    0,
                    NULL);
   // If FormatMessage fails using FORMAT_MESSAGE_ALLOCATE_BUFFER
@@ -71,7 +71,7 @@ static std::string get_error_str()
   if (rc == 0) {
     errMsg = "Failed to retrieve error message.";
   } else {
-    errMsg = reinterpret_cast<LPCTSTR>(lpMsgBuf);
+    errMsg = reinterpret_cast<LPSTR>(lpMsgBuf);
     LocalFree(lpMsgBuf);
   }
   return errMsg;

--- a/util/include/cppmicroservices/util/BundlePEFile.h
+++ b/util/include/cppmicroservices/util/BundlePEFile.h
@@ -25,6 +25,7 @@
 #include "BundleObjFile.h"
 #include "DataContainer.h"
 #include "Error.h"
+#include "String.h"
 #include "cppmicroservices_pe.h"
 
 #include <cerrno>
@@ -87,11 +88,12 @@ public:
   BundlePEFile(std::string location)
     : m_rawData(nullptr)
   {
-    HMODULE hBundleResources = LoadLibraryEx(location.c_str(), nullptr, LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+    std::wstring wpath(cppmicroservices::util::ToWString(location));
+    HMODULE hBundleResources = LoadLibraryExW(wpath.c_str(), nullptr, LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
     if (hBundleResources) {
       // RAII - automatically free the library handle on object destruction
       auto loadLibraryHandle = std::unique_ptr<HMODULE, hModuleDeleter>(hBundleResources, hModuleDeleter{});
-      HRSRC hResource = FindResource(hBundleResources, "US_RESOURCES", MAKEINTRESOURCE(300));
+      HRSRC hResource = FindResourceA(hBundleResources, "US_RESOURCES", MAKEINTRESOURCEA(300));
       HGLOBAL hRes = LoadResource(hBundleResources, hResource);
       const LPVOID res = LockResource(hRes);
       const DWORD zipSizeInBytes = SizeofResource(hBundleResources, hResource);


### PR DESCRIPTION
Fix an issue where code will fail to compile if explicitly built using Unicode (e.g. using /D_UNICODE /DUNICODE)

[ci skip]

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>