### PR TITLE
Fix manifest bundle version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.2)
 
 cmake_minimum_required(VERSION ${US_CMAKE_MINIMUM_REQUIRED_VERSION})
 
-project(CppMicroServices)
+project(CppMicroServices VERSION ${_version})
 
 set(US_GLOBAL_VERSION_SUFFIX ${${PROJECT_NAME}_VERSION_MAJOR})
 if (${PROJECT_NAME}_VERSION_MINOR EQUAL 99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.2)
 
 cmake_minimum_required(VERSION ${US_CMAKE_MINIMUM_REQUIRED_VERSION})
 
-project(CppMicroServices VERSION ${_version})
+project(CppMicroServices)
 
 set(US_GLOBAL_VERSION_SUFFIX ${${PROJECT_NAME}_VERSION_MAJOR})
 if (${PROJECT_NAME}_VERSION_MINOR EQUAL 99)

--- a/cmake/usMacroCreateBundle.cmake
+++ b/cmake/usMacroCreateBundle.cmake
@@ -2,14 +2,21 @@
 
 macro(usMacroCreateBundle _project_name)
 
-project(${_project_name})
-
-cmake_parse_arguments(${PROJECT_NAME}
+cmake_parse_arguments(${_project_name}
   "SKIP_EXAMPLES;SKIP_INIT"
   "VERSION;TARGET;SYMBOLIC_NAME;EMBED_RESOURCE_METHOD"
   "DEPENDS;PRIVATE_INCLUDE_DIRS;LINK_LIBRARIES;SOURCES;PRIVATE_HEADERS;PUBLIC_HEADERS;RESOURCES;BINARY_RESOURCES"
   ${ARGN}
 )
+
+project(${_project_name} VERSION "${${_project_name}_VERSION}")
+
+# ${PROJECT_NAME} is only valid AFTER a call to project()
+message(NOTICE "${_project_name} version is ${${PROJECT_NAME}_VERSION}")
+
+if(NOT ${PROJECT_NAME}_VERSION)
+  message(SEND_ERROR "VERSION argument is required")
+endif()
 
 if(NOT ${PROJECT_NAME}_VERSION MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
   message(SEND_ERROR "VERSION argument invalid: ${${PROJECT_NAME}_VERSION}")
@@ -72,6 +79,11 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}Config.h.in)
                  ${CMAKE_CURRENT_BINARY_DIR}/include/${${PROJECT_NAME}_INCLUDE_SUBDIR}/${PROJECT_NAME}Config.h)
   list(APPEND ${PROJECT_NAME}_PUBLIC_HEADERS
     ${CMAKE_CURRENT_BINARY_DIR}/include/${${PROJECT_NAME}_INCLUDE_SUBDIR}/${PROJECT_NAME}Config.h)
+endif()
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/resources/manifest.json.in)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/manifest.json.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/resources/manifest.json)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/compendium/ConfigurationAdmin/test/TestingConfig.h.in
+++ b/compendium/ConfigurationAdmin/test/TestingConfig.h.in
@@ -12,6 +12,12 @@
 #endif
 
 #define US_ConfigurationAdmin_VERSION_MAJOR "@ConfigurationAdmin_VERSION_MAJOR@"
+#define US_ConfigurationAdmin_VERSION_MINOR "@ConfigurationAdmin_VERSION_MINOR@"
+#define US_ConfigurationAdmin_VERSION_PATCH "@ConfigurationAdmin_VERSION_PATCH@"
+#define US_ConfigurationAdmin_VERSION @ConfigurationAdmin_VERSION@
+#define US_ConfigurationAdmin_VERSION_STR "@ConfigurationAdmin_VERSION@"
+
+#define US_ConfigurationAdmin_SYMBOLIC_NAME "@ConfigurationAdmin_SYMBOLIC_NAME@"
 
 namespace cppmicroservices
 {

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
@@ -33,6 +33,7 @@
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "TestUtils.hpp"
+#include "DSTestingConfig.h"
 
 namespace scr = cppmicroservices::service::component::runtime;
 
@@ -61,6 +62,18 @@ protected:
 
   cppmicroservices::Framework framework;
 };
+
+TEST_F(TestServiceComponentRuntime, testBundleProperties)
+{
+  // Test that the build system correctly generated the config admin bundle properties.
+  auto dsPluginPath = GetDSRuntimePluginFilePath();
+  auto bundles = framework.GetBundleContext().InstallBundles(dsPluginPath);
+  EXPECT_EQ(bundles.size(), 1ul)
+    << "DS Runtime bundle found at" << dsPluginPath;
+  auto bundle = bundles.at(0);
+  ASSERT_EQ(bundle.GetSymbolicName(), US_DeclarativeServices_SYMBOLIC_NAME);
+  ASSERT_EQ(bundle.GetVersion().ToString(), US_DeclarativeServices_VERSION_STR);
+}
 
 /**
  * Test if the declarative services runtime publishes a service with interface

--- a/compendium/DeclarativeServices/test/TestingConfig.h.in
+++ b/compendium/DeclarativeServices/test/TestingConfig.h.in
@@ -12,6 +12,12 @@
 #endif
 
 #define US_DeclarativeServices_VERSION_MAJOR "@DeclarativeServices_VERSION_MAJOR@"
+#define US_DeclarativeServices_VERSION_MINOR "@DeclarativeServices_VERSION_MINOR@"
+#define US_DeclarativeServices_VERSION_PATCH "@DeclarativeServices_VERSION_PATCH@"
+#define US_DeclarativeServices_VERSION @DeclarativeServices_VERSION@
+#define US_DeclarativeServices_VERSION_STR "@DeclarativeServices_VERSION@"
+
+#define US_DeclarativeServices_SYMBOLIC_NAME "@DeclarativeServices_SYMBOLIC_NAME@"
 
 namespace cppmicroservices
 {

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -28,13 +28,9 @@ endif()
 if(CMAKE_THREAD_LIBS_INIT)
   list(APPEND _link_libraries ${CMAKE_THREAD_LIBS_INIT})
 endif()
-
-# Configure the bundles manifest.json file
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/manifest.json.in
-               ${CMAKE_CURRENT_BINARY_DIR}/resources/manifest.json)
-
+               
 usMacroCreateBundle(Framework
-  VERSION "${CppMicroServices_VERSION}"
+  VERSION "${_version}"
   TARGET CppMicroServices
   SYMBOLIC_NAME system_bundle
   SKIP_INIT # we do it manually

--- a/framework/resources/manifest.json.in
+++ b/framework/resources/manifest.json.in
@@ -1,5 +1,5 @@
 {
   "bundle.symbolic_name" : "system_bundle",
   "bundle.name" : "System Bundle",
-  "bundle.version" : "@CppMicroServices_VERSION@"
+  "bundle.version" : "@Framework_VERSION@"
 }

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -371,6 +371,7 @@ TEST(FrameworkTest, Properties)
     f.GetSymbolicName(),
     Constants::SYSTEM_BUNDLE_SYMBOLICNAME); // "Test Framework Bundle Name"
   ASSERT_EQ(f.GetBundleId(), 0);            // "Test Framework Bundle Id"
+  ASSERT_EQ(f.GetVersion().ToString(), US_FRAMEWORK_VERSION_STR); // Test that the build correctly generated the version
 }
 
 TEST(Framework, LifeCycle)


### PR DESCRIPTION
Fixes #498

Set the bundle version in manifest.json automatically for any bundle using the usMacroCreateBundle macro.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>