### PR TITLE
Limit the thread pool to 2

### DIFF
--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -50,7 +50,8 @@ void SCRActivator::Start(BundleContext context)
 {
   runtimeContext = context;
 
-  threadpool = std::make_shared<boost::asio::thread_pool>();
+  // limit the number of threads to 2. There is currently no use case to warrant increasing it.
+  threadpool = std::make_shared<boost::asio::thread_pool>(2);
 
   // Create the component registry
   componentRegistry = std::make_shared<ComponentRegistry>();


### PR DESCRIPTION
There is currently no use case for setting the # of threads DS uses to the limit reported by the OS.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>