### PR TITLE
552 travis xcodebuild pretty

### DIFF
--- a/cmake/travis_xcodebuild_pretty.sh
+++ b/cmake/travis_xcodebuild_pretty.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# $1 = ${CTEST_BINARY_DIRECTORY}
+# $2 = ${CTEST_BUILD_CONFIGURATION}
+
+xcodebuild -project $1/CppMicroServices.xcodeproj build -target ALL_BUILD -configuration $2 -parallelizeTargets -hideShellScriptEnvironment | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Resolves #552 

Use "xcpretty" (https://github.com/xcpretty/xcpretty) to make travis-ci build logs less verbose on macOS, as some of our builds have been exceeding the 4MB log file size limit.