### PR TITLE
Made ToJSON for strings do proper escaping of special characters.

### DIFF
--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -57,7 +57,7 @@ namespace cppmicroservices {
 
 class Any;
 
-US_Framework_EXPORT std::ostream& indent_line(std::ostream& os, const uint8_t increment, const int32_t indent);
+US_Framework_EXPORT std::ostream& newline_and_indent(std::ostream& os, const uint8_t increment, const int32_t indent);
 US_Framework_EXPORT std::ostream& any_value_to_string(std::ostream& os, const Any& any);
 US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os, const Any& val, const uint8_t, const int32_t);
 US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os, const std::string& val, const uint8_t, const int32_t);
@@ -110,16 +110,13 @@ std::ostream& container_to_json(std::ostream& os, Iterator i1, Iterator i2, cons
   os << "[";
   const Iterator begin = i1;
   for (; i1 != i2; ++i1) {
-    if (i1 == begin) {
-      indent_line(os, increment, indent);
-      any_value_to_json(os, *i1, increment, indent + increment);
-    } else {
+    if (i1 != begin) {
       os << ",";
-      indent_line(os, increment, indent);
-      any_value_to_json(os, *i1, increment, indent + increment);
     }
+    newline_and_indent(os, increment, indent);
+    any_value_to_json(os, *i1, increment, indent + increment);
   }
-  indent_line(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent-increment);
   os << "]";
   return os;
 }
@@ -350,15 +347,12 @@ public:
   {
     return Empty() ? "null" : _content->ToJSON(increment, indent);
   }
-  std::string ToJSON(const uint8_t increment) const
-  {
-    return ToJSON(increment, increment);
-  }
   std::string ToJSON(bool prettyPrint = false) const
   {
-    // Standard indent by 4 spaces if pretty printing. If you want something else, call the uint8_t
-    // interface directly. 
-    return ToJSON(static_cast<uint8_t>(prettyPrint ? 4 : 0));
+    // Standard indent by 4 spaces if pretty printing. If you want something else, call the general
+    // interface directly.
+    uint8_t increment = prettyPrint ? 4 : 0;
+    return ToJSON(increment, increment);
   }
   /**
    * Returns the type information of the stored content.
@@ -693,17 +687,13 @@ std::ostream& any_value_to_json(std::ostream& os, const std::map<K, Any>& m, con
   const Iterator begin = i1;
   const Iterator end = m.end();
   for (; i1 != end; ++i1) {
-    if (i1 == begin) {
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
-    }
-    else {
+    if (i1 != begin) {
       os << ", ";
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
     }
+    newline_and_indent(os, increment, indent);
+    os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
   }
-  indent_line(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent-increment);
   os << "}";
   return os;
 }
@@ -719,17 +709,13 @@ std::ostream& any_value_to_json(std::ostream& os, const std::map<K, V>& m, const
   const Iterator begin = i1;
   const Iterator end = m.end();
   for (; i1 != end; ++i1) {
-    if (i1 == begin) {
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second;
-    }
-    else {
+    if (i1 != begin) {
       os << ", ";
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second;
     }
+    newline_and_indent(os, increment, indent);
+    os << "\"" << i1->first << "\" : " << i1->second;
   }
-  indent_line(os, increment, std::max(0, indent-increment));
+  newline_and_indent(os, increment, std::max(0, indent-increment));
   os << "}";
   return os;
 }

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -350,10 +350,15 @@ public:
   {
     return Empty() ? "null" : _content->ToJSON(increment, indent);
   }
-
-  std::string ToJSON(const uint8_t increment = 0) const
+  std::string ToJSON(const uint8_t increment) const
   {
     return ToJSON(increment, increment);
+  }
+  std::string ToJSON(bool prettyPrint = false) const
+  {
+    // Standard indent by 4 spaces if pretty printing. If you want something else, call the uint8_t
+    // interface directly. 
+    return ToJSON(static_cast<uint8_t>(prettyPrint ? 4 : 0));
   }
   /**
    * Returns the type information of the stored content.

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -406,7 +406,9 @@ US_Framework_EXPORT std::ostream& any_value_to_string(std::ostream& os,
 
 template<>
 US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
-                                                    const AnyMap& m);
+                                                    const AnyMap& m,
+                                                    const uint8_t increment,
+                                                    const int32_t indent);
 }
 
 #endif // CPPMICROSERVICES_ANYMAP_H

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -24,6 +24,7 @@
 #include "Utils.h"
 
 #include <stdexcept>
+#include <iomanip>
 
 namespace cppmicroservices {
 
@@ -54,9 +55,33 @@ std::ostream& any_value_to_json(std::ostream& os, const Any& val)
   return os;
 }
 
-std::ostream& any_value_to_json(std::ostream& os, const std::string& val)
+std::ostream& any_value_to_json(std::ostream& o, const std::string& s)
 {
+#if NEVER
+  // The original code for this function fails to properly escape the characters in the string to
+  // make it a proper JSON string. The new code below does so.
   return os << '"' << val << '"';
+#endif
+  o << '"';
+  for (auto c = s.cbegin(); c != s.cend(); c++) {
+    switch (*c) {
+      case '"' : o << "\\\""; break;
+      case '\\': o << "\\\\"; break;
+      case '\b': o << "\\b";  break;
+      case '\f': o << "\\f";  break;
+      case '\n': o << "\\n";  break;
+      case '\r': o << "\\r";  break;
+      case '\t': o << "\\t";  break;
+      default:
+        if ('\x00' <= *c && *c <= '\x1f') {
+          o << "\\u"
+            << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(*c);
+        } else {
+          o << *c;
+        }
+    }
+  }
+  return o << '"';
 }
 
 std::ostream& any_value_to_json(std::ostream& os, bool val)

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -65,11 +65,6 @@ std::ostream& any_value_to_json(std::ostream& os, const Any& val, const uint8_t 
 
 std::ostream& any_value_to_json(std::ostream& o, const std::string& s, const uint8_t, const int32_t)
 {
-#if NEVER
-  // The original code for this function fails to properly escape the characters in the string to
-  // make it a proper JSON string. The new code below does so.
-  return os << '"' << val << '"';
-#endif
   o << '"';
   for (auto c = s.cbegin(); c != s.cend(); c++) {
     switch (*c) {
@@ -94,7 +89,7 @@ std::ostream& any_value_to_json(std::ostream& o, const std::string& s, const uin
 
 std::ostream& any_value_to_json(std::ostream& os, bool val, const uint8_t, const int32_t)
 {
-  return os << std::boolalpha << val << std::noboolalpha;
+  return os << std::boolalpha << val;
 }
 
 // The default constructor implementation needs to be in the implementation file, not the

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -43,10 +43,18 @@ void ThrowBadAnyCastException(const std::string& funcName,
 }
 }
 
-std::ostream& indent_line(std::ostream& os, const uint8_t increment, const int32_t indent)
+std::ostream& newline_and_indent(std::ostream& os, const uint8_t increment, const int32_t indent)
 {
   if (increment > 0) {
-    os << std::endl << std::setw(std::max(0,indent)) << ' ';
+    // We only do formatting if increment > 0, because if increment was actually zero everything
+    // would just line up in one column, so there'd be no formatting.
+    //
+    // We always insert a newline if we're formatting
+    os << std::endl;
+    if (indent > 0) {
+      // And if we're indenting past the zeroth column, insert that many spaces
+      os << std::setw(indent) << ' ';
+    }
   }
   return os;
 }

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -43,19 +43,27 @@ void ThrowBadAnyCastException(const std::string& funcName,
 }
 }
 
+std::ostream& indent_line(std::ostream& os, const uint8_t increment, const int32_t indent)
+{
+  if (increment > 0) {
+    os << std::endl << std::setw(std::max(0,indent)) << ' ';
+  }
+  return os;
+}
+
 std::ostream& any_value_to_string(std::ostream& os, const Any& any)
 {
   os << any.ToString();
   return os;
 }
 
-std::ostream& any_value_to_json(std::ostream& os, const Any& val)
+std::ostream& any_value_to_json(std::ostream& os, const Any& val, const uint8_t increment, const int32_t indent)
 {
-  os << val.ToJSON();
+  os << val.ToJSON(increment, indent);
   return os;
 }
 
-std::ostream& any_value_to_json(std::ostream& o, const std::string& s)
+std::ostream& any_value_to_json(std::ostream& o, const std::string& s, const uint8_t, const int32_t)
 {
 #if NEVER
   // The original code for this function fails to properly escape the characters in the string to
@@ -84,9 +92,9 @@ std::ostream& any_value_to_json(std::ostream& o, const std::string& s)
   return o << '"';
 }
 
-std::ostream& any_value_to_json(std::ostream& os, bool val)
+std::ostream& any_value_to_json(std::ostream& os, bool val, const uint8_t, const int32_t)
 {
-  return os << (val ? "true" : "false");
+  return os << std::boolalpha << val << std::noboolalpha;
 }
 
 // The default constructor implementation needs to be in the implementation file, not the

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -996,17 +996,13 @@ std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m, const uint8_t
   const Iterator begin = i1;
   const Iterator end = m.end();
   for (; i1 != end; ++i1) {
-    if (i1 == begin) {
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
-    }
-    else {
+    if (i1 != begin) {
       os << ", ";
-      indent_line(os, increment, indent);
-      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
     }
+    newline_and_indent(os, increment, indent);
+    os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
   }
-  indent_line(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent-increment);
   os << "}";
   return os;
 }

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -986,20 +986,27 @@ std::ostream& any_value_to_string(std::ostream& os, const AnyMap& m)
 }
 
 template<>
-std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m)
+std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m, const uint8_t increment, const int32_t indent)
 {
+  if (m.empty()) { os << "{}"; return os; }
+
   os << "{";
   using Iterator = any_map::const_iterator;
   Iterator i1 = m.begin();
   const Iterator begin = i1;
   const Iterator end = m.end();
   for (; i1 != end; ++i1) {
-    if (i1 == begin)
-      os << "\"" << i1->first << "\" : " << i1->second.ToJSON();
-    else
-      os << ", "
-         << "\"" << i1->first << "\" : " << i1->second.ToJSON();
+    if (i1 == begin) {
+      indent_line(os, increment, indent);
+      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
+    }
+    else {
+      os << ", ";
+      indent_line(os, increment, indent);
+      os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
+    }
   }
+  indent_line(os, increment, indent-increment);
   os << "}";
   return os;
 }

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -180,9 +180,8 @@ TEST(AnyTest, AnyMapAny)
 
 TEST(AnyTest, AnyStringEscapeCharacters)
 {
-  Any anyString = std::string(R"("\	
-)");
-  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\x7F\\t\\n\\u000b\"");
+  Any anyString = std::string("\"\\\b\f\n\r\t\x1f");
+  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\\b\\f\\n\\r\\t\\u001f\"");
 }
 
 TEST(AnyTest, AnyToJSONWithFormatting)

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -181,8 +181,8 @@ TEST(AnyTest, AnyMapAny)
 TEST(AnyTest, AnyStringEscapeCharacters)
 {
   Any anyString = std::string(R"("\	
-)");
-  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\x7F\\t\\n\\r\\u000b\"");
+)");
+  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\x7F\\t\\n\\u000b\"");
 }
 
 TEST(AnyTest, AnyToJSONWithFormatting)

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -181,8 +181,8 @@ TEST(AnyTest, AnyMapAny)
 TEST(AnyTest, AnyStringEscapeCharacters)
 {
   Any anyString = std::string(R"("\	
-)");
-  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\x7F\\t\\n\\r\"");
+)");
+  EXPECT_EQ(anyString.ToJSON(), "\"\\\"\\\\\x7F\\t\\n\\r\\u000b\"");
 }
 
 TEST(AnyTest, AnyToJSONWithFormatting)

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -216,7 +216,7 @@ TEST(AnyTest, AnyToJSONWithFormatting)
         8,
         7
     ]
- })";
+})";
   EXPECT_EQ(anyMap.ToJSON(true), expected);
 }
 

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -218,7 +218,7 @@ TEST(AnyTest, AnyToJSONWithFormatting)
         7
     ]
  })";
-  EXPECT_EQ(anyMap.ToJSON(4), expected);
+  EXPECT_EQ(anyMap.ToJSON(true), expected);
 }
 
 TEST(AnyTest, AnyMapComplex)

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -101,12 +101,12 @@ TEST(AnyTest, AnyDouble)
 
 TEST(AnyTest, AnyString)
 {
-  Any anyString = std::string("bonjour");
+  Any anyString = std::string(R"(bon"jour)");
   EXPECT_EQ(anyString.Type(), typeid(std::string));
-  EXPECT_EQ(any_cast<std::string>(anyString), "bonjour");
-  EXPECT_EQ(anyString.ToString(), "bonjour");
-  EXPECT_EQ(anyString.ToJSON(), "\"bonjour\"");
-  TestUnsafeAnyCast<std::string>(anyString, std::string("bonjour"));
+  EXPECT_EQ(any_cast<std::string>(anyString), "bon\"jour");
+  EXPECT_EQ(anyString.ToString(), "bon\"jour");
+  EXPECT_EQ(anyString.ToJSON(), "\"bon\\\"jour\"");
+  TestUnsafeAnyCast<std::string>(anyString, std::string("bon\"jour"));
 }
 
 TEST(AnyTest, AnyVector)


### PR DESCRIPTION
While working on something that required converting an AnyMap to JSON I found that our implementation didn't properly escape special characters in strings when doing the conversion. I updated the test case with an example of the problem that I found, showed the failure, and then updated the code to show a pass.