### PR TITLE
Anymap erase and compare

### DIFF
--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -56,7 +56,7 @@ template <class T>
 struct has_op_eq
 {
   template <class U>
-  static auto op_eq_test(const U* u) -> decltype(*u == *u, char(0))
+  static auto op_eq_test(const U* u) -> decltype(char(*u == *u))
   { return char(0); }
 
   static std::array<char, 2> op_eq_test(...) { return std::array<char,2>{0,0}; }

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -57,9 +57,9 @@ struct has_op_eq
 {
   template <class U>
   static auto op_eq_test(const U* u) -> decltype(*u == *u, char(0))
-  { }
+  { return char(0); }
 
-  static std::array<char, 2> op_eq_test(...) { }
+  static std::array<char, 2> op_eq_test(...) { return std::array<char,2>{0,0}; }
 
   static const bool value = (sizeof(op_eq_test(static_cast<T*>(0))) == 1);
 };

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -59,7 +59,7 @@ struct has_op_eq
   static auto op_eq_test(const U* u) -> decltype(char(*u == *u))
   { return char(0); }
 
-  static std::array<char, 2> op_eq_test(...) { return std::array<char,2>{0,0}; }
+  static std::array<char, 2> op_eq_test(...) { return std::array<char,2>{{0,0}}; }
 
   static const bool value = (sizeof(op_eq_test(static_cast<T*>(0))) == 1);
 };

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -275,15 +275,25 @@ public:
 
   const_iterator find(const key_type& key) const;
 
+  /**
+   * Erase entry for value for 'key'
+   * @param key the key for the entry to Erase
+   * @return the number of elements erased.
+   */ 
   size_type erase(const key_type& key);
 
+  /**
+   * Compare the content of this map with those of rhs
+   * @param rhs an any_map to compare
+   * @return bool true rhs contains the same content as this
+   */
   bool operator==(const any_map& rhs) const;
   bool operator!=(const any_map& rhs) const { return !(operator==(rhs)); }
 protected:
   map_type type;
 
 private:
-  ordered_any_map const& o_m() const;
+  ordered_any_mt& o_m() const;
   ordered_any_map& o_m();
   unordered_any_map const& uo_m() const;
   unordered_any_map& uo_m();

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -293,7 +293,7 @@ protected:
   map_type type;
 
 private:
-  ordered_any_mt& o_m() const;
+  ordered_any_map const& o_m() const;
   ordered_any_map& o_m();
   unordered_any_map const& uo_m() const;
   unordered_any_map& uo_m();
@@ -425,9 +425,5 @@ US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
                                                     const int32_t indent);
 
 }
-
-bool operator==(const cppmicroservices::any_map& lhs, const cppmicroservices::any_map& rhs);
-cppmicroservices::AnyMap US_Framework_EXPORT manifest_from_cache(const cppmicroservices::any_map::key_type& key, cppmicroservices::any_map& cache);
-
 
 #endif // CPPMICROSERVICES_ANYMAP_H

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -273,6 +273,9 @@ public:
     }
   }
 
+  /**
+   * return the iterator to the value referenced by key
+   */
   const_iterator find(const key_type& key) const;
 
   /**

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -423,7 +423,6 @@ US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
                                                     const AnyMap& m,
                                                     const uint8_t increment,
                                                     const int32_t indent);
-
 }
 
 #endif // CPPMICROSERVICES_ANYMAP_H

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -275,6 +275,10 @@ public:
 
   const_iterator find(const key_type& key) const;
 
+  size_type erase(const key_type& key);
+
+  bool operator==(const any_map& rhs) const;
+  bool operator!=(const any_map& rhs) const { return !(operator==(rhs)); }
 protected:
   map_type type;
 
@@ -409,6 +413,11 @@ US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
                                                     const AnyMap& m,
                                                     const uint8_t increment,
                                                     const int32_t indent);
+
 }
+
+bool operator==(const cppmicroservices::any_map& lhs, const cppmicroservices::any_map& rhs);
+cppmicroservices::AnyMap US_Framework_EXPORT manifest_from_cache(const cppmicroservices::any_map::key_type& key, cppmicroservices::any_map& cache);
+
 
 #endif // CPPMICROSERVICES_ANYMAP_H

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -118,5 +118,4 @@ std::string Any::ToStringNoExcept() const
 {
   return Empty() ? std::string() : _content->ToString();
 }
-
 }

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -118,4 +118,5 @@ std::string Any::ToStringNoExcept() const
 {
   return Empty() ? std::string() : _content->ToString();
 }
+
 }

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -26,7 +26,6 @@
 #include "absl/strings/string_view.h"
 
 #include <stdexcept>
-#include <iostream>
 
 namespace cppmicroservices {
 

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -26,6 +26,7 @@
 #include "absl/strings/string_view.h"
 
 #include <stdexcept>
+#include <iostream>
 
 namespace cppmicroservices {
 
@@ -839,6 +840,17 @@ any_map::const_iterator any_map::find(const key_type& key) const
   }
 }
 
+any_map::size_type any_map::erase(const key_type& key)
+{
+  switch (type) {
+    case map_type::ORDERED_MAP                        : return o_m().erase(key);
+    case map_type::UNORDERED_MAP                      : return uo_m().erase(key);
+    case map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS : return uoci_m().erase(key);
+    default:
+      throw std::logic_error("invalid map type");
+  }
+}
+
 any_map::ordered_any_map const& any_map::o_m() const
 {
   return *map.o;
@@ -1006,4 +1018,20 @@ std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m, const uint8_t
   os << "}";
   return os;
 }
+
+bool any_map::operator==(const any_map& rhs) const
+{
+  if (type == rhs.type) {
+    switch (type) {
+      case map_type::ORDERED_MAP:
+        return (*map.o == *rhs.map.o);
+      case map_type::UNORDERED_MAP:
+        return (*map.uo == *rhs.map.uo);
+      case map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS:
+        return (*map.uoci == *rhs.map.uoci);
+    }
+  }
+  return false;
+}
+
 }

--- a/framework/test/gtest/AnyMapTest.cpp
+++ b/framework/test/gtest/AnyMapTest.cpp
@@ -369,22 +369,36 @@ cppmicroservices::AnyMap manifest_from_cache(const cppmicroservices::any_map::ke
 
 TEST(AnyMapTest, ManifestFromCache)
 {
-  AnyMap cache(AnyMap::ORDERED_MAP);
-  AnyMap bundles(AnyMap::ORDERED_MAP);
-  AnyMap entry(AnyMap::ORDERED_MAP);
+  AnyMap cache(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  AnyMap cache_bundles(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  AnyMap cache_bundle1(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  AnyMap cache_bundle2(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
 
-  entry["a"] = std::string("A");
-  entry["b"] = std::string("B");
-  entry["c"] = std::string("C");
-  auto entry_copy = entry;
+  cache_bundle1["a"] = std::string("A");
+  cache_bundle1["b"] = std::string("B");
+  cache_bundle1["c"] = std::string("C");
+  auto cache_bundle1_copy = cache_bundle1;
+
+  cache_bundle2["d"] = std::string("D");
+  cache_bundle2["e"] = std::string("E");
+  cache_bundle2["f"] = std::string("F");
+  auto cache_bundle2_copy = cache_bundle2;
   
-  bundles.emplace(std::string("entry"), std::move(entry));
+  cache_bundles.emplace(std::string("bundle1"), std::move(cache_bundle1));
+  cache_bundles.emplace(std::string("bundle2"), std::move(cache_bundle2));
   cache["created"] = 1234567890;
   cache["version"] = 1;
-  cache.emplace(std::string("bundles"),std::move(bundles));
+  cache.emplace(std::string("bundles"),std::move(cache_bundles));
+  EXPECT_EQ(3, cache.size()); // created, version, bundles
 
-  ASSERT_EQ(3, cache.size());
-  auto fetch = manifest_from_cache(std::string("entry"), cache);
-  ASSERT_EQ(3, fetch.size());
-  ASSERT_EQ(entry_copy, fetch);
+  auto const& bundles = ref_any_cast<AnyMap>(cache.at("bundles"));
+  EXPECT_EQ(2, bundles.size()); // bundle1, bundle2
+  
+  auto bundle1 = manifest_from_cache(std::string("bundle1"), cache);
+  EXPECT_EQ(cache_bundle1_copy, bundle1);
+  EXPECT_EQ(1, bundles.size());
+
+  auto bundle2 = manifest_from_cache(std::string("bundle2"), cache);
+  EXPECT_EQ(cache_bundle2_copy, bundle2);
+  EXPECT_EQ(0, bundles.size());
 }

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -252,3 +252,9 @@ TEST(AnyTest, AnyBadAnyCastException) {
   EXPECT_THROW(ref_any_cast<std::string>(uncastableAny),
                cppmicroservices::BadAnyCastException);
 }
+
+TEST(AnyTest, AnyEquality) {
+  Any lhs = std::string("VALUE");
+  Any rhs = std::string("VALUE");
+  EXPECT_EQ(lhs,rhs);
+}

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 =============================================================================*/
 
 #include "cppmicroservices/Any.h"
+#include "cppmicroservices/AnyMap.h"
 #include "cppmicroservices/GlobalConfig.h"
 
 #include "gtest/gtest.h"
@@ -253,8 +254,41 @@ TEST(AnyTest, AnyBadAnyCastException) {
                cppmicroservices::BadAnyCastException);
 }
 
+struct no_eq {
+  bool operator==(const no_eq&) const = delete;
+  friend std::ostream& operator<<(std::ostream& os, no_eq const&) { os << "OOPS"; return os; }
+};
 TEST(AnyTest, AnyEquality) {
-  Any lhs = std::string("VALUE");
-  Any rhs = std::string("VALUE");
-  EXPECT_EQ(lhs,rhs);
+  EXPECT_EQ(Any(std::string("A")), Any(std::string("A")));
+  EXPECT_NE(Any(std::string("A")), Any(std::string("B")));
+  EXPECT_NE(Any(1), Any(std::string("A")));
+  EXPECT_EQ(Any(1), Any(1));
+  EXPECT_NE(Any(1), Any(2));
+  EXPECT_EQ(Any(true), Any(true));
+  EXPECT_NE(Any(true), Any(false));
+  EXPECT_NE(Any(no_eq()), Any(no_eq()));
+  EXPECT_NE(Any(1), Any(true)); // type mismatch should never be equal
+  EXPECT_NE(Any(0), Any(false));
+  EXPECT_EQ(Any(1.5), Any(1.5));
+  EXPECT_NE(Any(1.5), Any(1.6));
+
+  AnyMap lhs(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  lhs["int"] = 1;
+  lhs["float"] = 2.5;
+  lhs["string"] = std::string("string");
+  lhs["bool"] = true;
+  AnyMap submap(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  submap["a"] = std::string("a");
+  submap["b"] = std::string("b");
+  lhs["submap"] = submap;
+
+  AnyMap rhs = lhs; // make a copy of lhs
+  EXPECT_EQ(lhs, rhs); // they should be equal
+
+  rhs["int"] = 2;
+  EXPECT_NE(lhs, rhs); // they should not be equal after modifying the rhs.
+  rhs["int"] = 1;
+  EXPECT_EQ(lhs, rhs); // they should not be equal after modifying the rhs.
+  rhs.erase("int");
+  EXPECT_NE(lhs, rhs);
 }

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -288,7 +288,8 @@ TEST(AnyTest, AnyEquality) {
   rhs["int"] = 2;
   EXPECT_NE(lhs, rhs); // they should not be equal after modifying the rhs.
   rhs["int"] = 1;
-  EXPECT_EQ(lhs, rhs); // they should not be equal after modifying the rhs.
+  EXPECT_EQ(lhs, rhs); // now they should be equal again
   rhs.erase("int");
-  EXPECT_NE(lhs, rhs);
+  EXPECT_NE(lhs, rhs); // and finally, with the "int" element erased, they should not be equal
+                       // anymore. 
 }

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -266,11 +266,15 @@ TEST(AnyTest, AnyEquality) {
   EXPECT_NE(Any(1), Any(2));
   EXPECT_EQ(Any(true), Any(true));
   EXPECT_NE(Any(true), Any(false));
-  EXPECT_NE(Any(no_eq()), Any(no_eq()));
   EXPECT_NE(Any(1), Any(true)); // type mismatch should never be equal
   EXPECT_NE(Any(0), Any(false));
   EXPECT_EQ(Any(1.5), Any(1.5));
   EXPECT_NE(Any(1.5), Any(1.6));
+
+  Any no_eq_operator { no_eq() };
+  EXPECT_NE(no_eq_operator, no_eq_operator); // Since no_eq has the equality operator deleted, Any,
+                                             // by design, always returns FALSE when equality is
+                                             // checked.
 
   AnyMap lhs(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
   lhs["int"] = 1;


### PR DESCRIPTION
Added implementations of AnyMap::erase(), AnyMap::operator==(), and Any::operator==(). The implementation of Any::operator==() behaves slightly differently than the standard interface: If one of the operator==() operands contains a value whose type does not have an operator==() implementation available, the comparison fails instead of failing to compile. This is because of the implementation of Any::Holder::operator==() which fails to compile if ValueType does not support operator==(), which would disallow storing anything in an Any container that does not provide the equality operator.