### PR TITLE
Suppress MSVC Warning C4834

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,6 @@ set(US_CXX_COVERAGE_FLAGS )
 if(MSVC)
   set(disabled_warnings
     4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-    4834 # discarding return value of function with 'nodiscard' attribute
   )
 
   if (${MSVC_VERSION} LESS 1910)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ set(US_CXX_COVERAGE_FLAGS )
 if(MSVC)
   set(disabled_warnings
     4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+    4834 # discarding return value of function with 'nodiscard' attribute
   )
 
   if (${MSVC_VERSION} LESS 1910)

--- a/httpservice/src/ServletContainer.cpp
+++ b/httpservice/src/ServletContainer.cpp
@@ -40,8 +40,8 @@
 #include "civetweb/CivetServer.h"
 
 #include <cassert>
-#include <utility>
 #include <memory>
+#include <utility>
 
 namespace cppmicroservices {
 
@@ -50,8 +50,7 @@ using Lock = std::unique_lock<std::mutex>;
 class ServletHandler : public CivetHandler
 {
 public:
-  ServletHandler(std::shared_ptr<HttpServlet>  servlet,
-                 std::string  servletPath)
+  ServletHandler(std::shared_ptr<HttpServlet> servlet, std::string servletPath)
     : m_Servlet(std::move(servlet))
     , m_ServletPath(std::move(servletPath))
   {}
@@ -279,7 +278,9 @@ void ServletContainer::SetContextPath(const std::string& path)
 
 std::string ServletContainer::GetContextPath() const
 {
-  return Lock(d->m_Mutex), d->m_ContextPath;
+  Lock l(d->m_Mutex);
+  US_UNUSED(l);
+  return d->m_ContextPath;
 }
 
 void ServletContainer::Start()
@@ -306,6 +307,8 @@ std::shared_ptr<ServletContext> ServletContainer::GetContext(
 std::string ServletContainer::GetContextPath(
   const ServletContext* /*context*/) const
 {
-  return Lock(d->m_Mutex), d->m_ContextPath;
+  Lock l(d->m_Mutex);
+  US_UNUSED(l);
+  return d->m_ContextPath;
 }
 }


### PR DESCRIPTION
AppVeyor builds are consistently failing due to this warning, most likely due to some upgrade on their side.

This PR suppresses the warning so that it is not treated as an error when building.