### PR TITLE
Fix #301 so TSAN builds work on Linux

### DIFF
--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -179,8 +179,9 @@ void validateManifestInArchive(mz_zip_archive* zipArchive,
                                const std::string& archiveFile,
                                const std::string& archiveEntry)
 {
+  size_t length = 0;
   void* data = mz_zip_reader_extract_file_to_heap(
-    zipArchive, archiveEntry.c_str(), nullptr, 0);
+    zipArchive, archiveEntry.c_str(), &length, 0);
   std::unique_ptr<void, void (*)(void*)> manifestFileContents(data, ::free);
 
   if (!manifestFileContents) {
@@ -191,7 +192,7 @@ void validateManifestInArchive(mz_zip_archive* zipArchive,
   try {
     Json::Value root;
     std::istringstream json(
-      reinterpret_cast<const char*>(manifestFileContents.get()));
+      std::string(reinterpret_cast<const char *>(manifestFileContents.get()), length));
     parseAndValidateJson(json, root);
   } catch (const InvalidManifest& e) {
     std::string exceptionMsg(archiveFile);

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,1 +1,0 @@
-race:usResourceCompiler4*


### PR DESCRIPTION
Fixes #301 .

This PR makes changes to ResourceCompiler.cpp to remove the ASAN and TSAN errors that occur when building.

Testing was done locally on Linux with US_ENABLE_TSAN turned on since the build would always fail previously if this was turned on.