### PR TITLE
changed "auto headers = " to "auto const& headers = "

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMActivator.cpp
+++ b/compendium/ConfigurationAdmin/src/CMActivator.cpp
@@ -80,7 +80,7 @@ namespace cppmicroservices {
 
     void CMActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
     {
-      auto headers = bundle.GetHeaders();
+      auto const& headers = bundle.GetHeaders();
       // bundle has no "cm" configuration
       if (headers.find(CMConstants::CM_KEY) == std::end(headers))
       {
@@ -118,7 +118,7 @@ namespace cppmicroservices {
 
     void CMActivator::RemoveExtension(const cppmicroservices::Bundle& bundle)
     {
-      auto headers = bundle.GetHeaders();
+      auto const& headers = bundle.GetHeaders();
       // bundle has no "cm" configuration
       if (headers.find(CMConstants::CM_KEY) == std::end(headers))
       {


### PR DESCRIPTION
The original version caused an unnecessary copy of the bundle's headers. We only read them, and
copying is time consuming.