### PR TITLE
Fix test target dependencies

### DIFF
--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -126,6 +126,11 @@ target_link_libraries(${us_configurationadmin_test_exe_name}
   gtest
   gmock
   util
+)
+
+add_dependencies(${us_configurationadmin_test_exe_name}
+  ConfigurationAdmin
+  DeclarativeServices
   ${_test_bundles}
 )
 

--- a/compendium/DeclarativeServices/test/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/CMakeLists.txt
@@ -148,6 +148,9 @@ set(_test_bundles
   DSGraph06
   DSGraph07
   DSSpellChecker
+  TestBindUnbindThrows
+  TestBundleDSa
+  TestBundleDSb
   TestBundleDSSLE1
   TestBundleDSSLE2
   TestBundleDSTOI1
@@ -160,7 +163,13 @@ set(_test_bundles
   TestBundleDSTOI3
   TestBundleDSTOI5
   TestBundleDSTOI6
+  TestBundleDSTOI7
+  TestBundleDSTOI8
   TestBundleDSTOI9
+  TestBundleDSDGMU
+  TestBundleDSDGOU
+  TestBundleDSDRMU
+  TestBundleDSDROU
   EnglishDictionary
   )
 
@@ -178,6 +187,10 @@ target_link_libraries(${us_declarativeservices_test_exe_name}
   gtest
   gmock
   util
+)
+
+add_dependencies(${us_declarativeservices_test_exe_name}
+  DeclarativeServices
   ${_test_bundles}
 )
 


### PR DESCRIPTION
Currently, usDeclarativeServiceTests and usConfigurationAdminTests have the following issues, especially visible on Xcode:
1. These test targets don't have any build-order dependency on the libraries that they're testing. This results in DS and ConfigAdmin library symlinks disappearing when Xcode builds the current dependent targets.
2. These test targets have link dependencies on the test bundles (not necessary)

The proposed solution here is to add these build-order dependencies by using "add_dependencies" CMake command, instead of adding them in "target_link_libraries" to avoid unnecessary linking.

Signed-off-by: The MathWorks, Inc. <kevinlee@mathworks.com>