### PR TITLE
Fix TestConcurrentBindUnbind error

### DIFF
--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -82,10 +82,14 @@ void ComponentContextImpl::InitializeServicesCache()
                 .ToStringNoExcept();
             cppmicroservices::ServiceObjects<void> sObjs =
               bc.GetServiceObjects(sRefU);
-            serviceMap.push_back(sObjs.GetService());
+            auto interfaceMap = sObjs.GetService();
+            if (interfaceMap) {
+                serviceMap.push_back(interfaceMap);
+            }
           }
         }
       });
+ 
   }
 }
 
@@ -208,7 +212,7 @@ void ComponentContextImpl::Invalidate()
   boundServicesCacheHandle->clear();
 }
 
-void ComponentContextImpl::AddToBoundServicesCache(
+bool ComponentContextImpl::AddToBoundServicesCache(
   const std::string& refName,
   const cppmicroservices::ServiceReferenceBase& sRef)
 {
@@ -216,11 +220,16 @@ void ComponentContextImpl::AddToBoundServicesCache(
   cppmicroservices::ServiceObjects<void> sObjs =
     bc.GetServiceObjects(ServiceReferenceU(sRef));
   auto boundServicesCacheHandle = boundServicesCache.lock();
+  auto interfaceMap = sObjs.GetService();
+  if (!interfaceMap) {
+      return false;
+  }
   (*boundServicesCacheHandle)[refName].emplace_back(
-    sObjs.GetService());
+    interfaceMap);
+  return true;
 }
 
-void ComponentContextImpl::RemoveFromBoundServicesCache(
+bool ComponentContextImpl::RemoveFromBoundServicesCache(
   const std::string& refName,
   const cppmicroservices::ServiceReferenceBase& sRef)
 {
@@ -229,6 +238,9 @@ void ComponentContextImpl::RemoveFromBoundServicesCache(
     bc.GetServiceObjects(ServiceReferenceU(sRef));
 
   const auto removedService = sObjs.GetService();
+  if (!removedService) {
+      return false;
+  }
   const auto& serviceInterface = removedService->begin()->first;
   auto boundServicesCacheHandle = boundServicesCache.lock();
   auto& services = boundServicesCacheHandle->at(refName);
@@ -249,6 +261,7 @@ void ComponentContextImpl::RemoveFromBoundServicesCache(
                 servicesMap->at(serviceInterface));
       }),
     services.end());
+  return true;
 }
 
 }

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -229,7 +229,7 @@ bool ComponentContextImpl::AddToBoundServicesCache(
   return true;
 }
 
-bool ComponentContextImpl::RemoveFromBoundServicesCache(
+void ComponentContextImpl::RemoveFromBoundServicesCache(
   const std::string& refName,
   const cppmicroservices::ServiceReferenceBase& sRef)
 {
@@ -238,9 +238,6 @@ bool ComponentContextImpl::RemoveFromBoundServicesCache(
     bc.GetServiceObjects(ServiceReferenceU(sRef));
 
   const auto removedService = sObjs.GetService();
-  if (!removedService) {
-      return false;
-  }
   const auto& serviceInterface = removedService->begin()->first;
   auto boundServicesCacheHandle = boundServicesCache.lock();
   auto& services = boundServicesCacheHandle->at(refName);
@@ -261,7 +258,7 @@ bool ComponentContextImpl::RemoveFromBoundServicesCache(
                 servicesMap->at(serviceInterface));
       }),
     services.end());
-  return true;
+  return;
 }
 
 }

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -197,10 +197,10 @@ public:
    */
   void Invalidate();
 
-  void AddToBoundServicesCache(const std::string& refName
+  bool AddToBoundServicesCache(const std::string& refName
                              , const cppmicroservices::ServiceReferenceBase& sRef);
     
-  void RemoveFromBoundServicesCache(const std::string& refName
+  bool RemoveFromBoundServicesCache(const std::string& refName
                              , const cppmicroservices::ServiceReferenceBase& sRef);
 
 private:

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -200,7 +200,7 @@ public:
   bool AddToBoundServicesCache(const std::string& refName
                              , const cppmicroservices::ServiceReferenceBase& sRef);
     
-  bool RemoveFromBoundServicesCache(const std::string& refName
+  void RemoveFromBoundServicesCache(const std::string& refName
                              , const cppmicroservices::ServiceReferenceBase& sRef);
 
 private:

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -125,7 +125,11 @@ void BundleOrPrototypeComponentConfigurationImpl::BindReference(const std::strin
   {
     auto& instance = instancePair.first;
     auto& context = instancePair.second;
-    context->AddToBoundServicesCache(refName, ref);
+    if (!context->AddToBoundServicesCache(refName, ref)) {
+        GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+            "Failure while trying to add reference to BoundServices Cache ");
+        return;
+    }
     try {
       instance->InvokeBindMethod(refName, ref);
     } catch (const std::exception&) {
@@ -155,7 +159,10 @@ void BundleOrPrototypeComponentConfigurationImpl::UnbindReference(const std::str
                        std::current_exception());
     }
     
-    context->RemoveFromBoundServicesCache(refName, ref);
+    if (!context->RemoveFromBoundServicesCache(refName, ref)) {
+        GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+            "Failure when removing a reference from the BoundServices Cache");
+    }
   }
 }
 

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -146,23 +146,21 @@ void BundleOrPrototypeComponentConfigurationImpl::UnbindReference(const std::str
                                                                  )
 {
   auto instancePairs = compInstanceMap.lock();
-  for (auto const& instancePair: *instancePairs)
+  for (auto const& instancePair : *instancePairs)
   {
-    auto& instance = instancePair.first;
-    auto& context = instancePair.second;
-    try {
-      instance->InvokeUnbindMethod(refName, ref);
-    } catch (const std::exception&) {
-      GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                       "Exception received from user code while unbinding a "
-                       "service reference.",
-                       std::current_exception());
-    }
-    
-    if (!context->RemoveFromBoundServicesCache(refName, ref)) {
-        GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-            "Failure when removing a reference from the BoundServices Cache");
-    }
+      auto& instance = instancePair.first;
+      auto& context = instancePair.second;
+      try {
+          instance->InvokeUnbindMethod(refName, ref);
+      }
+      catch (const std::exception&) {
+          GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+              "Exception received from user code while unbinding a "
+              "service reference.",
+              std::current_exception());
+      }
+
+      context->RemoveFromBoundServicesCache(refName, ref);
   }
 }
 

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -156,11 +156,7 @@ void SingletonComponentConfigurationImpl::UnbindReference(const std::string& ref
                      std::current_exception());
   }
   auto context = GetComponentContext();
-  if (!context->RemoveFromBoundServicesCache(refName, ref)) {
-      GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-          "Failure when removing a reference from the BoundServices Cache");
-  }
-
+  context->RemoveFromBoundServicesCache(refName, ref);
 }
 
 void SingletonComponentConfigurationImpl::SetComponentInstancePair(InstanceContextPair instCtxtPair)

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -129,7 +129,11 @@ void SingletonComponentConfigurationImpl::UngetService(const cppmicroservices::B
 void SingletonComponentConfigurationImpl::BindReference(const std::string& refName, const ServiceReferenceBase& ref)
 {
   auto context = GetComponentContext();
-  context->AddToBoundServicesCache(refName, ref);
+  if (!context->AddToBoundServicesCache(refName, ref)) {
+      GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+          "Failure while trying to add reference to BoundServices Cache ");
+      return;
+  }
   try {
     GetComponentInstance()->InvokeBindMethod(refName, ref);
   } catch (const std::exception&) {
@@ -152,7 +156,11 @@ void SingletonComponentConfigurationImpl::UnbindReference(const std::string& ref
                      std::current_exception());
   }
   auto context = GetComponentContext();
-  context->RemoveFromBoundServicesCache(refName, ref);
+  if (!context->RemoveFromBoundServicesCache(refName, ref)) {
+      GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+          "Failure when removing a reference from the BoundServices Cache");
+  }
+
 }
 
 void SingletonComponentConfigurationImpl::SetComponentInstancePair(InstanceContextPair instCtxtPair)

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -159,8 +159,14 @@ InterfaceMapConstPtr ServiceObjectsBase::GetServiceInterfaceMap() const
     return result;
   }
   // copy construct a new map to be handed out to consumers
-  result =
-    std::make_shared<const InterfaceMap>(*(d->GetServiceInterfaceMap().get()));
+  auto interfaceMap = d->GetServiceInterfaceMap();
+  // There are some circumstances that will cause the interfaceMap to be empty
+  // like when another thread has unregistered the service.
+  if (!interfaceMap) {
+      return result;
+  }
+  result = std::make_shared<const InterfaceMap>(*(interfaceMap.get()));
+
   std::shared_ptr<UngetHelper> h(new UngetHelper{
     result, d->m_reference, d->m_context->bundle->shared_from_this() });
   return InterfaceMapConstPtr(h, h->interfaceMap.get());


### PR DESCRIPTION
An exception was being thrown when running the TestConcurrentBindUnbind method because DS was in the middle of binding to a service reference while another thread was unregistering the service. The sObjs.GetService call in ComponentContextImpl::AddToBoundServicesCache was throwing the exception because the ServiceReferenceBasePrivate object had been cleared out by the unregister operation and was returning an empty InterfaceMap. Changed ServiceObjects.cpp to check for the return of an empty map and handle the condition. Signed-off-by: The MathWorks, Inc. <pelliott@mathworks.com>