### PR TITLE
Fix Xcode 12 build failure due to copying happening in range-based for-loop.

### DIFF
--- a/framework/doc/snippets/uServices-resources/main.cpp
+++ b/framework/doc/snippets/uServices-resources/main.cpp
@@ -42,7 +42,7 @@ void extenderPattern(const BundleContext& bundleCtx)
   // Check if a bundle defines a "service-component" property
   // and use its value to retrieve an embedded resource containing
   // a component description.
-  for (auto const bundle : bundleCtx.GetBundles()) {
+  for (auto const & bundle : bundleCtx.GetBundles()) {
     if (bundle.GetState() == Bundle::STATE_UNINSTALLED)
       continue;
     auto headers = bundle.GetHeaders();


### PR DESCRIPTION
Fix Xcode build failure stemming from range-based for-loop creating copies.

Signed-off-by: The MathWorks, Inc. kevinlee@mathworks.com