### PR TITLE
Format all code files using clang-format

### DIFF
--- a/cmake/CMakeResourceDependencies.cpp
+++ b/cmake/CMakeResourceDependencies.cpp
@@ -26,6 +26,6 @@ namespace {
 // empty object files.
 struct CMakeResourceDependencies
 {
-  CMakeResourceDependencies() { }
+  CMakeResourceDependencies() {}
 };
 }

--- a/compendium/CM/include/cppmicroservices/cm/Configuration.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/Configuration.hpp
@@ -28,95 +28,99 @@
 #include "cppmicroservices/AnyMap.h"
 
 namespace cppmicroservices {
-  namespace service {
-    namespace cm {
+namespace service {
+namespace cm {
 
-      /**
-      \defgroup gr_configuration Configuration
-      \brief Groups Configuration class related symbols.
-      */
+/**
+ \defgroup gr_configuration Configuration
+ \brief Groups Configuration class related symbols.
+ */
 
-      /**
-       * \ingroup gr_configuration
-       * 
-       * The Configuration object (normally obtained as a std::shared_ptr<Configuration>)
-       * is the principal means for clients of ConfigurationAdmin to inspect or update the
-       * Configuration of a given service or service factory.
-       */
-      class Configuration {
-      public:
-        virtual ~Configuration() noexcept = default;
+/**
+ * \ingroup gr_configuration
+ * 
+ * The Configuration object (normally obtained as a std::shared_ptr<Configuration>)
+ * is the principal means for clients of ConfigurationAdmin to inspect or update the
+ * Configuration of a given service or service factory.
+ */
+class Configuration
+{
+public:
+  virtual ~Configuration() noexcept = default;
 
-        /**
-         * Get the PID of this Configuration.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed
-         *
-         * @return the PID of this Configuration
-         */
-        virtual std::string GetPid() const = 0;
+  /**
+   * Get the PID of this Configuration.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed
+   *
+   * @return the PID of this Configuration
+   */
+  virtual std::string GetPid() const = 0;
 
-        /**
-         * Get the Factory PID which is responsible for this Configuration. If this
-         * Configuration does not belong to any Factory, returns an empty string.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed
-         *
-         * @return the Factory PID associated with this Configuration, if applicable
-         */
-        virtual std::string GetFactoryPid() const = 0;
+  /**
+   * Get the Factory PID which is responsible for this Configuration. If this
+   * Configuration does not belong to any Factory, returns an empty string.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed
+   *
+   * @return the Factory PID associated with this Configuration, if applicable
+   */
+  virtual std::string GetFactoryPid() const = 0;
 
-        /**
-         * Get the properties of this Configuration. Returns a copy.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed
-         *
-         * @return the properties of this Configuration
-         */
-        virtual AnyMap GetProperties() const = 0;
+  /**
+   * Get the properties of this Configuration. Returns a copy.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed
+   *
+   * @return the properties of this Configuration
+   */
+  virtual AnyMap GetProperties() const = 0;
 
-        /**
-         * Update the properties of this Configuration. Invoking this method will trigger the
-         * ConfigurationAdmin impl to push the updated properties to any ManagedService /
-         * ManagedServiceFactory which has a matching PID / Factory PID.
-         *
-         * If the properties are empty, the Configuration will not be removed, but instead
-         * updated with an empty properties map.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed
-         *
-         * @param properties The properties to update this Configuration with.
-         */
-        virtual void Update(AnyMap properties = AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS}) = 0;
+  /**
+   * Update the properties of this Configuration. Invoking this method will trigger the
+   * ConfigurationAdmin impl to push the updated properties to any ManagedService /
+   * ManagedServiceFactory which has a matching PID / Factory PID.
+   *
+   * If the properties are empty, the Configuration will not be removed, but instead
+   * updated with an empty properties map.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed
+   *
+   * @param properties The properties to update this Configuration with.
+   */
+  virtual void Update(AnyMap properties = AnyMap{
+                        AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }) = 0;
 
-        /**
-         * Update the properties of this Configuration if they differ from the current properties.
-         * Invoking this method will trigger the ConfigurationAdmin impl to push the updated
-         * properties to any ManagedService / ManagedServiceFactory which has a matching PID /
-         * Factory PID, but only if the properties differ from the current properties. It will
-         * return true in this case, and false otherwise.
-         *
-         * If the properties are empty, the Configuration will not be removed, but instead
-         * updated with an empty properties map, unless it already had empty properties.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed
-         *
-         * @param properties The properties to update this Configuration with (if they differ)
-         * @return boolean indicating whether the properties were updated or not.
-         */
-        virtual bool UpdateIfDifferent(AnyMap properties = AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS}) = 0;
+  /**
+   * Update the properties of this Configuration if they differ from the current properties.
+   * Invoking this method will trigger the ConfigurationAdmin impl to push the updated
+   * properties to any ManagedService / ManagedServiceFactory which has a matching PID /
+   * Factory PID, but only if the properties differ from the current properties. It will
+   * return true in this case, and false otherwise.
+   *
+   * If the properties are empty, the Configuration will not be removed, but instead
+   * updated with an empty properties map, unless it already had empty properties.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed
+   *
+   * @param properties The properties to update this Configuration with (if they differ)
+   * @return boolean indicating whether the properties were updated or not.
+   */
+  virtual bool UpdateIfDifferent(
+    AnyMap properties = AnyMap{
+      AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }) = 0;
 
-        /**
-         * Remove this Configuration from ConfigurationAdmin. This will trigger the ConfigurationAdmin
-         * implementation to update any corresponding ManagedService with an empty AnyMap. Any
-         * corresponding ManagedServiceFactory will have its Removed method invoked with the
-         * corresponding PID.
-         *
-         * @throws std::runtime_error if this Configuration object has been Removed already
-         */
-        virtual void Remove() = 0;
-      };
-    }
-  }
+  /**
+   * Remove this Configuration from ConfigurationAdmin. This will trigger the ConfigurationAdmin
+   * implementation to update any corresponding ManagedService with an empty AnyMap. Any
+   * corresponding ManagedServiceFactory will have its Removed method invoked with the
+   * corresponding PID.
+   *
+   * @throws std::runtime_error if this Configuration object has been Removed already
+   */
+  virtual void Remove() = 0;
+};
+}
+}
 }
 #endif // Configuration_hpp

--- a/compendium/CM/include/cppmicroservices/cm/ConfigurationAdmin.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ConfigurationAdmin.hpp
@@ -30,72 +30,78 @@
 #include <vector>
 
 namespace cppmicroservices {
-  namespace service {
-    namespace cm {
+namespace service {
+namespace cm {
 
-    /**
-    \defgroup gr_configurationadmin ConfigurationAdmin
-    \brief Groups ConfigurationAdmin class related symbols.
-    */
+/**
+ \defgroup gr_configurationadmin ConfigurationAdmin
+ \brief Groups ConfigurationAdmin class related symbols.
+ */
 
-      /**
-       * \ingroup gr_configurationadmin 
-       * The ConfigurationAdmin interface is the means by which applications and services can
-       * interract with the Configuration objects at runtime. It can be used to create or obtain
-       * Configuration objects, which can in turn be queried for their properties or be used to
-       * update the properties of a given service or service factory.
-       */
-      class ConfigurationAdmin {
-      public:
-        virtual ~ConfigurationAdmin() noexcept = default;
+/**
+ * \ingroup gr_configurationadmin 
+ * The ConfigurationAdmin interface is the means by which applications and services can
+ * interract with the Configuration objects at runtime. It can be used to create or obtain
+ * Configuration objects, which can in turn be queried for their properties or be used to
+ * update the properties of a given service or service factory.
+ */
+class ConfigurationAdmin
+{
+public:
+  virtual ~ConfigurationAdmin() noexcept = default;
 
-        /**
-         * Get an existing or new Configuration object. If the Configuration object for this
-         * PID does not exist, create a new Configuration object for that PID with empty
-         * properties.
-         *
-         * @param pid The PID to get the Configuration for
-         * @return the Configuration object for this PID
-         */
-        virtual std::shared_ptr<Configuration> GetConfiguration(const std::string& pid) = 0;
+  /**
+   * Get an existing or new Configuration object. If the Configuration object for this
+   * PID does not exist, create a new Configuration object for that PID with empty
+   * properties.
+   *
+   * @param pid The PID to get the Configuration for
+   * @return the Configuration object for this PID
+   */
+  virtual std::shared_ptr<Configuration> GetConfiguration(
+    const std::string& pid) = 0;
 
-        /**
-         * Create a new Configuration object for a ManagedServiceFactory. The factoryPid is the PID of the
-         * ManagedServiceFactory (which must be different from the PIDs of any services it manages) and the
-         * instanceName will be a randomly-generated, unique name. The Configuration object's properties
-         * are empty. The returned Configuration will have a PID of the form $factoryPid~$instanceName.
-         *
-         * @param factoryPid The Factory PID to create a new Configuration for
-         * @return a new Configuration object for this Factory PID with a randomly-generated unique name
-         */
-        virtual std::shared_ptr<Configuration> CreateFactoryConfiguration(const std::string& factoryPid) = 0;
+  /**
+   * Create a new Configuration object for a ManagedServiceFactory. The factoryPid is the PID of the
+   * ManagedServiceFactory (which must be different from the PIDs of any services it manages) and the
+   * instanceName will be a randomly-generated, unique name. The Configuration object's properties
+   * are empty. The returned Configuration will have a PID of the form $factoryPid~$instanceName.
+   *
+   * @param factoryPid The Factory PID to create a new Configuration for
+   * @return a new Configuration object for this Factory PID with a randomly-generated unique name
+   */
+  virtual std::shared_ptr<Configuration> CreateFactoryConfiguration(
+    const std::string& factoryPid) = 0;
 
-        /**
-         * Get an existing or new Configuration object for a ManagedServiceFactory. The factoryPid is the PID of the
-         * ManagedServiceFactory (which must be different from the PIDs of any services it manages) and the
-         * instanceName is the unique name of one of those managed services. If the Configuration object for this
-         * combination of factoryPid and instanceName does not exist, create a new Configuration object for that
-         * combination, where properties are empty. The returned Configuration will have a PID of the form
-         * $factoryPid~$instanceName.
-         *
-         * @param factoryPid The Factory PID to use to get an existing Configuration or create a new Configuration for
-         * @param instanceName The unique name of an instance of a serivce managed by the ManagedServiceFactory
-         * @return the Configuration object for this combination of Factory PID and instance name
-         */
-        virtual std::shared_ptr<Configuration> GetFactoryConfiguration(const std::string& factoryPid, const std::string& instanceName) = 0;
+  /**
+   * Get an existing or new Configuration object for a ManagedServiceFactory. The factoryPid is the PID of the
+   * ManagedServiceFactory (which must be different from the PIDs of any services it manages) and the
+   * instanceName is the unique name of one of those managed services. If the Configuration object for this
+   * combination of factoryPid and instanceName does not exist, create a new Configuration object for that
+   * combination, where properties are empty. The returned Configuration will have a PID of the form
+   * $factoryPid~$instanceName.
+   *
+   * @param factoryPid The Factory PID to use to get an existing Configuration or create a new Configuration for
+   * @param instanceName The unique name of an instance of a serivce managed by the ManagedServiceFactory
+   * @return the Configuration object for this combination of Factory PID and instance name
+   */
+  virtual std::shared_ptr<Configuration> GetFactoryConfiguration(
+    const std::string& factoryPid,
+    const std::string& instanceName) = 0;
 
-        /**
-         * Used to list all of the available configurations. An LDAP filter expression can be used to filter
-         * based on any property of the configuration, including service.pid and service.factoryPid
-         *
-         * NOT IMPLEMENTED - Will throw std::invalid_argument until this is implemented.
-         *
-         * @param filter An optional filter expression to limit the Configurations which are returned, or empty for all.
-         * @return a vector of Configurations matching the filter.
-         */
-        virtual std::vector<std::shared_ptr<Configuration>> ListConfigurations(const std::string& filter = {}) = 0;
-      };
-    }
-  }
+  /**
+   * Used to list all of the available configurations. An LDAP filter expression can be used to filter
+   * based on any property of the configuration, including service.pid and service.factoryPid
+   *
+   * NOT IMPLEMENTED - Will throw std::invalid_argument until this is implemented.
+   *
+   * @param filter An optional filter expression to limit the Configurations which are returned, or empty for all.
+   * @return a vector of Configurations matching the filter.
+   */
+  virtual std::vector<std::shared_ptr<Configuration>> ListConfigurations(
+    const std::string& filter = {}) = 0;
+};
+}
+}
 }
 #endif // ConfigurationAdmin_hpp

--- a/compendium/CM/include/cppmicroservices/cm/ConfigurationException.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ConfigurationException.hpp
@@ -27,77 +27,72 @@
 #include <string>
 
 namespace {
-  std::string makeMessage(const std::string reason, const std::string property) {
-    return "ConfigurationException due to " + reason +
-           (!property.empty() ? (" (with property: " + property + ")") : "");
-  }
+std::string makeMessage(const std::string reason, const std::string property)
+{
+  return "ConfigurationException due to " + reason +
+         (!property.empty() ? (" (with property: " + property + ")") : "");
+}
 }
 
 namespace cppmicroservices {
-  namespace service {
-    namespace cm {
+namespace service {
+namespace cm {
 
-      /**
-      \defgroup gr_configurationexception ConfigurationException
-      \brief Groups ConfigurationException class related symbols.
-      */
+/**
+ \defgroup gr_configurationexception ConfigurationException
+ \brief Groups ConfigurationException class related symbols.
+ */
 
-      /**
-       * \ingroup gr_configurationexception
-       *
-       * Exception which may be thrown by ManagedService or ManagedServiceFactory
-       * subclasses to indicate to the ConfigurationAdmin implementation that the
-       * Configuration they have been given is invalid. The ConfigurationAdmin
-       * implementation will log the exception with as much detail as it can. The
-       * ConfigurationException class is not final to ensure it can be used with
-       * std::throw_with_nested - the ConfigurationAdmin implementation will attempt
-       * to print the details of any nested exceptions as well.
-       */
-      class ConfigurationException : public std::runtime_error {
-      public:
+/**
+ * \ingroup gr_configurationexception
+ *
+ * Exception which may be thrown by ManagedService or ManagedServiceFactory
+ * subclasses to indicate to the ConfigurationAdmin implementation that the
+ * Configuration they have been given is invalid. The ConfigurationAdmin
+ * implementation will log the exception with as much detail as it can. The
+ * ConfigurationException class is not final to ensure it can be used with
+ * std::throw_with_nested - the ConfigurationAdmin implementation will attempt
+ * to print the details of any nested exceptions as well.
+ */
+class ConfigurationException : public std::runtime_error
+{
+public:
+  /**
+   * Construct a new ConfigurationException with the specified reason and
+   * optionally specify which property caused the error.
+   *
+   * @param rsn The reason for the exception.
+   * @param prop The property which caused the excpetion, if applicable.
+   */
+  ConfigurationException(std::string rsn, std::string prop = "")
+    : std::runtime_error(makeMessage(rsn, prop).c_str())
+    , reason(std::move(rsn))
+    , property(std::move(prop))
+  {}
 
-        /**
-         * Construct a new ConfigurationException with the specified reason and
-         * optionally specify which property caused the error.
-         *
-         * @param rsn The reason for the exception.
-         * @param prop The property which caused the excpetion, if applicable.
-         */
-        ConfigurationException(std::string rsn, std::string prop="")
-          : std::runtime_error(makeMessage(rsn, prop).c_str())
-          , reason(std::move(rsn))
-          , property(std::move(prop))
-          {}
+  /**
+   * Returns the reason for this exception.
+   *
+   * @return The reason for this exception.
+   */
+  std::string GetReason() const { return reason; }
 
-        /**
-         * Returns the reason for this exception.
-         *
-         * @return The reason for this exception.
-         */
-        std::string GetReason() const
-        {
-          return reason;
-        }
+  /**
+   * Returns the property which was resonsible for this exception being throws,
+   * if applicable. Could be empty.
+   *
+   * @return The property which caused this exception.
+   */
+  std::string GetProperty() const { return property; }
 
-        /**
-         * Returns the property which was resonsible for this exception being throws,
-         * if applicable. Could be empty.
-         *
-         * @return The property which caused this exception.
-         */
-        std::string GetProperty() const
-        {
-          return property;
-        }
+  virtual ~ConfigurationException() noexcept {}
 
-        virtual ~ConfigurationException() noexcept {}
-
-      private:
-        const std::string reason;
-        const std::string property;
-      };
-    }
-  }
+private:
+  const std::string reason;
+  const std::string property;
+};
+}
+}
 }
 
 #endif /* ConfigurationException_hpp */

--- a/compendium/CM/include/cppmicroservices/cm/ManagedService.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ManagedService.hpp
@@ -26,49 +26,50 @@
 #include "cppmicroservices/AnyMap.h"
 
 namespace cppmicroservices {
-  namespace service {
-    namespace cm {
+namespace service {
+namespace cm {
 
-     /**
-      \defgroup gr_managedservice ManagedService
-      \brief Groups ManagedService class related symbols.
-      */
+/**
+ \defgroup gr_managedservice ManagedService
+ \brief Groups ManagedService class related symbols.
+ */
 
-      /**
-       * \ingroup gr_managedservice
-       *
-       * The ManagedService interface is the interface that services should implement
-       * to receive updates from the ConfigurationAdmin implementation with their
-       * Configuration. The Configuration will be provided based on the service.pid
-       * ServiceProperty of the Service being registered with the CppMicroServices
-       * Framework. If this isn't provided, the component.name property injected by
-       * DeclarativeServices will be used instead. If no Configuration is available
-       * for either of these, an empty AnyMap will be used to call Updated. Per the
-       * OSGi Spec, ManagedService is intended to be used for services which have
-       * singleton scope, where there will only be one implementation of a given
-       * interface.
-       */
-      class ManagedService {
-      public:
-        virtual ~ManagedService() noexcept = default;
+/**
+ * \ingroup gr_managedservice
+ *
+ * The ManagedService interface is the interface that services should implement
+ * to receive updates from the ConfigurationAdmin implementation with their
+ * Configuration. The Configuration will be provided based on the service.pid
+ * ServiceProperty of the Service being registered with the CppMicroServices
+ * Framework. If this isn't provided, the component.name property injected by
+ * DeclarativeServices will be used instead. If no Configuration is available
+ * for either of these, an empty AnyMap will be used to call Updated. Per the
+ * OSGi Spec, ManagedService is intended to be used for services which have
+ * singleton scope, where there will only be one implementation of a given
+ * interface.
+ */
+class ManagedService
+{
+public:
+  virtual ~ManagedService() noexcept = default;
 
-        /**
-         * Called whenever the Configuration for this service is updated or removed from ConfigurationAdmin,
-         * and when the ManagedService is first registered with the Framework, to provide the initial Configuration.
-         *
-         * Can throw a ConfigurationException if there's a problem with the properties. This exception will
-         * be logged by the ConfigurationAdminImpl to aid the application author's investigation into the
-         * incorrect configuration.
-         *
-         * Will be called asynchronously from the Service's registration or an update to the Configuration.
-         *
-         * @throws ConfigurationException if something is wrong with the properties provided.
-         *
-         * @param properties The properties from the new/initial Configuration for this ManagedService
-         */
-        virtual void Updated(const AnyMap& properties) = 0;
-      };
-    }
-  }
+  /**
+   * Called whenever the Configuration for this service is updated or removed from ConfigurationAdmin,
+   * and when the ManagedService is first registered with the Framework, to provide the initial Configuration.
+   *
+   * Can throw a ConfigurationException if there's a problem with the properties. This exception will
+   * be logged by the ConfigurationAdminImpl to aid the application author's investigation into the
+   * incorrect configuration.
+   *
+   * Will be called asynchronously from the Service's registration or an update to the Configuration.
+   *
+   * @throws ConfigurationException if something is wrong with the properties provided.
+   *
+   * @param properties The properties from the new/initial Configuration for this ManagedService
+   */
+  virtual void Updated(const AnyMap& properties) = 0;
+};
+}
+}
 }
 #endif /* ManagedService_hpp */

--- a/compendium/CM/include/cppmicroservices/cm/ManagedServiceFactory.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ManagedServiceFactory.hpp
@@ -28,78 +28,79 @@
 #include "cppmicroservices/AnyMap.h"
 
 namespace cppmicroservices {
-  namespace service {
-    namespace cm {
+namespace service {
+namespace cm {
 
-     /**
-      \defgroup gr_managedservicefactory ManagedServiceFactory
-      \brief Groups ManagedServiceFactory class related symbols.
-      */
-      /**
-       * \ingroup gr_managedservicefactory
-       *
-       * The ManagedServiceFactory interface is the interface that service factories
-       * should implement to receive updates from the ConfigurationAdmin implementation
-       * with the Configurations for the services that the Factory will provide. The
-       * service.factoryPid ServiceProperty of the ManagedServiceFactory (or the
-       * component.name which is injected by DeclarativeServices if no service.factoryPid
-       * is provided) will be used to select all Configurations applicable to this factory.
-       * Per the OSGi Spec, the ManagedServiceFactory is intended to be used when multiple
-       * instances of a given Service will exist in the Framework, but each with different
-       * Configurations. For this reason, ManagedServiceFactory implementations are encouraged
-       * to mirror any properties (excluding security critical properties) into the
-       * ServiceProperty map when publishing the service with the Framework (if it is going to
-       * be published). Clients of the service can then filter on the properties they require.
-       *
-       * <p>
-       * The Updated method will be invoked once for each initial Configuration for this
-       * factory and then again whenever any of those Configurations change or whenever any
-       * new Configurations for this factory are added.</p>
-       *
-       * <p>
-       * The Removed method will be invoked whenever any Configuration which this factory
-       * has previously been configured with is removed from the ConfigurationAdmin implementation.</p>
-       */
-      class ManagedServiceFactory {
-      public:
-        virtual ~ManagedServiceFactory() noexcept = default;
+/**
+ \defgroup gr_managedservicefactory ManagedServiceFactory
+ \brief Groups ManagedServiceFactory class related symbols.
+ */
+/**
+ * \ingroup gr_managedservicefactory
+ *
+ * The ManagedServiceFactory interface is the interface that service factories
+ * should implement to receive updates from the ConfigurationAdmin implementation
+ * with the Configurations for the services that the Factory will provide. The
+ * service.factoryPid ServiceProperty of the ManagedServiceFactory (or the
+ * component.name which is injected by DeclarativeServices if no service.factoryPid
+ * is provided) will be used to select all Configurations applicable to this factory.
+ * Per the OSGi Spec, the ManagedServiceFactory is intended to be used when multiple
+ * instances of a given Service will exist in the Framework, but each with different
+ * Configurations. For this reason, ManagedServiceFactory implementations are encouraged
+ * to mirror any properties (excluding security critical properties) into the
+ * ServiceProperty map when publishing the service with the Framework (if it is going to
+ * be published). Clients of the service can then filter on the properties they require.
+ *
+ * <p>
+ * The Updated method will be invoked once for each initial Configuration for this
+ * factory and then again whenever any of those Configurations change or whenever any
+ * new Configurations for this factory are added.</p>
+ *
+ * <p>
+ * The Removed method will be invoked whenever any Configuration which this factory
+ * has previously been configured with is removed from the ConfigurationAdmin implementation.</p>
+ */
+class ManagedServiceFactory
+{
+public:
+  virtual ~ManagedServiceFactory() noexcept = default;
 
-        /**
-         * Called whenever any Configuration for this service factory is updated with ConfigurationAdmin,
-         * and (possibly multiple times) when the ManagedServiceFactory is first registered with the Framework.
-         *
-         * Can throw a ConfigurationException if there's a problem with the properties. This exception will be
-         * logged by the ConfigurationAdminImpl to aid the application author's investigation into the incorrect
-         * configuration.
-         *
-         * Will be called asynchronously from the Service registration or an update to the Configuration.
-         *
-         * The ManagedServiceFactory should update the corresponding service instance with the properties provided,
-         * and potentially update the properties of that service's registration with the Framework (if it is registered).
-         *
-         * If a corresponding service instance does not exist for this pid, the ManagedServiceFactory should create one
-         * with the properties provided. It should also register that new service with the Framework, if applicable.
-         *
-         * @throws ConfigurationException if something is wrong with the properties provided.
-         *
-         * @param pid The unique pid for this Configuration, of the form "$FACTORY_PID~$INSTANCE_NAME"
-         * @param properties The properties for this Configuration
-         */
-        virtual void Updated(const std::string& pid, const AnyMap& properties) = 0;
+  /**
+   * Called whenever any Configuration for this service factory is updated with ConfigurationAdmin,
+   * and (possibly multiple times) when the ManagedServiceFactory is first registered with the Framework.
+   *
+   * Can throw a ConfigurationException if there's a problem with the properties. This exception will be
+   * logged by the ConfigurationAdminImpl to aid the application author's investigation into the incorrect
+   * configuration.
+   *
+   * Will be called asynchronously from the Service registration or an update to the Configuration.
+   *
+   * The ManagedServiceFactory should update the corresponding service instance with the properties provided,
+   * and potentially update the properties of that service's registration with the Framework (if it is registered).
+   *
+   * If a corresponding service instance does not exist for this pid, the ManagedServiceFactory should create one
+   * with the properties provided. It should also register that new service with the Framework, if applicable.
+   *
+   * @throws ConfigurationException if something is wrong with the properties provided.
+   *
+   * @param pid The unique pid for this Configuration, of the form "$FACTORY_PID~$INSTANCE_NAME"
+   * @param properties The properties for this Configuration
+   */
+  virtual void Updated(const std::string& pid, const AnyMap& properties) = 0;
 
-        /**
-         * Called whenever one of the Configurations for this service is removed from ConfigurationAdmin.
-         *
-         * Will be called asynchronously from the removal of the Configuration.
-         *
-         * The ManagedServiceFactory should remove the corresponding service instance, and if it is registered with
-         * the Framework, it should be unregistered.
-         *
-         * @param pid The unique pid for the Configuration to remove, of the form "$FACTORY_PID~$INSTANCE_NAME"
-         */
-        virtual void Removed(const std::string& pid) = 0;
-      };
-    }
-  }
+  /**
+   * Called whenever one of the Configurations for this service is removed from ConfigurationAdmin.
+   *
+   * Will be called asynchronously from the removal of the Configuration.
+   *
+   * The ManagedServiceFactory should remove the corresponding service instance, and if it is registered with
+   * the Framework, it should be unregistered.
+   *
+   * @param pid The unique pid for the Configuration to remove, of the form "$FACTORY_PID~$INSTANCE_NAME"
+   */
+  virtual void Removed(const std::string& pid) = 0;
+};
+}
+}
 }
 #endif /* ManagedServiceFactory_hpp */

--- a/compendium/CM/test/TestConfigurationException.cpp
+++ b/compendium/CM/test/TestConfigurationException.cpp
@@ -30,31 +30,32 @@ using cppmicroservices::service::cm::ConfigurationException;
 
 namespace {
 
-  constexpr auto REASON = "A reason";
-  constexpr auto PROPERTY = "Foo";
+constexpr auto REASON = "A reason";
+constexpr auto PROPERTY = "Foo";
 
-  /**
-   * This test point is used to verify that the ConfigurationException
-   * behaves as expected.
-   */
-  TEST(ConfigurationException, VerifyConstructorAndGetters)
-  {
-    ConfigurationException e{REASON, PROPERTY};
-    ASSERT_EQ(REASON, e.GetReason());
-    ASSERT_EQ(PROPERTY, e.GetProperty());
+/**
+ * This test point is used to verify that the ConfigurationException
+ * behaves as expected.
+ */
+TEST(ConfigurationException, VerifyConstructorAndGetters)
+{
+  ConfigurationException e{ REASON, PROPERTY };
+  ASSERT_EQ(REASON, e.GetReason());
+  ASSERT_EQ(PROPERTY, e.GetProperty());
 
-    ConfigurationException e2{REASON};
-    ASSERT_EQ(REASON, e2.GetReason());
-    ASSERT_EQ("", e2.GetProperty());
-  }
+  ConfigurationException e2{ REASON };
+  ASSERT_EQ(REASON, e2.GetReason());
+  ASSERT_EQ("", e2.GetProperty());
+}
 
-  /**
-   * This test point is used to verify that the ConfigurationException
-   * can be thrown and caught as expected.
-   */
-  TEST(ConfigurationException, VerifyThrowAndCatch)
-  {
-    ASSERT_THROW({
+/**
+ * This test point is used to verify that the ConfigurationException
+ * can be thrown and caught as expected.
+ */
+TEST(ConfigurationException, VerifyThrowAndCatch)
+{
+  ASSERT_THROW(
+    {
       try {
         throw ConfigurationException(REASON, PROPERTY);
       } catch (const ConfigurationException& e) {
@@ -62,28 +63,33 @@ namespace {
         ASSERT_EQ(PROPERTY, e.GetProperty());
         throw;
       }
-    }, ConfigurationException);
-    ASSERT_THROW({
+    },
+    ConfigurationException);
+  ASSERT_THROW(
+    {
       try {
         throw ConfigurationException(REASON, PROPERTY);
       } catch (const std::runtime_error& e) {
-        auto what = std::string{e.what()};
+        auto what = std::string{ e.what() };
         ASSERT_NE("", what);
         ASSERT_NE(std::string::npos, what.find(REASON));
         ASSERT_NE(std::string::npos, what.find(PROPERTY));
         throw;
       }
-    }, std::runtime_error);
-    ASSERT_THROW({
+    },
+    std::runtime_error);
+  ASSERT_THROW(
+    {
       try {
         throw ConfigurationException(REASON);
       } catch (const std::exception& e) {
-        auto what = std::string{e.what()};
+        auto what = std::string{ e.what() };
         ASSERT_NE("", what);
         ASSERT_NE(std::string::npos, what.find(REASON));
         ASSERT_EQ(std::string::npos, what.find("property"));
         throw;
       }
-    }, std::exception);
-  }
+    },
+    std::exception);
+}
 }

--- a/compendium/CM/test/suite_registration.cpp
+++ b/compendium/CM/test/suite_registration.cpp
@@ -22,7 +22,7 @@
 
 #include "gmock/gmock.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/compendium/ConfigurationAdmin/src/CMActivator.cpp
+++ b/compendium/ConfigurationAdmin/src/CMActivator.cpp
@@ -29,142 +29,151 @@
 using cppmicroservices::logservice::SeverityLevel;
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    void CMActivator::Start(BundleContext context)
-    {
-      runtimeContext = context;
-      // Create the Logger object used by this runtime
-      logger = std::make_shared<CMLogger>(context);
-      logger->Log(SeverityLevel::LOG_DEBUG, "Starting CM bundle");
-      // Create ConfigurationAdminImpl
-      configAdminImpl = std::make_shared<ConfigurationAdminImpl>(runtimeContext, logger);
-      // Add bundle listener
-      bundleListenerToken = context.AddBundleListener(std::bind(&CMActivator::BundleChanged, this, std::placeholders::_1));
-      // HACK: Workaround for lack of Bundle Tracker. Iterate over all bundles and call the tracker method manually
-      for (const auto& bundle : context.GetBundles())
-      {
-        if (cppmicroservices::Bundle::State::STATE_ACTIVE == bundle.GetState())
-        {
-          cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
-          BundleChanged(evt);
-        }
-      }
-      // Publish ConfigurationAdmin service
-      configAdminReg = context.RegisterService<cppmicroservices::service::cm::ConfigurationAdmin>(configAdminImpl);
+namespace cmimpl {
+void CMActivator::Start(BundleContext context)
+{
+  runtimeContext = context;
+  // Create the Logger object used by this runtime
+  logger = std::make_shared<CMLogger>(context);
+  logger->Log(SeverityLevel::LOG_DEBUG, "Starting CM bundle");
+  // Create ConfigurationAdminImpl
+  configAdminImpl =
+    std::make_shared<ConfigurationAdminImpl>(runtimeContext, logger);
+  // Add bundle listener
+  bundleListenerToken = context.AddBundleListener(
+    std::bind(&CMActivator::BundleChanged, this, std::placeholders::_1));
+  // HACK: Workaround for lack of Bundle Tracker. Iterate over all bundles and call the tracker method manually
+  for (const auto& bundle : context.GetBundles()) {
+    if (cppmicroservices::Bundle::State::STATE_ACTIVE == bundle.GetState()) {
+      cppmicroservices::BundleEvent evt(
+        cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
+      BundleChanged(evt);
     }
+  }
+  // Publish ConfigurationAdmin service
+  configAdminReg =
+    context.RegisterService<cppmicroservices::service::cm::ConfigurationAdmin>(
+      configAdminImpl);
+}
 
-    void CMActivator::Stop(cppmicroservices::BundleContext context)
+void CMActivator::Stop(cppmicroservices::BundleContext context)
+{
+  try {
+    // remove the bundle listener
+    context.RemoveListener(std::move(bundleListenerToken));
+    // remove the runtime service from the framework
+    configAdminReg.Unregister();
+    // clear bundle registry
     {
-      try
-      {
-        // remove the bundle listener
-        context.RemoveListener(std::move(bundleListenerToken));
-        // remove the runtime service from the framework
-        configAdminReg.Unregister();
-        // clear bundle registry
-        {
-          std::lock_guard<std::mutex> l(bundleRegMutex);
-          bundleRegistry.clear();
-        }
-        // Clean up the ConfigurationAdminImpl
-        configAdminImpl = nullptr;
-        logger->Log(SeverityLevel::LOG_DEBUG, "CM Bundle stopped.");
-      }
-      catch (...)
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "Exception while stopping the CM bundle", std::current_exception());
-      }
-      logger = nullptr;
-      runtimeContext = nullptr;
+      std::lock_guard<std::mutex> l(bundleRegMutex);
+      bundleRegistry.clear();
     }
+    // Clean up the ConfigurationAdminImpl
+    configAdminImpl = nullptr;
+    logger->Log(SeverityLevel::LOG_DEBUG, "CM Bundle stopped.");
+  } catch (...) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Exception while stopping the CM bundle",
+                std::current_exception());
+  }
+  logger = nullptr;
+  runtimeContext = nullptr;
+}
 
-    void CMActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
+void CMActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
+{
+  auto const& headers = bundle.GetHeaders();
+  // bundle has no "cm" configuration
+  if (headers.find(CMConstants::CM_KEY) == std::end(headers)) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "No CM Configuration found in bundle " +
+                  bundle.GetSymbolicName());
+    return;
+  }
+
+  auto extensionFound = false;
+  {
+    std::lock_guard<std::mutex> l(bundleRegMutex);
+    extensionFound =
+      (bundleRegistry.find(bundle.GetBundleId()) != std::end(bundleRegistry));
+  }
+  // This bundle's configuration has not been loaded, so create the extension which will load it
+  if (extensionFound) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "CM Configuration already loaded from bundle " +
+                  bundle.GetSymbolicName());
+    return;
+  }
+
+  logger->Log(SeverityLevel::LOG_DEBUG,
+              "Creating CMBundleExtension ... " + bundle.GetSymbolicName());
+  try {
+    auto const& cmMetadata =
+      cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(
+        headers.at(CMConstants::CM_KEY));
+    auto be = std::make_unique<CMBundleExtension>(
+      bundle.GetBundleContext(), cmMetadata, configAdminImpl, logger);
     {
-      auto const& headers = bundle.GetHeaders();
-      // bundle has no "cm" configuration
-      if (headers.find(CMConstants::CM_KEY) == std::end(headers))
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "No CM Configuration found in bundle " + bundle.GetSymbolicName());
-        return;
-      }
-
-      auto extensionFound = false;
-      {
-        std::lock_guard<std::mutex> l(bundleRegMutex);
-        extensionFound = (bundleRegistry.find(bundle.GetBundleId()) != std::end(bundleRegistry));
-      }
-      // This bundle's configuration has not been loaded, so create the extension which will load it
-      if (extensionFound)
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "CM Configuration already loaded from bundle " + bundle.GetSymbolicName());
-        return;
-      }
-
-      logger->Log(SeverityLevel::LOG_DEBUG, "Creating CMBundleExtension ... " + bundle.GetSymbolicName());
-      try
-      {
-        auto const& cmMetadata = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(headers.at(CMConstants::CM_KEY));
-        auto be = std::make_unique<CMBundleExtension>(bundle.GetBundleContext(), cmMetadata, configAdminImpl, logger);
-        {
-          std::lock_guard<std::mutex> l(bundleRegMutex);
-          bundleRegistry.emplace(bundle.GetBundleId(), std::move(be));
-        }
-      }
-      catch (const std::exception&)
-      {
-        logger->Log(SeverityLevel::LOG_WARNING, "Failed to create CMBundleExtension for " + bundle.GetSymbolicName(), std::current_exception());
-      }
+      std::lock_guard<std::mutex> l(bundleRegMutex);
+      bundleRegistry.emplace(bundle.GetBundleId(), std::move(be));
     }
+  } catch (const std::exception&) {
+    logger->Log(SeverityLevel::LOG_WARNING,
+                "Failed to create CMBundleExtension for " +
+                  bundle.GetSymbolicName(),
+                std::current_exception());
+  }
+}
 
-    void CMActivator::RemoveExtension(const cppmicroservices::Bundle& bundle)
-    {
-      auto const& headers = bundle.GetHeaders();
-      // bundle has no "cm" configuration
-      if (headers.find(CMConstants::CM_KEY) == std::end(headers))
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "No CM Configuration found in bundle " + bundle.GetSymbolicName());
-        return;
-      }
+void CMActivator::RemoveExtension(const cppmicroservices::Bundle& bundle)
+{
+  auto const& headers = bundle.GetHeaders();
+  // bundle has no "cm" configuration
+  if (headers.find(CMConstants::CM_KEY) == std::end(headers)) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "No CM Configuration found in bundle " +
+                  bundle.GetSymbolicName());
+    return;
+  }
 
-      bool extensionFound = false;
-      {
-        std::lock_guard<std::mutex> l(bundleRegMutex);
-        auto extensionIt = bundleRegistry.find(bundle.GetBundleId());
-        if (extensionIt != std::end(bundleRegistry))
-        {
-          bundleRegistry.erase(extensionIt);
-          extensionFound = true;
-        }
-      }
-      if (extensionFound)
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "Removed CMBundleExtension for " + bundle.GetSymbolicName());
-        return;
-      }
-      logger->Log(SeverityLevel::LOG_DEBUG, "Found no CMBundleExtension for " + bundle.GetSymbolicName());
+  bool extensionFound = false;
+  {
+    std::lock_guard<std::mutex> l(bundleRegMutex);
+    auto extensionIt = bundleRegistry.find(bundle.GetBundleId());
+    if (extensionIt != std::end(bundleRegistry)) {
+      bundleRegistry.erase(extensionIt);
+      extensionFound = true;
     }
+  }
+  if (extensionFound) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Removed CMBundleExtension for " + bundle.GetSymbolicName());
+    return;
+  }
+  logger->Log(SeverityLevel::LOG_DEBUG,
+              "Found no CMBundleExtension for " + bundle.GetSymbolicName());
+}
 
-    void CMActivator::BundleChanged(const cppmicroservices::BundleEvent& evt)
-    {
-      auto bundle = evt.GetBundle();
-      const auto eventType = evt.GetType();
-      if (bundle == runtimeContext.GetBundle()) // skip events for this (runtime) bundle
-      {
-        return;
-      }
+void CMActivator::BundleChanged(const cppmicroservices::BundleEvent& evt)
+{
+  auto bundle = evt.GetBundle();
+  const auto eventType = evt.GetType();
+  if (bundle ==
+      runtimeContext.GetBundle()) // skip events for this (runtime) bundle
+  {
+    return;
+  }
 
-      // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
-      if (cppmicroservices::BundleEvent::BUNDLE_STARTED == eventType)
-      {
-        CreateExtension(bundle);
-      }
-      else if (cppmicroservices::BundleEvent::BUNDLE_STOPPING == eventType)
-      {
-        RemoveExtension(bundle);
-      }
-      // else ignore
-    }
-  } // cmimpl
+  // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
+  if (cppmicroservices::BundleEvent::BUNDLE_STARTED == eventType) {
+    CreateExtension(bundle);
+  } else if (cppmicroservices::BundleEvent::BUNDLE_STOPPING == eventType) {
+    RemoveExtension(bundle);
+  }
+  // else ignore
+}
+} // cmimpl
 } // cppmicroservices
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::cmimpl::CMActivator) // NOLINT
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::cmimpl::CMActivator) // NOLINT

--- a/compendium/ConfigurationAdmin/src/CMActivator.hpp
+++ b/compendium/ConfigurationAdmin/src/CMActivator.hpp
@@ -27,8 +27,8 @@
 #include <mutex>
 #include <unordered_map>
 
-#include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/BundleActivator.h"
+#include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/BundleEvent.h"
 #include "cppmicroservices/ListenerToken.h"
 
@@ -38,47 +38,50 @@
 #include "ConfigurationAdminImpl.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    class CMActivator final : public cppmicroservices::BundleActivator
-    {
-    public:
-      CMActivator() = default;
-      CMActivator(const CMActivator&) = delete;
-      CMActivator(CMActivator&&) = delete;
-      CMActivator& operator=(const CMActivator&) = delete;
-      CMActivator& operator=(CMActivator&&) = delete;
-      ~CMActivator() override = default;
+namespace cmimpl {
+class CMActivator final : public cppmicroservices::BundleActivator
+{
+public:
+  CMActivator() = default;
+  CMActivator(const CMActivator&) = delete;
+  CMActivator(CMActivator&&) = delete;
+  CMActivator& operator=(const CMActivator&) = delete;
+  CMActivator& operator=(CMActivator&&) = delete;
+  ~CMActivator() override = default;
 
-      // callback methods for bundle lifecycle
-      void Start(cppmicroservices::BundleContext context) override;
-      void Stop(cppmicroservices::BundleContext context) override;
+  // callback methods for bundle lifecycle
+  void Start(cppmicroservices::BundleContext context) override;
+  void Stop(cppmicroservices::BundleContext context) override;
 
-    // protected for pkgtests
-    protected:
-      /**
-       * Bundle listener callback
-       */
-      void BundleChanged(const cppmicroservices::BundleEvent&);
-      /*
-       * This method creates the CMBundleExtension object for a bundle
-       * with cm configuration metadata
-       */
-      void CreateExtension(const cppmicroservices::Bundle& bundle);
-      /*
-       * This method removes the CMBundleExtension object for a bundle
-       * with cm configuration metadata
-       */
-      void RemoveExtension(const cppmicroservices::Bundle& bundle);
-    private:
-      cppmicroservices::BundleContext runtimeContext;
-      std::shared_ptr<CMLogger> logger;
-      std::shared_ptr<ConfigurationAdminImpl> configAdminImpl;
-      std::mutex bundleRegMutex;
-      std::unordered_map<long, std::unique_ptr<CMBundleExtension>> bundleRegistry;
-      cppmicroservices::ListenerToken bundleListenerToken;
-      cppmicroservices::ServiceRegistration<cppmicroservices::service::cm::ConfigurationAdmin> configAdminReg;
-    };
-  } // cmimpl
+  // protected for pkgtests
+protected:
+  /**
+   * Bundle listener callback
+   */
+  void BundleChanged(const cppmicroservices::BundleEvent&);
+  /*
+   * This method creates the CMBundleExtension object for a bundle
+   * with cm configuration metadata
+   */
+  void CreateExtension(const cppmicroservices::Bundle& bundle);
+  /*
+   * This method removes the CMBundleExtension object for a bundle
+   * with cm configuration metadata
+   */
+  void RemoveExtension(const cppmicroservices::Bundle& bundle);
+
+private:
+  cppmicroservices::BundleContext runtimeContext;
+  std::shared_ptr<CMLogger> logger;
+  std::shared_ptr<ConfigurationAdminImpl> configAdminImpl;
+  std::mutex bundleRegMutex;
+  std::unordered_map<long, std::unique_ptr<CMBundleExtension>> bundleRegistry;
+  cppmicroservices::ListenerToken bundleListenerToken;
+  cppmicroservices::ServiceRegistration<
+    cppmicroservices::service::cm::ConfigurationAdmin>
+    configAdminReg;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif // CMACTIVATOR_HPP

--- a/compendium/ConfigurationAdmin/src/CMBundleExtension.cpp
+++ b/compendium/ConfigurationAdmin/src/CMBundleExtension.cpp
@@ -29,47 +29,52 @@
 #include "metadata/MetadataParserFactory.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    CMBundleExtension::CMBundleExtension(cppmicroservices::BundleContext context,
-                                         const cppmicroservices::AnyMap& cmMetadata,
-                                         std::shared_ptr<ConfigurationAdminPrivate> configAdmin,
-                                         std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
-    : bundleContext(std::move(context))
-    , configAdminImpl(std::move(configAdmin))
-    , logger(std::move(lggr))
-    {
-      if (!bundleContext || !configAdminImpl || !logger || cmMetadata.empty())
-      {
-        throw std::invalid_argument("Invalid parameters passed to CMBundleExtension constructor");
-      }
+namespace cmimpl {
+CMBundleExtension::CMBundleExtension(
+  cppmicroservices::BundleContext context,
+  const cppmicroservices::AnyMap& cmMetadata,
+  std::shared_ptr<ConfigurationAdminPrivate> configAdmin,
+  std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
+  : bundleContext(std::move(context))
+  , configAdminImpl(std::move(configAdmin))
+  , logger(std::move(lggr))
+{
+  if (!bundleContext || !configAdminImpl || !logger || cmMetadata.empty()) {
+    throw std::invalid_argument(
+      "Invalid parameters passed to CMBundleExtension constructor");
+  }
 
-      if (0u == cmMetadata.count(CMConstants::CM_VERSION))
-      {
-        throw std::runtime_error(std::string("Metadata is missing mandatory '") + CMConstants::CM_VERSION + "' property");
-      }
-      auto version = cppmicroservices::any_cast<int>(cmMetadata.at(CMConstants::CM_VERSION));
-      auto metadataParser = metadata::MetadataParserFactory::Create(version, logger);
-      auto configurationMetadata = metadataParser->ParseAndGetConfigurationMetadata(cmMetadata);
+  if (0u == cmMetadata.count(CMConstants::CM_VERSION)) {
+    throw std::runtime_error(std::string("Metadata is missing mandatory '") +
+                             CMConstants::CM_VERSION + "' property");
+  }
+  auto version =
+    cppmicroservices::any_cast<int>(cmMetadata.at(CMConstants::CM_VERSION));
+  auto metadataParser =
+    metadata::MetadataParserFactory::Create(version, logger);
+  auto configurationMetadata =
+    metadataParser->ParseAndGetConfigurationMetadata(cmMetadata);
 
-      pidsAndChangeCountsAndIDs = configAdminImpl->AddConfigurations(std::move(configurationMetadata));
+  pidsAndChangeCountsAndIDs =
+    configAdminImpl->AddConfigurations(std::move(configurationMetadata));
 
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "Created instance of CMBundleExtension for " + bundleContext.GetBundle().GetSymbolicName());
-    }
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "Created instance of CMBundleExtension for " +
+                bundleContext.GetBundle().GetSymbolicName());
+}
 
-    CMBundleExtension::~CMBundleExtension()
-    {
-      try
-      {
-        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                    "Deleting instance of CMBundleExtension for " + bundleContext.GetBundle().GetSymbolicName());
-        configAdminImpl->RemoveConfigurations(pidsAndChangeCountsAndIDs);
-      }
-      catch(const std::exception&)
-      {
-        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                    "Exception thrown while destroying CMBundleExtension object", std::current_exception());
-      }
-    };
-  } // cmimpl
+CMBundleExtension::~CMBundleExtension()
+{
+  try {
+    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                "Deleting instance of CMBundleExtension for " +
+                  bundleContext.GetBundle().GetSymbolicName());
+    configAdminImpl->RemoveConfigurations(pidsAndChangeCountsAndIDs);
+  } catch (const std::exception&) {
+    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                "Exception thrown while destroying CMBundleExtension object",
+                std::current_exception());
+  }
+};
+} // cmimpl
 } // cppmicroservices

--- a/compendium/ConfigurationAdmin/src/CMBundleExtension.hpp
+++ b/compendium/ConfigurationAdmin/src/CMBundleExtension.hpp
@@ -36,32 +36,34 @@
 #include "ConfigurationAdminPrivate.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    /**
+namespace cmimpl {
+/**
      * The CMBundleExtension is a helper class to load and unload configurations from
      * a single bundle. It pushes the configurations it finds to the ConfigurationAdmin
      * implementation. On destruction, it removes the configurations created during
      * construction.
      */
-    class CMBundleExtension final
-    {
-    public:
-      CMBundleExtension(cppmicroservices::BundleContext bundleContext,
-                        const cppmicroservices::AnyMap &cmMetadata,
-                        std::shared_ptr<ConfigurationAdminPrivate> configAdminImpl,
-                        std::shared_ptr<cppmicroservices::logservice::LogService> logger);
-      CMBundleExtension(const CMBundleExtension&) = delete;
-      CMBundleExtension(CMBundleExtension&&) = delete;
-      CMBundleExtension& operator=(const CMBundleExtension&) = delete;
-      CMBundleExtension& operator=(CMBundleExtension&&) = delete;
-      ~CMBundleExtension();
-    private:
-      cppmicroservices::BundleContext bundleContext;
-      std::shared_ptr<ConfigurationAdminPrivate> configAdminImpl;
-      std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-      std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
-    };
-  } // cmimpl
+class CMBundleExtension final
+{
+public:
+  CMBundleExtension(
+    cppmicroservices::BundleContext bundleContext,
+    const cppmicroservices::AnyMap& cmMetadata,
+    std::shared_ptr<ConfigurationAdminPrivate> configAdminImpl,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  CMBundleExtension(const CMBundleExtension&) = delete;
+  CMBundleExtension(CMBundleExtension&&) = delete;
+  CMBundleExtension& operator=(const CMBundleExtension&) = delete;
+  CMBundleExtension& operator=(CMBundleExtension&&) = delete;
+  ~CMBundleExtension();
+
+private:
+  cppmicroservices::BundleContext bundleContext;
+  std::shared_ptr<ConfigurationAdminPrivate> configAdminImpl;
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger;
+  std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif // CMBUNDLEEXTENSION_HPP

--- a/compendium/ConfigurationAdmin/src/CMConstants.cpp
+++ b/compendium/ConfigurationAdmin/src/CMConstants.cpp
@@ -25,51 +25,51 @@
 #include "CMConstants.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * Defines standard names for CM Constants.
-     */
-    namespace CMConstants {
-      /**
-       * Manifest key specifying the CM configuration object.
-       * <p>
-       * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-       * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
-       */
-      const std::string CM_KEY = "cm";
+/**
+ * Defines standard names for CM Constants.
+ */
+namespace CMConstants {
+/**
+ * Manifest key specifying the CM configuration object.
+ * <p>
+ * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+ * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
+ */
+const std::string CM_KEY = "cm";
 
-      /**
-       * Manifest key specifying the version of the CM configuration.
-       * <p>
-       * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-       * object associated with the CM_KEY entry.
-       */
-      const std::string CM_VERSION = "version";
+/**
+ * Manifest key specifying the version of the CM configuration.
+ * <p>
+ * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+ * object associated with the CM_KEY entry.
+ */
+const std::string CM_VERSION = "version";
 
-      /**
-       * Top level service property to declare the PID of a ManagedService or
-       * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
-       */
-       const std::string CM_SERVICE_KEY = "service";
+/**
+ * Top level service property to declare the PID of a ManagedService or
+ * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
+ */
+const std::string CM_SERVICE_KEY = "service";
 
-       /**
-       * Subkey to obtain the PID
-       */
-       const std::string CM_SERVICE_SUBKEY = "pid";
+/**
+ * Subkey to obtain the PID
+ */
+const std::string CM_SERVICE_SUBKEY = "pid";
 
-       /**
-       * Top level property added by DeclarativeServices, use as fallback if no service.pid
-       * property can be found for a ManagedService or ManagedServiceFactory. If found,
-       * CM_COMPONENT_SUBKEY could yield an alternative PID.
-       */
-       const std::string CM_COMPONENT_KEY = "component";
+/**
+ * Top level property added by DeclarativeServices, use as fallback if no service.pid
+ * property can be found for a ManagedService or ManagedServiceFactory. If found,
+ * CM_COMPONENT_SUBKEY could yield an alternative PID.
+ */
+const std::string CM_COMPONENT_KEY = "component";
 
-       /**
-       * Subkey to obtain an alternative PID
-       */
-       const std::string CM_COMPONENT_SUBKEY = "name";
+/**
+ * Subkey to obtain an alternative PID
+ */
+const std::string CM_COMPONENT_SUBKEY = "name";
 
-    } // CMConstantss
-  } // cmimpl
+} // CMConstantss
+} // cmimpl
 } // cppmicroservices

--- a/compendium/ConfigurationAdmin/src/CMConstants.hpp
+++ b/compendium/ConfigurationAdmin/src/CMConstants.hpp
@@ -26,54 +26,54 @@
 #include <string>
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * Defines standard names for CM Constants.
-     */
-    namespace CMConstants {
-      /**
-       * Manifest key specifying the CM configuration object.
-       * <p>
-       * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-       * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
-       */
-      extern const std::string CM_KEY;
+/**
+ * Defines standard names for CM Constants.
+ */
+namespace CMConstants {
+/**
+ * Manifest key specifying the CM configuration object.
+ * <p>
+ * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+ * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
+ */
+extern const std::string CM_KEY;
 
-      /**
-       * Manifest key specifying the version of the CM configuration.
-       * <p>
-       * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-       * object returned by the {@code Bundle.GetHeaders} method using
-       * {@code AnyMap.AtCompoundKey}.
-       */
-      extern const std::string CM_VERSION;
+/**
+ * Manifest key specifying the version of the CM configuration.
+ * <p>
+ * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+ * object returned by the {@code Bundle.GetHeaders} method using
+ * {@code AnyMap.AtCompoundKey}.
+ */
+extern const std::string CM_VERSION;
 
-      /**
-       * Top level service property to declare the PID of a ManagedService or
-       * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
-       */
-       extern const std::string CM_SERVICE_KEY;
+/**
+ * Top level service property to declare the PID of a ManagedService or
+ * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
+ */
+extern const std::string CM_SERVICE_KEY;
 
-       /**
-       * Subkey to obtain the PID
-       */
-       extern const std::string CM_SERVICE_SUBKEY;
+/**
+ * Subkey to obtain the PID
+ */
+extern const std::string CM_SERVICE_SUBKEY;
 
-       /**
-       * Top level property added by DeclarativeServices, use as fallback if no service.pid
-       * property can be found for a ManagedService or ManagedServiceFactory. If found,
-       * CM_COMPONENT_SUBKEY could yield an alternative PID.
-       */
-       extern const std::string CM_COMPONENT_KEY;
+/**
+ * Top level property added by DeclarativeServices, use as fallback if no service.pid
+ * property can be found for a ManagedService or ManagedServiceFactory. If found,
+ * CM_COMPONENT_SUBKEY could yield an alternative PID.
+ */
+extern const std::string CM_COMPONENT_KEY;
 
-       /**
-       * Subkey to obtain an alternative PID
-       */
-       extern const std::string CM_COMPONENT_SUBKEY;
+/**
+ * Subkey to obtain an alternative PID
+ */
+extern const std::string CM_COMPONENT_SUBKEY;
 
-    } // CMConstants
-  } // cmimpl
+} // CMConstants
+} // cmimpl
 } // cppmicroservices
 
 #endif // CMCONSTANTS_HPP

--- a/compendium/ConfigurationAdmin/src/CMLogger.cpp
+++ b/compendium/ConfigurationAdmin/src/CMLogger.cpp
@@ -23,95 +23,96 @@
 #include "CMLogger.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    CMLogger::CMLogger(cppmicroservices::BundleContext context)
-    : cmContext(std::move(context))
-    , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>(cmContext, this))
-    , logService(nullptr)
-    {
-      serviceTracker->Open(); // Start tracking
-    }
+namespace cmimpl {
+CMLogger::CMLogger(cppmicroservices::BundleContext context)
+  : cmContext(std::move(context))
+  , serviceTracker(
+      std::make_unique<cppmicroservices::ServiceTracker<
+        cppmicroservices::logservice::LogService>>(cmContext, this))
+  , logService(nullptr)
+{
+  serviceTracker->Open(); // Start tracking
+}
 
-    CMLogger::~CMLogger()
-    {
-      if (serviceTracker)
-      {
-        serviceTracker->Close();
-      }
-    }
+CMLogger::~CMLogger()
+{
+  if (serviceTracker) {
+    serviceTracker->Close();
+  }
+}
 
-    std::shared_ptr<cppmicroservices::logservice::LogService> CMLogger::AddingService(const ServiceReference<cppmicroservices::logservice::LogService>& reference)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-      if(!currLogger && reference)
-      {
-        logger = cmContext.GetService<cppmicroservices::logservice::LogService>(reference);
-        std::atomic_store(&logService, logger);
-      }
-      return logger;
-    }
+std::shared_ptr<cppmicroservices::logservice::LogService>
+CMLogger::AddingService(
+  const ServiceReference<cppmicroservices::logservice::LogService>& reference)
+{
+  auto currLogger = std::atomic_load(&logService);
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger;
+  if (!currLogger && reference) {
+    logger =
+      cmContext.GetService<cppmicroservices::logservice::LogService>(reference);
+    std::atomic_store(&logService, logger);
+  }
+  return logger;
+}
 
-    void CMLogger::ModifiedService(const ServiceReference<cppmicroservices::logservice::LogService>& /*reference*/,
-                                    const std::shared_ptr<cppmicroservices::logservice::LogService>& /*service*/)
-    {
-      // no-op. Don't care if properties change
-    }
+void CMLogger::ModifiedService(
+  const ServiceReference<
+    cppmicroservices::logservice::LogService>& /*reference*/,
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& /*service*/)
+{
+  // no-op. Don't care if properties change
+}
 
-    void CMLogger::RemovedService(const ServiceReference<cppmicroservices::logservice::LogService>& /*reference*/,
-                                   const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      if(service == currLogger)
-      {
-        // replace existing logger with a nullptr logger
-        std::shared_ptr<cppmicroservices::logservice::LogService> logger(nullptr);
-        std::atomic_store(&logService, logger);
-      }
-    }
+void CMLogger::RemovedService(
+  const ServiceReference<
+    cppmicroservices::logservice::LogService>& /*reference*/,
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+{
+  auto currLogger = std::atomic_load(&logService);
+  if (service == currLogger) {
+    // replace existing logger with a nullptr logger
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger(nullptr);
+    std::atomic_store(&logService, logger);
+  }
+}
 
-    void CMLogger::Log(logservice::SeverityLevel level, const std::string &message)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      if (currLogger)
-      {
-        currLogger->Log(level, message);
-      }
-    }
+void CMLogger::Log(logservice::SeverityLevel level, const std::string& message)
+{
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(level, message);
+  }
+}
 
-    void CMLogger::Log(logservice::SeverityLevel level,
-                        const std::string &message,
-                        const std::exception_ptr ex)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      if (currLogger)
-      {
-        currLogger->Log(level, message, ex);
-      }
-    }
+void CMLogger::Log(logservice::SeverityLevel level,
+                   const std::string& message,
+                   const std::exception_ptr ex)
+{
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(level, message, ex);
+  }
+}
 
-    void CMLogger::Log(const cppmicroservices::ServiceReferenceBase &sr,
-                        logservice::SeverityLevel level,
-                        const std::string &message)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      if (currLogger)
-      {
-        currLogger->Log(sr, level, message);
-      }
-    }
+void CMLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
+                   logservice::SeverityLevel level,
+                   const std::string& message)
+{
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(sr, level, message);
+  }
+}
 
-    void CMLogger::Log(const cppmicroservices::ServiceReferenceBase &sr,
-                        logservice::SeverityLevel level,
-                        const std::string &message,
-                        const std::exception_ptr ex)
-    {
-      auto currLogger = std::atomic_load(&logService);
-      if (currLogger)
-      {
-        currLogger->Log(sr, level, message, ex);
-      }
-    }
-  } // cmimpl
+void CMLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
+                   logservice::SeverityLevel level,
+                   const std::string& message,
+                   const std::exception_ptr ex)
+{
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(sr, level, message, ex);
+  }
+}
+} // cmimpl
 } // cppmicroservices
-

--- a/compendium/ConfigurationAdmin/src/CMLogger.hpp
+++ b/compendium/ConfigurationAdmin/src/CMLogger.hpp
@@ -28,44 +28,63 @@
 #include "cppmicroservices/logservice/LogService.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    /**
-     * This class is used to track the availability of LogService in the
-     * framework. If a LogService is available the calls to Log methods
-     * are forwarded to the LogService. Otherwise, the calls to Log methods
-     * are no-op calls. This class implements the LogService interface so that
-     * other classes within the runtime can easily use a mock log service for
-     * testing purposes.
-     */
-    class CMLogger final
-    : public cppmicroservices::logservice::LogService
-    , public cppmicroservices::ServiceTrackerCustomizer<cppmicroservices::logservice::LogService>
-    {
-    public:
-      explicit CMLogger(cppmicroservices::BundleContext context);
-      CMLogger(const CMLogger&) = delete;
-      CMLogger(CMLogger&&) = delete;
-      CMLogger& operator=(const CMLogger&) = delete;
-      CMLogger& operator=(CMLogger&&) = delete;
-      ~CMLogger() override;
+namespace cmimpl {
+/**
+ * This class is used to track the availability of LogService in the
+ * framework. If a LogService is available the calls to Log methods
+ * are forwarded to the LogService. Otherwise, the calls to Log methods
+ * are no-op calls. This class implements the LogService interface so that
+ * other classes within the runtime can easily use a mock log service for
+ * testing purposes.
+ */
+class CMLogger final
+  : public cppmicroservices::logservice::LogService
+  , public cppmicroservices::ServiceTrackerCustomizer<
+      cppmicroservices::logservice::LogService>
+{
+public:
+  explicit CMLogger(cppmicroservices::BundleContext context);
+  CMLogger(const CMLogger&) = delete;
+  CMLogger(CMLogger&&) = delete;
+  CMLogger& operator=(const CMLogger&) = delete;
+  CMLogger& operator=(CMLogger&&) = delete;
+  ~CMLogger() override;
 
-      // methods from the cppmicroservices::logservice::LogService interface
-      void Log(logservice::SeverityLevel level, const std::string& message) override;
-      void Log(logservice::SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
-      void Log(const ServiceReferenceBase& sr, logservice::SeverityLevel level, const std::string& message) override;
-      void Log(const ServiceReferenceBase& sr, logservice::SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
+  // methods from the cppmicroservices::logservice::LogService interface
+  void Log(logservice::SeverityLevel level,
+           const std::string& message) override;
+  void Log(logservice::SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
+  void Log(const ServiceReferenceBase& sr,
+           logservice::SeverityLevel level,
+           const std::string& message) override;
+  void Log(const ServiceReferenceBase& sr,
+           logservice::SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
 
-      // methods from the cppmicroservices::ServiceTrackerCustomizer interface
-      std::shared_ptr<TrackedParamType> AddingService(const ServiceReference<cppmicroservices::logservice::LogService>& reference) override;
-      void ModifiedService(const ServiceReference<cppmicroservices::logservice::LogService>& reference, const std::shared_ptr<cppmicroservices::logservice::LogService>& service) override;
-      void RemovedService(const ServiceReference<cppmicroservices::logservice::LogService>& reference, const std::shared_ptr<cppmicroservices::logservice::LogService>& service) override;
+  // methods from the cppmicroservices::ServiceTrackerCustomizer interface
+  std::shared_ptr<TrackedParamType> AddingService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference)
+    override;
+  void ModifiedService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+    override;
+  void RemovedService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+    override;
 
-    private:
-      cppmicroservices::BundleContext cmContext;
-      std::unique_ptr<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>> serviceTracker;
-      std::shared_ptr<cppmicroservices::logservice::LogService> logService;
-    };
-  } // cmimpl
+private:
+  cppmicroservices::BundleContext cmContext;
+  std::unique_ptr<
+    cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
+    serviceTracker;
+  std::shared_ptr<cppmicroservices::logservice::LogService> logService;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif // CMLOGGER_HPP

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -33,714 +33,757 @@
 using cppmicroservices::logservice::SeverityLevel;
 
 namespace {
-  std::string getFactoryPid(const std::string& pid)
-  {
-    const auto pos = pid.find_first_of('~');
-    if (pos == std::string::npos)
-    {
-      return {};
-    }
-    return pid.substr(0, pos);
-  }
-
-  void handleUpdatedException(const std::string& pid,
-                              const cppmicroservices::AnyMap& properties,
-                              cppmicroservices::logservice::LogService& logger,
-                              bool isFactory)
-  {
-    auto thrownByMessage = "thrown by ManagedService" + (isFactory ? std::string("Factory") : "");
-    thrownByMessage += " with PID " + pid + " whilst being Updated with new properties.\n\t";
-    try
-    {
-      throw;
-    }
-    catch(const cppmicroservices::service::cm::ConfigurationException& ce)
-    {
-      const auto& property = ce.GetProperty();
-      std::string propertyCausingError;
-      if (!property.empty())
-      {
-        propertyCausingError += "The property which caused this error was '" + property + "' which had the value: \n\t";
-        propertyCausingError += properties.AtCompoundKey(property, cppmicroservices::Any()).ToStringNoExcept();
-      }
-      else
-      {
-        propertyCausingError += "It was not specified which property caused this error.";
-      }
-      logger.Log(SeverityLevel::LOG_ERROR, "ConfigurationException " + thrownByMessage + "Exception reason: "
-                                         + ce.GetReason() + "\n\t" + propertyCausingError);
-    }
-    catch (const std::exception &e)
-    {
-      logger.Log(SeverityLevel::LOG_ERROR, "Exception " + thrownByMessage + "Exception: " + e.what());
-    }
-    catch (...)
-    {
-      logger.Log(SeverityLevel::LOG_ERROR, "Unknown exception " + thrownByMessage);
-    }
-  }
-
-  void notifyServiceUpdated(const std::string& pid,
-                            cppmicroservices::service::cm::ManagedService& managedService,
-                            const cppmicroservices::AnyMap& properties,
-                            cppmicroservices::logservice::LogService& logger)
-  {
-    try
-    {
-      managedService.Updated(properties);
-    }
-    catch (...)
-    {
-      handleUpdatedException(pid, properties, logger, /* isFactory = */ false);
-    }
-  }
-
-  void notifyServiceUpdated(const std::string& pid,
-                            cppmicroservices::service::cm::ManagedServiceFactory& managedServiceFactory,
-                            const cppmicroservices::AnyMap& properties,
-                            cppmicroservices::logservice::LogService& logger)
-  {
-    try
-    {
-      managedServiceFactory.Updated(pid, properties);
-    }
-    catch (...)
-    {
-      handleUpdatedException(pid, properties, logger, /* isFactory = */ true);
-    }
-  }
-
-  void notifyServiceRemoved(const std::string& pid,
-                            cppmicroservices::service::cm::ManagedServiceFactory& managedServiceFactory,
-                            cppmicroservices::logservice::LogService& logger)
-  {
-    try
-    {
-      managedServiceFactory.Removed(pid);
-    }
-    catch (const std::exception &e)
-    {
-      logger.Log(SeverityLevel::LOG_ERROR,
-                 "Exception thrown by ManagedServiceFactory with PID " + pid
-               + " whilst being notified of Configuration Removal.\n\t" + "Exception: " + e.what());
-    }
-    catch (...)
-    {
-      logger.Log(SeverityLevel::LOG_ERROR,
-                 "Unknown exception thrown by ManagedServiceFactory with PID " + pid
-               + " whilst being notified of Configuration Removal.");
-    }
-  }
-
-  template <typename T>
-  std::string getPidFromServiceReference(const T& reference)
-  {
-    using namespace cppmicroservices::cmimpl::CMConstants;
-    try
-    {
-      const auto serviceProp = reference.GetProperty(CM_SERVICE_KEY);
-      const auto &serviceMap = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(serviceProp);
-      return cppmicroservices::any_cast<std::string>(serviceMap.AtCompoundKey(CM_SERVICE_SUBKEY));
-    }
-    catch (...)
-    {
-      // Service does not have a "service" property with a "pid" string subproperty.
-    }
-    try
-    {
-      const auto componentProp = reference.GetProperty(CM_COMPONENT_KEY);
-      const auto &componentMap = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(componentProp);
-      return cppmicroservices::any_cast<std::string>(componentMap.AtCompoundKey(CM_COMPONENT_SUBKEY));
-    }
-    catch (...)
-    {
-      // Service does not have a "component" property with a "name" string property.
-    }
-    try
-    {
-      return cppmicroservices::any_cast<std::string>(reference.GetProperty(CM_SERVICE_KEY + std::string(".") + CM_SERVICE_SUBKEY));
-    }
-    catch (...)
-    {
-      // Service does not have a "service.pid" string property.
-    }
-    try
-    {
-      return cppmicroservices::any_cast<std::string>(reference.GetProperty(CM_COMPONENT_KEY + std::string(".") + CM_COMPONENT_SUBKEY));
-    }
-    catch (...)
-    {
-      // Service does not have a "component.name" string property.
-    }
+std::string getFactoryPid(const std::string& pid)
+{
+  const auto pos = pid.find_first_of('~');
+  if (pos == std::string::npos) {
     return {};
   }
-}  // namespace
+  return pid.substr(0, pos);
+}
+
+void handleUpdatedException(const std::string& pid,
+                            const cppmicroservices::AnyMap& properties,
+                            cppmicroservices::logservice::LogService& logger,
+                            bool isFactory)
+{
+  auto thrownByMessage =
+    "thrown by ManagedService" + (isFactory ? std::string("Factory") : "");
+  thrownByMessage +=
+    " with PID " + pid + " whilst being Updated with new properties.\n\t";
+  try {
+    throw;
+  } catch (const cppmicroservices::service::cm::ConfigurationException& ce) {
+    const auto& property = ce.GetProperty();
+    std::string propertyCausingError;
+    if (!property.empty()) {
+      propertyCausingError += "The property which caused this error was '" +
+                              property + "' which had the value: \n\t";
+      propertyCausingError +=
+        properties.AtCompoundKey(property, cppmicroservices::Any())
+          .ToStringNoExcept();
+    } else {
+      propertyCausingError +=
+        "It was not specified which property caused this error.";
+    }
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "ConfigurationException " + thrownByMessage +
+                 "Exception reason: " + ce.GetReason() + "\n\t" +
+                 propertyCausingError);
+  } catch (const std::exception& e) {
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "Exception " + thrownByMessage + "Exception: " + e.what());
+  } catch (...) {
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "Unknown exception " + thrownByMessage);
+  }
+}
+
+void notifyServiceUpdated(
+  const std::string& pid,
+  cppmicroservices::service::cm::ManagedService& managedService,
+  const cppmicroservices::AnyMap& properties,
+  cppmicroservices::logservice::LogService& logger)
+{
+  try {
+    managedService.Updated(properties);
+  } catch (...) {
+    handleUpdatedException(pid, properties, logger, /* isFactory = */ false);
+  }
+}
+
+void notifyServiceUpdated(
+  const std::string& pid,
+  cppmicroservices::service::cm::ManagedServiceFactory& managedServiceFactory,
+  const cppmicroservices::AnyMap& properties,
+  cppmicroservices::logservice::LogService& logger)
+{
+  try {
+    managedServiceFactory.Updated(pid, properties);
+  } catch (...) {
+    handleUpdatedException(pid, properties, logger, /* isFactory = */ true);
+  }
+}
+
+void notifyServiceRemoved(
+  const std::string& pid,
+  cppmicroservices::service::cm::ManagedServiceFactory& managedServiceFactory,
+  cppmicroservices::logservice::LogService& logger)
+{
+  try {
+    managedServiceFactory.Removed(pid);
+  } catch (const std::exception& e) {
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "Exception thrown by ManagedServiceFactory with PID " + pid +
+                 " whilst being notified of Configuration Removal.\n\t" +
+                 "Exception: " + e.what());
+  } catch (...) {
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "Unknown exception thrown by ManagedServiceFactory with PID " +
+                 pid + " whilst being notified of Configuration Removal.");
+  }
+}
+
+template<typename T>
+std::string getPidFromServiceReference(const T& reference)
+{
+  using namespace cppmicroservices::cmimpl::CMConstants;
+  try {
+    const auto serviceProp = reference.GetProperty(CM_SERVICE_KEY);
+    const auto& serviceMap =
+      cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(serviceProp);
+    return cppmicroservices::any_cast<std::string>(
+      serviceMap.AtCompoundKey(CM_SERVICE_SUBKEY));
+  } catch (...) {
+    // Service does not have a "service" property with a "pid" string subproperty.
+  }
+  try {
+    const auto componentProp = reference.GetProperty(CM_COMPONENT_KEY);
+    const auto& componentMap =
+      cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(componentProp);
+    return cppmicroservices::any_cast<std::string>(
+      componentMap.AtCompoundKey(CM_COMPONENT_SUBKEY));
+  } catch (...) {
+    // Service does not have a "component" property with a "name" string property.
+  }
+  try {
+    return cppmicroservices::any_cast<std::string>(reference.GetProperty(
+      CM_SERVICE_KEY + std::string(".") + CM_SERVICE_SUBKEY));
+  } catch (...) {
+    // Service does not have a "service.pid" string property.
+  }
+  try {
+    return cppmicroservices::any_cast<std::string>(reference.GetProperty(
+      CM_COMPONENT_KEY + std::string(".") + CM_COMPONENT_SUBKEY));
+  } catch (...) {
+    // Service does not have a "component.name" string property.
+  }
+  return {};
+}
+} // namespace
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    ConfigurationAdminImpl::ConfigurationAdminImpl(cppmicroservices::BundleContext context,
-                                                   std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
-    : cmContext(std::move(context))
-    , logger(std::move(lggr))
-    , futuresID{0u}
-    , managedServiceTracker(cmContext, this)
-    , managedServiceFactoryTracker(cmContext, this)
-    , randomGenerator(std::random_device{}())
-    {
-      managedServiceTracker.Open();
-      managedServiceFactoryTracker.Open();
+ConfigurationAdminImpl::ConfigurationAdminImpl(
+  cppmicroservices::BundleContext context,
+  std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
+  : cmContext(std::move(context))
+  , logger(std::move(lggr))
+  , futuresID{ 0u }
+  , managedServiceTracker(cmContext, this)
+  , managedServiceFactoryTracker(cmContext, this)
+  , randomGenerator(std::random_device{}())
+{
+  managedServiceTracker.Open();
+  managedServiceFactoryTracker.Open();
+}
+
+ConfigurationAdminImpl::~ConfigurationAdminImpl()
+{
+  auto managedServiceWrappers = managedServiceTracker.GetServices();
+  auto managedServiceFactoryWrappers =
+    managedServiceFactoryTracker.GetServices();
+
+  managedServiceFactoryTracker.Close();
+  managedServiceTracker.Close();
+
+  decltype(factoryInstances) factoryInstancesCopy;
+  decltype(configurations) configurationsToInvalidate;
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    factoryInstancesCopy.swap(factoryInstances);
+    configurationsToInvalidate.swap(configurations);
+  }
+  for (auto& configuration : configurationsToInvalidate) {
+    configuration.second->Invalidate();
+  }
+  AnyMap emptyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  for (auto& managedService : managedServiceWrappers) {
+    // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
+    // that we aren't tracking. We must be careful not to dereference these!
+    if (managedService) {
+      notifyServiceUpdated(managedService->pid,
+                           *(managedService->trackedService),
+                           emptyMap,
+                           *logger);
     }
-
-    ConfigurationAdminImpl::~ConfigurationAdminImpl()
-    {
-      auto managedServiceWrappers = managedServiceTracker.GetServices();
-      auto managedServiceFactoryWrappers = managedServiceFactoryTracker.GetServices();
-
-      managedServiceFactoryTracker.Close();
-      managedServiceTracker.Close();
-
-      decltype(factoryInstances) factoryInstancesCopy;
-      decltype(configurations) configurationsToInvalidate;
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        factoryInstancesCopy.swap(factoryInstances);
-        configurationsToInvalidate.swap(configurations);
-      }
-      for (auto& configuration : configurationsToInvalidate)
-      {
-        configuration.second->Invalidate();
-      }
-      AnyMap emptyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      for (auto& managedService : managedServiceWrappers)
-      {
-        // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
-        // that we aren't tracking. We must be careful not to dereference these!
-        if (managedService)
-        {
-          notifyServiceUpdated(managedService->pid, *(managedService->trackedService), emptyMap, *logger);
-        }
-      }
-      for (auto & managedServiceFactory : managedServiceFactoryWrappers)
-      {
-        // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
-        // that we aren't tracking. We must be careful not to dereference these!
-        if (!managedServiceFactory)
-        {
-          continue;
-        }
-        auto it = factoryInstancesCopy.find(managedServiceFactory->pid);
-        if (it == std::end(factoryInstancesCopy))
-        {
-          continue;
-        }
-        for (const auto& pid : it->second)
-        {
-          notifyServiceRemoved(pid, *(managedServiceFactory->trackedService), *logger);
-        }
-      }
-      std::unique_lock<std::mutex> ul{futuresMutex};
-      if (!incompleteFutures.empty())
-      {
-        futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
-      }
+  }
+  for (auto& managedServiceFactory : managedServiceFactoryWrappers) {
+    // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
+    // that we aren't tracking. We must be careful not to dereference these!
+    if (!managedServiceFactory) {
+      continue;
     }
-
-    std::shared_ptr<cppmicroservices::service::cm::Configuration> ConfigurationAdminImpl::GetConfiguration(const std::string& pid)
-    {
-      std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
-      auto created = false;
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        auto it = configurations.find(pid);
-        if (it == std::end(configurations)) {
-            auto factoryPid = getFactoryPid(pid);
-            AddFactoryInstanceIfRequired(pid, factoryPid);
-            it = configurations.emplace(pid, std::make_shared<ConfigurationImpl>(this, pid, std::move(factoryPid), AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS})).first;
-            created = true;
-        }
-        result = it->second;
-      }
-       logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "GetConfiguration: returning " + (created ? std::string("new") : "existing") + " Configuration instance with PID " + pid);
-      return result;
+    auto it = factoryInstancesCopy.find(managedServiceFactory->pid);
+    if (it == std::end(factoryInstancesCopy)) {
+      continue;
     }
+    for (const auto& pid : it->second) {
+      notifyServiceRemoved(
+        pid, *(managedServiceFactory->trackedService), *logger);
+    }
+  }
+  std::unique_lock<std::mutex> ul{ futuresMutex };
+  if (!incompleteFutures.empty()) {
+    futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
+  }
+}
 
-    std::shared_ptr<cppmicroservices::service::cm::Configuration> ConfigurationAdminImpl::CreateFactoryConfiguration(const std::string& factoryPid)
-    {
-      std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
-      auto pid = factoryPid + "~" + RandomInstanceName();
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        auto it = configurations.find(pid);
-        while (it != std::end(configurations))
-        {
-          pid = factoryPid + "~" + RandomInstanceName();
-          it = configurations.find(pid);
-        }
+std::shared_ptr<cppmicroservices::service::cm::Configuration>
+ConfigurationAdminImpl::GetConfiguration(const std::string& pid)
+{
+  std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
+  auto created = false;
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    auto it = configurations.find(pid);
+    if (it == std::end(configurations)) {
+      auto factoryPid = getFactoryPid(pid);
+      AddFactoryInstanceIfRequired(pid, factoryPid);
+      it = configurations
+             .emplace(pid,
+                      std::make_shared<ConfigurationImpl>(
+                        this,
+                        pid,
+                        std::move(factoryPid),
+                        AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
+             .first;
+      created = true;
+    }
+    result = it->second;
+  }
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "GetConfiguration: returning " +
+                (created ? std::string("new") : "existing") +
+                " Configuration instance with PID " + pid);
+  return result;
+}
+
+std::shared_ptr<cppmicroservices::service::cm::Configuration>
+ConfigurationAdminImpl::CreateFactoryConfiguration(
+  const std::string& factoryPid)
+{
+  std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
+  auto pid = factoryPid + "~" + RandomInstanceName();
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    auto it = configurations.find(pid);
+    while (it != std::end(configurations)) {
+      pid = factoryPid + "~" + RandomInstanceName();
+      it = configurations.find(pid);
+    }
+    AddFactoryInstanceIfRequired(pid, factoryPid);
+    it = configurations
+           .emplace(pid,
+                    std::make_shared<ConfigurationImpl>(
+                      this,
+                      pid,
+                      factoryPid,
+                      AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
+           .first;
+    result = it->second;
+  }
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "CreateFactoryConfiguration: returning new Configuration "
+              "instance with PID " +
+                pid);
+  return result;
+}
+
+std::shared_ptr<cppmicroservices::service::cm::Configuration>
+ConfigurationAdminImpl::GetFactoryConfiguration(const std::string& factoryPid,
+                                                const std::string& instanceName)
+{
+  const auto pid = factoryPid + "~" + instanceName;
+  logger->Log(
+    cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+    "GetFactoryConfiguration: deferring to GetConfiguration for PID " + pid);
+  return GetConfiguration(pid);
+}
+
+std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>>
+ConfigurationAdminImpl::ListConfigurations(const std::string& /* filter */)
+{
+  throw std::invalid_argument("Method not currently implemented");
+}
+
+std::vector<ConfigurationAddedInfo> ConfigurationAdminImpl::AddConfigurations(
+  std::vector<metadata::ConfigurationMetadata> configurationMetadata)
+{
+  std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
+  std::vector<bool> createdOrUpdated;
+  std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    for (auto& configMetadata : configurationMetadata) {
+      auto& pid = configMetadata.pid;
+      auto it = configurations.find(pid);
+      if (it == std::end(configurations)) {
+        auto factoryPid = getFactoryPid(pid);
         AddFactoryInstanceIfRequired(pid, factoryPid);
-        it = configurations.emplace(pid, std::make_shared<ConfigurationImpl>(this, pid, factoryPid, AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS})).first;
-        result = it->second;
+        it = configurations
+               .emplace(pid,
+                        std::make_shared<ConfigurationImpl>(
+                          this,
+                          pid,
+                          std::move(factoryPid),
+                          std::move(configMetadata.properties)))
+               .first;
+        pidsAndChangeCountsAndIDs.emplace_back(
+          pid, 1u, reinterpret_cast<std::uintptr_t>(it->second.get()));
+        createdOrUpdated.push_back(true);
+        continue;
       }
+      // else Configuration already exists
+      try {
+        const auto updatedAndChangeCount =
+          it->second->UpdateWithoutNotificationIfDifferent(
+            configMetadata.properties);
+        pidsAndChangeCountsAndIDs.emplace_back(
+          pid,
+          updatedAndChangeCount.second,
+          reinterpret_cast<std::uintptr_t>(it->second.get()));
+        createdOrUpdated.push_back(updatedAndChangeCount.first);
+      } catch (
+        const std::
+          runtime_error&) // Configuration has been Removed by someone else, but we've won the race to handle that.
+      {
+        configurationsToInvalidate.push_back(std::move(it->second));
+        it->second = std::make_shared<ConfigurationImpl>(
+          this, pid, getFactoryPid(pid), std::move(configMetadata.properties));
+        pidsAndChangeCountsAndIDs.emplace_back(
+          pid, 1u, reinterpret_cast<std::uintptr_t>(it->second.get()));
+        createdOrUpdated.push_back(true);
+      }
+    }
+  }
+  // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
+  for (auto& configurationToInvalidate : configurationsToInvalidate) {
+    configurationToInvalidate->Invalidate();
+  }
+  auto idx = 0u;
+  for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs) {
+    const auto& pid = pidAndChangeCountAndID.pid;
+    if (createdOrUpdated[idx]) {
+      NotifyConfigurationUpdated(pid);
       logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "CreateFactoryConfiguration: returning new Configuration instance with PID " + pid);
-      return result;
-    }
-
-    std::shared_ptr<cppmicroservices::service::cm::Configuration> ConfigurationAdminImpl::GetFactoryConfiguration(const std::string& factoryPid, const std::string& instanceName)
-    {
-      const auto pid = factoryPid + "~" + instanceName;
+                  "AddConfigurations: Created or Updated Configuration "
+                  "instance with PID " +
+                    pid);
+    } else {
       logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "GetFactoryConfiguration: deferring to GetConfiguration for PID " + pid);
-      return GetConfiguration(pid);
+                  "AddConfigurations: Configuration already existed with "
+                  "identical properties with PID " +
+                    pid);
     }
+    ++idx;
+  }
+  return pidsAndChangeCountsAndIDs;
+}
 
-    std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>> ConfigurationAdminImpl::ListConfigurations(const std::string& /* filter */)
-    {
-      throw std::invalid_argument("Method not currently implemented");
-    }
-
-    std::vector<ConfigurationAddedInfo> ConfigurationAdminImpl::AddConfigurations(std::vector<metadata::ConfigurationMetadata> configurationMetadata)
-    {
-      std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
-      std::vector<bool> createdOrUpdated;
-      std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        for (auto& configMetadata : configurationMetadata)
-        {
-          auto &pid = configMetadata.pid;
-          auto it = configurations.find(pid);
-          if (it == std::end(configurations))
-          {
-            auto factoryPid = getFactoryPid(pid);
-            AddFactoryInstanceIfRequired(pid, factoryPid);
-            it = configurations.emplace(pid, std::make_shared<ConfigurationImpl>(this, pid, std::move(factoryPid), std::move(configMetadata.properties))).first;
-            pidsAndChangeCountsAndIDs.emplace_back(pid, 1u, reinterpret_cast<std::uintptr_t>(it->second.get()));
-            createdOrUpdated.push_back(true);
-            continue;
-          }
-          // else Configuration already exists
-          try {
-            const auto updatedAndChangeCount = it->second->UpdateWithoutNotificationIfDifferent(configMetadata.properties);
-            pidsAndChangeCountsAndIDs.emplace_back(pid, updatedAndChangeCount.second, reinterpret_cast<std::uintptr_t>(it->second.get()));
-            createdOrUpdated.push_back(updatedAndChangeCount.first);
-          }
-          catch (const std::runtime_error&) // Configuration has been Removed by someone else, but we've won the race to handle that.
-          {
-            configurationsToInvalidate.push_back(std::move(it->second));
-            it->second = std::make_shared<ConfigurationImpl>(this, pid, getFactoryPid(pid), std::move(configMetadata.properties));
-            pidsAndChangeCountsAndIDs.emplace_back(pid, 1u, reinterpret_cast<std::uintptr_t>(it->second.get()));
-            createdOrUpdated.push_back(true);
-          }
-        }
+void ConfigurationAdminImpl::RemoveConfigurations(
+  std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs)
+{
+  std::vector<bool> removed;
+  std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs) {
+      const auto& pid = pidAndChangeCountAndID.pid;
+      const auto it = configurations.find(pid);
+      if (it == std::end(configurations)) {
+        removed.push_back(false);
+        continue;
       }
-      // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
-      for (auto& configurationToInvalidate : configurationsToInvalidate)
-      {
-        configurationToInvalidate->Invalidate();
+      // else Configuration still exists
+      if (reinterpret_cast<std::uintptr_t>(it->second.get()) !=
+          pidAndChangeCountAndID.configurationId) {
+        // This Configuration is not the same one that was originally created by the CMBundleExtension. It must have been
+        // removed and re-added by someone else in the interim.
+        removed.push_back(false);
+        continue;
       }
-      auto idx = 0u;
-      for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
-      {
-        const auto& pid = pidAndChangeCountAndID.pid;
-        if (createdOrUpdated[idx])
-        {
-          NotifyConfigurationUpdated(pid);
-          logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                      "AddConfigurations: Created or Updated Configuration instance with PID " + pid);
+      try {
+        const auto configurationWasRemoved =
+          it->second->RemoveWithoutNotificationIfChangeCountEquals(
+            pidAndChangeCountAndID.changeCount);
+        if (configurationWasRemoved) {
+          configurationsToInvalidate.push_back(std::move(it->second));
+          removed.push_back(true);
+          configurations.erase(it);
+          RemoveFactoryInstanceIfRequired(pid);
+          continue;
         }
-        else
-        {
-          logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                      "AddConfigurations: Configuration already existed with identical properties with PID " + pid);
-        }
-        ++idx;
-      }
-      return pidsAndChangeCountsAndIDs;
-    }
-
-    void ConfigurationAdminImpl::RemoveConfigurations(std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs)
-    {
-      std::vector<bool> removed;
-      std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
-        {
-          const auto& pid = pidAndChangeCountAndID.pid;
-          const auto it = configurations.find(pid);
-          if (it == std::end(configurations))
-          {
-            removed.push_back(false);
-            continue;
-          }
-          // else Configuration still exists
-          if (reinterpret_cast<std::uintptr_t>(it->second.get()) != pidAndChangeCountAndID.configurationId)
-          {
-            // This Configuration is not the same one that was originally created by the CMBundleExtension. It must have been
-            // removed and re-added by someone else in the interim.
-            removed.push_back(false);
-            continue;
-          }
-          try {
-            const auto configurationWasRemoved = it->second->RemoveWithoutNotificationIfChangeCountEquals(pidAndChangeCountAndID.changeCount);
-            if (configurationWasRemoved)
-            {
-              configurationsToInvalidate.push_back(std::move(it->second));
-              removed.push_back(true);
-              configurations.erase(it);
-              RemoveFactoryInstanceIfRequired(pid);
-              continue;
-            }
-            // else Configuration now differs from the one the CMBundleExtension added. Do not remove it.
-            removed.push_back(false);
-          }
-          catch (const std::runtime_error&)
-          {
-            // Configuration already Removed by someone else, but we've won the race to handle that in ComponentAdminImpl
-            configurationsToInvalidate.push_back(std::move(it->second));
-            removed.push_back(true);
-            configurations.erase(it);
-            RemoveFactoryInstanceIfRequired(pid);
-          }
-        }
-      }
-      // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
-      for (auto& configurationToInvalidate : configurationsToInvalidate)
-      {
-        configurationToInvalidate->Invalidate();
-      }
-      auto idx = 0u;
-      for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
-      {
-        const auto& pid = pidAndChangeCountAndID.pid;
-        if (removed[idx])
-        {
-          NotifyConfigurationUpdated(pid);
-          logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                      "RemoveConfigurations: Removed Configuration instance with PID " + pid);
-        }
-        else
-        {
-          logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                      "RemoveConfigurations: Configuration with PID " + pid + " was not removed"
-                      " (either already removed, or it has been subsequently updated)");
-        }
-        ++idx;
-      }
-    }
-
-    void ConfigurationAdminImpl::NotifyConfigurationUpdated(const std::string& pid)
-    {
-      PerformAsync([this, pid]
-      {
-        AnyMap properties{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-        auto removed = false;
-        {
-          std::lock_guard<std::mutex> lk{configurationsMutex};
-          const auto it = configurations.find(pid);
-          if (it == std::end(configurations))
-          {
-            removed = true;
-          }
-          else
-          {
-            try
-            {
-              properties = it->second->GetProperties();
-            }
-            catch (const std::runtime_error&)
-            {
-              // Configuration is being removed
-              removed = true;
-            }
-          }
-        }
-        const auto managedServiceWrappers = managedServiceTracker.GetServices();
-        const auto it = std::find_if(std::begin(managedServiceWrappers), std::end(managedServiceWrappers),
-                                     [&pid](const auto& managedServiceWrapper)
-                                     {
-                                       // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
-                                       // that we aren't tracking. We must be careful not to dereference these!
-                                       return (managedServiceWrapper ? (pid == managedServiceWrapper->pid) : false);
-                                     });
-        if (it != std::end(managedServiceWrappers))
-        {
-          const auto &managedServiceWrapper = *it;
-          notifyServiceUpdated(pid, *(managedServiceWrapper->trackedService), properties, *logger);
-        }
-        const auto factoryPid = getFactoryPid(pid);
-        if (factoryPid.empty())
-        {
-          return;
-        }
-        const auto managedServiceFactoryWrappers = managedServiceFactoryTracker.GetServices();
-        const auto factoryIt = std::find_if(std::begin(managedServiceFactoryWrappers), std::end(managedServiceFactoryWrappers),
-                                            [&factoryPid](const auto& managedServiceFactoryWrapper)
-                                            {
-                                              // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
-                                              // that we aren't tracking. We must be careful not to dereference these!
-                                              return (managedServiceFactoryWrapper ? (factoryPid == managedServiceFactoryWrapper->pid) : false);
-                                            });
-        if (factoryIt != std::end(managedServiceFactoryWrappers))
-        {
-          const auto &managedServiceFactoryWrapper = *factoryIt;
-          if (removed)
-          {
-            notifyServiceRemoved(pid, *(managedServiceFactoryWrapper->trackedService), *logger);
-          }
-          else
-          {
-            notifyServiceUpdated(pid, *(managedServiceFactoryWrapper->trackedService), properties, *logger);
-          }
-        }
-      });
-    }
-
-    void ConfigurationAdminImpl::NotifyConfigurationRemoved(const std::string &pid, std::uintptr_t configurationId)
-    {
-      std::shared_ptr<ConfigurationImpl> configurationToInvalidate;
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        auto it = configurations.find(pid);
-        if (it == std::end(configurations))
-        {
-          // This Configuration has already been removed. The thread which removed it will have triggered
-          // the notification of any ManagedService or ManagedServiceFactory, so nothing more to do.
-          return;
-        }
-        if (configurationId != reinterpret_cast<std::uintptr_t>(it->second.get()))
-        {
-          // The Configuration with this PID has already been removed and replaced by a new one, and the thread
-          // which did that will have triggered the notification of any ManagedService or ManagedServiceFactory,
-          // so nothing more to do.
-          return;
-        }
-        configurationToInvalidate = it->second;
+        // else Configuration now differs from the one the CMBundleExtension added. Do not remove it.
+        removed.push_back(false);
+      } catch (const std::runtime_error&) {
+        // Configuration already Removed by someone else, but we've won the race to handle that in ComponentAdminImpl
+        configurationsToInvalidate.push_back(std::move(it->second));
+        removed.push_back(true);
         configurations.erase(it);
         RemoveFactoryInstanceIfRequired(pid);
       }
-      if (configurationToInvalidate)
-      {
-        NotifyConfigurationUpdated(pid);
-        // This functor will run on another thread. Just being overly cautious to guarantee that the
-        // ConfigurationImpl which has called this method doesn't run its own destructor.
-        PerformAsync([this, pid, configuration = std::move(configurationToInvalidate)]
-        {
-          logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                      "Configuration with PID " + pid + " has been removed.");
-        });
-      }
     }
+  }
+  // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
+  for (auto& configurationToInvalidate : configurationsToInvalidate) {
+    configurationToInvalidate->Invalidate();
+  }
+  auto idx = 0u;
+  for (const auto& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs) {
+    const auto& pid = pidAndChangeCountAndID.pid;
+    if (removed[idx]) {
+      NotifyConfigurationUpdated(pid);
+      logger->Log(
+        cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+        "RemoveConfigurations: Removed Configuration instance with PID " + pid);
+    } else {
+      logger->Log(
+        cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+        "RemoveConfigurations: Configuration with PID " + pid +
+          " was not removed"
+          " (either already removed, or it has been subsequently updated)");
+    }
+    ++idx;
+  }
+}
 
-    std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
-    ConfigurationAdminImpl::AddingService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& reference)
+void ConfigurationAdminImpl::NotifyConfigurationUpdated(const std::string& pid)
+{
+  PerformAsync([this, pid] {
+    AnyMap properties{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+    auto removed = false;
     {
-      const auto pid = getPidFromServiceReference(reference);
-      if (pid.empty())
-      {
-        const auto bundle = reference.GetBundle();
-        const auto serviceID = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
-        logger->Log(SeverityLevel::LOG_WARNING, "Ignoring ManagedService with ID " + serviceID + " from bundle "
-                                              + (bundle ? bundle.GetSymbolicName() : "Unknown")
-                                              + " as it does not have a service.pid or component.name property");
-        return nullptr;
-      }
-      auto managedService = cmContext.GetService(reference);
-      if (!managedService)
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "Ignoring ManagedService as a valid service could not be obtained from the BundleContext");
-        return nullptr;
-      }
-      // Ensure there's a Configuration for this PID if one doesn't exist already.
-      {
-        std::lock_guard<std::mutex> lk{configurationsMutex};
-        const auto it = configurations.find(pid);
-        if (it == std::end(configurations)) {
-            auto factoryPid = getFactoryPid(pid);
-            AddFactoryInstanceIfRequired(pid, factoryPid);
-            configurations.emplace(pid, std::make_shared<ConfigurationImpl>(this, pid, std::move(factoryPid), AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS}));
+      std::lock_guard<std::mutex> lk{ configurationsMutex };
+      const auto it = configurations.find(pid);
+      if (it == std::end(configurations)) {
+        removed = true;
+      } else {
+        try {
+          properties = it->second->GetProperties();
+        } catch (const std::runtime_error&) {
+          // Configuration is being removed
+          removed = true;
         }
       }
-      PerformAsync([this, pid, managedService]
-      {
-        AnyMap properties{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-        {
-          std::lock_guard<std::mutex> lk{configurationsMutex};
-          const auto it = configurations.find(pid);
-          if (it != std::end(configurations))
-          {
-            try
-            {
-              properties = it->second->GetProperties();
-            }
-            catch (const std::runtime_error&)
-            {
-              // Configuration is being removed
-            }
+    }
+    const auto managedServiceWrappers = managedServiceTracker.GetServices();
+    const auto it = std::find_if(
+      std::begin(managedServiceWrappers),
+      std::end(managedServiceWrappers),
+      [&pid](const auto& managedServiceWrapper) {
+        // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
+        // that we aren't tracking. We must be careful not to dereference these!
+        return (managedServiceWrapper ? (pid == managedServiceWrapper->pid)
+                                      : false);
+      });
+    if (it != std::end(managedServiceWrappers)) {
+      const auto& managedServiceWrapper = *it;
+      notifyServiceUpdated(
+        pid, *(managedServiceWrapper->trackedService), properties, *logger);
+    }
+    const auto factoryPid = getFactoryPid(pid);
+    if (factoryPid.empty()) {
+      return;
+    }
+    const auto managedServiceFactoryWrappers =
+      managedServiceFactoryTracker.GetServices();
+    const auto factoryIt = std::find_if(
+      std::begin(managedServiceFactoryWrappers),
+      std::end(managedServiceFactoryWrappers),
+      [&factoryPid](const auto& managedServiceFactoryWrapper) {
+        // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
+        // that we aren't tracking. We must be careful not to dereference these!
+        return (managedServiceFactoryWrapper
+                  ? (factoryPid == managedServiceFactoryWrapper->pid)
+                  : false);
+      });
+    if (factoryIt != std::end(managedServiceFactoryWrappers)) {
+      const auto& managedServiceFactoryWrapper = *factoryIt;
+      if (removed) {
+        notifyServiceRemoved(
+          pid, *(managedServiceFactoryWrapper->trackedService), *logger);
+      } else {
+        notifyServiceUpdated(pid,
+                             *(managedServiceFactoryWrapper->trackedService),
+                             properties,
+                             *logger);
+      }
+    }
+  });
+}
+
+void ConfigurationAdminImpl::NotifyConfigurationRemoved(
+  const std::string& pid,
+  std::uintptr_t configurationId)
+{
+  std::shared_ptr<ConfigurationImpl> configurationToInvalidate;
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    auto it = configurations.find(pid);
+    if (it == std::end(configurations)) {
+      // This Configuration has already been removed. The thread which removed it will have triggered
+      // the notification of any ManagedService or ManagedServiceFactory, so nothing more to do.
+      return;
+    }
+    if (configurationId != reinterpret_cast<std::uintptr_t>(it->second.get())) {
+      // The Configuration with this PID has already been removed and replaced by a new one, and the thread
+      // which did that will have triggered the notification of any ManagedService or ManagedServiceFactory,
+      // so nothing more to do.
+      return;
+    }
+    configurationToInvalidate = it->second;
+    configurations.erase(it);
+    RemoveFactoryInstanceIfRequired(pid);
+  }
+  if (configurationToInvalidate) {
+    NotifyConfigurationUpdated(pid);
+    // This functor will run on another thread. Just being overly cautious to guarantee that the
+    // ConfigurationImpl which has called this method doesn't run its own destructor.
+    PerformAsync(
+      [this, pid, configuration = std::move(configurationToInvalidate)] {
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "Configuration with PID " + pid + " has been removed.");
+      });
+  }
+}
+
+std::shared_ptr<
+  TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
+ConfigurationAdminImpl::AddingService(
+  const ServiceReference<cppmicroservices::service::cm::ManagedService>&
+    reference)
+{
+  const auto pid = getPidFromServiceReference(reference);
+  if (pid.empty()) {
+    const auto bundle = reference.GetBundle();
+    const auto serviceID = std::to_string(cppmicroservices::any_cast<long>(
+      reference.GetProperty(Constants::SERVICE_ID)));
+    logger->Log(
+      SeverityLevel::LOG_WARNING,
+      "Ignoring ManagedService with ID " + serviceID + " from bundle " +
+        (bundle ? bundle.GetSymbolicName() : "Unknown") +
+        " as it does not have a service.pid or component.name property");
+    return nullptr;
+  }
+  auto managedService = cmContext.GetService(reference);
+  if (!managedService) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Ignoring ManagedService as a valid service could not be "
+                "obtained from the BundleContext");
+    return nullptr;
+  }
+  // Ensure there's a Configuration for this PID if one doesn't exist already.
+  {
+    std::lock_guard<std::mutex> lk{ configurationsMutex };
+    const auto it = configurations.find(pid);
+    if (it == std::end(configurations)) {
+      auto factoryPid = getFactoryPid(pid);
+      AddFactoryInstanceIfRequired(pid, factoryPid);
+      configurations.emplace(
+        pid,
+        std::make_shared<ConfigurationImpl>(
+          this,
+          pid,
+          std::move(factoryPid),
+          AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }));
+    }
+  }
+  PerformAsync([this, pid, managedService] {
+    AnyMap properties{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+    {
+      std::lock_guard<std::mutex> lk{ configurationsMutex };
+      const auto it = configurations.find(pid);
+      if (it != std::end(configurations)) {
+        try {
+          properties = it->second->GetProperties();
+        } catch (const std::runtime_error&) {
+          // Configuration is being removed
+        }
+      }
+    }
+    notifyServiceUpdated(pid, *managedService, properties, *logger);
+  });
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "New ManagedService with PID " + pid +
+                " has been added, and async Update has been queued.");
+  return std::make_shared<
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>(
+    pid, std::move(managedService));
+}
+
+void ConfigurationAdminImpl::ModifiedService(
+  const ServiceReference<
+    cppmicroservices::service::cm::ManagedService>& /* reference */,
+  const std::shared_ptr<TrackedServiceWrapper<
+    cppmicroservices::service::cm::ManagedService>>& /* service */)
+{
+  // Assume the PID and component.name properties will never change, so noop
+}
+
+void ConfigurationAdminImpl::RemovedService(
+  const ServiceReference<
+    cppmicroservices::service::cm::ManagedService>& /* reference */,
+  const std::shared_ptr<
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>&
+    service)
+{
+  // No need to do anything other than log; ManagedService just won't receive any more updates to its Configuration.
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "ManagedService with PID " + service->pid + " has been removed.");
+}
+
+std::shared_ptr<
+  TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
+ConfigurationAdminImpl::AddingService(
+  const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>&
+    reference)
+{
+  const auto pid = getPidFromServiceReference(reference);
+  if (pid.empty()) {
+    const auto bundle = reference.GetBundle();
+    const auto serviceID = std::to_string(cppmicroservices::any_cast<long>(
+      reference.GetProperty(Constants::SERVICE_ID)));
+    logger->Log(
+      SeverityLevel::LOG_WARNING,
+      "Ignoring ManagedServiceFactory with ID " + serviceID + " from bundle " +
+        (bundle ? bundle.GetSymbolicName() : "Unknown") +
+        " as it does not have a service.pid or component.name property");
+    return nullptr;
+  }
+  auto managedServiceFactory = cmContext.GetService(reference);
+  if (!managedServiceFactory) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Ignoring ManagedServiceFactory as a valid service could not "
+                "be obtained from the BundleContext");
+    return nullptr;
+  }
+  PerformAsync([this, pid, managedServiceFactory] {
+    std::vector<std::pair<std::string, AnyMap>> pidsAndProperties;
+    {
+      std::lock_guard<std::mutex> lk{ configurationsMutex };
+      const auto it = factoryInstances.find(pid);
+      if (it != std::end(factoryInstances)) {
+        for (const auto& instance : it->second) {
+          const auto configurationIt = configurations.find(instance);
+          assert(configurationIt != std::end(configurations) &&
+                 "Invalid Configuration iterator");
+          try {
+            auto properties = configurationIt->second->GetProperties();
+            pidsAndProperties.emplace_back(instance, std::move(properties));
+          } catch (const std::runtime_error&) {
+            // Configuration is being removed
           }
         }
-        notifyServiceUpdated(pid, *managedService, properties, *logger);
-      });
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "New ManagedService with PID " + pid + " has been added, and async Update has been queued.");
-      return std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>(pid, std::move(managedService));
-    }
-
-    void ConfigurationAdminImpl::ModifiedService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& /* reference */,
-                                                 const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>& /* service */)
-    {
-      // Assume the PID and component.name properties will never change, so noop
-    }
-
-    void ConfigurationAdminImpl::RemovedService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& /* reference */,
-                                                const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>& service)
-    {
-      // No need to do anything other than log; ManagedService just won't receive any more updates to its Configuration.
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "ManagedService with PID " + service->pid + " has been removed.");
-    }
-
-    std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
-    ConfigurationAdminImpl::AddingService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& reference)
-    {
-      const auto pid = getPidFromServiceReference(reference);
-      if (pid.empty())
-      {
-        const auto bundle = reference.GetBundle();
-        const auto serviceID = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
-        logger->Log(SeverityLevel::LOG_WARNING, "Ignoring ManagedServiceFactory with ID " + serviceID + " from bundle "
-                                              + (bundle ? bundle.GetSymbolicName() : "Unknown")
-                                              + " as it does not have a service.pid or component.name property");
-        return nullptr;
-      }
-      auto managedServiceFactory = cmContext.GetService(reference);
-      if (!managedServiceFactory)
-      {
-        logger->Log(SeverityLevel::LOG_DEBUG, "Ignoring ManagedServiceFactory as a valid service could not be obtained from the BundleContext");
-        return nullptr;
-      }
-      PerformAsync([this, pid, managedServiceFactory]
-      {
-        std::vector<std::pair<std::string, AnyMap>> pidsAndProperties;
-        {
-          std::lock_guard<std::mutex> lk{configurationsMutex};
-          const auto it = factoryInstances.find(pid);
-          if (it != std::end(factoryInstances))
-          {
-            for (const auto &instance : it->second)
-            {
-              const auto configurationIt = configurations.find(instance);
-              assert(configurationIt != std::end(configurations) && "Invalid Configuration iterator");
-              try
-              {
-                auto properties = configurationIt->second->GetProperties();
-                pidsAndProperties.emplace_back(instance, std::move(properties));
-              }
-              catch (const std::runtime_error&)
-              {
-                // Configuration is being removed
-              }
-            }
-          }
-        }
-        for (const auto &pidAndProperties : pidsAndProperties)
-        {
-          notifyServiceUpdated(pidAndProperties.first, *managedServiceFactory, pidAndProperties.second, *logger);
-        }
-      });
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "New ManagedServiceFactory with PID " + pid + " has been added, and async Update has been queued for all instances.");
-      return std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>(pid, std::move(managedServiceFactory));
-    }
-
-    void ConfigurationAdminImpl::ModifiedService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& /* reference */,
-                                                 const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>& /* service */)
-    {
-      // Assume the PID and component.name properties will never change, so noop
-    }
-
-    void ConfigurationAdminImpl::RemovedService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& /* reference */,
-                                                const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>& service)
-    {
-      // No need to do anything other than log; ManagedServiceFactory just won't receive any more updates to any of its Configurations.
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  "ManagedServiceFactory with PID " + service->pid + " has been removed.");
-    }
-
-    template <typename Functor>
-    void ConfigurationAdminImpl::PerformAsync(Functor&& f)
-    {
-       std::lock_guard<std::mutex> lk{futuresMutex};
-       decltype(completeFutures){}.swap(completeFutures);
-       auto id = ++futuresID;
-       incompleteFutures.emplace(id, std::async(std::launch::async, [this, func = std::forward<Functor>(f), id]
-       {
-         func();
-         std::lock_guard<std::mutex> lk{futuresMutex};
-         auto it = incompleteFutures.find(id);
-         assert(it != std::end(incompleteFutures) && "Invalid future iterator");
-         completeFutures.push_back(std::move(it->second));
-         incompleteFutures.erase(it);
-         if (incompleteFutures.empty())
-         {
-           futuresCV.notify_one();
-         }
-       }));
-    }
-
-    std::string ConfigurationAdminImpl::RandomInstanceName()
-    {
-      static const auto characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-      std::uniform_int_distribution<> dist(0, 61);
-      std::string randomString(6, '\0');
-      for(auto& c: randomString)
-      {
-        c = characters[dist(randomGenerator)];
-      }
-      return randomString;
-    }
-
-    void ConfigurationAdminImpl::AddFactoryInstanceIfRequired(const std::string& pid, const std::string &factoryPid)
-    {
-      if (factoryPid.empty())
-      {
-        return;
-      }
-      auto it = factoryInstances.find(factoryPid);
-      if (it == std::end(factoryInstances))
-      {
-        it = factoryInstances.emplace(factoryPid, std::set<std::string>{}).first;
-      }
-      it->second.insert(pid);
-    }
-
-    void ConfigurationAdminImpl::RemoveFactoryInstanceIfRequired(const std::string& pid)
-    {
-      const auto factoryPid = getFactoryPid(pid);
-      if (factoryPid.empty())
-      {
-        return;
-      }
-      auto it = factoryInstances.find(factoryPid);
-      if (it != std::end(factoryInstances))
-      {
-        it->second.erase(pid);
-        if (it->second.empty())
-        {
-          factoryInstances.erase(it);
-        }
       }
     }
-
-    void ConfigurationAdminImpl::WaitForAllAsync()
-    {
-      std::unique_lock<std::mutex> ul{futuresMutex};
-      if (!incompleteFutures.empty())
-      {
-        futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
-      }
+    for (const auto& pidAndProperties : pidsAndProperties) {
+      notifyServiceUpdated(pidAndProperties.first,
+                           *managedServiceFactory,
+                           pidAndProperties.second,
+                           *logger);
     }
-  } // cmimpl
+  });
+  logger->Log(
+    cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+    "New ManagedServiceFactory with PID " + pid +
+      " has been added, and async Update has been queued for all instances.");
+  return std::make_shared<TrackedServiceWrapper<
+    cppmicroservices::service::cm::ManagedServiceFactory>>(
+    pid, std::move(managedServiceFactory));
+}
+
+void ConfigurationAdminImpl::ModifiedService(
+  const ServiceReference<
+    cppmicroservices::service::cm::ManagedServiceFactory>& /* reference */,
+  const std::shared_ptr<TrackedServiceWrapper<
+    cppmicroservices::service::cm::ManagedServiceFactory>>& /* service */)
+{
+  // Assume the PID and component.name properties will never change, so noop
+}
+
+void ConfigurationAdminImpl::RemovedService(
+  const ServiceReference<
+    cppmicroservices::service::cm::ManagedServiceFactory>& /* reference */,
+  const std::shared_ptr<TrackedServiceWrapper<
+    cppmicroservices::service::cm::ManagedServiceFactory>>& service)
+{
+  // No need to do anything other than log; ManagedServiceFactory just won't receive any more updates to any of its Configurations.
+  logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+              "ManagedServiceFactory with PID " + service->pid +
+                " has been removed.");
+}
+
+template<typename Functor>
+void ConfigurationAdminImpl::PerformAsync(Functor&& f)
+{
+  std::lock_guard<std::mutex> lk{ futuresMutex };
+  decltype(completeFutures){}.swap(completeFutures);
+  auto id = ++futuresID;
+  incompleteFutures.emplace(
+    id,
+    std::async(std::launch::async, [this, func = std::forward<Functor>(f), id] {
+      func();
+      std::lock_guard<std::mutex> lk{ futuresMutex };
+      auto it = incompleteFutures.find(id);
+      assert(it != std::end(incompleteFutures) && "Invalid future iterator");
+      completeFutures.push_back(std::move(it->second));
+      incompleteFutures.erase(it);
+      if (incompleteFutures.empty()) {
+        futuresCV.notify_one();
+      }
+    }));
+}
+
+std::string ConfigurationAdminImpl::RandomInstanceName()
+{
+  static const auto characters =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  std::uniform_int_distribution<> dist(0, 61);
+  std::string randomString(6, '\0');
+  for (auto& c : randomString) {
+    c = characters[dist(randomGenerator)];
+  }
+  return randomString;
+}
+
+void ConfigurationAdminImpl::AddFactoryInstanceIfRequired(
+  const std::string& pid,
+  const std::string& factoryPid)
+{
+  if (factoryPid.empty()) {
+    return;
+  }
+  auto it = factoryInstances.find(factoryPid);
+  if (it == std::end(factoryInstances)) {
+    it = factoryInstances.emplace(factoryPid, std::set<std::string>{}).first;
+  }
+  it->second.insert(pid);
+}
+
+void ConfigurationAdminImpl::RemoveFactoryInstanceIfRequired(
+  const std::string& pid)
+{
+  const auto factoryPid = getFactoryPid(pid);
+  if (factoryPid.empty()) {
+    return;
+  }
+  auto it = factoryInstances.find(factoryPid);
+  if (it != std::end(factoryInstances)) {
+    it->second.erase(pid);
+    if (it->second.empty()) {
+      factoryInstances.erase(it);
+    }
+  }
+}
+
+void ConfigurationAdminImpl::WaitForAllAsync()
+{
+  std::unique_lock<std::mutex> ul{ futuresMutex };
+  if (!incompleteFutures.empty()) {
+    futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
+  }
+}
+} // cmimpl
 } // cppmicroservices

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -41,162 +41,202 @@
 #include "ConfigurationImpl.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * A wrapper class used for storing the pid of a given ManagedService or ManagedServiceFactory
-     * with the service in the ServiceTracker.
-     */
-    template <typename T>
-    class TrackedServiceWrapper
-    {
-    public:
-      using TrackedServiceType = T;
+/**
+ * A wrapper class used for storing the pid of a given ManagedService or ManagedServiceFactory
+ * with the service in the ServiceTracker.
+ */
+template<typename T>
+class TrackedServiceWrapper
+{
+public:
+  using TrackedServiceType = T;
 
-      TrackedServiceWrapper(std::string trackedPid, std::shared_ptr<TrackedServiceType> service)
-      : pid(std::move(trackedPid))
-      , trackedService(std::move(service))
-      {
-      }
+  TrackedServiceWrapper(std::string trackedPid,
+                        std::shared_ptr<TrackedServiceType> service)
+    : pid(std::move(trackedPid))
+    , trackedService(std::move(service))
+  {}
 
-      TrackedServiceWrapper(const TrackedServiceWrapper&) = delete;
-      TrackedServiceWrapper& operator=(const TrackedServiceWrapper&) = delete;
-      TrackedServiceWrapper(TrackedServiceWrapper&&) = delete;
-      TrackedServiceWrapper& operator=(TrackedServiceWrapper&&) = delete;
+  TrackedServiceWrapper(const TrackedServiceWrapper&) = delete;
+  TrackedServiceWrapper& operator=(const TrackedServiceWrapper&) = delete;
+  TrackedServiceWrapper(TrackedServiceWrapper&&) = delete;
+  TrackedServiceWrapper& operator=(TrackedServiceWrapper&&) = delete;
 
-      explicit operator bool() const
-      {
-        return static_cast<bool>(trackedService);
-      }
+  explicit operator bool() const { return static_cast<bool>(trackedService); }
 
-      std::string pid;
-      std::shared_ptr<TrackedServiceType> trackedService;
-    };
+  std::string pid;
+  std::shared_ptr<TrackedServiceType> trackedService;
+};
 
-    /**
-     * This class implements the {@code cppmicroservices::service::cm::ConfigurationAdmin} interface.
-     */
-    class ConfigurationAdminImpl final
-    : public cppmicroservices::service::cm::ConfigurationAdmin
-    , public ConfigurationAdminPrivate
-    , public cppmicroservices::ServiceTrackerCustomizer<cppmicroservices::service::cm::ManagedService,
-                                                        TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
-    , public cppmicroservices::ServiceTrackerCustomizer<cppmicroservices::service::cm::ManagedServiceFactory,
-                                                        TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
-    {
-    public:
-      ConfigurationAdminImpl(cppmicroservices::BundleContext cmContext,
-                             std::shared_ptr<cppmicroservices::logservice::LogService> logger);
-      ~ConfigurationAdminImpl() override;
-      ConfigurationAdminImpl(const ConfigurationAdminImpl&) = delete;
-      ConfigurationAdminImpl& operator=(const ConfigurationAdminImpl&) = delete;
-      ConfigurationAdminImpl(ConfigurationAdminImpl&&) = delete;
-      ConfigurationAdminImpl& operator=(ConfigurationAdminImpl&&) = delete;
+/**
+ * This class implements the {@code cppmicroservices::service::cm::ConfigurationAdmin} interface.
+ */
+class ConfigurationAdminImpl final
+  : public cppmicroservices::service::cm::ConfigurationAdmin
+  , public ConfigurationAdminPrivate
+  , public cppmicroservices::ServiceTrackerCustomizer<
+      cppmicroservices::service::cm::ManagedService,
+      TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
+  , public cppmicroservices::ServiceTrackerCustomizer<
+      cppmicroservices::service::cm::ManagedServiceFactory,
+      TrackedServiceWrapper<
+        cppmicroservices::service::cm::ManagedServiceFactory>>
+{
+public:
+  ConfigurationAdminImpl(
+    cppmicroservices::BundleContext cmContext,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  ~ConfigurationAdminImpl() override;
+  ConfigurationAdminImpl(const ConfigurationAdminImpl&) = delete;
+  ConfigurationAdminImpl& operator=(const ConfigurationAdminImpl&) = delete;
+  ConfigurationAdminImpl(ConfigurationAdminImpl&&) = delete;
+  ConfigurationAdminImpl& operator=(ConfigurationAdminImpl&&) = delete;
 
-      /**
-       * Get an existing or new {@code Configuration} object.
-       *
-       * See {@code ConfigurationAdmin#GetConfiguration}
-       */
-      std::shared_ptr<cppmicroservices::service::cm::Configuration> GetConfiguration(const std::string& pid) override;
+  /**
+   * Get an existing or new {@code Configuration} object.
+   *
+   * See {@code ConfigurationAdmin#GetConfiguration}
+   */
+  std::shared_ptr<cppmicroservices::service::cm::Configuration>
+  GetConfiguration(const std::string& pid) override;
 
-      /**
-       * Create a new {@code Configuration} object for a {@code ManagedServiceFactory}.
-       *
-       * See {@code ConfigurationAdmin#CreateFactoryConfiguration}
-       */
-      std::shared_ptr<cppmicroservices::service::cm::Configuration> CreateFactoryConfiguration(const std::string& factoryPid) override;
+  /**
+   * Create a new {@code Configuration} object for a {@code ManagedServiceFactory}.
+   *
+   * See {@code ConfigurationAdmin#CreateFactoryConfiguration}
+   */
+  std::shared_ptr<cppmicroservices::service::cm::Configuration>
+  CreateFactoryConfiguration(const std::string& factoryPid) override;
 
-      /**
-       * Get an existing or new {@code Configuration} object for a {@code ManagedServiceFactory}.
-       *
-       * See {@code ConfigurationAdmin#GetFactoryConfiguration}
-       */
-      std::shared_ptr<cppmicroservices::service::cm::Configuration> GetFactoryConfiguration(const std::string& factoryPid, const std::string& instanceName) override;
+  /**
+   * Get an existing or new {@code Configuration} object for a {@code ManagedServiceFactory}.
+   *
+   * See {@code ConfigurationAdmin#GetFactoryConfiguration}
+   */
+  std::shared_ptr<cppmicroservices::service::cm::Configuration>
+  GetFactoryConfiguration(const std::string& factoryPid,
+                          const std::string& instanceName) override;
 
-      /**
-       * Used to list all of the available {@code Configuration} objects.
-       *
-       * See {@code ConfigurationAdmin#ListConfigurations}
-       */
-      std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>> ListConfigurations(const std::string& filter) override;
+  /**
+   * Used to list all of the available {@code Configuration} objects.
+   *
+   * See {@code ConfigurationAdmin#ListConfigurations}
+   */
+  std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>>
+  ListConfigurations(const std::string& filter) override;
 
-      /**
-       * Internal method used by {@code CMBundleExtension} to add new {@code Configuration} objects
-       *
-       * See {@code ConfigurationAdminPrivate#AddConfigurations}
-       */
-       std::vector<ConfigurationAddedInfo>
-       AddConfigurations(std::vector<metadata::ConfigurationMetadata> configurationMetadata) override;
+  /**
+   * Internal method used by {@code CMBundleExtension} to add new {@code Configuration} objects
+   *
+   * See {@code ConfigurationAdminPrivate#AddConfigurations}
+   */
+  std::vector<ConfigurationAddedInfo> AddConfigurations(
+    std::vector<metadata::ConfigurationMetadata> configurationMetadata)
+    override;
 
-      /**
-       * Internal method used by {@code CMBundleExtension} to remove the {@code Configuration} objects that it created
-       *
-       * See {@code ConfigurationAdminPrivate#RemoveConfigurations}
-       */
-      void RemoveConfigurations(std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs) override;
+  /**
+   * Internal method used by {@code CMBundleExtension} to remove the {@code Configuration} objects that it created
+   *
+   * See {@code ConfigurationAdminPrivate#RemoveConfigurations}
+   */
+  void RemoveConfigurations(
+    std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs) override;
 
-      /**
-       * Internal method used to notify any {@code ManagedService} or {@code ManagedServiceFactory} of an
-       * update to a {@code Configuration}. Performs the notifications asynchronously with the latest state
-       * of the properties at the time.
-       *
-       * See {@code ConfigurationAdminPrivate#NotifyConfigurationUpdated}
-       */
-      void NotifyConfigurationUpdated(const std::string& pid) override;
+  /**
+   * Internal method used to notify any {@code ManagedService} or {@code ManagedServiceFactory} of an
+   * update to a {@code Configuration}. Performs the notifications asynchronously with the latest state
+   * of the properties at the time.
+   *
+   * See {@code ConfigurationAdminPrivate#NotifyConfigurationUpdated}
+   */
+  void NotifyConfigurationUpdated(const std::string& pid) override;
 
-      /**
-       * Internal method used by {@code ConfigurationImpl} to notify any {@code ManagedService} or
-       * {@code ManagedServiceFactory} of the removal of a {@code Configuration}. Performs the notifications
-       * asynchronously.
-       *
-       * See {@code ConfigurationAdminPrivate#NotifyConfigurationRemoved}
-       */
-      void NotifyConfigurationRemoved(const std::string& pid, std::uintptr_t configurationId) override;
+  /**
+   * Internal method used by {@code ConfigurationImpl} to notify any {@code ManagedService} or
+   * {@code ManagedServiceFactory} of the removal of a {@code Configuration}. Performs the notifications
+   * asynchronously.
+   *
+   * See {@code ConfigurationAdminPrivate#NotifyConfigurationRemoved}
+   */
+  void NotifyConfigurationRemoved(const std::string& pid,
+                                  std::uintptr_t configurationId) override;
 
-      // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedService
-      std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> AddingService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& reference) override;
-      void ModifiedService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& reference,
-                           const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>& service) override;
-      void RemovedService(const ServiceReference<cppmicroservices::service::cm::ManagedService>& reference,
-                          const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>& service) override;
+  // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedService
+  std::shared_ptr<
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
+  AddingService(
+    const ServiceReference<cppmicroservices::service::cm::ManagedService>&
+      reference) override;
+  void ModifiedService(
+    const ServiceReference<cppmicroservices::service::cm::ManagedService>&
+      reference,
+    const std::shared_ptr<
+      TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>&
+      service) override;
+  void RemovedService(
+    const ServiceReference<cppmicroservices::service::cm::ManagedService>&
+      reference,
+    const std::shared_ptr<
+      TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>&
+      service) override;
 
-      // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedServiceFactory
-      std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> AddingService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& reference) override;
-      void ModifiedService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& reference,
-                           const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>& service) override;
-      void RemovedService(const ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory>& reference,
-                          const std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>& service) override;
+  // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedServiceFactory
+  std::shared_ptr<
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
+  AddingService(const ServiceReference<
+                cppmicroservices::service::cm::ManagedServiceFactory>&
+                  reference) override;
+  void ModifiedService(
+    const ServiceReference<
+      cppmicroservices::service::cm::ManagedServiceFactory>& reference,
+    const std::shared_ptr<TrackedServiceWrapper<
+      cppmicroservices::service::cm::ManagedServiceFactory>>& service) override;
+  void RemovedService(
+    const ServiceReference<
+      cppmicroservices::service::cm::ManagedServiceFactory>& reference,
+    const std::shared_ptr<TrackedServiceWrapper<
+      cppmicroservices::service::cm::ManagedServiceFactory>>& service) override;
 
-      // Only used by pkgtest to avoid race conditions.
-      void WaitForAllAsync();
+  // Only used by pkgtest to avoid race conditions.
+  void WaitForAllAsync();
 
-    private:
-      // Convenience wrapper which is used to perform asyncronous operations
-      template <typename Functor> void PerformAsync(Functor&& f);
+private:
+  // Convenience wrapper which is used to perform asyncronous operations
+  template<typename Functor>
+  void PerformAsync(Functor&& f);
 
-      // Used to generate a random instance name for CreateFactoryConfiguration
-      std::string RandomInstanceName();
+  // Used to generate a random instance name for CreateFactoryConfiguration
+  std::string RandomInstanceName();
 
-      // Used to keep track of the instances of each ManagedServiceFactory
-      void AddFactoryInstanceIfRequired(const std::string& pid, const std::string& factoryPid);
-      void RemoveFactoryInstanceIfRequired(const std::string& pid);
+  // Used to keep track of the instances of each ManagedServiceFactory
+  void AddFactoryInstanceIfRequired(const std::string& pid,
+                                    const std::string& factoryPid);
+  void RemoveFactoryInstanceIfRequired(const std::string& pid);
 
-      cppmicroservices::BundleContext cmContext;
-      std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-      std::mutex configurationsMutex;
-      std::unordered_map<std::string, std::shared_ptr<ConfigurationImpl>> configurations;
-      std::unordered_map<std::string, std::set<std::string>> factoryInstances;
-      std::mutex futuresMutex;
-      std::uint64_t futuresID;
-      std::condition_variable futuresCV;
-      std::vector<std::future<void>> completeFutures;
-      std::unordered_map<std::uint64_t, std::future<void>> incompleteFutures;
-      cppmicroservices::ServiceTracker<cppmicroservices::service::cm::ManagedService, TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> managedServiceTracker;
-      cppmicroservices::ServiceTracker<cppmicroservices::service::cm::ManagedServiceFactory, TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> managedServiceFactoryTracker;
-      std::mt19937 randomGenerator;
-    };
-  } // cmimpl
+  cppmicroservices::BundleContext cmContext;
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger;
+  std::mutex configurationsMutex;
+  std::unordered_map<std::string, std::shared_ptr<ConfigurationImpl>>
+    configurations;
+  std::unordered_map<std::string, std::set<std::string>> factoryInstances;
+  std::mutex futuresMutex;
+  std::uint64_t futuresID;
+  std::condition_variable futuresCV;
+  std::vector<std::future<void>> completeFutures;
+  std::unordered_map<std::uint64_t, std::future<void>> incompleteFutures;
+  cppmicroservices::ServiceTracker<
+    cppmicroservices::service::cm::ManagedService,
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
+    managedServiceTracker;
+  cppmicroservices::ServiceTracker<
+    cppmicroservices::service::cm::ManagedServiceFactory,
+    TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
+    managedServiceFactoryTracker;
+  std::mt19937 randomGenerator;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif /* CONFIGURATIONADMINIMPL_HPP */

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminPrivate.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminPrivate.hpp
@@ -29,83 +29,83 @@
 #include "metadata/ConfigurationMetadata.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * This class is a convenience container for tracking added Configurations.
-     */
-    struct ConfigurationAddedInfo final
-    {
-      ConfigurationAddedInfo(std::string pidAdded,
-                             unsigned long changeCountAdded,
-                             std::uintptr_t configurationIdAdded)
-      : pid(std::move(pidAdded))
-      , changeCount(std::move(changeCountAdded))
-      , configurationId(std::move(configurationIdAdded))
-      {
-      }
+/**
+ * This class is a convenience container for tracking added Configurations.
+ */
+struct ConfigurationAddedInfo final
+{
+  ConfigurationAddedInfo(std::string pidAdded,
+                         unsigned long changeCountAdded,
+                         std::uintptr_t configurationIdAdded)
+    : pid(std::move(pidAdded))
+    , changeCount(std::move(changeCountAdded))
+    , configurationId(std::move(configurationIdAdded))
+  {}
 
-      bool operator==(const ConfigurationAddedInfo& other) const
-      {
-        return ((pid == other.pid) &&
-                (changeCount == other.changeCount) &&
-                (configurationId == other.configurationId));
-      }
+  bool operator==(const ConfigurationAddedInfo& other) const
+  {
+    return ((pid == other.pid) && (changeCount == other.changeCount) &&
+            (configurationId == other.configurationId));
+  }
 
-      std::string pid;
-      unsigned long changeCount;
-      std::uintptr_t configurationId;
-    };
+  std::string pid;
+  unsigned long changeCount;
+  std::uintptr_t configurationId;
+};
 
-    /**
-     * This class declares the internal methods of ConfigurationAdmin.
-     */
-    class ConfigurationAdminPrivate
-    {
-    public:
-      virtual ~ConfigurationAdminPrivate() = default;
+/**
+ * This class declares the internal methods of ConfigurationAdmin.
+ */
+class ConfigurationAdminPrivate
+{
+public:
+  virtual ~ConfigurationAdminPrivate() = default;
 
-      /**
-       * Internal method used by {@code CMBundleExtension} to add new {@code Configuration} objects
-       *
-       * @param configurationMetadata A vector of {@code ConfigurationMetadata} to create {@code Configuration} objects for
-       * @return A vector of ConfigurationAddedInfos, which store the PIDs, changeCounts, and configurationIds of the
-       *         Configurations that have been created/updated by this method.
-       */
-       virtual std::vector<ConfigurationAddedInfo>
-       AddConfigurations(std::vector<metadata::ConfigurationMetadata> configurationMetadata) = 0;
+  /**
+   * Internal method used by {@code CMBundleExtension} to add new {@code Configuration} objects
+   *
+   * @param configurationMetadata A vector of {@code ConfigurationMetadata} to create {@code Configuration} objects for
+   * @return A vector of ConfigurationAddedInfos, which store the PIDs, changeCounts, and configurationIds of the
+   *         Configurations that have been created/updated by this method.
+   */
+  virtual std::vector<ConfigurationAddedInfo> AddConfigurations(
+    std::vector<metadata::ConfigurationMetadata> configurationMetadata) = 0;
 
-      /**
-       * Internal method used by {@code CMBundleExtension} to remove the {@code Configuration} objects that it created
-       *
-       * @param pidsAndChangeCountsAndIDs A vector of ConfigurationAddedInfos which contain the PIDs to remove,
-       *        the changeCount that was associated with adding them, and the IDs of the Configuration objects
-       *        when they were added. The combination of these three values is used to prevent the removal of
-       *        any  {@code Configuration} which has subsequently been updated by other services since the
-       *        {@code CMBundleExtension} added them.
-       */
-      virtual void RemoveConfigurations(std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs) = 0;
+  /**
+   * Internal method used by {@code CMBundleExtension} to remove the {@code Configuration} objects that it created
+   *
+   * @param pidsAndChangeCountsAndIDs A vector of ConfigurationAddedInfos which contain the PIDs to remove,
+   *        the changeCount that was associated with adding them, and the IDs of the Configuration objects
+   *        when they were added. The combination of these three values is used to prevent the removal of
+   *        any  {@code Configuration} which has subsequently been updated by other services since the
+   *        {@code CMBundleExtension} added them.
+   */
+  virtual void RemoveConfigurations(
+    std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs) = 0;
 
-      /**
-       * Internal method used to notify any {@code ManagedService} or {@code ManagedServiceFactory} of an
-       * update to a {@code Configuration}. Performs the notifications asynchronously with the latest state
-       * of the properties at the time.
-       *
-       * @param pid The PID of the {@code Configuration} which has been updated
-       */
-      virtual void NotifyConfigurationUpdated(const std::string& pid)  = 0;
+  /**
+   * Internal method used to notify any {@code ManagedService} or {@code ManagedServiceFactory} of an
+   * update to a {@code Configuration}. Performs the notifications asynchronously with the latest state
+   * of the properties at the time.
+   *
+   * @param pid The PID of the {@code Configuration} which has been updated
+   */
+  virtual void NotifyConfigurationUpdated(const std::string& pid) = 0;
 
-      /**
-       * Internal method used by {@code ConfigurationImpl} to notify any {@code ManagedService} or
-       * {@code ManagedServiceFactory} of the removal of a {@code Configuration}. Performs the notifications
-       * asynchronously.
-       *
-       * @param pid The PID of the {@code Configuration} which has been removed.
-       * @param configurationId The unique id of the configuration which has been removed. Used to avoid race conditions.
-       */
-      virtual void NotifyConfigurationRemoved(const std::string& pid, std::uintptr_t configurationId) = 0;
-    };
-  } // cmimpl
+  /**
+   * Internal method used by {@code ConfigurationImpl} to notify any {@code ManagedService} or
+   * {@code ManagedServiceFactory} of the removal of a {@code Configuration}. Performs the notifications
+   * asynchronously.
+   *
+   * @param pid The PID of the {@code Configuration} which has been removed.
+   * @param configurationId The unique id of the configuration which has been removed. Used to avoid race conditions.
+   */
+  virtual void NotifyConfigurationRemoved(const std::string& pid,
+                                          std::uintptr_t configurationId) = 0;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif /* CONFIGURATIONADMINPRIVATE_HPP */

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
@@ -31,100 +31,104 @@
 #include "ConfigurationPrivate.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * This class implements the {@code cppmicroservices::service::cm::Configuration} interface.
-     */
-    class ConfigurationImpl final : public cppmicroservices::service::cm::Configuration, public ConfigurationPrivate
-    {
-    public:
-      ConfigurationImpl(ConfigurationAdminPrivate* configAdminImpl,
-                        std::string pid,
-                        std::string factoryPid,
-                        AnyMap properties);
-      ~ConfigurationImpl() override = default;
-      ConfigurationImpl(const ConfigurationImpl&) = delete;
-      ConfigurationImpl& operator=(const ConfigurationImpl&) = delete;
-      ConfigurationImpl(ConfigurationImpl&&) = delete;
-      ConfigurationImpl& operator=(ConfigurationImpl&&) = delete;
+/**
+ * This class implements the {@code cppmicroservices::service::cm::Configuration} interface.
+ */
+class ConfigurationImpl final
+  : public cppmicroservices::service::cm::Configuration
+  , public ConfigurationPrivate
+{
+public:
+  ConfigurationImpl(ConfigurationAdminPrivate* configAdminImpl,
+                    std::string pid,
+                    std::string factoryPid,
+                    AnyMap properties);
+  ~ConfigurationImpl() override = default;
+  ConfigurationImpl(const ConfigurationImpl&) = delete;
+  ConfigurationImpl& operator=(const ConfigurationImpl&) = delete;
+  ConfigurationImpl(ConfigurationImpl&&) = delete;
+  ConfigurationImpl& operator=(ConfigurationImpl&&) = delete;
 
-      /**
-       * Get the PID of this Configuration.
-       *
-       * See {@code Configuration#GetPid}
-       */
-      std::string GetPid() const override;
+  /**
+   * Get the PID of this Configuration.
+   *
+   * See {@code Configuration#GetPid}
+   */
+  std::string GetPid() const override;
 
-      /**
-       * Get the Factory PID which is responsible for this Configuration.
-       *
-       * See {@code Configuration#GetFactoryPid}
-       */
-      std::string GetFactoryPid() const override;
+  /**
+   * Get the Factory PID which is responsible for this Configuration.
+   *
+   * See {@code Configuration#GetFactoryPid}
+   */
+  std::string GetFactoryPid() const override;
 
-      /**
-       * Get the properties of this Configuration.
-       *
-       * See {@code Configuration#GetProperties}
-       */
-      AnyMap GetProperties() const override;
+  /**
+   * Get the properties of this Configuration.
+   *
+   * See {@code Configuration#GetProperties}
+   */
+  AnyMap GetProperties() const override;
 
-      /**
-       * Update the properties of this Configuration.
-       *
-       * See {@code Configuration#Update}
-       */
-      void Update(AnyMap properties) override;
+  /**
+   * Update the properties of this Configuration.
+   *
+   * See {@code Configuration#Update}
+   */
+  void Update(AnyMap properties) override;
 
-      /**
-       * Update the properties of this Configuration if they differ from the current properties.
-       *
-       * See {@code Configuration#UpdateIfDifferent}
-       */
-      bool UpdateIfDifferent(AnyMap properties) override;
+  /**
+   * Update the properties of this Configuration if they differ from the current properties.
+   *
+   * See {@code Configuration#UpdateIfDifferent}
+   */
+  bool UpdateIfDifferent(AnyMap properties) override;
 
-      /**
-       * Remove this Configuration from ConfigurationAdmin.
-       *
-       * See {@code Configuration#Remove}
-       */
-      void Remove() override;
+  /**
+   * Remove this Configuration from ConfigurationAdmin.
+   *
+   * See {@code Configuration#Remove}
+   */
+  void Remove() override;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to update the properties without triggering
-       * the notification to the corresponding ManagedService / ManagedServiceFactory.
-       *
-       * See {@code ConfigurationPrivate#UpdateWithoutNotificationIfDifferent}
-       */
-      std::pair<bool, unsigned long> UpdateWithoutNotificationIfDifferent(AnyMap properties) override;
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to update the properties without triggering
+   * the notification to the corresponding ManagedService / ManagedServiceFactory.
+   *
+   * See {@code ConfigurationPrivate#UpdateWithoutNotificationIfDifferent}
+   */
+  std::pair<bool, unsigned long> UpdateWithoutNotificationIfDifferent(
+    AnyMap properties) override;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to Remove the Configuration without triggering
-       * the notification to the corresponding ManagedService / ManagedServiceFactory.
-       *
-       * See {@code ConfigurationPrivate#RemoveWithoutNotificationIfChangeCountEquals}
-       */
-      bool RemoveWithoutNotificationIfChangeCountEquals(unsigned long expectedChangeCount) override;
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to Remove the Configuration without triggering
+   * the notification to the corresponding ManagedService / ManagedServiceFactory.
+   *
+   * See {@code ConfigurationPrivate#RemoveWithoutNotificationIfChangeCountEquals}
+   */
+  bool RemoveWithoutNotificationIfChangeCountEquals(
+    unsigned long expectedChangeCount) override;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to invalidate the Configuration.
-       *
-       * See {@code ConfigurationPrivate#Invalidate}
-       */
-      void Invalidate() override;
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to invalidate the Configuration.
+   *
+   * See {@code ConfigurationPrivate#Invalidate}
+   */
+  void Invalidate() override;
 
-    private:
-      std::mutex configAdminMutex;
-      ConfigurationAdminPrivate* configAdminImpl;
-      mutable std::mutex propertiesMutex;
-      std::string pid;
-      std::string factoryPid;
-      AnyMap properties;
-      unsigned long changeCount;
-      bool removed;
-    };
-  } // cmimpl
+private:
+  std::mutex configAdminMutex;
+  ConfigurationAdminPrivate* configAdminImpl;
+  mutable std::mutex propertiesMutex;
+  std::string pid;
+  std::string factoryPid;
+  AnyMap properties;
+  unsigned long changeCount;
+  bool removed;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif // CONFIGURATIONIMPL_HPP

--- a/compendium/ConfigurationAdmin/src/ConfigurationPrivate.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationPrivate.hpp
@@ -28,45 +28,47 @@
 #include "ConfigurationAdminPrivate.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * This class declares the internal methods of Configuration
-     */
-    class ConfigurationPrivate
-    {
-    public:
-      virtual ~ConfigurationPrivate() = default;
+/**
+ * This class declares the internal methods of Configuration
+ */
+class ConfigurationPrivate
+{
+public:
+  virtual ~ConfigurationPrivate() = default;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to update the properties without triggering
-       * the notification to the corresponding ManagedService / ManagedServiceFactory. That will be taken
-       * care of by {@code ConfigurationAdminImpl} instead.
-       *
-       * @param properties The properties to update this Configuration with (if they differ)
-       * @return boolean indicating whether this Configuration has been updated or not, and the value of
-       */
-      virtual std::pair<bool, unsigned long> UpdateWithoutNotificationIfDifferent(AnyMap properties) = 0;
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to update the properties without triggering
+   * the notification to the corresponding ManagedService / ManagedServiceFactory. That will be taken
+   * care of by {@code ConfigurationAdminImpl} instead.
+   *
+   * @param properties The properties to update this Configuration with (if they differ)
+   * @return boolean indicating whether this Configuration has been updated or not, and the value of
+   */
+  virtual std::pair<bool, unsigned long> UpdateWithoutNotificationIfDifferent(
+    AnyMap properties) = 0;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to Remove the Configuration without triggering
-       * the notification to the corresponding ManagedService / ManagedServiceFactory. That will be taken
-       * care of by {@code ConfigurationAdminImpl} instead.
-       *
-       * @param expectedChangeCount the expected value of the changeCount. The Configuration will only be
-       *        removed if this equals the actual change count.
-       * @return boolean indicating whether the change count was correct, and therefore whether this
-       *         configuration has been Removed or not.
-       */
-      virtual bool RemoveWithoutNotificationIfChangeCountEquals(unsigned long expectedChangeCount) = 0;
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to Remove the Configuration without triggering
+   * the notification to the corresponding ManagedService / ManagedServiceFactory. That will be taken
+   * care of by {@code ConfigurationAdminImpl} instead.
+   *
+   * @param expectedChangeCount the expected value of the changeCount. The Configuration will only be
+   *        removed if this equals the actual change count.
+   * @return boolean indicating whether the change count was correct, and therefore whether this
+   *         configuration has been Removed or not.
+   */
+  virtual bool RemoveWithoutNotificationIfChangeCountEquals(
+    unsigned long expectedChangeCount) = 0;
 
-      /**
-       * Internal method used by {@code ConfigurationAdminImpl} to invalidate the Configuration. Used when
-       * ConfigurationAdminImpl is shutting down or when it is deleting a Configuration.
-       */
-      virtual void Invalidate() = 0;
-    };
-  } // cmimpl
+  /**
+   * Internal method used by {@code ConfigurationAdminImpl} to invalidate the Configuration. Used when
+   * ConfigurationAdminImpl is shutting down or when it is deleting a Configuration.
+   */
+  virtual void Invalidate() = 0;
+};
+} // cmimpl
 } // cppmicroservices
 
 #endif // CONFIGURATIONPRIVATE_HPP

--- a/compendium/ConfigurationAdmin/src/metadata/ConfigurationMetadata.hpp
+++ b/compendium/ConfigurationAdmin/src/metadata/ConfigurationMetadata.hpp
@@ -28,28 +28,28 @@
 #include "cppmicroservices/AnyMap.h"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
-      /**
-       * Stores configuration information parsed from the configuration properties
-       */
-      struct ConfigurationMetadata final
-      {
-        ConfigurationMetadata()
-        : pid()
-        , properties(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
-        {}
+namespace cmimpl {
+namespace metadata {
+/**
+ * Stores configuration information parsed from the configuration properties
+ */
+struct ConfigurationMetadata final
+{
+  ConfigurationMetadata()
+    : pid()
+    , properties(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
+  {}
 
-        ConfigurationMetadata(std::string thePid, AnyMap props)
-        : pid(std::move(thePid))
-        , properties(std::move(props))
-        {}
+  ConfigurationMetadata(std::string thePid, AnyMap props)
+    : pid(std::move(thePid))
+    , properties(std::move(props))
+  {}
 
-        std::string pid;
-        AnyMap properties;
-      };
-    } // metadata
-  } // cmimpl
+  std::string pid;
+  AnyMap properties;
+};
+} // metadata
+} // cmimpl
 } // cppmicroservices
 
 #endif //CONFIGURATIONMETADATA_HPP

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParser.hpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParser.hpp
@@ -26,38 +26,41 @@
 #include "ConfigurationMetadata.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
+namespace cmimpl {
+namespace metadata {
 
-      /*
-       * @brief Represents an abstract metadata parser.
-       *
-       * Whenever there is a change in the service description JSON file-format:
-       *  1. The "version" field in the manifest should be bumped-up by one.
-       *  2. A new concrete class that implements the following
-       *     interface is implemented, which would contain the logic to parse
-       *     that particular change of the manifest file-format.
-       *  3. The MetadataParserFactory is changed to create and return
-       *     that implementation for the corresponding version of the manifest.
-       * This way, because the CM Bundle Extension depends on the
-       * following interface instead of any concrete implementation, it
-       * supports multiple versions of the manifest.
-       */
-      class MetadataParser {
-      public:
-        virtual ~MetadataParser() = default;
+/*
+ * @brief Represents an abstract metadata parser.
+ *
+ * Whenever there is a change in the service description JSON file-format:
+ *  1. The "version" field in the manifest should be bumped-up by one.
+ *  2. A new concrete class that implements the following
+ *     interface is implemented, which would contain the logic to parse
+ *     that particular change of the manifest file-format.
+ *  3. The MetadataParserFactory is changed to create and return
+ *     that implementation for the corresponding version of the manifest.
+ * This way, because the CM Bundle Extension depends on the
+ * following interface instead of any concrete implementation, it
+ * supports multiple versions of the manifest.
+ */
+class MetadataParser
+{
+public:
+  virtual ~MetadataParser() = default;
 
-        /*
-         * @brief Parses and returns a vector of the configuration metadata
-         * @param anymap An @c AnyMap representation of the configuration properties
-         * @returns a vector of parsed @c ConfigurationMetadata
-         */
-        virtual std::vector<ConfigurationMetadata> ParseAndGetConfigurationMetadata(const AnyMap& anymap) const = 0;
-      protected:
-        MetadataParser() = default;
-      };
-    } // metadata
-  } // cmimpl
+  /*
+   * @brief Parses and returns a vector of the configuration metadata
+   * @param anymap An @c AnyMap representation of the configuration properties
+   * @returns a vector of parsed @c ConfigurationMetadata
+   */
+  virtual std::vector<ConfigurationMetadata> ParseAndGetConfigurationMetadata(
+    const AnyMap& anymap) const = 0;
+
+protected:
+  MetadataParser() = default;
+};
+} // metadata
+} // cmimpl
 } // cppmicroservices
 
 #endif //METADATAPARSER_HPP

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParserFactory.hpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParserFactory.hpp
@@ -26,36 +26,37 @@
 #include "MetadataParserImpl.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
-      /*
-       * Houses a factory member function to return a @c MetadataParser
-       */
-      class MetadataParserFactory final
-      {
-      public:
-        /*
-         * @brief returns a @c MetadataParser object
-         * @param version The version of the metadataparser to be parsed
-         * @param logger A @c LogService object
-         * @returns an unique_ptr to the created @c MetadataParser object
-         * @throws std::runtime_error if the version isn't supported
-         */
-        static std::unique_ptr<MetadataParser> Create(uint64_t version, std::shared_ptr<cppmicroservices::logservice::LogService> logger)
-        {
-          switch (version)
-          {
-            case 1:
-              return std::make_unique<MetadataParserImplV1>(logger);
-            default:
-              throw std::runtime_error("Unsupported manifest file version '" + std::to_string(version) + "'");
-              return nullptr;
-          }
-        }
-      };
-    } // metadata
-  } // cmimpl
+namespace cmimpl {
+namespace metadata {
+/*
+ * Houses a factory member function to return a @c MetadataParser
+ */
+class MetadataParserFactory final
+{
+public:
+  /*
+   * @brief returns a @c MetadataParser object
+   * @param version The version of the metadataparser to be parsed
+   * @param logger A @c LogService object
+   * @returns an unique_ptr to the created @c MetadataParser object
+   * @throws std::runtime_error if the version isn't supported
+   */
+  static std::unique_ptr<MetadataParser> Create(
+    uint64_t version,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+  {
+    switch (version) {
+      case 1:
+        return std::make_unique<MetadataParserImplV1>(logger);
+      default:
+        throw std::runtime_error("Unsupported manifest file version '" +
+                                 std::to_string(version) + "'");
+        return nullptr;
+    }
+  }
+};
+} // metadata
+} // cmimpl
 } // cppmicroservices
 
 #endif //METADATAPARSERFACTORY_HPP
-

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
@@ -28,49 +28,49 @@
 #include "MetadataParserImpl.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
+namespace cmimpl {
+namespace metadata {
 
-      MetadataParserImplV1::MetadataParserImplV1(std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
-      : logger(std::move(lggr))
-      {
-      }
+MetadataParserImplV1::MetadataParserImplV1(
+  std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
+  : logger(std::move(lggr))
+{}
 
-      std::vector<ConfigurationMetadata>
-      MetadataParserImplV1::ParseAndGetConfigurationMetadata(const cppmicroservices::AnyMap& cmMap) const
-      {
-        std::vector<ConfigurationMetadata> configurationMetadata;
+std::vector<ConfigurationMetadata>
+MetadataParserImplV1::ParseAndGetConfigurationMetadata(
+  const cppmicroservices::AnyMap& cmMap) const
+{
+  std::vector<ConfigurationMetadata> configurationMetadata;
 
-        // Will throw if the object doesn't exist or has the wrong type
-        if (0u == cmMap.count("configurations"))
-        {
-          throw std::runtime_error("Metadata is missing mandatory 'configurations' property");
-        }
-        auto &configurations = cppmicroservices::ref_any_cast<std::vector<cppmicroservices::Any>>(
-          cmMap.at("configurations"));
+  // Will throw if the object doesn't exist or has the wrong type
+  if (0u == cmMap.count("configurations")) {
+    throw std::runtime_error(
+      "Metadata is missing mandatory 'configurations' property");
+  }
+  auto& configurations =
+    cppmicroservices::ref_any_cast<std::vector<cppmicroservices::Any>>(
+      cmMap.at("configurations"));
 
-        std::size_t index = 0;
-        for (auto& configurationAny : configurations)
-        {
-          // Allow exception to escape if any Configuration isn't an AnyMap
-          auto& config =
-              cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(configurationAny);
-          try
-          {
-              auto pid = cppmicroservices::any_cast<std::string>(config.at("pid"));
-              auto properties = cppmicroservices::any_cast<cppmicroservices::AnyMap>(config.at("properties"));
-              configurationMetadata.emplace_back(std::move(pid), std::move(properties));
-          }
-          catch (const std::exception& ex)
-          {
-            auto msg = std::string(ex.what());
-            msg += " Could not load the configuration with index: " + std::to_string(index);
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, msg);
-          }
-          ++index;
-        }
-        return configurationMetadata;
-      }
-    } // metadata
-  } // cmimpl
+  std::size_t index = 0;
+  for (auto& configurationAny : configurations) {
+    // Allow exception to escape if any Configuration isn't an AnyMap
+    auto& config = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(
+      configurationAny);
+    try {
+      auto pid = cppmicroservices::any_cast<std::string>(config.at("pid"));
+      auto properties = cppmicroservices::any_cast<cppmicroservices::AnyMap>(
+        config.at("properties"));
+      configurationMetadata.emplace_back(std::move(pid), std::move(properties));
+    } catch (const std::exception& ex) {
+      auto msg = std::string(ex.what());
+      msg += " Could not load the configuration with index: " +
+             std::to_string(index);
+      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, msg);
+    }
+    ++index;
+  }
+  return configurationMetadata;
+}
+} // metadata
+} // cmimpl
 } // cppmicroservices

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.hpp
@@ -28,34 +28,36 @@
 #include "MetadataParser.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
-      /*
-       * Represents a concrete implementation (Version 1) of the MetadataParser
-       */
-      class MetadataParserImplV1 final : public MetadataParser
-      {
-      public:
-        MetadataParserImplV1(std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+namespace cmimpl {
+namespace metadata {
+/*
+ * Represents a concrete implementation (Version 1) of the MetadataParser
+ */
+class MetadataParserImplV1 final : public MetadataParser
+{
+public:
+  MetadataParserImplV1(
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
 
-        ~MetadataParserImplV1() override = default;
-        MetadataParserImplV1(const MetadataParserImplV1&) = delete;
-        MetadataParserImplV1& operator=(const MetadataParserImplV1&) = delete;
-        MetadataParserImplV1(MetadataParserImplV1&&) = delete;
-        MetadataParserImplV1& operator=(MetadataParserImplV1&&) = delete;
+  ~MetadataParserImplV1() override = default;
+  MetadataParserImplV1(const MetadataParserImplV1&) = delete;
+  MetadataParserImplV1& operator=(const MetadataParserImplV1&) = delete;
+  MetadataParserImplV1(MetadataParserImplV1&&) = delete;
+  MetadataParserImplV1& operator=(MetadataParserImplV1&&) = delete;
 
-        /*
-         * @brief Parse and return the vector of ComponentMetadata
-         * @param metadata The value of the key "cm" in the manifest
-         * @returns the vector of @ConfigurationMetadata objects
-         */
-        std::vector<ConfigurationMetadata> ParseAndGetConfigurationMetadata(const AnyMap& scrmap) const override;
+  /*
+   * @brief Parse and return the vector of ComponentMetadata
+   * @param metadata The value of the key "cm" in the manifest
+   * @returns the vector of @ConfigurationMetadata objects
+   */
+  std::vector<ConfigurationMetadata> ParseAndGetConfigurationMetadata(
+    const AnyMap& scrmap) const override;
 
-      private:
-        std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-      };
-    } // metadata
-  } // cmimpl
+private:
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger;
+};
+} // metadata
+} // cmimpl
 } // cppmicroservices
 
 #endif //METADATAPARSERIMPL_HPP

--- a/compendium/ConfigurationAdmin/test/Mocks.hpp
+++ b/compendium/ConfigurationAdmin/test/Mocks.hpp
@@ -32,68 +32,99 @@
 #include "../src/ConfigurationAdminPrivate.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    /**
-     * This class is used in tests where the logger is required and the test
-     * needs to verify what is sent to the logger
-     */
-    class MockLogger : public cppmicroservices::logservice::LogService
-    {
-    public:
-      MOCK_METHOD2(Log, void(cppmicroservices::logservice::SeverityLevel, const std::string&));
-      MOCK_METHOD3(Log, void(cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr));
-      MOCK_METHOD3(Log, void(const cppmicroservices::ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&));
-      MOCK_METHOD4(Log, void(const cppmicroservices::ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr));
-    };
+/**
+ * This class is used in tests where the logger is required and the test
+ * needs to verify what is sent to the logger
+ */
+class MockLogger : public cppmicroservices::logservice::LogService
+{
+public:
+  MOCK_METHOD2(Log,
+               void(cppmicroservices::logservice::SeverityLevel,
+                    const std::string&));
+  MOCK_METHOD3(Log,
+               void(cppmicroservices::logservice::SeverityLevel,
+                    const std::string&,
+                    const std::exception_ptr));
+  MOCK_METHOD3(Log,
+               void(const cppmicroservices::ServiceReferenceBase&,
+                    cppmicroservices::logservice::SeverityLevel,
+                    const std::string&));
+  MOCK_METHOD4(Log,
+               void(const cppmicroservices::ServiceReferenceBase&,
+                    cppmicroservices::logservice::SeverityLevel,
+                    const std::string&,
+                    const std::exception_ptr));
+};
 
-    /**
-     * This class is used in tests where the logger is required but the test
-     * does not care if anything is actually sent to the logger
-     */
-    class FakeLogger : public cppmicroservices::logservice::LogService
-    {
-    public:
-      void Log(cppmicroservices::logservice::SeverityLevel, const std::string&) override {}
-      void Log(cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr) override {}
-      void Log(const ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&) override {}
-      void Log(const ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr) override {}
-    };
+/**
+ * This class is used in tests where the logger is required but the test
+ * does not care if anything is actually sent to the logger
+ */
+class FakeLogger : public cppmicroservices::logservice::LogService
+{
+public:
+  void Log(cppmicroservices::logservice::SeverityLevel,
+           const std::string&) override
+  {}
+  void Log(cppmicroservices::logservice::SeverityLevel,
+           const std::string&,
+           const std::exception_ptr) override
+  {}
+  void Log(const ServiceReferenceBase&,
+           cppmicroservices::logservice::SeverityLevel,
+           const std::string&) override
+  {}
+  void Log(const ServiceReferenceBase&,
+           cppmicroservices::logservice::SeverityLevel,
+           const std::string&,
+           const std::exception_ptr) override
+  {}
+};
 
-    /**
-     * This class is used in tests which need to verify that the Updated method of
-     * a ManagedService is called as expected. The mock can be registered with the
-     * Framework to "inject" it into the class under test.
-     */
-    class MockManagedService : public cppmicroservices::service::cm::ManagedService {
-    public:
-      MOCK_METHOD1(Updated, void(const AnyMap&));
-    };
+/**
+ * This class is used in tests which need to verify that the Updated method of
+ * a ManagedService is called as expected. The mock can be registered with the
+ * Framework to "inject" it into the class under test.
+ */
+class MockManagedService : public cppmicroservices::service::cm::ManagedService
+{
+public:
+  MOCK_METHOD1(Updated, void(const AnyMap&));
+};
 
-    /**
-     * This class is used in tests which need to verify that the Updated and Removed
-     * methods of a ManagedService are called as expected. The mock can be registered
-     * with the Framework to "inject" it into the class under test.
-     */
-    class MockManagedServiceFactory : public cppmicroservices::service::cm::ManagedServiceFactory {
-    public:
-      MOCK_METHOD2(Updated, void(const std::string&, const AnyMap&));
-      MOCK_METHOD1(Removed, void(const std::string&));
-    };
+/**
+ * This class is used in tests which need to verify that the Updated and Removed
+ * methods of a ManagedService are called as expected. The mock can be registered
+ * with the Framework to "inject" it into the class under test.
+ */
+class MockManagedServiceFactory
+  : public cppmicroservices::service::cm::ManagedServiceFactory
+{
+public:
+  MOCK_METHOD2(Updated, void(const std::string&, const AnyMap&));
+  MOCK_METHOD1(Removed, void(const std::string&));
+};
 
-    /**
-     * This class is used in tests of classes which would normally callback to a
-     * ConfigurationAdminPrivate. It allows the test to verify that the correct
-     * methods are invoked as expected.
-     */
-    class MockConfigurationAdminPrivate : public ConfigurationAdminPrivate {
-    public:
-      MOCK_METHOD1(AddConfigurations, std::vector<ConfigurationAddedInfo>(std::vector<metadata::ConfigurationMetadata>));
-      MOCK_METHOD1(RemoveConfigurations, void(std::vector<ConfigurationAddedInfo>));
-      MOCK_METHOD1(NotifyConfigurationUpdated, void(const std::string&));
-      MOCK_METHOD2(NotifyConfigurationRemoved, void(const std::string&, std::uintptr_t));
-    };
-  }
+/**
+ * This class is used in tests of classes which would normally callback to a
+ * ConfigurationAdminPrivate. It allows the test to verify that the correct
+ * methods are invoked as expected.
+ */
+class MockConfigurationAdminPrivate : public ConfigurationAdminPrivate
+{
+public:
+  MOCK_METHOD1(AddConfigurations,
+               std::vector<ConfigurationAddedInfo>(
+                 std::vector<metadata::ConfigurationMetadata>));
+  MOCK_METHOD1(RemoveConfigurations, void(std::vector<ConfigurationAddedInfo>));
+  MOCK_METHOD1(NotifyConfigurationUpdated, void(const std::string&));
+  MOCK_METHOD2(NotifyConfigurationRemoved,
+               void(const std::string&, std::uintptr_t));
+};
+}
 }
 
 #endif /* MOCKS_HPP */

--- a/compendium/ConfigurationAdmin/test/TestCMActivator.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMActivator.cpp
@@ -24,12 +24,12 @@
 
 #include "gmock/gmock.h"
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/BundleImport.h"
 #include "cppmicroservices/Constants.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 #include "../src/CMActivator.hpp"
 
@@ -37,96 +37,97 @@
 #define xstr(s) str(s)
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    // The fixture for testing class CMActivator.
-    class TestCMActivator : public ::testing::Test {
-    protected:
-      TestCMActivator() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-      { }
-      ~TestCMActivator() override = default;
+namespace cmimpl {
+// The fixture for testing class CMActivator.
+class TestCMActivator : public ::testing::Test
+{
+protected:
+  TestCMActivator()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
+  ~TestCMActivator() override = default;
 
-      void SetUp() override {
-        framework.Start();
+  void SetUp() override { framework.Start(); }
+
+  void TearDown() override
+  {
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
+  }
+
+  cppmicroservices::Framework& GetFramework() { return framework; }
+
+private:
+  cppmicroservices::Framework framework;
+};
+
+TEST_F(TestCMActivator, VerifyConfigAdmin)
+{
+  EXPECT_NO_THROW({
+    auto bundleContext = GetFramework().GetBundleContext();
+    auto allBundles = bundleContext.GetBundles();
+    EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
+    cppmicroservices::Bundle selfBundle;
+    for (const auto& bundle : allBundles) {
+      if (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName()) {
+        selfBundle = bundle;
+        break;
       }
-
-      void TearDown() override {
-        framework.Stop();
-        framework.WaitForStop(std::chrono::milliseconds::zero());
-      }
-
-      cppmicroservices::Framework& GetFramework() { return framework; }
-    private:
-      cppmicroservices::Framework framework;
-    };
-
-    TEST_F(TestCMActivator, VerifyConfigAdmin) {
-      EXPECT_NO_THROW({
-        auto bundleContext = GetFramework().GetBundleContext();
-        auto allBundles = bundleContext.GetBundles();
-        EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
-        cppmicroservices::Bundle selfBundle;
-        for (const auto& bundle : allBundles)
-        {
-          if (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName())
-          {
-            selfBundle = bundle;
-            break;
-          }
-        }
-        ASSERT_TRUE(selfBundle);
-        selfBundle.Start();
-        EXPECT_EQ(selfBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE);
-        auto selfContext = selfBundle.GetBundleContext();
-        EXPECT_EQ(selfBundle.GetRegisteredServices().size(), static_cast<size_t>(1));
-        auto serviceRef = bundleContext.GetServiceReference<cppmicroservices::service::cm::ConfigurationAdmin>();
-        auto service = bundleContext.GetService<cppmicroservices::service::cm::ConfigurationAdmin>(serviceRef);
-        EXPECT_NE(service.get(), nullptr);
-      });
     }
+    ASSERT_TRUE(selfBundle);
+    selfBundle.Start();
+    EXPECT_EQ(selfBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE);
+    auto selfContext = selfBundle.GetBundleContext();
+    EXPECT_EQ(selfBundle.GetRegisteredServices().size(),
+              static_cast<size_t>(1));
+    auto serviceRef = bundleContext.GetServiceReference<
+      cppmicroservices::service::cm::ConfigurationAdmin>();
+    auto service =
+      bundleContext
+        .GetService<cppmicroservices::service::cm::ConfigurationAdmin>(
+          serviceRef);
+    EXPECT_NE(service.get(), nullptr);
+  });
+}
 
-    TEST_F(TestCMActivator, VerifyConcurrentStartStop) {
-      auto bundleContext = GetFramework().GetBundleContext();
-      auto allBundles = bundleContext.GetBundles();
-      EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
-      cppmicroservices::Bundle selfBundle;
-      for(auto bundle : allBundles)
-      {
-        if (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName())
-        {
-          selfBundle = bundle;
-          break;
-        }
-      }
-      ASSERT_TRUE(selfBundle);
-      std::promise<void> go;
-      std::shared_future<void> ready(go.get_future());
-      int numCalls = 50;
-      std::vector<std::promise<void>> readies(numCalls);
-      std::vector<std::future<void>> bundle_state_changes(numCalls);
-      EXPECT_NO_THROW({
-        for (int i = 0; i<numCalls; ++i)
-        {
-          bundle_state_changes[i] = std::async(std::launch::async,
-                                               [&selfBundle, ready, &readies, i]()
-                                               {
-                                                 readies[i].set_value();
-                                                 ready.wait();
-                                                 ((i%2) ? selfBundle.Start() : selfBundle.Stop());
-                                               });
-        }
-
-        for(int i = 0; i< numCalls; i++)
-        {
-          readies[i].get_future().wait();
-        }
-        go.set_value();
-        for(int i = 0; i< numCalls; i++)
-        {
-          bundle_state_changes[i].wait();
-        }
-      });
+TEST_F(TestCMActivator, VerifyConcurrentStartStop)
+{
+  auto bundleContext = GetFramework().GetBundleContext();
+  auto allBundles = bundleContext.GetBundles();
+  EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
+  cppmicroservices::Bundle selfBundle;
+  for (auto bundle : allBundles) {
+    if (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName()) {
+      selfBundle = bundle;
+      break;
     }
   }
+  ASSERT_TRUE(selfBundle);
+  std::promise<void> go;
+  std::shared_future<void> ready(go.get_future());
+  int numCalls = 50;
+  std::vector<std::promise<void>> readies(numCalls);
+  std::vector<std::future<void>> bundle_state_changes(numCalls);
+  EXPECT_NO_THROW({
+    for (int i = 0; i < numCalls; ++i) {
+      bundle_state_changes[i] =
+        std::async(std::launch::async, [&selfBundle, ready, &readies, i]() {
+          readies[i].set_value();
+          ready.wait();
+          ((i % 2) ? selfBundle.Start() : selfBundle.Stop());
+        });
+    }
+
+    for (int i = 0; i < numCalls; i++) {
+      readies[i].get_future().wait();
+    }
+    go.set_value();
+    for (int i = 0; i < numCalls; i++) {
+      bundle_state_changes[i].wait();
+    }
+  });
+}
+}
 }
 
 CPPMICROSERVICES_IMPORT_BUNDLE(US_BUNDLE_NAME);

--- a/compendium/ConfigurationAdmin/test/TestCMBundleExtension.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMBundleExtension.cpp
@@ -22,10 +22,10 @@
 
 #include <chrono>
 
-#include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
-#include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
 
 #include "../src/CMBundleExtension.hpp"
 #include "../src/CMConstants.hpp"
@@ -35,97 +35,106 @@
 #define xstr(s) str(s)
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    // The fixture for testing class CMBundleExtension.
-    class TestCMBundleExtension : public ::testing::Test {
-    protected:
-      TestCMBundleExtension() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-      { }
-      ~TestCMBundleExtension() = default;
+namespace cmimpl {
+// The fixture for testing class CMBundleExtension.
+class TestCMBundleExtension : public ::testing::Test
+{
+protected:
+  TestCMBundleExtension()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
+  ~TestCMBundleExtension() = default;
 
-      void SetUp() override {
-        framework.Start();
-      }
+  void SetUp() override { framework.Start(); }
 
-      void TearDown() override {
-        framework.Stop();
-        framework.WaitForStop(std::chrono::milliseconds::zero());
-      }
-
-      cppmicroservices::Framework& GetFramework() { return framework; }
-    private:
-      cppmicroservices::Framework framework;
-    };
-
-    TEST_F(TestCMBundleExtension, CtorInvalidArgs)
-    {
-      AnyMap headers(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
-      headers["test"] = std::string{"value"};
-      auto mockConfigAdmin = std::make_shared<MockConfigurationAdminPrivate>();
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(BundleContext(),
-                                    headers,
-                                    mockConfigAdmin,
-                                    fakeLogger);
-      }, std::invalid_argument);
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    AnyMap{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS},
-                                    mockConfigAdmin,
-                                    fakeLogger);
-      }, std::invalid_argument);
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    headers,
-                                    nullptr,
-                                    fakeLogger);
-      }, std::invalid_argument);
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    headers,
-                                    mockConfigAdmin,
-                                    nullptr);
-      }, std::invalid_argument);
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    headers,
-                                    mockConfigAdmin,
-                                    fakeLogger);
-      }, std::runtime_error);
-    }
-
-    TEST_F(TestCMBundleExtension, CtorWithValidArgs)
-    {
-      auto bundles = GetFramework().GetBundleContext().GetBundles();
-      auto thisBundleItr = std::find_if(bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& bundle){
-        return (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName());
-      });
-      auto thisBundle = thisBundleItr != bundles.end() ? *thisBundleItr : cppmicroservices::Bundle();
-      ASSERT_TRUE(static_cast<bool>(thisBundle));
-      auto const& cm = cppmicroservices::ref_any_cast<AnyMap>(thisBundle.GetHeaders().at("cm_test_0"));
-
-      auto mockConfigAdmin = std::make_shared<MockConfigurationAdminPrivate>();
-      std::vector<ConfigurationAddedInfo> returnValue{{std::string{"test"}, 1u, static_cast<std::uintptr_t>(42u)}};
-      EXPECT_CALL(*mockConfigAdmin, AddConfigurations(testing::_))
-        .Times(2)
-        .WillOnce(testing::Throw(std::runtime_error("Failed to add component")))
-        .WillOnce(testing::Return(returnValue));
-      EXPECT_CALL(*mockConfigAdmin, RemoveConfigurations(returnValue))
-        .Times(1);
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      EXPECT_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    cm,
-                                    mockConfigAdmin,
-                                    fakeLogger);
-      }, std::runtime_error);
-      EXPECT_NO_THROW({
-        CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
-                                    cm,
-                                    mockConfigAdmin,
-                                    fakeLogger);
-      });
-    }
+  void TearDown() override
+  {
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
   }
+
+  cppmicroservices::Framework& GetFramework() { return framework; }
+
+private:
+  cppmicroservices::Framework framework;
+};
+
+TEST_F(TestCMBundleExtension, CtorInvalidArgs)
+{
+  AnyMap headers(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  headers["test"] = std::string{ "value" };
+  auto mockConfigAdmin = std::make_shared<MockConfigurationAdminPrivate>();
+  auto fakeLogger = std::make_shared<FakeLogger>();
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(
+        BundleContext(), headers, mockConfigAdmin, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(
+        GetFramework().GetBundleContext(),
+        AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS },
+        mockConfigAdmin,
+        fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(
+        GetFramework().GetBundleContext(), headers, nullptr, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(
+        GetFramework().GetBundleContext(), headers, mockConfigAdmin, nullptr);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(GetFramework().GetBundleContext(),
+                                  headers,
+                                  mockConfigAdmin,
+                                  fakeLogger);
+    },
+    std::runtime_error);
+}
+
+TEST_F(TestCMBundleExtension, CtorWithValidArgs)
+{
+  auto bundles = GetFramework().GetBundleContext().GetBundles();
+  auto thisBundleItr = std::find_if(
+    bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& bundle) {
+      return (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName());
+    });
+  auto thisBundle = thisBundleItr != bundles.end() ? *thisBundleItr
+                                                   : cppmicroservices::Bundle();
+  ASSERT_TRUE(static_cast<bool>(thisBundle));
+  auto const& cm = cppmicroservices::ref_any_cast<AnyMap>(
+    thisBundle.GetHeaders().at("cm_test_0"));
+
+  auto mockConfigAdmin = std::make_shared<MockConfigurationAdminPrivate>();
+  std::vector<ConfigurationAddedInfo> returnValue{
+    { std::string{ "test" }, 1u, static_cast<std::uintptr_t>(42u) }
+  };
+  EXPECT_CALL(*mockConfigAdmin, AddConfigurations(testing::_))
+    .Times(2)
+    .WillOnce(testing::Throw(std::runtime_error("Failed to add component")))
+    .WillOnce(testing::Return(returnValue));
+  EXPECT_CALL(*mockConfigAdmin, RemoveConfigurations(returnValue)).Times(1);
+  auto fakeLogger = std::make_shared<FakeLogger>();
+  EXPECT_THROW(
+    {
+      CMBundleExtension bundleExt(
+        GetFramework().GetBundleContext(), cm, mockConfigAdmin, fakeLogger);
+    },
+    std::runtime_error);
+  EXPECT_NO_THROW({
+    CMBundleExtension bundleExt(
+      GetFramework().GetBundleContext(), cm, mockConfigAdmin, fakeLogger);
+  });
+}
+}
 }

--- a/compendium/ConfigurationAdmin/test/TestCMLogger.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMLogger.cpp
@@ -21,14 +21,14 @@
  =============================================================================*/
 
 #include <chrono>
-#include <thread>
-#include <memory>
 #include <future>
+#include <memory>
+#include <thread>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
 #include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 #include "../src/CMLogger.hpp"
 #include "Mocks.hpp"
@@ -36,152 +36,175 @@
 using cppmicroservices::logservice::LogService;
 using cppmicroservices::logservice::SeverityLevel;
 
-namespace cppmicroservices{
-  namespace cmimpl {
-    // The fixture for testing class CMLogger.
-    class TestCMLogger : public ::testing::Test {
-    protected:
-      TestCMLogger() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-      {
-      }
+namespace cppmicroservices {
+namespace cmimpl {
+// The fixture for testing class CMLogger.
+class TestCMLogger : public ::testing::Test
+{
+protected:
+  TestCMLogger()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
 
-      ~TestCMLogger() override = default;
+  ~TestCMLogger() override = default;
 
-      void SetUp() override {
-        framework.Start();
-      }
+  void SetUp() override { framework.Start(); }
 
-      void TearDown() override {
-        framework.Stop();
-        framework.WaitForStop(std::chrono::milliseconds::zero());
-      }
-
-      cppmicroservices::Framework& GetFramework() { return framework; }
-    private:
-      cppmicroservices::Framework framework;
-    };
-
-    TEST_F(TestCMLogger, VerifyWithoutLoggerService) {
-      auto bundleContext = GetFramework().GetBundleContext();
-      CMLogger logger(bundleContext);
-      cppmicroservices::ServiceReferenceU dummyRef;
-      // check that calling log method is safe even if a LogService is unavailable
-      EXPECT_NO_THROW({
-        logger.Log(SeverityLevel::LOG_DEBUG, "sample log message");
-        logger.Log(SeverityLevel::LOG_DEBUG, "sample log message", std::make_exception_ptr(new std::runtime_error("error occured")));
-        logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message");
-        logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message", std::make_exception_ptr(new std::runtime_error("error occured")));
-      });
-    }
-
-    TEST_F(TestCMLogger, VerifyWithLoggerService) {
-      EXPECT_NO_THROW({
-        // Register a mock logger implementaion
-        auto mockLogger = std::make_shared<MockLogger>();
-        auto bundleContext = GetFramework().GetBundleContext();
-        auto reg = bundleContext.RegisterService<LogService>(mockLogger);
-        // set expectations
-        EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(1);
-        EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_ERROR, testing::_, testing::_))
-        .Times(1);
-        EXPECT_CALL(*(mockLogger.get()), Log(testing::_, SeverityLevel::LOG_WARNING, testing::_))
-        .Times(1);
-        EXPECT_CALL(*(mockLogger.get()), Log(testing::_, SeverityLevel::LOG_ERROR, testing::_, testing::_))
-        .Times(1);
-        // exercise methods on instance of CMLogger
-        CMLogger logger(bundleContext);
-        logger.Log(SeverityLevel::LOG_DEBUG, "some sample debug message");
-        logger.Log(SeverityLevel::LOG_ERROR, "some sample error message", std::make_exception_ptr(new std::runtime_error("error occured")));
-        cppmicroservices::ServiceReferenceU dummyRef;
-        logger.Log(dummyRef, SeverityLevel::LOG_WARNING, "some sample warning message");
-        logger.Log(dummyRef, SeverityLevel::LOG_ERROR, "some sample error message with service reference", std::make_exception_ptr(new std::runtime_error("error occured")));
-        reg.Unregister();
-      });
-    }
-
-    TEST_F(TestCMLogger, VerifyLoggerServiceStaticBinding) {
-      EXPECT_NO_THROW({
-        auto mockLogger1 = std::make_shared<MockLogger>();
-        auto mockLogger2 = std::make_shared<MockLogger>();
-        auto mockLogger3 = std::make_shared<MockLogger>();
-        // setup expectations.
-        // mockLogger1 received first two calls because it is registered first.
-        // mockLogger2 does not receive any calls because it is never bound to CMLogger.
-        // mockLogger3 receives 1 call because it is registered after mockLogger1 is unbound.
-        EXPECT_CALL(*(mockLogger1.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(2);
-        EXPECT_CALL(*(mockLogger2.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(0);
-        EXPECT_CALL(*(mockLogger3.get()), Log(SeverityLevel::LOG_DEBUG, "3. sample debug message"))
-        .Times(1);
-        auto bundleContext = GetFramework().GetBundleContext();
-        CMLogger logger(bundleContext);
-        auto reg1 = bundleContext.RegisterService<LogService>(mockLogger1);
-        auto reg2 = bundleContext.RegisterService<LogService>(mockLogger2);
-        logger.Log(SeverityLevel::LOG_DEBUG, "1. sample debug message");
-        logger.Log(SeverityLevel::LOG_DEBUG, "2. sample debug message");
-        reg1.Unregister();
-        auto reg3 = bundleContext.RegisterService<LogService>(mockLogger3);
-        logger.Log(SeverityLevel::LOG_DEBUG, "3. sample debug message");
-        reg2.Unregister();
-        reg3.Unregister();
-      });
-    }
-
-    TEST_F(TestCMLogger, VerifyMultiThreadedAccess) {
-      // log from multiple threads while one thread is continously registering
-      // and unregistering the log service.
-      EXPECT_NO_THROW({
-        auto bundleContext = GetFramework().GetBundleContext();
-        CMLogger logger(bundleContext);
-        std::promise<void> startPromise;
-        std::shared_future<void> start(startPromise.get_future());
-        std::promise<void> stopPromise;
-        std::shared_future<void> stop(stopPromise.get_future());
-        int numThreads = 20;
-        std::vector<std::promise<void>> readies(numThreads);
-        std::vector<std::future<void>> logging_futures(numThreads);
-        for(int i = 0; i<numThreads; i++)
-        {
-          // launch a task to continously log until stop signal is received
-          logging_futures[i] = std::async(std::launch::async,
-                                          [&logger, i, start, stop, &readies]() {
-                                            readies[i].set_value();
-                                            start.wait();
-                                            do
-                                            {
-                                              logger.Log(SeverityLevel::LOG_DEBUG, "sample debug message");
-                                            }while(stop.wait_for(std::chrono::milliseconds(1)) != std::future_status::ready);
-                                          });
-        }
-        for(int i = 0; i< numThreads; i++)
-        {
-          readies[i].get_future().wait();
-        }
-        startPromise.set_value();
-        // on a separate thread, register and unregister mock logger service.
-        auto serviceReg = std::async(std::launch::async,
-                                     [start, stop, &bundleContext]() {
-                                       start.wait();
-                                       auto mockLogger = std::make_shared<MockLogger>();
-                                       EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-                                       .Times(testing::AtLeast(1));
-                                       do
-                                       {
-                                         auto reg1 = bundleContext.RegisterService<LogService>(mockLogger);
-                                         std::this_thread::sleep_for(std::chrono::seconds(1));
-                                         reg1.Unregister();
-                                       }while(stop.wait_for(std::chrono::milliseconds(1)) != std::future_status::ready);
-                                     });
-        std::this_thread::sleep_for(std::chrono::seconds(30));
-        stopPromise.set_value(); // stop all threads
-        serviceReg.get();
-        for(int i = 0; i< numThreads; i++)
-        {
-          logging_futures[i].get();
-        }
-      });
-    }
+  void TearDown() override
+  {
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
   }
+
+  cppmicroservices::Framework& GetFramework() { return framework; }
+
+private:
+  cppmicroservices::Framework framework;
+};
+
+TEST_F(TestCMLogger, VerifyWithoutLoggerService)
+{
+  auto bundleContext = GetFramework().GetBundleContext();
+  CMLogger logger(bundleContext);
+  cppmicroservices::ServiceReferenceU dummyRef;
+  // check that calling log method is safe even if a LogService is unavailable
+  EXPECT_NO_THROW({
+    logger.Log(SeverityLevel::LOG_DEBUG, "sample log message");
+    logger.Log(
+      SeverityLevel::LOG_DEBUG,
+      "sample log message",
+      std::make_exception_ptr(new std::runtime_error("error occured")));
+    logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message");
+    logger.Log(
+      dummyRef,
+      SeverityLevel::LOG_DEBUG,
+      "sample log message",
+      std::make_exception_ptr(new std::runtime_error("error occured")));
+  });
+}
+
+TEST_F(TestCMLogger, VerifyWithLoggerService)
+{
+  EXPECT_NO_THROW({
+    // Register a mock logger implementaion
+    auto mockLogger = std::make_shared<MockLogger>();
+    auto bundleContext = GetFramework().GetBundleContext();
+    auto reg = bundleContext.RegisterService<LogService>(mockLogger);
+    // set expectations
+    EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(1);
+    EXPECT_CALL(*(mockLogger.get()),
+                Log(SeverityLevel::LOG_ERROR, testing::_, testing::_))
+      .Times(1);
+    EXPECT_CALL(*(mockLogger.get()),
+                Log(testing::_, SeverityLevel::LOG_WARNING, testing::_))
+      .Times(1);
+    EXPECT_CALL(
+      *(mockLogger.get()),
+      Log(testing::_, SeverityLevel::LOG_ERROR, testing::_, testing::_))
+      .Times(1);
+    // exercise methods on instance of CMLogger
+    CMLogger logger(bundleContext);
+    logger.Log(SeverityLevel::LOG_DEBUG, "some sample debug message");
+    logger.Log(
+      SeverityLevel::LOG_ERROR,
+      "some sample error message",
+      std::make_exception_ptr(new std::runtime_error("error occured")));
+    cppmicroservices::ServiceReferenceU dummyRef;
+    logger.Log(
+      dummyRef, SeverityLevel::LOG_WARNING, "some sample warning message");
+    logger.Log(
+      dummyRef,
+      SeverityLevel::LOG_ERROR,
+      "some sample error message with service reference",
+      std::make_exception_ptr(new std::runtime_error("error occured")));
+    reg.Unregister();
+  });
+}
+
+TEST_F(TestCMLogger, VerifyLoggerServiceStaticBinding)
+{
+  EXPECT_NO_THROW({
+    auto mockLogger1 = std::make_shared<MockLogger>();
+    auto mockLogger2 = std::make_shared<MockLogger>();
+    auto mockLogger3 = std::make_shared<MockLogger>();
+    // setup expectations.
+    // mockLogger1 received first two calls because it is registered first.
+    // mockLogger2 does not receive any calls because it is never bound to CMLogger.
+    // mockLogger3 receives 1 call because it is registered after mockLogger1 is unbound.
+    EXPECT_CALL(*(mockLogger1.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(2);
+    EXPECT_CALL(*(mockLogger2.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(0);
+    EXPECT_CALL(*(mockLogger3.get()),
+                Log(SeverityLevel::LOG_DEBUG, "3. sample debug message"))
+      .Times(1);
+    auto bundleContext = GetFramework().GetBundleContext();
+    CMLogger logger(bundleContext);
+    auto reg1 = bundleContext.RegisterService<LogService>(mockLogger1);
+    auto reg2 = bundleContext.RegisterService<LogService>(mockLogger2);
+    logger.Log(SeverityLevel::LOG_DEBUG, "1. sample debug message");
+    logger.Log(SeverityLevel::LOG_DEBUG, "2. sample debug message");
+    reg1.Unregister();
+    auto reg3 = bundleContext.RegisterService<LogService>(mockLogger3);
+    logger.Log(SeverityLevel::LOG_DEBUG, "3. sample debug message");
+    reg2.Unregister();
+    reg3.Unregister();
+  });
+}
+
+TEST_F(TestCMLogger, VerifyMultiThreadedAccess)
+{
+  // log from multiple threads while one thread is continously registering
+  // and unregistering the log service.
+  EXPECT_NO_THROW({
+    auto bundleContext = GetFramework().GetBundleContext();
+    CMLogger logger(bundleContext);
+    std::promise<void> startPromise;
+    std::shared_future<void> start(startPromise.get_future());
+    std::promise<void> stopPromise;
+    std::shared_future<void> stop(stopPromise.get_future());
+    int numThreads = 20;
+    std::vector<std::promise<void>> readies(numThreads);
+    std::vector<std::future<void>> logging_futures(numThreads);
+    for (int i = 0; i < numThreads; i++) {
+      // launch a task to continously log until stop signal is received
+      logging_futures[i] =
+        std::async(std::launch::async, [&logger, i, start, stop, &readies]() {
+          readies[i].set_value();
+          start.wait();
+          do {
+            logger.Log(SeverityLevel::LOG_DEBUG, "sample debug message");
+          } while (stop.wait_for(std::chrono::milliseconds(1)) !=
+                   std::future_status::ready);
+        });
+    }
+    for (int i = 0; i < numThreads; i++) {
+      readies[i].get_future().wait();
+    }
+    startPromise.set_value();
+    // on a separate thread, register and unregister mock logger service.
+    auto serviceReg =
+      std::async(std::launch::async, [start, stop, &bundleContext]() {
+        start.wait();
+        auto mockLogger = std::make_shared<MockLogger>();
+        EXPECT_CALL(*(mockLogger.get()),
+                    Log(SeverityLevel::LOG_DEBUG, testing::_))
+          .Times(testing::AtLeast(1));
+        do {
+          auto reg1 = bundleContext.RegisterService<LogService>(mockLogger);
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+          reg1.Unregister();
+        } while (stop.wait_for(std::chrono::milliseconds(1)) !=
+                 std::future_status::ready);
+      });
+    std::this_thread::sleep_for(std::chrono::seconds(30));
+    stopPromise.set_value(); // stop all threads
+    serviceReg.get();
+    for (int i = 0; i < numThreads; i++) {
+      logging_futures[i].get();
+    }
+  });
+}
+}
 }

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -187,7 +187,8 @@ public:
     // since installing an already installed bundle is a no-op.
     auto installedBundles = m_framework.GetBundleContext().InstallBundles(
       GetConfigAdminRuntimePluginFilePath());
-    ASSERT_EQ(installedBundles.size(), 1ul) << "Only one configadmin bundle should be installed";
+    ASSERT_EQ(installedBundles.size(), 1ul)
+      << "Only one configadmin bundle should be installed";
     m_bundle = installedBundles.at(0);
 
     auto const numBundles =
@@ -217,17 +218,15 @@ protected:
 
 private:
   cppmicroservices::Framework m_framework;
-  cppmicroservices::Bundle m_bundle;  ///< The ConfigAdmin bundle object
+  cppmicroservices::Bundle m_bundle; ///< The ConfigAdmin bundle object
 };
 
 TEST_F(ConfigAdminTests, testProperties)
 {
   // Test that the build system correctly generated the config admin bundle properties.
   auto b = GetConfigAdminBundle();
-  ASSERT_EQ(
-    b.GetSymbolicName(), US_ConfigurationAdmin_SYMBOLIC_NAME);
-  ASSERT_EQ(
-    b.GetVersion().ToString(), US_ConfigurationAdmin_VERSION_STR);
+  ASSERT_EQ(b.GetSymbolicName(), US_ConfigurationAdmin_SYMBOLIC_NAME);
+  ASSERT_EQ(b.GetVersion().ToString(), US_ConfigurationAdmin_VERSION_STR);
 }
 
 TEST_F(ConfigAdminTests, testInstallAndStart)
@@ -335,7 +334,7 @@ TEST_F(ConfigAdminTests, testServiceRemoved)
 
   auto configuration = m_configAdmin->GetConfiguration("cm.testservice");
 
-  // Remove sends an asynchronous notification to the ManagedService so we 
+  // Remove sends an asynchronous notification to the ManagedService so we
   // have to wait until it's finished before checking the result.
   configuration->Remove();
   expectedCount -= 1;
@@ -350,7 +349,7 @@ TEST_F(ConfigAdminTests, testServiceRemoved)
 
   // Should create a new configuration and call Updated()
   // GetConfiguration doesn't send a notification to the ManagedService so
-  // we don't have to wait for the result. 
+  // we don't have to wait for the result.
   configuration = m_configAdmin->GetConfiguration("cm.testservice");
   EXPECT_TRUE(configuration->GetProperties().empty());
   EXPECT_EQ(service->getCounter(), expectedCount);
@@ -553,7 +552,8 @@ TEST_F(ConfigAdminTests, testRemoveFactoryConfiguration)
     m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config1");
 
   EXPECT_TRUE(configuration_config1->GetProperties().empty());
-  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config1"), expectedCount_config1);
+  EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config1"),
+            expectedCount_config1);
   EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config2"),
             expectedCount_config2);
 }

--- a/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
@@ -26,119 +26,145 @@
 
 #include <cppmicroservices/Constants.h>
 #include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
 #include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
 
-#include "Mocks.hpp"
 #include "../src/ConfigurationImpl.hpp"
+#include "Mocks.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
+namespace cmimpl {
 
-    MATCHER_P(AnyMapEquals, value, "")
-    {
-      std::ostringstream argString;
-      std::ostringstream valueString;
-      cppmicroservices::any_value_to_string(argString, arg);
-      cppmicroservices::any_value_to_string(valueString, value);
-      return (argString.str() == valueString.str());
-    }
+MATCHER_P(AnyMapEquals, value, "")
+{
+  std::ostringstream argString;
+  std::ostringstream valueString;
+  cppmicroservices::any_value_to_string(argString, arg);
+  cppmicroservices::any_value_to_string(valueString, value);
+  return (argString.str() == valueString.str());
+}
 
-    TEST(TestConfigurationImpl, VerifyGetters) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_EQ(conf.GetPid(), pid);
-      EXPECT_EQ(conf.GetFactoryPid(), factoryPid);
-      EXPECT_THAT(conf.GetProperties(), AnyMapEquals(props));
-    }
+TEST(TestConfigurationImpl, VerifyGetters)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_EQ(conf.GetPid(), pid);
+  EXPECT_EQ(conf.GetFactoryPid(), factoryPid);
+  EXPECT_THAT(conf.GetProperties(), AnyMapEquals(props));
+}
 
-    TEST(TestConfigurationImpl, ThrowsWhenRemoved) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(&conf))).Times(1);
-      EXPECT_NO_THROW(conf.Remove());
-      EXPECT_THROW(conf.GetPid(), std::runtime_error);
-      EXPECT_THROW(conf.GetFactoryPid(), std::runtime_error);
-      EXPECT_THROW(conf.GetProperties(), std::runtime_error);
-      EXPECT_THROW(conf.Update(props), std::runtime_error);
-      EXPECT_THROW(conf.UpdateIfDifferent(props), std::runtime_error);
-      EXPECT_THROW(conf.Remove(), std::runtime_error);
-      EXPECT_THROW(conf.UpdateWithoutNotificationIfDifferent(props), std::runtime_error);
-      EXPECT_THROW(conf.RemoveWithoutNotificationIfChangeCountEquals(1u), std::runtime_error);
-      EXPECT_NO_THROW(conf.Invalidate());
-    }
+TEST(TestConfigurationImpl, ThrowsWhenRemoved)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(
+    *mockConfigAdmin,
+    NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(&conf)))
+    .Times(1);
+  EXPECT_NO_THROW(conf.Remove());
+  EXPECT_THROW(conf.GetPid(), std::runtime_error);
+  EXPECT_THROW(conf.GetFactoryPid(), std::runtime_error);
+  EXPECT_THROW(conf.GetProperties(), std::runtime_error);
+  EXPECT_THROW(conf.Update(props), std::runtime_error);
+  EXPECT_THROW(conf.UpdateIfDifferent(props), std::runtime_error);
+  EXPECT_THROW(conf.Remove(), std::runtime_error);
+  EXPECT_THROW(conf.UpdateWithoutNotificationIfDifferent(props),
+               std::runtime_error);
+  EXPECT_THROW(conf.RemoveWithoutNotificationIfChangeCountEquals(1u),
+               std::runtime_error);
+  EXPECT_NO_THROW(conf.Invalidate());
+}
 
-    TEST(TestConfigurationImpl, NoCallbacksAfterInvalidate) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationRemoved(testing::_, testing::_)).Times(0);
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(testing::_)).Times(0);
-      EXPECT_NO_THROW(conf.Invalidate());
-      EXPECT_NO_THROW(conf.Update(props));
-      props["bar"] = std::string("foo");
-      EXPECT_TRUE(conf.UpdateIfDifferent(props));
-      EXPECT_NO_THROW(conf.Remove());
-    }
+TEST(TestConfigurationImpl, NoCallbacksAfterInvalidate)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(*mockConfigAdmin,
+              NotifyConfigurationRemoved(testing::_, testing::_))
+    .Times(0);
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(testing::_))
+    .Times(0);
+  EXPECT_NO_THROW(conf.Invalidate());
+  EXPECT_NO_THROW(conf.Update(props));
+  props["bar"] = std::string("foo");
+  EXPECT_TRUE(conf.UpdateIfDifferent(props));
+  EXPECT_NO_THROW(conf.Remove());
+}
 
-    TEST(TestConfigurationImpl, VerifyUpdate) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(1);
-      EXPECT_NO_THROW(conf.Update(props));
-    }
+TEST(TestConfigurationImpl, VerifyUpdate)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(1);
+  EXPECT_NO_THROW(conf.Update(props));
+}
 
-    TEST(TestConfigurationImpl, VerifyUpdateIfDifferent) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(1);
-      EXPECT_FALSE(conf.UpdateIfDifferent(props));
-      props["bar"] = std::string("baz");
-      EXPECT_TRUE(conf.UpdateIfDifferent(props));
-    }
+TEST(TestConfigurationImpl, VerifyUpdateIfDifferent)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(1);
+  EXPECT_FALSE(conf.UpdateIfDifferent(props));
+  props["bar"] = std::string("baz");
+  EXPECT_TRUE(conf.UpdateIfDifferent(props));
+}
 
-    TEST(TestConfigurationImpl, VerifyUpdateWithoutNotificationIfDifferent) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(0);
-      EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props), std::make_pair(false, 0ul));
-      props["bar"] = std::string("baz");
-      EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props), std::make_pair(true, 2ul));
-    }
+TEST(TestConfigurationImpl, VerifyUpdateWithoutNotificationIfDifferent)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid)).Times(0);
+  EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props),
+            std::make_pair(false, 0ul));
+  props["bar"] = std::string("baz");
+  EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props),
+            std::make_pair(true, 2ul));
+}
 
-    TEST(TestConfigurationImpl, VerifyRemoveWithoutNotificationIfChangeCountEquals) {
-      auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
-      AnyMap props{AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS};
-      props["foo"] = std::string("bar");
-      std::string pid{"test~instance"};
-      std::string factoryPid{"test"};
-      ConfigurationImpl conf{mockConfigAdmin.get(), pid, factoryPid, props};
-      EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationRemoved(testing::_, testing::_)).Times(0);
-      EXPECT_FALSE(conf.RemoveWithoutNotificationIfChangeCountEquals(2ul));
-      EXPECT_TRUE(conf.RemoveWithoutNotificationIfChangeCountEquals(1ul));
-    }
-  }
+TEST(TestConfigurationImpl, VerifyRemoveWithoutNotificationIfChangeCountEquals)
+{
+  auto mockConfigAdmin =
+    std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+  AnyMap props{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+  props["foo"] = std::string("bar");
+  std::string pid{ "test~instance" };
+  std::string factoryPid{ "test" };
+  ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
+  EXPECT_CALL(*mockConfigAdmin,
+              NotifyConfigurationRemoved(testing::_, testing::_))
+    .Times(0);
+  EXPECT_FALSE(conf.RemoveWithoutNotificationIfChangeCountEquals(2ul));
+  EXPECT_TRUE(conf.RemoveWithoutNotificationIfChangeCountEquals(1ul));
+}
+}
 }

--- a/compendium/ConfigurationAdmin/test/TestMetadataParserFactory.cpp
+++ b/compendium/ConfigurationAdmin/test/TestMetadataParserFactory.cpp
@@ -21,23 +21,20 @@
  =============================================================================*/
 #include "gtest/gtest.h"
 
-#include "../src/metadata/MetadataParserFactory.hpp"
 #include "../src/metadata/MetadataParser.hpp"
+#include "../src/metadata/MetadataParserFactory.hpp"
 #include "Mocks.hpp"
 
 namespace cppmicroservices {
-  namespace cmimpl {
-    namespace metadata {
+namespace cmimpl {
+namespace metadata {
 
-      TEST(TestMetadataParserFactory, ManifestVersionInvalid) {
-        auto logger = std::make_shared<FakeLogger>();
-        EXPECT_THROW(
-        MetadataParserFactory::Create(0, logger);,
-        std::runtime_error);
-        EXPECT_THROW(
-        MetadataParserFactory::Create(2, logger);,
-        std::runtime_error);
-      }
-    }
-  }
+TEST(TestMetadataParserFactory, ManifestVersionInvalid)
+{
+  auto logger = std::make_shared<FakeLogger>();
+  EXPECT_THROW(MetadataParserFactory::Create(0, logger);, std::runtime_error);
+  EXPECT_THROW(MetadataParserFactory::Create(2, logger);, std::runtime_error);
+}
+}
+}
 }

--- a/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
+++ b/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
@@ -19,277 +19,277 @@
  limitations under the License.
 
  =============================================================================*/
+#include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/Framework.h"
 #include "cppmicroservices/FrameworkEvent.h"
 #include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/BundleContext.h"
 
 #include "gtest/gtest.h"
 
 #include "../src/CMConstants.hpp"
 #include "../src/metadata/ConfigurationMetadata.hpp"
-#include "../src/metadata/MetadataParserImpl.hpp"
 #include "../src/metadata/MetadataParserFactory.hpp"
+#include "../src/metadata/MetadataParserImpl.hpp"
 #include "Mocks.hpp"
 
 using cppmicroservices::AnyMap;
 using cppmicroservices::cmimpl::FakeLogger;
-using cppmicroservices::cmimpl::metadata::ConfigurationMetadata;
-using cppmicroservices::cmimpl::metadata::MetadataParserFactory;
-using cppmicroservices::cmimpl::metadata::MetadataParserImplV1;
 using cppmicroservices::cmimpl::MockLogger;
 using cppmicroservices::cmimpl::CMConstants::CM_KEY;
 using cppmicroservices::cmimpl::CMConstants::CM_VERSION;
+using cppmicroservices::cmimpl::metadata::ConfigurationMetadata;
+using cppmicroservices::cmimpl::metadata::MetadataParserFactory;
+using cppmicroservices::cmimpl::metadata::MetadataParserImplV1;
 
 #define str(s) #s
 #define xstr(s) str(s)
 
 namespace {
 
-  namespace ManifestHelper {
-    static cppmicroservices::Framework framework(cppmicroservices::FrameworkFactory().NewFramework());
-    static cppmicroservices::Bundle thisBundle;
+namespace ManifestHelper {
+static cppmicroservices::Framework framework(
+  cppmicroservices::FrameworkFactory().NewFramework());
+static cppmicroservices::Bundle thisBundle;
 
-    static void StartFramework() {
-      framework.Start();
-      auto bundles = framework.GetBundleContext().GetBundles();
-      auto thisBundleItr = std::find_if(bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& bundle) {
-        return (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName());
-      });
-      thisBundle = (thisBundleItr != bundles.end()) ? *thisBundleItr : cppmicroservices::Bundle();
-      ASSERT_TRUE(static_cast<bool>(thisBundle)) << "bundle for pkgtest executable not found";
-    }
+static void StartFramework()
+{
+  framework.Start();
+  auto bundles = framework.GetBundleContext().GetBundles();
+  auto thisBundleItr = std::find_if(
+    bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& bundle) {
+      return (xstr(US_BUNDLE_NAME) == bundle.GetSymbolicName());
+    });
+  thisBundle = (thisBundleItr != bundles.end()) ? *thisBundleItr
+                                                : cppmicroservices::Bundle();
+  ASSERT_TRUE(static_cast<bool>(thisBundle))
+    << "bundle for pkgtest executable not found";
+}
 
-    static void StopFramework() {
-      framework.Stop();
-      framework.WaitForStop(std::chrono::milliseconds::zero());
-      thisBundle = nullptr;
-    }
+static void StopFramework()
+{
+  framework.Stop();
+  framework.WaitForStop(std::chrono::milliseconds::zero());
+  thisBundle = nullptr;
+}
 
-    static const AnyMap& GetTestManifest(const std::string& manifest_name)
-    {
-      const AnyMap& headers = thisBundle.GetHeaders();
-      try
-      {
-        auto const& testMetadata = headers.AtCompoundKey("test_metadata." + manifest_name + "." + CM_KEY);
-        return cppmicroservices::ref_any_cast<AnyMap>(testMetadata);
-      }
-      catch(const std::out_of_range& e)
-      {
-        std::cout << "Exception: " << e.what() << std::endl;
-        for(auto const& kv : headers)
-        {
-          std::cout << kv.first  << " : " << kv.second.ToStringNoExcept() << std::endl;
-        }
-      }
-      return headers;
+static const AnyMap& GetTestManifest(const std::string& manifest_name)
+{
+  const AnyMap& headers = thisBundle.GetHeaders();
+  try {
+    auto const& testMetadata =
+      headers.AtCompoundKey("test_metadata." + manifest_name + "." + CM_KEY);
+    return cppmicroservices::ref_any_cast<AnyMap>(testMetadata);
+  } catch (const std::out_of_range& e) {
+    std::cout << "Exception: " << e.what() << std::endl;
+    for (auto const& kv : headers) {
+      std::cout << kv.first << " : " << kv.second.ToStringNoExcept()
+                << std::endl;
     }
   }
+  return headers;
+}
+}
 
-  // Test parsing representations of valid service descriptions
-  class TestMetadataParserImplV1 : public ::testing::Test {
-  protected:
-    TestMetadataParserImplV1()
+// Test parsing representations of valid service descriptions
+class TestMetadataParserImplV1 : public ::testing::Test
+{
+protected:
+  TestMetadataParserImplV1()
     : logger(std::make_shared<FakeLogger>())
-    {}
-    ~TestMetadataParserImplV1() override = default;
-  private:
-    std::shared_ptr<FakeLogger> logger;
-  public:
+  {}
+  ~TestMetadataParserImplV1() override = default;
 
-    static void SetUpTestCase()
-    {
-      ManifestHelper::StartFramework();
-    }
+private:
+  std::shared_ptr<FakeLogger> logger;
 
-    static void TearDownTestCase()
-    {
-      ManifestHelper::StopFramework();
-    }
+public:
+  static void SetUpTestCase() { ManifestHelper::StartFramework(); }
 
-    std::shared_ptr<FakeLogger> GetLogger() { return logger; }
-  };
+  static void TearDownTestCase() { ManifestHelper::StopFramework(); }
 
-  TEST_F(TestMetadataParserImplV1, ParseValidManifest)
-  {
-    auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
-    auto configurations = metadataParser->ParseAndGetConfigurationMetadata(ManifestHelper::GetTestManifest("manifest_json"));
-    ASSERT_THAT(configurations, ::testing::SizeIs(1));
-    const auto& configuration = configurations[0];
-    ASSERT_EQ(configuration.pid, std::string("test"));
-    ASSERT_THAT(configuration.properties, ::testing::SizeIs(3));
-  }
+  std::shared_ptr<FakeLogger> GetLogger() { return logger; }
+};
 
-  TEST_F(TestMetadataParserImplV1, ParseManifestEmptyProps)
-  {
-    auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
-    auto configurations = metadataParser->ParseAndGetConfigurationMetadata(ManifestHelper::GetTestManifest("manifest_empty_props"));
-    ASSERT_THAT(configurations, ::testing::SizeIs(1));
-    const auto& configuration = configurations[0];
-    ASSERT_EQ(configuration.pid, std::string("test"));
-    ASSERT_THAT(configuration.properties, ::testing::SizeIs(0));
-  }
+TEST_F(TestMetadataParserImplV1, ParseValidManifest)
+{
+  auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
+  auto configurations = metadataParser->ParseAndGetConfigurationMetadata(
+    ManifestHelper::GetTestManifest("manifest_json"));
+  ASSERT_THAT(configurations, ::testing::SizeIs(1));
+  const auto& configuration = configurations[0];
+  ASSERT_EQ(configuration.pid, std::string("test"));
+  ASSERT_THAT(configuration.properties, ::testing::SizeIs(3));
+}
 
-  TEST_F(TestMetadataParserImplV1, ParseManifestEmptyConfigurations)
-  {
-    auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
-    auto configurations = metadataParser->ParseAndGetConfigurationMetadata(ManifestHelper::GetTestManifest("manifest_empty_conf"));
-    ASSERT_THAT(configurations, ::testing::SizeIs(0));
-  }
+TEST_F(TestMetadataParserImplV1, ParseManifestEmptyProps)
+{
+  auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
+  auto configurations = metadataParser->ParseAndGetConfigurationMetadata(
+    ManifestHelper::GetTestManifest("manifest_empty_props"));
+  ASSERT_THAT(configurations, ::testing::SizeIs(1));
+  const auto& configuration = configurations[0];
+  ASSERT_EQ(configuration.pid, std::string("test"));
+  ASSERT_THAT(configuration.properties, ::testing::SizeIs(0));
+}
 
-  TEST_F(TestMetadataParserImplV1, ParseMultipleConfigurations)
-  {
-    auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
-    auto configurations = metadataParser->ParseAndGetConfigurationMetadata(ManifestHelper::GetTestManifest("manifest_mult_conf"));
-    ASSERT_THAT(configurations, ::testing::SizeIs(2));
+TEST_F(TestMetadataParserImplV1, ParseManifestEmptyConfigurations)
+{
+  auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
+  auto configurations = metadataParser->ParseAndGetConfigurationMetadata(
+    ManifestHelper::GetTestManifest("manifest_empty_conf"));
+  ASSERT_THAT(configurations, ::testing::SizeIs(0));
+}
 
-    auto configuration = configurations[0];
-    ASSERT_EQ(configuration.pid, std::string("test"));
-    ASSERT_THAT(configuration.properties, ::testing::SizeIs(1));
+TEST_F(TestMetadataParserImplV1, ParseMultipleConfigurations)
+{
+  auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
+  auto configurations = metadataParser->ParseAndGetConfigurationMetadata(
+    ManifestHelper::GetTestManifest("manifest_mult_conf"));
+  ASSERT_THAT(configurations, ::testing::SizeIs(2));
 
-    configuration = configurations[1];
-    ASSERT_EQ(configuration.pid, std::string("test2"));
-    ASSERT_THAT(configuration.properties, ::testing::SizeIs(2));
-  }
+  auto configuration = configurations[0];
+  ASSERT_EQ(configuration.pid, std::string("test"));
+  ASSERT_THAT(configuration.properties, ::testing::SizeIs(1));
 
-  struct MetadataInvalidManifestState
-  {
-    MetadataInvalidManifestState(std::string manifest,
-                                 std::string errorOut)
+  configuration = configurations[1];
+  ASSERT_EQ(configuration.pid, std::string("test2"));
+  ASSERT_THAT(configuration.properties, ::testing::SizeIs(2));
+}
+
+struct MetadataInvalidManifestState
+{
+  MetadataInvalidManifestState(std::string manifest, std::string errorOut)
     : manifestName(std::move(manifest))
     , errorOutput(std::move(errorOut))
-    {}
- 
-    std::string manifestName;
-    std::string errorOutput;
- 
-    friend std::ostream& operator<<(std::ostream& os,
+  {}
+
+  std::string manifestName;
+  std::string errorOutput;
+
+  friend std::ostream& operator<<(std::ostream& os,
                                   const MetadataInvalidManifestState& obj)
-    {
-      return os << "Manifest Name: " << obj.manifestName
-                << " error output: " << obj.errorOutput
-                << "\n";
-    }
-  };
-
-  // Test failure modes where the exceptions are thrown
-  class TestInvalidMetadata : public ::testing::TestWithParam<MetadataInvalidManifestState>
   {
-  private:
-    std::shared_ptr<FakeLogger> logger;
-  protected:
-    TestInvalidMetadata()
-      : logger(std::make_shared<FakeLogger>())
-    {}
+    return os << "Manifest Name: " << obj.manifestName
+              << " error output: " << obj.errorOutput << "\n";
+  }
+};
 
-    ~TestInvalidMetadata() override = default;
+// Test failure modes where the exceptions are thrown
+class TestInvalidMetadata
+  : public ::testing::TestWithParam<MetadataInvalidManifestState>
+{
+private:
+  std::shared_ptr<FakeLogger> logger;
 
-  public:
+protected:
+  TestInvalidMetadata()
+    : logger(std::make_shared<FakeLogger>())
+  {}
 
-    static void SetUpTestCase()
+  ~TestInvalidMetadata() override = default;
+
+public:
+  static void SetUpTestCase() { ManifestHelper::StartFramework(); }
+
+  static void TearDownTestCase() { ManifestHelper::StopFramework(); }
+
+  std::shared_ptr<FakeLogger> GetLogger() { return logger; }
+};
+
+TEST_P(TestInvalidMetadata, TestMetadataFailureModes)
+{
+  const auto params = GetParam();
+  EXPECT_THROW(
     {
-      ManifestHelper::StartFramework();
-    }
-
-    static void TearDownTestCase()
-    {
-      ManifestHelper::StopFramework();
-    }
-
-    std::shared_ptr<FakeLogger> GetLogger() { return logger; }
-  };
-
-  TEST_P(TestInvalidMetadata, TestMetadataFailureModes)
-  {
-    const auto params = GetParam();
-    EXPECT_THROW({
-      try
-      {
+      try {
         const AnyMap& cm = ManifestHelper::GetTestManifest(params.manifestName);
-        if (0u == cm.count(CM_VERSION))
-        {
-          throw std::runtime_error(std::string("Metadata is missing mandatory '") + CM_VERSION + "' property");
+        if (0u == cm.count(CM_VERSION)) {
+          throw std::runtime_error(
+            std::string("Metadata is missing mandatory '") + CM_VERSION +
+            "' property");
         }
         auto version = cppmicroservices::any_cast<int>(cm.at(CM_VERSION));
-        auto metadataParser = MetadataParserFactory::Create(version, GetLogger());
+        auto metadataParser =
+          MetadataParserFactory::Create(version, GetLogger());
         metadataParser->ParseAndGetConfigurationMetadata(cm);
-      }
-      catch(const std::exception& err)
-      {
+      } catch (const std::exception& err) {
         std::string exceptionStr{ err.what() };
         ASSERT_THAT(exceptionStr, ::testing::HasSubstr(params.errorOutput));
         throw;
       }
-    }, std::exception);
+    },
+    std::exception);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  FailureModes,
+  TestInvalidMetadata,
+  testing::Values(
+    MetadataInvalidManifestState("manifest_illegal_ver",
+                                 "Unsupported manifest file version '0'"),
+    MetadataInvalidManifestState(
+      "manifest_missing_ver",
+      "Metadata is missing mandatory 'version' property"),
+    MetadataInvalidManifestState("manifest_illegal_ver2",
+                                 "cppmicroservices::BadAnyCastException"),
+    MetadataInvalidManifestState("manifest_illegal_ver3",
+                                 "cppmicroservices::BadAnyCastException"),
+    MetadataInvalidManifestState(
+      "manifest_no_conf",
+      "Metadata is missing mandatory 'configurations' property"),
+    MetadataInvalidManifestState("manifest_bad_conf",
+                                 "cppmicroservices::BadAnyCastException"),
+    MetadataInvalidManifestState("manifest_bad_arraytype",
+                                 "cppmicroservices::BadAnyCastException")));
+
+// Test failure modes where the exceptions are eaten by metadataParser
+// and logged through the logger
+class TestInvalidMetadataThroughLogger
+  : public ::testing::TestWithParam<MetadataInvalidManifestState>
+{
+public:
+  static void SetUpTestCase() { ManifestHelper::StartFramework(); }
+
+  static void TearDownTestCase() { ManifestHelper::StopFramework(); }
+};
+
+// We are only interested in the message logged by the metadataParser.
+class CustomLogger : public FakeLogger
+{
+public:
+  std::string msg;
+  using FakeLogger::Log;
+  void Log(cppmicroservices::logservice::SeverityLevel /* level */,
+           const std::string& message) override
+  {
+    msg = message;
   }
+};
 
-  INSTANTIATE_TEST_SUITE_P(FailureModes, TestInvalidMetadata,
-    testing::Values(
-      MetadataInvalidManifestState("manifest_illegal_ver",
-        "Unsupported manifest file version '0'"),
-      MetadataInvalidManifestState("manifest_missing_ver",
-        "Metadata is missing mandatory 'version' property"),
-      MetadataInvalidManifestState("manifest_illegal_ver2",
-        "cppmicroservices::BadAnyCastException"),
-      MetadataInvalidManifestState("manifest_illegal_ver3",
-        "cppmicroservices::BadAnyCastException"),
-      MetadataInvalidManifestState("manifest_no_conf",
-        "Metadata is missing mandatory 'configurations' property"),
-      MetadataInvalidManifestState("manifest_bad_conf",
-        "cppmicroservices::BadAnyCastException"),
-      MetadataInvalidManifestState("manifest_bad_arraytype",
-        "cppmicroservices::BadAnyCastException")
-      ));
+TEST_P(TestInvalidMetadataThroughLogger, TestMetadataFailureModes)
+{
+  const auto params = GetParam();
+  auto logger = std::make_shared<CustomLogger>();
+  EXPECT_NO_THROW({
+    const auto& cm = ManifestHelper::GetTestManifest(params.manifestName);
+    auto version = cppmicroservices::any_cast<int>(cm.at(CM_VERSION));
+    auto metadataParser = MetadataParserFactory::Create(version, logger);
+    metadataParser->ParseAndGetConfigurationMetadata(cm);
+  });
+  EXPECT_THAT(
+    logger->msg,
+    ::testing::HasSubstr("Could not load the configuration with index: " +
+                         params.errorOutput));
+}
 
-  // Test failure modes where the exceptions are eaten by metadataParser
-  // and logged through the logger
-  class TestInvalidMetadataThroughLogger : public ::testing::TestWithParam<MetadataInvalidManifestState>
-  {
-  public:
+INSTANTIATE_TEST_SUITE_P(
+  FailureModes,
+  TestInvalidMetadataThroughLogger,
+  testing::Values(MetadataInvalidManifestState("manifest_missing_pid", "0"),
+                  MetadataInvalidManifestState("manifest_missing_properties",
+                                               "0"),
+                  MetadataInvalidManifestState("manifest_bad_pid", "0"),
+                  MetadataInvalidManifestState("manifest_bad_properties", "0"),
+                  MetadataInvalidManifestState("manifest_bad_index1", "1")));
 
-    static void SetUpTestCase()
-    {
-      ManifestHelper::StartFramework();
-    }
-
-    static void TearDownTestCase()
-    {
-      ManifestHelper::StopFramework();
-    }
-  };
-
-  // We are only interested in the message logged by the metadataParser.
-  class CustomLogger : public FakeLogger
-  {
-  public:
-    std::string msg;
-    using FakeLogger::Log;
-    void Log(cppmicroservices::logservice::SeverityLevel /* level */, const std::string& message) override
-    {
-      msg = message;
-    }
-  };
-
-  TEST_P(TestInvalidMetadataThroughLogger, TestMetadataFailureModes)
-  {
-    const auto params = GetParam();
-    auto logger = std::make_shared<CustomLogger>();
-    EXPECT_NO_THROW({
-      const auto& cm = ManifestHelper::GetTestManifest(params.manifestName);
-      auto version = cppmicroservices::any_cast<int>(cm.at(CM_VERSION));
-      auto metadataParser = MetadataParserFactory::Create(version, logger);
-      metadataParser->ParseAndGetConfigurationMetadata(cm);
-    });
-    EXPECT_THAT(logger->msg, ::testing::HasSubstr("Could not load the configuration with index: " + params.errorOutput));
-  }
-
-  INSTANTIATE_TEST_SUITE_P(FailureModes, TestInvalidMetadataThroughLogger,
-    testing::Values(
-      MetadataInvalidManifestState("manifest_missing_pid", "0"),
-      MetadataInvalidManifestState("manifest_missing_properties", "0"),
-      MetadataInvalidManifestState("manifest_bad_pid", "0"),
-      MetadataInvalidManifestState("manifest_bad_properties", "0"),
-      MetadataInvalidManifestState("manifest_bad_index1", "1")
-      ));
-
-}  // namespace
+} // namespace

--- a/compendium/ConfigurationAdmin/test/main.cpp
+++ b/compendium/ConfigurationAdmin/test/main.cpp
@@ -22,7 +22,7 @@
 
 #include "gmock/gmock.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -216,8 +216,7 @@ void ComponentContextImpl::AddToBoundServicesCache(
   cppmicroservices::ServiceObjects<void> sObjs =
     bc.GetServiceObjects(ServiceReferenceU(sRef));
   auto boundServicesCacheHandle = boundServicesCache.lock();
-  (*boundServicesCacheHandle)[refName].emplace_back(
-    sObjs.GetService());
+  (*boundServicesCacheHandle)[refName].emplace_back(sObjs.GetService());
 }
 
 void ComponentContextImpl::RemoveFromBoundServicesCache(

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -23,13 +23,13 @@
 #ifndef __COMPONENT_CONTEXT_IMPL_HPP__
 #define __COMPONENT_CONTEXT_IMPL_HPP__
 
-#include <string>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4503)
+#  pragma warning(push)
+#  pragma warning(disable : 4503)
 #endif
 
 #include "cppmicroservices/Any.h"
@@ -68,7 +68,8 @@ public:
    * \return a map of string and cppmicroservices::Any key-value pairs
    * \throws {@link ComponentException} if this {@link ComponentContext} is invalid
    */
-  std::unordered_map<std::string, cppmicroservices::Any> GetProperties() const override;
+  std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
+    const override;
 
   /**
    * Returns the service object for the specified reference name.
@@ -91,7 +92,8 @@ public:
    *         exception while activating the bound service or if this
    *         {@link ComponentContext} is invalid
    */
-  std::shared_ptr<void>  LocateService(const std::string& name, const std::string& type) const override;
+  std::shared_ptr<void> LocateService(const std::string& name,
+                                      const std::string& type) const override;
 
   /**
    * Returns the service objects for the specified reference name.
@@ -108,7 +110,9 @@ public:
    *         exception while activating a bound service or if this
    *         {@link ComponentContext} is invalid
    */
-  std::vector<std::shared_ptr<void>> LocateServices(const std::string& name, const std::string& type) const override;
+  std::vector<std::shared_ptr<void>> LocateServices(
+    const std::string& name,
+    const std::string& type) const override;
 
   /**
    * Returns the {@link BundleContext} of the bundle which contains this
@@ -197,11 +201,13 @@ public:
    */
   void Invalidate();
 
-  void AddToBoundServicesCache(const std::string& refName
-                             , const cppmicroservices::ServiceReferenceBase& sRef);
-    
-  void RemoveFromBoundServicesCache(const std::string& refName
-                             , const cppmicroservices::ServiceReferenceBase& sRef);
+  void AddToBoundServicesCache(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef);
+
+  void RemoveFromBoundServicesCache(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef);
 
 private:
   /**
@@ -215,7 +221,10 @@ private:
 
   std::weak_ptr<ComponentConfiguration> configManager;
   cppmicroservices::Bundle usingBundle;
-  mutable Guarded<std::unordered_map<std::string, std::vector<cppmicroservices::InterfaceMapConstPtr>>> boundServicesCache;
+  mutable Guarded<
+    std::unordered_map<std::string,
+                       std::vector<cppmicroservices::InterfaceMapConstPtr>>>
+    boundServicesCache;
 };
 }
 }

--- a/compendium/DeclarativeServices/src/ComponentRegistry.cpp
+++ b/compendium/DeclarativeServices/src/ComponentRegistry.cpp
@@ -25,42 +25,46 @@
 namespace cppmicroservices {
 namespace scrimpl {
 
-std::vector<std::shared_ptr<ComponentManager>> ComponentRegistry::GetComponentManagers() const
+std::vector<std::shared_ptr<ComponentManager>>
+ComponentRegistry::GetComponentManagers() const
 {
-  std::lock_guard<std::mutex> lock(mMapsMutex); 
+  std::lock_guard<std::mutex> lock(mMapsMutex);
   std::vector<std::shared_ptr<ComponentManager>> managers;
-  for (const auto& kv : mComponentsByName)
-  {
+  for (const auto& kv : mComponentsByName) {
     managers.push_back(kv.second);
   }
   return managers;
 }
 
-std::vector<std::shared_ptr<ComponentManager>> ComponentRegistry::GetComponentManagers(unsigned long bundleId) const
+std::vector<std::shared_ptr<ComponentManager>>
+ComponentRegistry::GetComponentManagers(unsigned long bundleId) const
 {
   std::lock_guard<std::mutex> lock(mMapsMutex);
   std::vector<std::shared_ptr<ComponentManager>> managers;
-  for (const auto& kv : mComponentsByName)
-  {
-    if(kv.first.first == bundleId)
-    {
+  for (const auto& kv : mComponentsByName) {
+    if (kv.first.first == bundleId) {
       managers.push_back(kv.second);
     }
   }
   return managers;
 }
 
-std::shared_ptr<ComponentManager> ComponentRegistry::GetComponentManager(unsigned long bundleId,
-                                                                         const std::string& compName) const
+std::shared_ptr<ComponentManager> ComponentRegistry::GetComponentManager(
+  unsigned long bundleId,
+  const std::string& compName) const
 {
   std::lock_guard<std::mutex> lock(mMapsMutex);
   return mComponentsByName.at(std::make_pair(bundleId, compName));
 }
 
-bool ComponentRegistry::AddComponentManager(const std::shared_ptr<ComponentManager>& cm)
+bool ComponentRegistry::AddComponentManager(
+  const std::shared_ptr<ComponentManager>& cm)
 {
   std::lock_guard<std::mutex> lock(mMapsMutex);
-  auto result = mComponentsByName.insert(std::make_pair(std::make_pair(static_cast<unsigned long>(cm->GetBundleId()), cm->GetName()), cm));
+  auto result = mComponentsByName.insert(
+    std::make_pair(std::make_pair(static_cast<unsigned long>(cm->GetBundleId()),
+                                  cm->GetName()),
+                   cm));
   return result.second;
 }
 
@@ -71,10 +75,10 @@ void ComponentRegistry::RemoveComponentManager(unsigned long bundleId,
   mComponentsByName.erase(std::make_pair(bundleId, compName));
 }
 
-void ComponentRegistry::RemoveComponentManager(const std::shared_ptr<ComponentManager>& cm)
+void ComponentRegistry::RemoveComponentManager(
+  const std::shared_ptr<ComponentManager>& cm)
 {
-  RemoveComponentManager(cm->GetBundleId(),
-                         cm->GetName());
+  RemoveComponentManager(cm->GetBundleId(), cm->GetName());
 }
 
 void ComponentRegistry::Clear()

--- a/compendium/DeclarativeServices/src/ComponentRegistry.hpp
+++ b/compendium/DeclarativeServices/src/ComponentRegistry.hpp
@@ -23,9 +23,9 @@
 #ifndef __COMPONENT_REGISTRY_HPP__
 #define __COMPONENT_REGISTRY_HPP__
 
+#include "manager/ComponentManager.hpp"
 #include <memory>
 #include <vector>
-#include "manager/ComponentManager.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -49,7 +49,8 @@ public:
    * \return a vector of {@link ComponentManager} objects that are stored in
    * the registry
    */
-  virtual std::vector<std::shared_ptr<ComponentManager>> GetComponentManagers() const;
+  virtual std::vector<std::shared_ptr<ComponentManager>> GetComponentManagers()
+    const;
 
   /**
    * Method returns all the component manager objects from a bundle, stored
@@ -61,7 +62,8 @@ public:
    *         the registry and which belong to the {@link Bundle} with the
    *         given id.
    */
-  virtual std::vector<std::shared_ptr<ComponentManager>> GetComponentManagers(unsigned long bundleId) const;
+  virtual std::vector<std::shared_ptr<ComponentManager>> GetComponentManagers(
+    unsigned long bundleId) const;
 
   /**
    * Method returns a component manager object with the given name and from the given bundle
@@ -74,8 +76,9 @@ public:
    *         the registry and which belong to the {@link Bundle} with the
    *         given id.
    */
-  virtual std::shared_ptr<ComponentManager> GetComponentManager(unsigned long bundleId,
-                                                                const std::string& compName) const;
+  virtual std::shared_ptr<ComponentManager> GetComponentManager(
+    unsigned long bundleId,
+    const std::string& compName) const;
 
   /**
    * Method removes a component manager object from the component registry
@@ -109,7 +112,8 @@ public:
    * \param cm is the {@link ComponentManager} object which will be removed
    *        from the registry
    */
-  virtual void RemoveComponentManager(const std::shared_ptr<ComponentManager>& cm);
+  virtual void RemoveComponentManager(
+    const std::shared_ptr<ComponentManager>& cm);
 
   /**
    * Removes all entries from the component registry
@@ -120,8 +124,11 @@ public:
    * Returns the number of elements in the component regsitry
    */
   size_t Count() const;
+
 private:
-  std::map<std::pair<unsigned long,std::string>,std::shared_ptr<ComponentManager>> mComponentsByName;
+  std::map<std::pair<unsigned long, std::string>,
+           std::shared_ptr<ComponentManager>>
+    mComponentsByName;
   mutable std::mutex mMapsMutex;
 };
 } // scrimpl

--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -20,17 +20,17 @@
 
   =============================================================================*/
 
-#include <iostream>
-#include <vector>
-#include <memory>
-#include <future>
-#include <functional>
-#include <stdexcept>
 #include "SCRActivator.hpp"
 #include "SCRLogger.hpp"
+#include "ServiceComponentRuntimeImpl.hpp"
 #include "manager/ComponentManager.hpp"
 #include "manager/ReferenceManager.hpp"
-#include "ServiceComponentRuntimeImpl.hpp"
+#include <functional>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
 
 #include "cppmicroservices/SharedLibraryException.h"
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
@@ -41,7 +41,8 @@
 #include "cppmicroservices/detail/ScopeGuard.h"
 
 using cppmicroservices::logservice::SeverityLevel;
-using cppmicroservices::service::component::ComponentConstants::SERVICE_COMPONENT;
+using cppmicroservices::service::component::ComponentConstants::
+  SERVICE_COMPONENT;
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -60,25 +61,26 @@ void SCRActivator::Start(BundleContext context)
   logger = std::make_shared<SCRLogger>(context);
   logger->Log(SeverityLevel::LOG_DEBUG, "Starting SCR bundle");
   // Add bundle listener
-  bundleListenerToken = context.AddBundleListener(std::bind(&SCRActivator::BundleChanged, this, std::placeholders::_1));
+  bundleListenerToken = context.AddBundleListener(
+    std::bind(&SCRActivator::BundleChanged, this, std::placeholders::_1));
   // HACK: Workaround for lack of Bundle Tracker. Iterate over all bundles and call the tracker method manually
-  for (const auto& bundle : context.GetBundles())
-  {
-    if (bundle.GetState() == cppmicroservices::Bundle::State::STATE_ACTIVE)
-    {
-      cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
+  for (const auto& bundle : context.GetBundles()) {
+    if (bundle.GetState() == cppmicroservices::Bundle::State::STATE_ACTIVE) {
+      cppmicroservices::BundleEvent evt(
+        cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
       BundleChanged(evt);
     }
   }
   // Publish ServiceComponentRuntimeService
-  auto service = std::make_shared<ServiceComponentRuntimeImpl>(runtimeContext, componentRegistry, logger);
-  scrServiceReg = context.RegisterService<ServiceComponentRuntime>(std::move(service));
+  auto service = std::make_shared<ServiceComponentRuntimeImpl>(
+    runtimeContext, componentRegistry, logger);
+  scrServiceReg =
+    context.RegisterService<ServiceComponentRuntime>(std::move(service));
 }
 
 void SCRActivator::Stop(cppmicroservices::BundleContext context)
 {
-  try
-  {
+  try {
     cppmicroservices::detail::ScopeGuard joinThreadPool{ [this]() {
       if (threadpool) {
         try {
@@ -96,8 +98,7 @@ void SCRActivator::Stop(cppmicroservices::BundleContext context)
     scrServiceReg.Unregister();
     // dispose all components created by SCR
     const auto bundles = context.GetBundles();
-    for (auto const& bundle : bundles)
-    {
+    for (auto const& bundle : bundles) {
       DisposeExtension(bundle);
     }
 
@@ -110,10 +111,11 @@ void SCRActivator::Stop(cppmicroservices::BundleContext context)
     componentRegistry->Clear();
 
     logger->Log(SeverityLevel::LOG_DEBUG, "SCR Bundle stopped.");
-  }
-  catch (...)
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "Exception while stopping the declarative services runtime bundle", std::current_exception());
+  } catch (...) {
+    logger->Log(
+      SeverityLevel::LOG_DEBUG,
+      "Exception while stopping the declarative services runtime bundle",
+      std::current_exception());
   }
   logger->StopTracking();
 }
@@ -122,9 +124,10 @@ void SCRActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
 {
   const auto& headers = bundle.GetHeaders();
   // bundle has no "scr" property
-  if (headers.count(SERVICE_COMPONENT) == 0u)
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "No SCR components found in bundle " + bundle.GetSymbolicName());
+  if (headers.count(SERVICE_COMPONENT) == 0u) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "No SCR components found in bundle " +
+                  bundle.GetSymbolicName());
     return;
   }
 
@@ -134,26 +137,34 @@ void SCRActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
     extensionFound = (bundleRegistry.count(bundle.GetBundleId()) != 0u);
   }
   // bundle components have not been loaded, so create the extension which will load the components
-  if (!extensionFound)
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "Creating SCRBundleExtension ... " + bundle.GetSymbolicName());
-    try
-    {
-      auto const& scrMap = ref_any_cast<cppmicroservices::AnyMap>(headers.at(SERVICE_COMPONENT));
-      auto ba = std::make_unique<SCRBundleExtension>(bundle.GetBundleContext(), scrMap, componentRegistry, logger, threadpool);
+  if (!extensionFound) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Creating SCRBundleExtension ... " + bundle.GetSymbolicName());
+    try {
+      auto const& scrMap =
+        ref_any_cast<cppmicroservices::AnyMap>(headers.at(SERVICE_COMPONENT));
+      auto ba = std::make_unique<SCRBundleExtension>(bundle.GetBundleContext(),
+                                                     scrMap,
+                                                     componentRegistry,
+                                                     logger,
+                                                     threadpool);
       {
         std::lock_guard<std::mutex> l(bundleRegMutex);
-        bundleRegistry.insert(std::make_pair(bundle.GetBundleId(),std::move(ba)));
+        bundleRegistry.insert(
+          std::make_pair(bundle.GetBundleId(), std::move(ba)));
       }
     } catch (const cppmicroservices::SharedLibraryException&) {
       throw;
     } catch (const std::exception&) {
-      logger->Log(SeverityLevel::LOG_DEBUG, "Failed to create SCRBundleExtension for " + bundle.GetSymbolicName(), std::current_exception());
+      logger->Log(SeverityLevel::LOG_DEBUG,
+                  "Failed to create SCRBundleExtension for " +
+                    bundle.GetSymbolicName(),
+                  std::current_exception());
     }
-  }
-  else
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "SCR components already loaded from bundle " + bundle.GetSymbolicName());
+  } else {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "SCR components already loaded from bundle " +
+                  bundle.GetSymbolicName());
   }
 }
 
@@ -161,9 +172,9 @@ void SCRActivator::DisposeExtension(const cppmicroservices::Bundle& bundle)
 {
   const auto& headers = bundle.GetHeaders();
   // bundle has no scr-component property
-  if (headers.count(SERVICE_COMPONENT) == 0u)
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCR Metadata for " + bundle.GetSymbolicName());
+  if (headers.count(SERVICE_COMPONENT) == 0u) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Found No SCR Metadata for " + bundle.GetSymbolicName());
     return;
   }
 
@@ -172,18 +183,17 @@ void SCRActivator::DisposeExtension(const cppmicroservices::Bundle& bundle)
     std::lock_guard<std::mutex> l(bundleRegMutex);
     extensionFound = (bundleRegistry.count(bundle.GetBundleId()) != 0u);
   }
-  if (extensionFound)
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "Found SCRBundleExtension for " + bundle.GetSymbolicName());
+  if (extensionFound) {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Found SCRBundleExtension for " + bundle.GetSymbolicName());
     // remove the bundle extension object from the map.
     {
       std::lock_guard<std::mutex> l(bundleRegMutex);
       bundleRegistry.erase(bundle.GetBundleId());
     }
-  }
-  else
-  {
-    logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCRBundleExtension for " + bundle.GetSymbolicName());
+  } else {
+    logger->Log(SeverityLevel::LOG_DEBUG,
+                "Found No SCRBundleExtension for " + bundle.GetSymbolicName());
   }
 }
 
@@ -191,18 +201,16 @@ void SCRActivator::BundleChanged(const cppmicroservices::BundleEvent& evt)
 {
   auto bundle = evt.GetBundle();
   const auto eventType = evt.GetType();
-  if (bundle == runtimeContext.GetBundle()) // skip events for this (runtime) bundle
+  if (bundle ==
+      runtimeContext.GetBundle()) // skip events for this (runtime) bundle
   {
     return;
   }
 
   // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
-  if (eventType == cppmicroservices::BundleEvent::BUNDLE_STARTED)
-  {
+  if (eventType == cppmicroservices::BundleEvent::BUNDLE_STARTED) {
     CreateExtension(bundle);
-  }
-  else if (eventType == cppmicroservices::BundleEvent::BUNDLE_STOPPING)
-  {
+  } else if (eventType == cppmicroservices::BundleEvent::BUNDLE_STOPPING) {
     DisposeExtension(bundle);
   }
   // else ignore
@@ -210,4 +218,5 @@ void SCRActivator::BundleChanged(const cppmicroservices::BundleEvent& evt)
 } // scrimpl
 } // cppmicroservices
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::scrimpl::SCRActivator) // NOLINT
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::scrimpl::SCRActivator) // NOLINT

--- a/compendium/DeclarativeServices/src/SCRActivator.hpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.hpp
@@ -22,24 +22,23 @@
 
 #ifndef SCRACTIVATOR_HPP
 #define SCRACTIVATOR_HPP
-#include <map>
-#include <vector>
-#include "boost/asio/thread_pool.hpp"
-#include "cppmicroservices/BundleContext.h"
-#include "cppmicroservices/BundleActivator.h"
-#include "cppmicroservices/BundleEvent.h"
-#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 #include "ComponentRegistry.hpp"
 #include "SCRBundleExtension.hpp"
 #include "SCRLogger.hpp"
+#include "boost/asio/thread_pool.hpp"
+#include "cppmicroservices/BundleActivator.h"
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/BundleEvent.h"
+#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
+#include <map>
+#include <vector>
 
 using cppmicroservices::service::component::runtime::ServiceComponentRuntime;
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class SCRActivator
-  : public cppmicroservices::BundleActivator
+class SCRActivator : public cppmicroservices::BundleActivator
 {
 public:
   SCRActivator() = default;
@@ -52,6 +51,7 @@ public:
   // callback methods for bundle lifecycle
   void Start(cppmicroservices::BundleContext context) override;
   void Stop(cppmicroservices::BundleContext context) override;
+
 protected:
   /**
    * bundle listener callback
@@ -67,6 +67,7 @@ protected:
    * with declarative services metadata
    */
   void DisposeExtension(const cppmicroservices::Bundle& bundle);
+
 private:
   cppmicroservices::BundleContext runtimeContext;
   cppmicroservices::ServiceRegistration<ServiceComponentRuntime> scrServiceReg;

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -23,17 +23,17 @@
 #ifndef __SCRBUNDLEEXTENSION_HPP__
 #define __SCRBUNDLEEXTENSION_HPP__
 
-#include <memory>
 #include "boost/asio/thread_pool.hpp"
+#include <memory>
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
-#include "cppmicroservices/BundleContext.h"
 #include "ComponentRegistry.hpp"
-#include "manager/ComponentManager.hpp"
+#include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/logservice/LogService.hpp"
+#include "manager/ComponentManager.hpp"
 #include "metadata/Util.hpp"
 
 using cppmicroservices::logservice::LogService;
@@ -49,16 +49,18 @@ namespace scrimpl {
 class SCRBundleExtension
 {
 public:
-  SCRBundleExtension(const cppmicroservices::BundleContext& bundleContext,
-                     const cppmicroservices::AnyMap& scrMetadata,
-                     const std::shared_ptr<ComponentRegistry>& registry,
-                     const std::shared_ptr<LogService>& logger,
-                     const std::shared_ptr<boost::asio::thread_pool>& threadpool);
+  SCRBundleExtension(
+    const cppmicroservices::BundleContext& bundleContext,
+    const cppmicroservices::AnyMap& scrMetadata,
+    const std::shared_ptr<ComponentRegistry>& registry,
+    const std::shared_ptr<LogService>& logger,
+    const std::shared_ptr<boost::asio::thread_pool>& threadpool);
   SCRBundleExtension(const SCRBundleExtension&) = delete;
   SCRBundleExtension(SCRBundleExtension&&) = delete;
   SCRBundleExtension& operator=(const SCRBundleExtension&) = delete;
   SCRBundleExtension& operator=(SCRBundleExtension&&) = delete;
   ~SCRBundleExtension();
+
 private:
   FRIEND_TEST(SCRBundleExtensionTest, CtorWithValidArgs);
 

--- a/compendium/DeclarativeServices/src/SCRLogger.cpp
+++ b/compendium/DeclarativeServices/src/SCRLogger.cpp
@@ -27,7 +27,8 @@ namespace scrimpl {
 
 SCRLogger::SCRLogger(cppmicroservices::BundleContext context)
   : scrContext(context)
-  , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>(context, this))
+  , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<
+                     cppmicroservices::logservice::LogService>>(context, this))
   , logService(nullptr)
 {
   serviceTracker->Open(); // Start tracking
@@ -40,85 +41,84 @@ SCRLogger::~SCRLogger()
 
 void SCRLogger::StopTracking()
 {
-  if (serviceTracker)
-  {
+  if (serviceTracker) {
     serviceTracker->Close();
     serviceTracker.reset();
   }
 }
 
-std::shared_ptr<cppmicroservices::logservice::LogService> SCRLogger::AddingService(const ServiceReference<cppmicroservices::logservice::LogService>& reference)
+std::shared_ptr<cppmicroservices::logservice::LogService>
+SCRLogger::AddingService(
+  const ServiceReference<cppmicroservices::logservice::LogService>& reference)
 {
   auto currLogger = std::atomic_load(&logService);
   std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-  if(!currLogger && reference)
-  {
-    logger = scrContext.GetService<cppmicroservices::logservice::LogService>(reference);
+  if (!currLogger && reference) {
+    logger = scrContext.GetService<cppmicroservices::logservice::LogService>(
+      reference);
     std::atomic_store(&logService, logger);
   }
   return logger;
 }
 
-void SCRLogger::ModifiedService(const ServiceReference<cppmicroservices::logservice::LogService>& /*reference*/,
-                                const std::shared_ptr<cppmicroservices::logservice::LogService>& /*service*/)
+void SCRLogger::ModifiedService(
+  const ServiceReference<
+    cppmicroservices::logservice::LogService>& /*reference*/,
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& /*service*/)
 {
   // no-op. Don't care if properties change
 }
 
-void SCRLogger::RemovedService(const ServiceReference<cppmicroservices::logservice::LogService>& /*reference*/,
-                               const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+void SCRLogger::RemovedService(
+  const ServiceReference<
+    cppmicroservices::logservice::LogService>& /*reference*/,
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
 {
   auto currLogger = std::atomic_load(&logService);
-  if(service == currLogger)
-  {
+  if (service == currLogger) {
     // replace existing logger with a nullptr logger
     std::shared_ptr<cppmicroservices::logservice::LogService> logger(nullptr);
     std::atomic_store(&logService, logger);
   }
 }
 
-void SCRLogger::Log(logservice::SeverityLevel level, const std::string &message)
+void SCRLogger::Log(logservice::SeverityLevel level, const std::string& message)
 {
   auto currLogger = std::atomic_load(&logService);
-  if (currLogger)
-  {
+  if (currLogger) {
     currLogger->Log(level, message);
   }
 }
 
 void SCRLogger::Log(logservice::SeverityLevel level,
-                    const std::string &message,
+                    const std::string& message,
                     const std::exception_ptr ex)
 {
   auto currLogger = std::atomic_load(&logService);
-  if (currLogger)
-  {
+  if (currLogger) {
     currLogger->Log(level, message, ex);
   }
 }
 
-void SCRLogger::Log(const cppmicroservices::ServiceReferenceBase &sr,
+void SCRLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
                     logservice::SeverityLevel level,
-                    const std::string &message)
+                    const std::string& message)
 {
   auto currLogger = std::atomic_load(&logService);
-  if (currLogger)
-  {
+  if (currLogger) {
     currLogger->Log(sr, level, message);
   }
 }
 
-void SCRLogger::Log(const cppmicroservices::ServiceReferenceBase &sr,
+void SCRLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
                     logservice::SeverityLevel level,
-                    const std::string &message,
+                    const std::string& message,
                     const std::exception_ptr ex)
 {
   auto currLogger = std::atomic_load(&logService);
-  if (currLogger)
-  {
+  if (currLogger) {
     currLogger->Log(sr, level, message, ex);
   }
 }
 } // scrimpl
 } // cppmicroservices
-

--- a/compendium/DeclarativeServices/src/SCRLogger.hpp
+++ b/compendium/DeclarativeServices/src/SCRLogger.hpp
@@ -37,7 +37,8 @@ namespace scrimpl {
  */
 class SCRLogger
   : public cppmicroservices::logservice::LogService
-  , public cppmicroservices::ServiceTrackerCustomizer<cppmicroservices::logservice::LogService>
+  , public cppmicroservices::ServiceTrackerCustomizer<
+      cppmicroservices::logservice::LogService>
 {
 public:
   explicit SCRLogger(cppmicroservices::BundleContext context);
@@ -48,22 +49,41 @@ public:
   ~SCRLogger() override;
 
   // methods from the cppmicroservices::logservice::LogService interface
-  void Log(logservice::SeverityLevel level, const std::string& message) override;
-  void Log(logservice::SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
-  void Log(const ServiceReferenceBase& sr, logservice::SeverityLevel level, const std::string& message) override;
-  void Log(const ServiceReferenceBase& sr, logservice::SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
+  void Log(logservice::SeverityLevel level,
+           const std::string& message) override;
+  void Log(logservice::SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
+  void Log(const ServiceReferenceBase& sr,
+           logservice::SeverityLevel level,
+           const std::string& message) override;
+  void Log(const ServiceReferenceBase& sr,
+           logservice::SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
 
   // methods from the cppmicroservices::ServiceTrackerCustomizer interface
-  std::shared_ptr<TrackedParamType> AddingService(const ServiceReference<cppmicroservices::logservice::LogService>& reference) override;
-  void ModifiedService(const ServiceReference<cppmicroservices::logservice::LogService>& reference, const std::shared_ptr<cppmicroservices::logservice::LogService>& service) override;
-  void RemovedService(const ServiceReference<cppmicroservices::logservice::LogService>& reference, const std::shared_ptr<cppmicroservices::logservice::LogService>& service) override;
+  std::shared_ptr<TrackedParamType> AddingService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference)
+    override;
+  void ModifiedService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+    override;
+  void RemovedService(
+    const ServiceReference<cppmicroservices::logservice::LogService>& reference,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
+    override;
 
   // method to stop tracking the Log Service. This must be called from the SCR BundleActivator's Stop method.
   // Not Thread-safe. must not be called simultaneously from multiple threads
   void StopTracking();
+
 private:
   cppmicroservices::BundleContext scrContext;
-  std::unique_ptr<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>> serviceTracker;
+  std::unique_ptr<
+    cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
+    serviceTracker;
   std::shared_ptr<cppmicroservices::logservice::LogService> logService;
 };
 } // scrimpl

--- a/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.cpp
+++ b/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.cpp
@@ -20,19 +20,19 @@
 
   =============================================================================*/
 
-#include <chrono>
 #include "ServiceComponentRuntimeImpl.hpp"
-#include "cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp"
 #include "cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp"
+#include "cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp"
 #include "cppmicroservices/servicecomponent/runtime/dto/ReferenceDTO.hpp"
+#include "manager/ComponentConfiguration.hpp"
 #include "manager/ComponentManager.hpp"
 #include "manager/ReferenceManager.hpp"
-#include "manager/ComponentConfiguration.hpp"
+#include <chrono>
 
 using cppmicroservices::framework::dto::BundleDTO;
 using cppmicroservices::framework::dto::ServiceReferenceDTO;
-using cppmicroservices::service::component::runtime::dto::ReferenceDTO;
 using cppmicroservices::scrimpl::metadata::ReferenceMetadata;
+using cppmicroservices::service::component::runtime::dto::ReferenceDTO;
 
 using std::chrono::steady_clock;
 using std::chrono::system_clock;
@@ -42,9 +42,11 @@ namespace scrimpl {
 /**
  * Utility Methods used in ServiceComponentRuntimeImpl
  */
-time_t steady_clock_to_time_t( steady_clock::time_point t )
+time_t steady_clock_to_time_t(steady_clock::time_point t)
 {
-  return system_clock::to_time_t(system_clock::now() + std::chrono::duration_cast<system_clock::duration>(t - steady_clock::now()));
+  return system_clock::to_time_t(
+    system_clock::now() + std::chrono::duration_cast<system_clock::duration>(
+                            t - steady_clock::now()));
 }
 
 BundleDTO ToDTO(const cppmicroservices::Bundle& bundle)
@@ -52,7 +54,8 @@ BundleDTO ToDTO(const cppmicroservices::Bundle& bundle)
   BundleDTO bundleDTO = {};
   bundleDTO.id = bundle.GetBundleId();
   bundleDTO.symbolicName = bundle.GetSymbolicName();
-  bundleDTO.lastModified = static_cast<unsigned long>(steady_clock_to_time_t(bundle.GetLastModified()));
+  bundleDTO.lastModified = static_cast<unsigned long>(
+    steady_clock_to_time_t(bundle.GetLastModified()));
   bundleDTO.state = bundle.GetState();
   bundleDTO.version = bundle.GetVersion().ToString();
   return bundleDTO;
@@ -61,20 +64,18 @@ BundleDTO ToDTO(const cppmicroservices::Bundle& bundle)
 ServiceReferenceDTO ToDTO(const cppmicroservices::ServiceReferenceBase& sRef)
 {
   ServiceReferenceDTO refDTO = {};
-  refDTO.id = cppmicroservices::any_cast<long>(sRef.GetProperty(cppmicroservices::Constants::SERVICE_ID));
+  refDTO.id = cppmicroservices::any_cast<long>(
+    sRef.GetProperty(cppmicroservices::Constants::SERVICE_ID));
   refDTO.bundle = sRef ? sRef.GetBundle().GetBundleId() : 0;
   std::vector<std::string> keys;
   sRef.GetPropertyKeys(keys);
-  for(auto& key : keys)
-  {
+  for (auto& key : keys) {
     cppmicroservices::Any val = sRef.GetProperty(key);
     refDTO.properties.insert(std::make_pair(key, val));
   }
   std::vector<cppmicroservices::Bundle> bundles = sRef.GetUsingBundles();
-  for(auto& bundle : bundles)
-  {
-    if(bundle)
-    {
+  for (auto& bundle : bundles) {
+    if (bundle) {
       refDTO.usingBundles.push_back(bundle.GetBundleId());
     }
   }
@@ -94,66 +95,71 @@ ReferenceDTO ToDTO(const ReferenceMetadata& refData)
   return refDTO;
 }
 
-ServiceComponentRuntimeImpl::ServiceComponentRuntimeImpl(cppmicroservices::BundleContext context,
-                                                         std::shared_ptr<ComponentRegistry> componentRegistry,
-                                                         std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+ServiceComponentRuntimeImpl::ServiceComponentRuntimeImpl(
+  cppmicroservices::BundleContext context,
+  std::shared_ptr<ComponentRegistry> componentRegistry,
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger)
   : scrContext(std::move(context))
   , registry(std::move(componentRegistry))
   , logger(std::move(logger))
 {
-  if(!scrContext || !registry || !(this->logger))
-  {
-    throw std::invalid_argument("ServiceComponentRuntimeImpl Constructor provided with invalid arguments");
+  if (!scrContext || !registry || !(this->logger)) {
+    throw std::invalid_argument("ServiceComponentRuntimeImpl Constructor "
+                                "provided with invalid arguments");
   }
 }
 
-std::vector<ComponentDescriptionDTO> ServiceComponentRuntimeImpl::GetComponentDescriptionDTOs(const std::vector<cppmicroservices::Bundle>& bundles) const
+std::vector<ComponentDescriptionDTO>
+ServiceComponentRuntimeImpl::GetComponentDescriptionDTOs(
+  const std::vector<cppmicroservices::Bundle>& bundles) const
 {
   std::vector<std::shared_ptr<ComponentManager>> compMgrs;
-  if (bundles.empty())
-  {
+  if (bundles.empty()) {
     compMgrs = registry->GetComponentManagers();
-  }
-  else
-  {
-    for (auto& bundle : bundles)
-    {
-      auto managersInBundle = registry->GetComponentManagers(bundle.GetBundleId());
-      compMgrs.insert(std::end(compMgrs), std::begin(managersInBundle), std::end(managersInBundle));
+  } else {
+    for (auto& bundle : bundles) {
+      auto managersInBundle =
+        registry->GetComponentManagers(bundle.GetBundleId());
+      compMgrs.insert(std::end(compMgrs),
+                      std::begin(managersInBundle),
+                      std::end(managersInBundle));
     }
   }
   std::vector<ComponentDescriptionDTO> componentDTOs;
-  for (auto holder : compMgrs)
-  {
+  for (auto holder : compMgrs) {
     componentDTOs.push_back(CreateDTO(holder));
   }
   return componentDTOs;
 }
 
-ComponentDescriptionDTO ServiceComponentRuntimeImpl::GetComponentDescriptionDTO(const cppmicroservices::Bundle& bundle, const std::string& name) const
+ComponentDescriptionDTO ServiceComponentRuntimeImpl::GetComponentDescriptionDTO(
+  const cppmicroservices::Bundle& bundle,
+  const std::string& name) const
 {
   ComponentDescriptionDTO compDTO = {};
-  try
-  {
-    std::shared_ptr<ComponentManager> manager = registry->GetComponentManager(bundle.GetBundleId(), name);
+  try {
+    std::shared_ptr<ComponentManager> manager =
+      registry->GetComponentManager(bundle.GetBundleId(), name);
     compDTO = CreateDTO(manager);
-  }
-  catch (const std::exception&)
-  {
-    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, "Exception: ", std::current_exception());
+  } catch (const std::exception&) {
+    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                "Exception: ",
+                std::current_exception());
   }
   return compDTO;
 }
 
-std::vector<ComponentConfigurationDTO> ServiceComponentRuntimeImpl::GetComponentConfigurationDTOs(const ComponentDescriptionDTO& description) const
+std::vector<ComponentConfigurationDTO>
+ServiceComponentRuntimeImpl::GetComponentConfigurationDTOs(
+  const ComponentDescriptionDTO& description) const
 {
   std::vector<ComponentConfigurationDTO> compConfigDTOs;
-  std::shared_ptr<ComponentManager> manager = registry->GetComponentManager(description.bundle.id, description.name);
-  if(manager)
-  {
-    std::vector<std::shared_ptr<ComponentConfiguration>> configs = manager->GetComponentConfigurations();
-    for(auto& aConfig : configs)
-    {
+  std::shared_ptr<ComponentManager> manager =
+    registry->GetComponentManager(description.bundle.id, description.name);
+  if (manager) {
+    std::vector<std::shared_ptr<ComponentConfiguration>> configs =
+      manager->GetComponentConfigurations();
+    for (auto& aConfig : configs) {
       auto compConfigDTO = CreateComponentConfigurationDTO(aConfig);
       compConfigDTO.description = CreateDTO(manager);
       compConfigDTOs.push_back(compConfigDTO);
@@ -162,30 +168,36 @@ std::vector<ComponentConfigurationDTO> ServiceComponentRuntimeImpl::GetComponent
   return compConfigDTOs;
 }
 
-bool ServiceComponentRuntimeImpl::IsComponentEnabled(const ComponentDescriptionDTO& description) const
+bool ServiceComponentRuntimeImpl::IsComponentEnabled(
+  const ComponentDescriptionDTO& description) const
 {
-  std::shared_ptr<ComponentManager> mgr = registry->GetComponentManager(description.bundle.id, description.name);
+  std::shared_ptr<ComponentManager> mgr =
+    registry->GetComponentManager(description.bundle.id, description.name);
   return mgr ? mgr->IsEnabled() : false;
 }
 
-std::shared_future<void> ServiceComponentRuntimeImpl::EnableComponent(const ComponentDescriptionDTO& description)
+std::shared_future<void> ServiceComponentRuntimeImpl::EnableComponent(
+  const ComponentDescriptionDTO& description)
 {
-  std::shared_ptr<ComponentManager> holder = registry->GetComponentManager(description.bundle.id, description.name);
+  std::shared_ptr<ComponentManager> holder =
+    registry->GetComponentManager(description.bundle.id, description.name);
   return holder->Enable();
 }
 
-std::shared_future<void> ServiceComponentRuntimeImpl::DisableComponent(const ComponentDescriptionDTO& description)
+std::shared_future<void> ServiceComponentRuntimeImpl::DisableComponent(
+  const ComponentDescriptionDTO& description)
 {
-  std::shared_ptr<ComponentManager> holder = registry->GetComponentManager(description.bundle.id, description.name);
+  std::shared_ptr<ComponentManager> holder =
+    registry->GetComponentManager(description.bundle.id, description.name);
   return holder->Disable();
 }
 
-ComponentDescriptionDTO ServiceComponentRuntimeImpl::CreateDTO(const std::shared_ptr<ComponentManager>& compManager) const
+ComponentDescriptionDTO ServiceComponentRuntimeImpl::CreateDTO(
+  const std::shared_ptr<ComponentManager>& compManager) const
 {
   ComponentDescriptionDTO compDescription = {};
   auto compMetadata = compManager->GetMetadata();
-  if(compMetadata)
-  {
+  if (compMetadata) {
     compDescription.name = compMetadata->name;
     auto bundleId = compManager->GetBundleId();
     compDescription.bundle = ToDTO(scrContext.GetBundle(bundleId));
@@ -199,56 +211,56 @@ ComponentDescriptionDTO ServiceComponentRuntimeImpl::CreateDTO(const std::shared
     compDescription.implementationClass = compMetadata->implClassName;
     compDescription.defaultEnabled = compMetadata->enabled;
     compDescription.properties = compMetadata->properties;
-    for (auto oneRef : compMetadata->refsMetadata)
-    {
+    for (auto oneRef : compMetadata->refsMetadata) {
       compDescription.references.push_back(ToDTO(oneRef));
     }
   }
   return compDescription;
 }
 
-ComponentConfigurationDTO ServiceComponentRuntimeImpl::CreateComponentConfigurationDTO(const std::shared_ptr<ComponentConfiguration>& config) const
+ComponentConfigurationDTO
+ServiceComponentRuntimeImpl::CreateComponentConfigurationDTO(
+  const std::shared_ptr<ComponentConfiguration>& config) const
 {
   ComponentConfigurationDTO configDTO = {};
   configDTO.id = config->GetId();
   configDTO.properties = config->GetProperties();
   configDTO.state = config->GetConfigState();
   auto refManagers = config->GetAllDependencyManagers();
-  for(auto& refManager : refManagers)
-  {
-    if(refManager->IsSatisfied())
-    {
-      configDTO.satisfiedReferences.push_back(CreateSatisfiedReferenceDTO(refManager));
-    }
-    else
-    {
-      configDTO.unsatisfiedReferences.push_back(CreateUnsatisfiedReferenceDTO(refManager));
+  for (auto& refManager : refManagers) {
+    if (refManager->IsSatisfied()) {
+      configDTO.satisfiedReferences.push_back(
+        CreateSatisfiedReferenceDTO(refManager));
+    } else {
+      configDTO.unsatisfiedReferences.push_back(
+        CreateUnsatisfiedReferenceDTO(refManager));
     }
   }
   return configDTO;
 }
 
-SatisfiedReferenceDTO ServiceComponentRuntimeImpl::CreateSatisfiedReferenceDTO(const std::shared_ptr<ReferenceManager>& refManager) const
+SatisfiedReferenceDTO ServiceComponentRuntimeImpl::CreateSatisfiedReferenceDTO(
+  const std::shared_ptr<ReferenceManager>& refManager) const
 {
   SatisfiedReferenceDTO refDTO = {};
   refDTO.name = refManager->GetReferenceName();
   refDTO.target = refManager->GetLDAPString();
   auto sRefs = refManager->GetBoundReferences();
-  for(auto& sRef : sRefs)
-  {
+  for (auto& sRef : sRefs) {
     refDTO.boundServices.push_back(ToDTO(sRef));
   }
   return refDTO;
 }
 
-UnsatisfiedReferenceDTO ServiceComponentRuntimeImpl::CreateUnsatisfiedReferenceDTO(const std::shared_ptr<ReferenceManager>& refManager) const
+UnsatisfiedReferenceDTO
+ServiceComponentRuntimeImpl::CreateUnsatisfiedReferenceDTO(
+  const std::shared_ptr<ReferenceManager>& refManager) const
 {
   UnsatisfiedReferenceDTO refDTO = {};
   refDTO.name = refManager->GetReferenceName();
   refDTO.target = refManager->GetLDAPString();
   auto sRefs = refManager->GetTargetReferences();
-  for(auto& sRef : sRefs)
-  {
+  for (auto& sRef : sRefs) {
     refDTO.targetServices.push_back(ToDTO(sRef));
   }
   return refDTO;

--- a/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.hpp
+++ b/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.hpp
@@ -24,20 +24,23 @@
 #define __SERVICECOMPONENTRUNTIMEIMPL_HPP__
 
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
-#include "cppmicroservices/logservice/LogService.hpp"
-#include "cppmicroservices/BundleContext.h"
-#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 #include "ComponentRegistry.hpp"
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/logservice/LogService.hpp"
+#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
 using cppmicroservices::service::component::runtime::ServiceComponentRuntime;
-using cppmicroservices::service::component::runtime::dto::ComponentDescriptionDTO;
-using cppmicroservices::service::component::runtime::dto::ComponentConfigurationDTO;
+using cppmicroservices::service::component::runtime::dto::
+  ComponentConfigurationDTO;
+using cppmicroservices::service::component::runtime::dto::
+  ComponentDescriptionDTO;
 using cppmicroservices::service::component::runtime::dto::SatisfiedReferenceDTO;
-using cppmicroservices::service::component::runtime::dto::UnsatisfiedReferenceDTO;
+using cppmicroservices::service::component::runtime::dto::
+  UnsatisfiedReferenceDTO;
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -47,32 +50,36 @@ class ComponentConfiguration;
 /**
  * This class implements the {@code ServiceComponentRuntime} interface.
  */
-class ServiceComponentRuntimeImpl final
-  : public ServiceComponentRuntime
+class ServiceComponentRuntimeImpl final : public ServiceComponentRuntime
 {
 public:
-  ServiceComponentRuntimeImpl(cppmicroservices::BundleContext context,
-                              std::shared_ptr<ComponentRegistry> componentRegistry,
-                              std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  ServiceComponentRuntimeImpl(
+    cppmicroservices::BundleContext context,
+    std::shared_ptr<ComponentRegistry> componentRegistry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
   ~ServiceComponentRuntimeImpl() override = default;
   ServiceComponentRuntimeImpl(const ServiceComponentRuntimeImpl&) = delete;
-  ServiceComponentRuntimeImpl& operator=(const ServiceComponentRuntimeImpl&) = delete;
+  ServiceComponentRuntimeImpl& operator=(const ServiceComponentRuntimeImpl&) =
+    delete;
   ServiceComponentRuntimeImpl(ServiceComponentRuntimeImpl&&) = delete;
-  ServiceComponentRuntimeImpl& operator=(ServiceComponentRuntimeImpl&&) = delete;
+  ServiceComponentRuntimeImpl& operator=(ServiceComponentRuntimeImpl&&) =
+    delete;
 
   /**
    * This method returns the component descriptions from the list of bundles provided.
    * See {@code ServiceComponentRuntime#GetComponentDescriptionDTOs}
    */
-  std::vector<ComponentDescriptionDTO> GetComponentDescriptionDTOs(const std::vector<cppmicroservices::Bundle>& bundles) const override;
+  std::vector<ComponentDescriptionDTO> GetComponentDescriptionDTOs(
+    const std::vector<cppmicroservices::Bundle>& bundles) const override;
 
   /**
    * This method returns the component description for the component with the given
    * name in the given {@code Bundle}
    * See {@code ServiceComponentRuntime#GetComponentDescriptionDTO}
    */
-  ComponentDescriptionDTO GetComponentDescriptionDTO(const cppmicroservices::Bundle& bundle,
-                                                     const std::string& name) const override;
+  ComponentDescriptionDTO GetComponentDescriptionDTO(
+    const cppmicroservices::Bundle& bundle,
+    const std::string& name) const override;
 
   /**
    * This method returns a vector of DTO objects representing component configurations
@@ -81,7 +88,8 @@ public:
    * @throw std::out_of_range exception if the provided ComponentDescriptionDTO does not match
    * any of the known components in the runtime.
    */
-  std::vector<ComponentConfigurationDTO> GetComponentConfigurationDTOs(const ComponentDescriptionDTO& description) const override;
+  std::vector<ComponentConfigurationDTO> GetComponentConfigurationDTOs(
+    const ComponentDescriptionDTO& description) const override;
 
   /**
    * This method returns true if a component represented by the {@code ComponentDescriptionDTO}
@@ -92,7 +100,8 @@ public:
    * any of the known components in the runtime.
    */
 
-  bool IsComponentEnabled(const ComponentDescriptionDTO& description) const override;
+  bool IsComponentEnabled(
+    const ComponentDescriptionDTO& description) const override;
 
   /**
    * This method changes the state of the component represented by the {@code ComponentDescriptionDTO}
@@ -104,7 +113,8 @@ public:
    * @throw std::out_of_range exception if the provided ComponentDescriptionDTO does not match
    * any of the known components in the runtime.
    */
-  std::shared_future<void> EnableComponent(const ComponentDescriptionDTO& description) override;
+  std::shared_future<void> EnableComponent(
+    const ComponentDescriptionDTO& description) override;
 
   /**
    * This method changes the state of the component represented by the {@code ComponentDescriptionDTO}
@@ -116,14 +126,20 @@ public:
    * @throw std::out_of_range exception if the provided ComponentDescriptionDTO does not match
    * any of the known components in the runtime.
    */
-  std::shared_future<void> DisableComponent(const ComponentDescriptionDTO& description) override;
+  std::shared_future<void> DisableComponent(
+    const ComponentDescriptionDTO& description) override;
+
 private:
   FRIEND_TEST(ServiceComponentRuntimeImplTest, Validate_Ctor);
 
-  ComponentDescriptionDTO CreateDTO(const std::shared_ptr<ComponentManager>& compManager) const;
-  SatisfiedReferenceDTO CreateSatisfiedReferenceDTO(const std::shared_ptr<ReferenceManager>& refManager) const;
-  UnsatisfiedReferenceDTO CreateUnsatisfiedReferenceDTO(const std::shared_ptr<ReferenceManager>& refManager) const;
-  ComponentConfigurationDTO CreateComponentConfigurationDTO(const std::shared_ptr<ComponentConfiguration>& config) const;
+  ComponentDescriptionDTO CreateDTO(
+    const std::shared_ptr<ComponentManager>& compManager) const;
+  SatisfiedReferenceDTO CreateSatisfiedReferenceDTO(
+    const std::shared_ptr<ReferenceManager>& refManager) const;
+  UnsatisfiedReferenceDTO CreateUnsatisfiedReferenceDTO(
+    const std::shared_ptr<ReferenceManager>& refManager) const;
+  ComponentConfigurationDTO CreateComponentConfigurationDTO(
+    const std::shared_ptr<ComponentConfiguration>& config) const;
 
   cppmicroservices::BundleContext scrContext;
   std::shared_ptr<ComponentRegistry> registry;

--- a/compendium/DeclarativeServices/src/ServiceReferenceComparator.hpp
+++ b/compendium/DeclarativeServices/src/ServiceReferenceComparator.hpp
@@ -25,8 +25,8 @@
 
 #include "cppmicroservices/Constants.h"
 
-using cppmicroservices::Constants::SERVICE_RANKING;
 using cppmicroservices::Constants::SERVICE_ID;
+using cppmicroservices::Constants::SERVICE_RANKING;
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -40,27 +40,22 @@ namespace scrimpl {
 class ServiceReferenceComparator
 {
 public:
-  bool operator() (const ServiceReferenceU& lhs,
-                   const ServiceReferenceU& rhs)
+  bool operator()(const ServiceReferenceU& lhs, const ServiceReferenceU& rhs)
   {
     auto lRankAny = lhs.GetProperty(SERVICE_RANKING);
     auto rRankAny = rhs.GetProperty(SERVICE_RANKING);
     int lRank = lRankAny.Empty() ? 0 : any_cast<int>(lRankAny);
     int rRank = rRankAny.Empty() ? 0 : any_cast<int>(rRankAny);
-    if(lRank == rRank)
-    {
+    if (lRank == rRank) {
       auto lId = any_cast<long>(lhs.GetProperty(SERVICE_ID));
       auto rId = any_cast<long>(rhs.GetProperty(SERVICE_ID));
       return lId > rId;
-    }
-    else
-    {
+    } else {
       return lRank < rRank;
     }
   };
 };
 }
 }
-
 
 #endif /* __SERVICEREFERENCECOMPARATOR_HPP__ */

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
@@ -74,7 +74,7 @@ void ReferenceManagerBaseImpl::BindingPolicyDynamicGreedy::ServiceAdded(
       // The bind notification must happen before the unbind notification
       // to eliminate any gaps between unbinding the current bound target service
       // and binding to the new bound target service.
-      notifications.push_back(RefChangeNotification {
+      notifications.push_back(RefChangeNotification{
         mgr.metadata.name, RefEvent::REBIND, reference, svcRefToUnBind });
     }
   }

--- a/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
@@ -83,7 +83,8 @@ GetComponentCreatorDeletors(const std::string& compName,
     } catch (const std::system_error& ex) {
       // SharedLibrary::Load() will throw a std::system_error when a shared library
       // fails to load. Creating a SharedLibraryException here to throw with fromBundle information.
-      throw cppmicroservices::SharedLibraryException(ex.code(), ex.what(), std::move(fromBundle));
+      throw cppmicroservices::SharedLibraryException(
+        ex.code(), ex.what(), std::move(fromBundle));
     }
     handle = sh.GetHandle();
     bundleBinaries.lock()->emplace(bundleLoc, handle);
@@ -93,10 +94,10 @@ GetComponentCreatorDeletors(const std::string& compName,
     std::regex_replace(compName, std::regex("::"), "_");
   const std::string newInstanceFuncName("NewInstance_" + symbolName);
   const std::string deleteInstanceFuncName("DeleteInstance_" + symbolName);
-  
+
   void* newsym = fromBundle.GetSymbol(handle, newInstanceFuncName);
   void* delsym = fromBundle.GetSymbol(handle, deleteInstanceFuncName);
-  
+
   if (newsym == nullptr || delsym == nullptr) {
     std::string errMsg("Unable to find entry-point functions in bundle ");
     errMsg += fromBundle.GetLocation();

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -25,42 +25,47 @@
 namespace cppmicroservices {
 namespace scrimpl {
 
-BundleOrPrototypeComponentConfigurationImpl::BundleOrPrototypeComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                                                                                         const cppmicroservices::Bundle& bundle,
-                                                                                         std::shared_ptr<const ComponentRegistry> registry,
-                                                                                         std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+BundleOrPrototypeComponentConfigurationImpl::
+  BundleOrPrototypeComponentConfigurationImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    const cppmicroservices::Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger)
   : ComponentConfigurationImpl(metadata, bundle, registry, logger)
-{
-}
+{}
 
-std::shared_ptr<ServiceFactory> BundleOrPrototypeComponentConfigurationImpl::GetFactory()
+std::shared_ptr<ServiceFactory>
+BundleOrPrototypeComponentConfigurationImpl::GetFactory()
 {
-  auto thisPtr = std::dynamic_pointer_cast<BundleOrPrototypeComponentConfigurationImpl>(shared_from_this());
+  auto thisPtr =
+    std::dynamic_pointer_cast<BundleOrPrototypeComponentConfigurationImpl>(
+      shared_from_this());
   return ToFactory(thisPtr);
 }
 
-BundleOrPrototypeComponentConfigurationImpl::~BundleOrPrototypeComponentConfigurationImpl()
+BundleOrPrototypeComponentConfigurationImpl::
+  ~BundleOrPrototypeComponentConfigurationImpl()
 {
   DestroyComponentInstances();
 }
 
-std::shared_ptr<ComponentInstance> BundleOrPrototypeComponentConfigurationImpl::CreateAndActivateComponentInstance(const cppmicroservices::Bundle& bundle)
+std::shared_ptr<ComponentInstance>
+BundleOrPrototypeComponentConfigurationImpl::CreateAndActivateComponentInstance(
+  const cppmicroservices::Bundle& bundle)
 {
-  if(GetState()->GetValue() != service::component::runtime::dto::ComponentState::ACTIVE)
-  {
+  if (GetState()->GetValue() !=
+      service::component::runtime::dto::ComponentState::ACTIVE) {
     return nullptr;
   }
   auto compInstCtxtPairList = compInstanceMap.lock();
-  try
-  {
+  try {
     auto instCtxtTuple = CreateAndActivateComponentInstanceHelper(bundle);
     compInstCtxtPairList->emplace_back(instCtxtTuple);
     return instCtxtTuple.first;
-  }
-  catch(...)
-  {
+  } catch (...) {
     GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                     "Exception received from user code while activating the component configuration",
+                     "Exception received from user code while activating the "
+                     "component configuration",
                      std::current_exception());
   }
   return nullptr;
@@ -69,60 +74,62 @@ std::shared_ptr<ComponentInstance> BundleOrPrototypeComponentConfigurationImpl::
 void BundleOrPrototypeComponentConfigurationImpl::DestroyComponentInstances()
 {
   auto compInstCtxtPairList = compInstanceMap.lock();
-  for(auto& valPair : *compInstCtxtPairList)
-  {
+  for (auto& valPair : *compInstCtxtPairList) {
     DeactivateComponentInstance(valPair);
   }
   compInstCtxtPairList->clear();
 }
 
-void BundleOrPrototypeComponentConfigurationImpl::DeactivateComponentInstance(const InstanceContextPair& instCtxt)
+void BundleOrPrototypeComponentConfigurationImpl::DeactivateComponentInstance(
+  const InstanceContextPair& instCtxt)
 {
-  try
-  {
+  try {
     instCtxt.first->Deactivate();
     instCtxt.first->UnbindReferences();
-  }
-  catch(...)
-  {
+  } catch (...) {
     GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                     "Exception received from user code while deactivating the component configuration",
+                     "Exception received from user code while deactivating the "
+                     "component configuration",
                      std::current_exception());
   }
   instCtxt.second->Invalidate();
 }
 
-InterfaceMapConstPtr BundleOrPrototypeComponentConfigurationImpl::GetService(const cppmicroservices::Bundle& bundle,
-                                                                             const cppmicroservices::ServiceRegistrationBase& /*registration*/)
+InterfaceMapConstPtr BundleOrPrototypeComponentConfigurationImpl::GetService(
+  const cppmicroservices::Bundle& bundle,
+  const cppmicroservices::ServiceRegistrationBase& /*registration*/)
 {
   // if activation passed, return the interface map from the instance
   auto compInstance = Activate(bundle);
   return compInstance ? compInstance->GetInterfaceMap() : nullptr;
 }
 
-void BundleOrPrototypeComponentConfigurationImpl::UngetService(const cppmicroservices::Bundle&,
-                                                               const cppmicroservices::ServiceRegistrationBase& /*registration*/,
-                                                               const cppmicroservices::InterfaceMapConstPtr& service)
+void BundleOrPrototypeComponentConfigurationImpl::UngetService(
+  const cppmicroservices::Bundle&,
+  const cppmicroservices::ServiceRegistrationBase& /*registration*/,
+  const cppmicroservices::InterfaceMapConstPtr& service)
 {
   std::shared_ptr<void> obj = cppmicroservices::ExtractInterface(service, "");
   auto compInstCtxtPairList = compInstanceMap.lock();
-  auto itr = std::find_if(compInstCtxtPairList->begin(), compInstCtxtPairList->end(), [&obj](const InstanceContextPair& instCtxtPair) {
-      return (obj == cppmicroservices::ExtractInterface(instCtxtPair.first->GetInterfaceMap(), ""));
-    });
-  if(itr != compInstCtxtPairList->end())
-  {
+  auto itr =
+    std::find_if(compInstCtxtPairList->begin(),
+                 compInstCtxtPairList->end(),
+                 [&obj](const InstanceContextPair& instCtxtPair) {
+                   return (obj == cppmicroservices::ExtractInterface(
+                                    instCtxtPair.first->GetInterfaceMap(), ""));
+                 });
+  if (itr != compInstCtxtPairList->end()) {
     DeactivateComponentInstance(*itr);
     compInstCtxtPairList->erase(itr);
   }
 }
 
-void BundleOrPrototypeComponentConfigurationImpl::BindReference(const std::string& refName
-                                                                , const ServiceReferenceBase& ref
-                                                               )
+void BundleOrPrototypeComponentConfigurationImpl::BindReference(
+  const std::string& refName,
+  const ServiceReferenceBase& ref)
 {
   auto instancePairs = compInstanceMap.lock();
-  for (auto const& instancePair : *instancePairs)
-  {
+  for (auto const& instancePair : *instancePairs) {
     auto& instance = instancePair.first;
     auto& context = instancePair.second;
     context->AddToBoundServicesCache(refName, ref);
@@ -130,20 +137,19 @@ void BundleOrPrototypeComponentConfigurationImpl::BindReference(const std::strin
       instance->InvokeBindMethod(refName, ref);
     } catch (const std::exception&) {
       GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                      "Exception received from user code while binding a "
-                      "service reference.",
-                      std::current_exception());
-    } 
+                       "Exception received from user code while binding a "
+                       "service reference.",
+                       std::current_exception());
+    }
   }
 }
 
-void BundleOrPrototypeComponentConfigurationImpl::UnbindReference(const std::string& refName
-                                                                  , const ServiceReferenceBase& ref
-                                                                 )
+void BundleOrPrototypeComponentConfigurationImpl::UnbindReference(
+  const std::string& refName,
+  const ServiceReferenceBase& ref)
 {
   auto instancePairs = compInstanceMap.lock();
-  for (auto const& instancePair: *instancePairs)
-  {
+  for (auto const& instancePair : *instancePairs) {
     auto& instance = instancePair.first;
     auto& context = instancePair.second;
     try {
@@ -154,10 +160,10 @@ void BundleOrPrototypeComponentConfigurationImpl::UnbindReference(const std::str
                        "service reference.",
                        std::current_exception());
     }
-    
+
     context->RemoveFromBoundServicesCache(refName, ref);
   }
 }
 
-}}
-
+}
+}

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
@@ -39,14 +39,19 @@ class BundleOrPrototypeComponentConfigurationImpl final
   , public cppmicroservices::ServiceFactory
 {
 public:
-  explicit BundleOrPrototypeComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                                                       const cppmicroservices::Bundle& bundle,
-                                                       std::shared_ptr<const ComponentRegistry> registry,
-                                                       std::shared_ptr<cppmicroservices::logservice::LogService> logger);
-  BundleOrPrototypeComponentConfigurationImpl(const BundleOrPrototypeComponentConfigurationImpl&) = delete;
-  BundleOrPrototypeComponentConfigurationImpl(BundleOrPrototypeComponentConfigurationImpl&&) = delete;
-  BundleOrPrototypeComponentConfigurationImpl& operator=(const BundleOrPrototypeComponentConfigurationImpl&) = delete;
-  BundleOrPrototypeComponentConfigurationImpl& operator=(BundleOrPrototypeComponentConfigurationImpl&&) = delete;
+  explicit BundleOrPrototypeComponentConfigurationImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    const cppmicroservices::Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  BundleOrPrototypeComponentConfigurationImpl(
+    const BundleOrPrototypeComponentConfigurationImpl&) = delete;
+  BundleOrPrototypeComponentConfigurationImpl(
+    BundleOrPrototypeComponentConfigurationImpl&&) = delete;
+  BundleOrPrototypeComponentConfigurationImpl& operator=(
+    const BundleOrPrototypeComponentConfigurationImpl&) = delete;
+  BundleOrPrototypeComponentConfigurationImpl& operator=(
+    BundleOrPrototypeComponentConfigurationImpl&&) = delete;
   ~BundleOrPrototypeComponentConfigurationImpl() override;
 
   /**
@@ -59,8 +64,8 @@ public:
    *
    * \param the bundle making the service request
    */
-  std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(const cppmicroservices::Bundle& bundle) override;
-
+  std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(
+    const cppmicroservices::Bundle& bundle) override;
 
   /**
    * Method removes all instances of {@link ComponentInstance} object created by this object.
@@ -73,15 +78,17 @@ public:
    * This method always returns the same service implementation object.
    * A nullptr is returned if a service instance cannot be created or activated.
    */
-  cppmicroservices::InterfaceMapConstPtr GetService(const cppmicroservices::Bundle& bundle,
-                                                    const cppmicroservices::ServiceRegistrationBase& registration) override;
+  cppmicroservices::InterfaceMapConstPtr GetService(
+    const cppmicroservices::Bundle& bundle,
+    const cppmicroservices::ServiceRegistrationBase& registration) override;
 
   /**
    * Implements the {@link ServiceFactory#UngetService} interface.
    */
-  void UngetService(const cppmicroservices::Bundle& bundle,
-                    const cppmicroservices::ServiceRegistrationBase& registration,
-                    const cppmicroservices::InterfaceMapConstPtr& service) override;
+  void UngetService(
+    const cppmicroservices::Bundle& bundle,
+    const cppmicroservices::ServiceRegistrationBase& registration,
+    const cppmicroservices::InterfaceMapConstPtr& service) override;
 
   /**
    * Calls the service component's bind method while performing a dynamic rebind.
@@ -90,7 +97,8 @@ public:
    * \param ref is the service reference to the target service to bind. A default
    *  constructed \c ServiceReferenceBase denotes that there is no service to bind.
    */
-  void BindReference(const std::string& refName, const ServiceReferenceBase& ref) override;
+  void BindReference(const std::string& refName,
+                     const ServiceReferenceBase& ref) override;
 
   /**
    * Calls the service component's unbind method while performing a dynamic rebind.
@@ -98,18 +106,19 @@ public:
    * \param refName is the name of the reference as defined in the SCR JSON
    * \param ref is the service reference to the target service to unbind. A default
    *  constructed \c ServiceReferenceBase denotes that there is no service to unbind.
-   */  
-  void UnbindReference(const std::string& refName, const ServiceReferenceBase& ref) override;
+   */
+  void UnbindReference(const std::string& refName,
+                       const ServiceReferenceBase& ref) override;
 
 private:
-
   /**
    * Helper method to deactivate the component instance and invalidate the
    * associated context object
    */
   void DeactivateComponentInstance(const InstanceContextPair& instCtxt);
 
-  Guarded<std::vector<InstanceContextPair>> compInstanceMap; ///< map of component instance and context objects associated with this configuration
+  Guarded<std::vector<InstanceContextPair>>
+    compInstanceMap; ///< map of component instance and context objects associated with this configuration
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
@@ -22,10 +22,10 @@
 
 #ifndef __COMPONENTCONFIGURATION_HPP__
 #define __COMPONENTCONFIGURATION_HPP__
-#include <unordered_map>
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/ServiceReference.h"
 #include "cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp"
+#include <unordered_map>
 
 using cppmicroservices::service::component::runtime::dto::ComponentState;
 
@@ -56,13 +56,15 @@ public:
    * Returns a list of all the reference manager objects used to track
    * this configuration's dependencies
    */
-  virtual std::vector<std::shared_ptr<ReferenceManager>> GetAllDependencyManagers() const = 0;
+  virtual std::vector<std::shared_ptr<ReferenceManager>>
+  GetAllDependencyManagers() const = 0;
 
   /**
    * Returns the reference manager object used to track a service dependency
    * with a specific name
    */
-  virtual std::shared_ptr<ReferenceManager> GetDependencyManager(const std::string& refName) const = 0;
+  virtual std::shared_ptr<ReferenceManager> GetDependencyManager(
+    const std::string& refName) const = 0;
 
   /**
    * Returns a valid ServiceReference object if this component is registered in
@@ -79,7 +81,8 @@ public:
   /**
    * Returns a map with properties specific to this component configuration
    */
-  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties() const = 0;
+  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
+    const = 0;
 
   /**
    * Returns the bundle that contains this component

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
@@ -21,36 +21,30 @@
   =============================================================================*/
 
 #include "ComponentConfigurationFactory.hpp"
-#include "SingletonComponentConfiguration.hpp"
 #include "BundleOrPrototypeComponentConfiguration.hpp"
+#include "SingletonComponentConfiguration.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-std::shared_ptr<ComponentConfigurationImpl> ComponentConfigurationFactory::CreateConfigurationManager(std::shared_ptr<const metadata::ComponentMetadata> compDesc,
-                                                                                                      const cppmicroservices::Bundle& bundle,
-                                                                                                      std::shared_ptr<const ComponentRegistry> registry,
-                                                                                                      std::shared_ptr<logservice::LogService> logger)
+std::shared_ptr<ComponentConfigurationImpl>
+ComponentConfigurationFactory::CreateConfigurationManager(
+  std::shared_ptr<const metadata::ComponentMetadata> compDesc,
+  const cppmicroservices::Bundle& bundle,
+  std::shared_ptr<const ComponentRegistry> registry,
+  std::shared_ptr<logservice::LogService> logger)
 {
   std::shared_ptr<ComponentConfigurationImpl> retVal;
   std::string scope = compDesc->serviceMetadata.scope;
-  if(scope == cppmicroservices::Constants::SCOPE_SINGLETON)
-  {
-    retVal = std::make_shared<SingletonComponentConfigurationImpl>(compDesc,
-                                                                   bundle,
-                                                                   registry,
-                                                                   logger);
+  if (scope == cppmicroservices::Constants::SCOPE_SINGLETON) {
+    retVal = std::make_shared<SingletonComponentConfigurationImpl>(
+      compDesc, bundle, registry, logger);
+  } else if (scope == cppmicroservices::Constants::SCOPE_BUNDLE ||
+             scope == cppmicroservices::Constants::SCOPE_PROTOTYPE) {
+    retVal = std::make_shared<BundleOrPrototypeComponentConfigurationImpl>(
+      compDesc, bundle, registry, logger);
   }
-  else if (scope == cppmicroservices::Constants::SCOPE_BUNDLE ||
-           scope == cppmicroservices::Constants::SCOPE_PROTOTYPE)
-  {
-    retVal = std::make_shared<BundleOrPrototypeComponentConfigurationImpl>(compDesc,
-                                                                           bundle,
-                                                                           registry,
-                                                                           logger);
-  }
-  if(retVal)
-  {
+  if (retVal) {
     retVal->Initialize();
   }
   return retVal;

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
@@ -36,10 +36,11 @@ public:
    * Factory method to create the appropriate {@link ComponentConfigurationImpl}
    * object based on the Component' service scope
    */
-  static std::shared_ptr<ComponentConfigurationImpl> CreateConfigurationManager(std::shared_ptr<const metadata::ComponentMetadata> compDesc,
-                                                                                const cppmicroservices::Bundle& bundle,
-                                                                                std::shared_ptr<const ComponentRegistry> registry,
-                                                                                std::shared_ptr<logservice::LogService> logger);
+  static std::shared_ptr<ComponentConfigurationImpl> CreateConfigurationManager(
+    std::shared_ptr<const metadata::ComponentMetadata> compDesc,
+    const cppmicroservices::Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<logservice::LogService> logger);
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -25,26 +25,28 @@
 
 #include <memory>
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
+#include "../ComponentContextImpl.hpp"
+#include "../metadata/ComponentMetadata.hpp"
+#include "ComponentConfiguration.hpp"
+#include "ReferenceManager.hpp"
 #include "cppmicroservices/ServiceFactory.h"
 #include "cppmicroservices/logservice/LogService.hpp"
 #include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
-#include "ComponentConfiguration.hpp"
-#include "../ComponentContextImpl.hpp"
-#include "../metadata/ComponentMetadata.hpp"
-#include "ReferenceManager.hpp"
 #include "states/ComponentConfigurationState.hpp"
 
-using cppmicroservices::service::component::detail::ComponentInstance;
 using cppmicroservices::scrimpl::ReferenceManager;
+using cppmicroservices::service::component::detail::ComponentInstance;
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-typedef std::pair<std::shared_ptr<ComponentInstance>, std::shared_ptr<ComponentContextImpl>> InstanceContextPair;
+typedef std::pair<std::shared_ptr<ComponentInstance>,
+                  std::shared_ptr<ComponentContextImpl>>
+  InstanceContextPair;
 /**
  * Abstract class responsible for implementing the state machine
  * for component configurations and some utility methods to create and
@@ -59,20 +61,23 @@ public:
   /**
    * \throws std::invalid_argument exception if any of the params is a nullptr 
    */
-  explicit ComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata
-                                      , const Bundle& bundle
-                                      , std::shared_ptr<const ComponentRegistry> registry
-                                      , std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  explicit ComponentConfigurationImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    const Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
   ComponentConfigurationImpl(const ComponentConfigurationImpl&) = delete;
   ComponentConfigurationImpl(ComponentConfigurationImpl&&) = delete;
-  ComponentConfigurationImpl& operator=(const ComponentConfigurationImpl&) = delete;
+  ComponentConfigurationImpl& operator=(const ComponentConfigurationImpl&) =
+    delete;
   ComponentConfigurationImpl& operator=(ComponentConfigurationImpl&&) = delete;
   virtual ~ComponentConfigurationImpl();
 
   /**
    * Returns all the dependency manager objects associated with this component configuration
    */
-  std::vector<std::shared_ptr<ReferenceManager>> GetAllDependencyManagers() const override;
+  std::vector<std::shared_ptr<ReferenceManager>> GetAllDependencyManagers()
+    const override;
 
   /**
    * Returns the dependency manager associated with a particular reference
@@ -81,7 +86,8 @@ public:
    * \return The {@link ReferenceManager} associated with \c refName.
    *         nullptr if no reference manager exists with \c refName
    */
-  std::shared_ptr<ReferenceManager> GetDependencyManager(const std::string& refName) const override;
+  std::shared_ptr<ReferenceManager> GetDependencyManager(
+    const std::string& refName) const override;
 
   /** @copydoc ComponentConfiguration::GetServiceReference()
    *
@@ -91,13 +97,17 @@ public:
   /** @copydoc ComponentConfiguration::GetRegistry()
    *
    */
-  std::shared_ptr<const ComponentRegistry> GetRegistry() const override { return registry; } ;
+  std::shared_ptr<const ComponentRegistry> GetRegistry() const override
+  {
+    return registry;
+  };
 
   /** @copydoc ComponentConfiguration::GetProperties()
    * These properties must include \c ComponentConstants::COMPONENT_NAME and
    * \c ComponentConstants::COMPONENT_ID
    */
-  std::unordered_map<std::string, cppmicroservices::Any> GetProperties() const override;
+  std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
+    const override;
 
   /** @copydoc ComponentConfiguration::GetBundle()
    *
@@ -118,14 +128,20 @@ public:
    * This method returns the {@link ComponentMetadata} object created by
    * parsing the component description.
    */
-  std::shared_ptr<const metadata::ComponentMetadata> GetMetadata() const { return metadata; };
+  std::shared_ptr<const metadata::ComponentMetadata> GetMetadata() const
+  {
+    return metadata;
+  };
 
   /**
    * Method to check if this component provides a service
    *
    * \return \c true if this component implements a service interface, \c false otherwise
    */
-  bool IsServiceProvider() { return !(metadata->serviceMetadata.interfaces.empty()); }
+  bool IsServiceProvider()
+  {
+    return !(metadata->serviceMetadata.interfaces.empty());
+  }
 
   /**
    * Method used to register this component configuration's service. This
@@ -159,7 +175,8 @@ public:
    * \note This function is noexcept. It is not marked as such because gmock does
    *  not support mocking methods with the noexcept keyword.
    */
-  virtual std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(const cppmicroservices::Bundle& bundle) = 0;
+  virtual std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(
+    const cppmicroservices::Bundle& bundle) = 0;
 
   /**
    * Method called while \c DEACTIVATING this component configuration. Subclasses
@@ -180,8 +197,9 @@ public:
    *
    * Note: This method is virtual only for testing purposes
    */
-  bool virtual CompareAndSetState(std::shared_ptr<ComponentConfigurationState>* expectedState,
-                                  std::shared_ptr<ComponentConfigurationState> desiredState);
+  bool virtual CompareAndSetState(
+    std::shared_ptr<ComponentConfigurationState>* expectedState,
+    std::shared_ptr<ComponentConfigurationState> desiredState);
 
   /**
    * Accessor method that returns the state object associated with this object
@@ -247,13 +265,15 @@ protected:
   /**
    * Helper function used by sub-classes to create and activate a {@link ComponentInstance} object
    */
-  InstanceContextPair CreateAndActivateComponentInstanceHelper(const cppmicroservices::Bundle& bundle);
+  InstanceContextPair CreateAndActivateComponentInstanceHelper(
+    const cppmicroservices::Bundle& bundle);
 
   /**
    * Sets the function pointers used to create and delete a {@link ComponentInstance} object
    */
-  void SetComponentInstanceCreateDeleteMethods(std::function<ComponentInstance*(void)> newFunc,
-                                               std::function<void(ComponentInstance*)> deleteFunc)
+  void SetComponentInstanceCreateDeleteMethods(
+    std::function<ComponentInstance*(void)> newFunc,
+    std::function<void(ComponentInstance*)> deleteFunc)
   {
     newCompInstanceFunc = newFunc;
     deleteCompInstanceFunc = deleteFunc;
@@ -268,7 +288,7 @@ protected:
     auto oldState = ComponentConfigurationImpl::GetState();
     ComponentConfigurationImpl::CompareAndSetState(&oldState, newState);
   }
-  
+
 private:
   /**
    * Observer callback method. This method is registered with the dependency
@@ -302,32 +322,46 @@ private:
    * Friends used in unittests
    */
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyCtor);
-  FRIEND_TEST(ComponentConfigurationImplTest, VerifyInitializeForImmediateComponent);
-  FRIEND_TEST(ComponentConfigurationImplTest, VerifyInitializeForDelayedComponent);
+  FRIEND_TEST(ComponentConfigurationImplTest,
+              VerifyInitializeForImmediateComponent);
+  FRIEND_TEST(ComponentConfigurationImplTest,
+              VerifyInitializeForDelayedComponent);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyRegister);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyActivate_Success);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyActivate_Failure);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyDeactivate);
-  FRIEND_TEST(ComponentConfigurationImplTest, VerifyConcurrentRegisterDeactivate);
-  FRIEND_TEST(ComponentConfigurationImplTest, VerifyConcurrentActivateDeactivate);
+  FRIEND_TEST(ComponentConfigurationImplTest,
+              VerifyConcurrentRegisterDeactivate);
+  FRIEND_TEST(ComponentConfigurationImplTest,
+              VerifyConcurrentActivateDeactivate);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyRefSatisfied);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyRefUnsatisfied);
   FRIEND_TEST(ComponentConfigurationImplTest, VerifyStateChangeDelegation);
   FRIEND_TEST(ComponentConfigurationImplTest, TestGetDependencyManagers);
 
   unsigned long configID; ///< unique Id for the component configuration
-  static std::atomic<unsigned long> idCounter; ///< used to assign unique identifiers to component configurations
-  const std::shared_ptr<const metadata::ComponentMetadata> metadata; ///< component description
+  static std::atomic<unsigned long>
+    idCounter; ///< used to assign unique identifiers to component configurations
+  const std::shared_ptr<const metadata::ComponentMetadata>
+    metadata;    ///< component description
   Bundle bundle; ///< bundle this component configuration belongs to
-  const std::shared_ptr<const ComponentRegistry> registry; ///< component registry of the runtime
-  const std::shared_ptr<cppmicroservices::logservice::LogService> logger; ///< logger used for reporting errors/execptions
-  std::unique_ptr<RegistrationManager> regManager; ///< registration manager used to manage registration/unregistration of the service provided by this component
-  std::unordered_map<std::string, std::shared_ptr<ReferenceManager>> referenceManagers; ///< map of all the reference managers
-  std::unordered_map<std::shared_ptr<ReferenceManager>, ListenerTokenId> referenceManagerTokens; ///< map of the listener tokens received from the reference managers
-  std::shared_ptr<ComponentConfigurationState> state; ///< only modified using std::atomic operations
+  const std::shared_ptr<const ComponentRegistry>
+    registry; ///< component registry of the runtime
+  const std::shared_ptr<cppmicroservices::logservice::LogService>
+    logger; ///< logger used for reporting errors/execptions
+  std::unique_ptr<RegistrationManager>
+    regManager; ///< registration manager used to manage registration/unregistration of the service provided by this component
+  std::unordered_map<std::string, std::shared_ptr<ReferenceManager>>
+    referenceManagers; ///< map of all the reference managers
+  std::unordered_map<std::shared_ptr<ReferenceManager>, ListenerTokenId>
+    referenceManagerTokens; ///< map of the listener tokens received from the reference managers
+  std::shared_ptr<ComponentConfigurationState>
+    state; ///< only modified using std::atomic operations
 
-  std::function<ComponentInstance*(void)> newCompInstanceFunc; ///< extern C function to create a new instance {@link ComponentInstance} class from the component's bundle
-  std::function<void(ComponentInstance*)> deleteCompInstanceFunc; ///< extern C function to delete an instance of the {@link ComponentInstance} class from the component's bundle
+  std::function<ComponentInstance*(void)>
+    newCompInstanceFunc; ///< extern C function to create a new instance {@link ComponentInstance} class from the component's bundle
+  std::function<void(ComponentInstance*)>
+    deleteCompInstanceFunc; ///< extern C function to delete an instance of the {@link ComponentInstance} class from the component's bundle
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/ComponentManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManager.hpp
@@ -23,11 +23,11 @@
 #ifndef __COMPONENTMANAGER_HPP__
 #define __COMPONENTMANAGER_HPP__
 
-#include <memory>
-#include <future>
+#include "../metadata/ComponentMetadata.hpp"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/ServiceFactory.h"
-#include "../metadata/ComponentMetadata.hpp"
+#include <future>
+#include <memory>
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -81,13 +81,15 @@ public:
    * Returns a vector of ComponentConfiguration objects representing each of the configurations
    * created for the component.
    */
-  virtual std::vector<std::shared_ptr<ComponentConfiguration>> GetComponentConfigurations() const = 0;
+  virtual std::vector<std::shared_ptr<ComponentConfiguration>>
+  GetComponentConfigurations() const = 0;
 
   /**
    * Returns the metadata object representing the component description for the
    * component managed by this object.
    */
-  virtual std::shared_ptr<const metadata::ComponentMetadata> GetMetadata() const = 0;
+  virtual std::shared_ptr<const metadata::ComponentMetadata> GetMetadata()
+    const = 0;
 };
 } // scrimpl
 } // cppmicroservices

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -25,13 +25,13 @@
 
 #include "boost/asio/thread_pool.hpp"
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
+#include "ComponentManager.hpp"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/logservice/LogService.hpp"
-#include "ComponentManager.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -44,15 +44,15 @@ class ComponentManagerState;
  * service component. It implements a thread safe state design pattern to
  * handle requests for enabling and disabling a component.
  */
-class ComponentManagerImpl
-  : public ComponentManager
+class ComponentManagerImpl : public ComponentManager
 {
 public:
-  ComponentManagerImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                       std::shared_ptr<const ComponentRegistry> registry,
-                       cppmicroservices::BundleContext bundleContext,
-                       std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                       std::shared_ptr<boost::asio::thread_pool> threadpool);
+  ComponentManagerImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    std::shared_ptr<const ComponentRegistry> registry,
+    cppmicroservices::BundleContext bundleContext,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+    std::shared_ptr<boost::asio::thread_pool> threadpool);
   ComponentManagerImpl(const ComponentManagerImpl&) = delete;
   ComponentManagerImpl(ComponentManagerImpl&&) = delete;
   ComponentManagerImpl& operator=(const ComponentManagerImpl&) = delete;
@@ -82,12 +82,17 @@ public:
   /** @copydoc ComponentManager::GetComponentConfigurations()
    * Delegates the call to the current state object
    */
-  std::vector<std::shared_ptr<ComponentConfiguration>> GetComponentConfigurations() const override;
+  std::vector<std::shared_ptr<ComponentConfiguration>>
+  GetComponentConfigurations() const override;
 
   /** @copydoc ComponentManager::GetMetadata()
    * Returns the stored component description
    */
-  std::shared_ptr<const metadata::ComponentMetadata> GetMetadata() const override { return compDesc; }
+  std::shared_ptr<const metadata::ComponentMetadata> GetMetadata()
+    const override
+  {
+    return compDesc;
+  }
 
   /** @copydoc ComponentManager::GetName()
    * Returns the names from the stored component description
@@ -97,18 +102,26 @@ public:
   /** @copydoc ComponentManager::GetBundleId()
    * Returns the id of the {@link Bundle} which contains the component managed by this object
    */
-  unsigned long GetBundleId() const override { return GetBundle().GetBundleId(); }
+  unsigned long GetBundleId() const override
+  {
+    return GetBundle().GetBundleId();
+  }
 
   /**
    * This method returns the {@link Bundle} which contains the component managed by this object.
    */
-  Bundle GetBundle() const { return bundleContext ? bundleContext.GetBundle() : Bundle(); }
+  Bundle GetBundle() const
+  {
+    return bundleContext ? bundleContext.GetBundle() : Bundle();
+  }
 
   /**
    * Returns the logger object associated with this ComponentManager
    */
   std::shared_ptr<cppmicroservices::logservice::LogService> GetLogger() const
-  { return logger; }
+  {
+    return logger;
+  }
 
   /**
    * This method modifies the vector of futures stored in this object. If
@@ -125,8 +138,9 @@ public:
    * \param expectedState is the pointer to the current state object
    * \param desiredState is the state the caller wishes to set on this object
    */
-  virtual bool CompareAndSetState(std::shared_ptr<ComponentManagerState>* expectedState,
-                                  std::shared_ptr<ComponentManagerState> desiredState);
+  virtual bool CompareAndSetState(
+    std::shared_ptr<ComponentManagerState>* expectedState,
+    std::shared_ptr<ComponentManagerState> desiredState);
 
   /**
    * This method returns the current state object of this object.
@@ -137,7 +151,10 @@ public:
    * Returns the {@link ComponentRegistry} object associated with this
    * runtime instance
    */
-  virtual std::shared_ptr<const ComponentRegistry> GetRegistry() const { return registry; }
+  virtual std::shared_ptr<const ComponentRegistry> GetRegistry() const
+  {
+    return registry;
+  }
 
   /**
    * Attempts to change the state from disabled to enabled and posts asynchronous work
@@ -161,19 +178,26 @@ public:
     std::shared_ptr<cppmicroservices::scrimpl::ComponentManagerState>&
       currentState);
 
-
 private:
   FRIEND_TEST(ComponentManagerImplParameterizedTest, TestAccumulateFutures);
 
-  const std::shared_ptr<const ComponentRegistry> registry; ///< component registry associated with the current runtime
-  const std::shared_ptr<const metadata::ComponentMetadata> compDesc; ///< the component description
-  cppmicroservices::BundleContext bundleContext; ///< context of the bundle which contains the component
-  const std::shared_ptr<cppmicroservices::logservice::LogService> logger; ///< logger associated with the current runtime
-  std::shared_ptr<ComponentManagerState> state; ///< This member is always accessed using atomic operations
-  std::vector<std::shared_future<void>> disableFutures; ///< futures created when the component transitioned to \c DISABLED state
+  const std::shared_ptr<const ComponentRegistry>
+    registry; ///< component registry associated with the current runtime
+  const std::shared_ptr<const metadata::ComponentMetadata>
+    compDesc; ///< the component description
+  cppmicroservices::BundleContext
+    bundleContext; ///< context of the bundle which contains the component
+  const std::shared_ptr<cppmicroservices::logservice::LogService>
+    logger; ///< logger associated with the current runtime
+  std::shared_ptr<ComponentManagerState>
+    state; ///< This member is always accessed using atomic operations
+  std::vector<std::shared_future<void>>
+    disableFutures; ///< futures created when the component transitioned to \c DISABLED state
   std::mutex futuresMutex; ///< mutex to protect the #disableFutures member
-  std::shared_ptr<boost::asio::thread_pool> threadpool; ///< thread pool used to execute async work
-  std::mutex transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic
+  std::shared_ptr<boost::asio::thread_pool>
+    threadpool; ///< thread pool used to execute async work
+  std::mutex
+    transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
@@ -23,10 +23,10 @@
 #ifndef __CONCURRENCYUTIL_HPP__
 #define __CONCURRENCYUTIL_HPP__
 
+#include <chrono>
+#include <future>
 #include <memory>
 #include <mutex>
-#include <future>
-#include <chrono>
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -37,7 +37,8 @@ namespace scrimpl {
 template<typename T>
 bool is_ready(T&& futObj)
 {
-  return (futObj.wait_for(std::chrono::seconds::zero()) == std::future_status::ready);
+  return (futObj.wait_for(std::chrono::seconds::zero()) ==
+          std::future_status::ready);
 }
 
 /**
@@ -53,20 +54,21 @@ class Guarded
   class Handle
   {
     std::unique_lock<std::mutex> lk;
-    Data *ptr;
+    Data* ptr;
+
   public:
-    Handle(std::unique_lock<std::mutex> lk, Data *p) :
-      lk(std::move(lk)),
-    ptr(p)
-    { }
+    Handle(std::unique_lock<std::mutex> lk, Data* p)
+      : lk(std::move(lk))
+      , ptr(p)
+    {}
 
     Handle(const Handle&) = delete;
     Handle& operator=(const Handle&) = delete;
 
-    Handle(Handle&& rhs) :
-      lk(std::move(rhs.lk)),
-    ptr(std::move(rhs.ptr))
-    { }
+    Handle(Handle&& rhs)
+      : lk(std::move(rhs.lk))
+      , ptr(std::move(rhs.ptr))
+    {}
 
     Handle& operator=(Handle&& rhs)
     {
@@ -79,6 +81,7 @@ class Guarded
     Data* operator->() const { return ptr; }
     Data& operator*() const { return *ptr; }
   };
+
 public:
   /**
    * Locks the member mutex and returns an RAII object responsible for
@@ -89,7 +92,7 @@ public:
   Handle lock()
   {
     std::unique_lock<std::mutex> lock(mtx);
-    return Handle{std::move(lock), &data};
+    return Handle{ std::move(lock), &data };
   }
 };
 

--- a/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
@@ -27,8 +27,8 @@
 #include "cppmicroservices/ServiceTracker.h"
 
 #include "../metadata/ReferenceMetadata.hpp"
-#include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
 #include "cppmicroservices/logservice/LogService.hpp"
+#include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -37,11 +37,11 @@ namespace scrimpl {
  */
 enum class RefEvent
 {
-  BECAME_SATISFIED,  /* used to notify the listener that the reference has
+  BECAME_SATISFIED,   /* used to notify the listener that the reference has
                         become satisfied */
-  BECAME_UNSATISFIED,/* used to notify the listener that the reference has
+  BECAME_UNSATISFIED, /* used to notify the listener that the reference has
                         become unsatisfied */
-  REBIND,            /* used to notify the listener that dynamic rebinding
+  REBIND,             /* used to notify the listener that dynamic rebinding
                         needs to happen */
 };
 
@@ -114,18 +114,21 @@ public:
   /**
    * Returns a set of ServiceReferences that are bound to the component.
    */
-  virtual std::set<cppmicroservices::ServiceReferenceBase> GetBoundReferences() const = 0;
+  virtual std::set<cppmicroservices::ServiceReferenceBase> GetBoundReferences()
+    const = 0;
 
   /**
    * Returns a set of ServiceReferences that match the reference criteria but
    * are not bound to the component because the cardinality is not satisfied yet.
    */
-  virtual std::set<cppmicroservices::ServiceReferenceBase> GetTargetReferences() const = 0;
+  virtual std::set<cppmicroservices::ServiceReferenceBase> GetTargetReferences()
+    const = 0;
 
   /**
    * Method is used to receive callbacks when the dependency is satisfied
    */
-  virtual cppmicroservices::ListenerTokenId RegisterListener(std::function<void(const RefChangeNotification&)> notify) = 0;
+  virtual cppmicroservices::ListenerTokenId RegisterListener(
+    std::function<void(const RefChangeNotification&)> notify) = 0;
 
   /**
    * Method is used to remove the callbacks registered using RegisterListener
@@ -136,6 +139,7 @@ public:
    * Method to stop tracking the reference service.
    */
   virtual void StopTracking() = 0;
+
 protected:
   ReferenceManager() = default;
 };

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -26,9 +26,9 @@
 #include <mutex>
 
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
 #include "ConcurrencyUtil.hpp"
 #include "ReferenceManager.hpp"

--- a/compendium/DeclarativeServices/src/manager/RegistrationManager.cpp
+++ b/compendium/DeclarativeServices/src/manager/RegistrationManager.cpp
@@ -19,51 +19,51 @@
   limitations under the License.
 
   =============================================================================*/
-#include <cassert>
-#include "cppmicroservices/ServiceFactory.h"
-#include "cppmicroservices/Constants.h"
 #include "RegistrationManager.hpp"
+#include "cppmicroservices/Constants.h"
+#include "cppmicroservices/ServiceFactory.h"
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include <cassert>
 
-using cppmicroservices::Constants::SERVICE_SCOPE;
 using cppmicroservices::Constants::SCOPE_BUNDLE;
-using cppmicroservices::Constants::SCOPE_SINGLETON;
 using cppmicroservices::Constants::SCOPE_PROTOTYPE;
+using cppmicroservices::Constants::SCOPE_SINGLETON;
+using cppmicroservices::Constants::SERVICE_SCOPE;
 
 namespace cppmicroservices {
 namespace scrimpl {
 
 bool inline IsValidScope(const std::string& scope)
 {
-  return (scope == SCOPE_SINGLETON || scope == SCOPE_BUNDLE || scope == SCOPE_PROTOTYPE);
+  return (scope == SCOPE_SINGLETON || scope == SCOPE_BUNDLE ||
+          scope == SCOPE_PROTOTYPE);
 }
 
-RegistrationManager::RegistrationManager(const cppmicroservices::BundleContext& bc,
-                                         const std::vector<std::string>& services,
-                                         const std::string& scope,
-                                         const std::shared_ptr<cppmicroservices::logservice::LogService>& logger)
+RegistrationManager::RegistrationManager(
+  const cppmicroservices::BundleContext& bc,
+  const std::vector<std::string>& services,
+  const std::string& scope,
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& logger)
   : bundleContext(bc)
   , services(services)
   , scope(scope)
   , logger(logger)
 {
-  if(!bc || services.empty() || !IsValidScope(scope) || !logger)
-  {
-    throw std::invalid_argument("RegistrationManager: Invalid arguments passed to constructor");
+  if (!bc || services.empty() || !IsValidScope(scope) || !logger) {
+    throw std::invalid_argument(
+      "RegistrationManager: Invalid arguments passed to constructor");
   }
 }
 
 RegistrationManager::~RegistrationManager()
 {
-  if(IsServiceRegistered())
-  {
-    try
-    {
+  if (IsServiceRegistered()) {
+    try {
       serviceReg.Unregister();
-    }
-    catch (...)
-    {
-      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, "Service Unregistration failed with exception", std::current_exception());
+    } catch (...) {
+      logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                  "Service Unregistration failed with exception",
+                  std::current_exception());
     }
   }
 }
@@ -73,28 +73,26 @@ bool RegistrationManager::IsServiceRegistered() const
   return static_cast<bool>(serviceReg); //(serviceReg ? true : false);
 }
 
-bool RegistrationManager::RegisterService(const std::shared_ptr<cppmicroservices::ServiceFactory>& factory,
-                                          const cppmicroservices::ServiceProperties& props)
+bool RegistrationManager::RegisterService(
+  const std::shared_ptr<cppmicroservices::ServiceFactory>& factory,
+  const cppmicroservices::ServiceProperties& props)
 {
-  if(IsServiceRegistered())
-  {
+  if (IsServiceRegistered()) {
     return true;
   }
-  try
-  {
+  try {
     cppmicroservices::InterfaceMapPtr imap = MakeInterfaceMap<>(factory);
     std::shared_ptr<void> instance = std::static_pointer_cast<void>(factory);
-    for(auto interface : services)
-    {
+    for (auto interface : services) {
       imap->emplace(interface, instance);
     }
     auto localProps = props;
     localProps.emplace(SERVICE_SCOPE, Any(scope));
     serviceReg = bundleContext.RegisterService(imap, localProps);
-  }
-  catch(...)
-  {
-    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, "Service Registration failed with exception", std::current_exception());
+  } catch (...) {
+    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                "Service Registration failed with exception",
+                std::current_exception());
   }
   return IsServiceRegistered();
 }
@@ -107,7 +105,8 @@ void RegistrationManager::UnregisterService()
   serviceReg = nullptr;
 }
 
-cppmicroservices::ServiceReferenceBase RegistrationManager::GetServiceReference() const
+cppmicroservices::ServiceReferenceBase
+RegistrationManager::GetServiceReference() const
 {
   return serviceReg ? serviceReg.GetReference() : ServiceReferenceU();
 }

--- a/compendium/DeclarativeServices/src/manager/RegistrationManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/RegistrationManager.hpp
@@ -23,9 +23,9 @@
 #ifndef __REGISTRATION_MANAGER_HPP__
 #define __REGISTRATION_MANAGER_HPP__
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/ServiceFactory.h"
@@ -57,10 +57,11 @@ public:
    *             \c scope is not one of "singleton", "bundle" or "prototype"
    *             \c logger is nullptr
    */
-  RegistrationManager(const cppmicroservices::BundleContext& bc,
-                      const std::vector<std::string>& services,
-                      const std::string& scope,
-                      const std::shared_ptr<cppmicroservices::logservice::LogService>& logger);
+  RegistrationManager(
+    const cppmicroservices::BundleContext& bc,
+    const std::vector<std::string>& services,
+    const std::string& scope,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& logger);
   RegistrationManager(const RegistrationManager&) = delete;
   RegistrationManager(RegistrationManager&&) = delete;
   RegistrationManager& operator=(const RegistrationManager&) = delete;
@@ -90,8 +91,9 @@ public:
    * \param props - a map with properties used for service registration
    * \return \c true if registration succeeded, \c false otherwise
    */
-  bool RegisterService(const std::shared_ptr<cppmicroservices::ServiceFactory>& factory,
-                       const cppmicroservices::ServiceProperties& props);
+  bool RegisterService(
+    const std::shared_ptr<cppmicroservices::ServiceFactory>& factory,
+    const cppmicroservices::ServiceProperties& props);
 
   /**
    * This method unregisters the service from the framework service registry. The
@@ -101,6 +103,7 @@ public:
    * \throws std::logic_error if the service was never registered or has already been unregistered
    */
   void UnregisterService();
+
 private:
   FRIEND_TEST(RegistrationManagerTest, VerifyUnregister);
 

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -37,17 +37,20 @@ using cppmicroservices::service::component::ComponentConstants::COMPONENT_NAME;
 namespace cppmicroservices {
 namespace scrimpl {
 
-SingletonComponentConfigurationImpl::SingletonComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                                                                         const Bundle& bundle,
-                                                                         std::shared_ptr<const ComponentRegistry> registry,
-                                                                         std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+SingletonComponentConfigurationImpl::SingletonComponentConfigurationImpl(
+  std::shared_ptr<const metadata::ComponentMetadata> metadata,
+  const Bundle& bundle,
+  std::shared_ptr<const ComponentRegistry> registry,
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger)
   : ComponentConfigurationImpl(metadata, bundle, registry, logger)
-{
-}
+{}
 
-std::shared_ptr<ServiceFactory> SingletonComponentConfigurationImpl::GetFactory()
+std::shared_ptr<ServiceFactory>
+SingletonComponentConfigurationImpl::GetFactory()
 {
-  std::shared_ptr<SingletonComponentConfigurationImpl> thisPtr = std::dynamic_pointer_cast<SingletonComponentConfigurationImpl>(shared_from_this());
+  std::shared_ptr<SingletonComponentConfigurationImpl> thisPtr =
+    std::dynamic_pointer_cast<SingletonComponentConfigurationImpl>(
+      shared_from_this());
   return ToFactory(thisPtr);
 }
 
@@ -56,18 +59,18 @@ SingletonComponentConfigurationImpl::~SingletonComponentConfigurationImpl()
   DestroyComponentInstances();
 }
 
-std::shared_ptr<ComponentInstance> SingletonComponentConfigurationImpl::CreateAndActivateComponentInstance(const cppmicroservices::Bundle& /*bundle*/)
+std::shared_ptr<ComponentInstance>
+SingletonComponentConfigurationImpl::CreateAndActivateComponentInstance(
+  const cppmicroservices::Bundle& /*bundle*/)
 {
   auto instanceContextPair = data.lock();
-  if(GetState()->GetValue() != service::component::runtime::dto::ComponentState::ACTIVE)
-  {
+  if (GetState()->GetValue() !=
+      service::component::runtime::dto::ComponentState::ACTIVE) {
     return nullptr;
   }
 
-  if(!instanceContextPair->first)
-  {
-    try
-    {
+  if (!instanceContextPair->first) {
+    try {
       auto instCtxtTuple = CreateAndActivateComponentInstanceHelper(Bundle());
       instanceContextPair->first = instCtxtTuple.first;
       instanceContextPair->second = instCtxtTuple.second;
@@ -78,7 +81,8 @@ std::shared_ptr<ComponentInstance> SingletonComponentConfigurationImpl::CreateAn
       throw;
     } catch (...) {
       GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                       "Exception received from user code while activating the component configuration",
+                       "Exception received from user code while activating the "
+                       "component configuration",
                        std::current_exception());
     }
   }
@@ -88,45 +92,45 @@ std::shared_ptr<ComponentInstance> SingletonComponentConfigurationImpl::CreateAn
 void SingletonComponentConfigurationImpl::DestroyComponentInstances()
 {
   auto instanceContextPair = data.lock();
-  try
-  {
-    if(instanceContextPair->first)
-    {
+  try {
+    if (instanceContextPair->first) {
       instanceContextPair->first->Deactivate();
       instanceContextPair->first->UnbindReferences();
     }
-  }
-  catch(...)
-  {
+  } catch (...) {
     GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                     "Exception received from user code while deactivating the component configuration",
+                     "Exception received from user code while deactivating the "
+                     "component configuration",
                      std::current_exception());
   }
-  if(instanceContextPair->second)
-  {
+  if (instanceContextPair->second) {
     instanceContextPair->second->Invalidate();
   }
   instanceContextPair->first.reset();
   instanceContextPair->second.reset();
 }
 
-InterfaceMapConstPtr SingletonComponentConfigurationImpl::GetService(const cppmicroservices::Bundle& bundle,
-                                                                     const cppmicroservices::ServiceRegistrationBase& /*registration*/)
+InterfaceMapConstPtr SingletonComponentConfigurationImpl::GetService(
+  const cppmicroservices::Bundle& bundle,
+  const cppmicroservices::ServiceRegistrationBase& /*registration*/)
 {
   // if activation passed, return the interface map from the instance
   auto compInstance = Activate(bundle);
   return compInstance ? compInstance->GetInterfaceMap() : nullptr;
 }
 
-void SingletonComponentConfigurationImpl::UngetService(const cppmicroservices::Bundle& /*bundle*/,
-                                                       const cppmicroservices::ServiceRegistrationBase& /*registration*/,
-                                                       const cppmicroservices::InterfaceMapConstPtr& /*service*/)
+void SingletonComponentConfigurationImpl::UngetService(
+  const cppmicroservices::Bundle& /*bundle*/,
+  const cppmicroservices::ServiceRegistrationBase& /*registration*/,
+  const cppmicroservices::InterfaceMapConstPtr& /*service*/)
 {
   // The singleton instance is not reset when UngetService is called.
   // The instance is reset when the component is deactivated.
 }
 
-void SingletonComponentConfigurationImpl::BindReference(const std::string& refName, const ServiceReferenceBase& ref)
+void SingletonComponentConfigurationImpl::BindReference(
+  const std::string& refName,
+  const ServiceReferenceBase& ref)
 {
   auto context = GetComponentContext();
   context->AddToBoundServicesCache(refName, ref);
@@ -138,10 +142,11 @@ void SingletonComponentConfigurationImpl::BindReference(const std::string& refNa
                      "service reference.",
                      std::current_exception());
   }
-  
 }
 
-void SingletonComponentConfigurationImpl::UnbindReference(const std::string& refName, const ServiceReferenceBase& ref)
+void SingletonComponentConfigurationImpl::UnbindReference(
+  const std::string& refName,
+  const ServiceReferenceBase& ref)
 {
   try {
     GetComponentInstance()->InvokeUnbindMethod(refName, ref);
@@ -155,19 +160,22 @@ void SingletonComponentConfigurationImpl::UnbindReference(const std::string& ref
   context->RemoveFromBoundServicesCache(refName, ref);
 }
 
-void SingletonComponentConfigurationImpl::SetComponentInstancePair(InstanceContextPair instCtxtPair)
+void SingletonComponentConfigurationImpl::SetComponentInstancePair(
+  InstanceContextPair instCtxtPair)
 {
   auto instanceContextPair = data.lock();
   instanceContextPair->first = instCtxtPair.first;
   instanceContextPair->second = instCtxtPair.second;
 }
 
-std::shared_ptr<ComponentContextImpl> SingletonComponentConfigurationImpl::GetComponentContext()
+std::shared_ptr<ComponentContextImpl>
+SingletonComponentConfigurationImpl::GetComponentContext()
 {
   return data.lock()->second;
 }
 
-std::shared_ptr<ComponentInstance> SingletonComponentConfigurationImpl::GetComponentInstance()
+std::shared_ptr<ComponentInstance>
+SingletonComponentConfigurationImpl::GetComponentInstance()
 {
   return data.lock()->first;
 }

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -39,14 +39,19 @@ class SingletonComponentConfigurationImpl final
   , public cppmicroservices::ServiceFactory
 {
 public:
-  explicit SingletonComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                                               const cppmicroservices::Bundle& bundle,
-                                               std::shared_ptr<const ComponentRegistry> registry,
-                                               std::shared_ptr<cppmicroservices::logservice::LogService> logger);
-  SingletonComponentConfigurationImpl(const SingletonComponentConfigurationImpl&) = delete;
-  SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl&&) = delete;
-  SingletonComponentConfigurationImpl& operator=(const SingletonComponentConfigurationImpl&) = delete;
-  SingletonComponentConfigurationImpl& operator=(SingletonComponentConfigurationImpl&&) = delete;
+  explicit SingletonComponentConfigurationImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    const cppmicroservices::Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger);
+  SingletonComponentConfigurationImpl(
+    const SingletonComponentConfigurationImpl&) = delete;
+  SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl&&) =
+    delete;
+  SingletonComponentConfigurationImpl& operator=(
+    const SingletonComponentConfigurationImpl&) = delete;
+  SingletonComponentConfigurationImpl& operator=(
+    SingletonComponentConfigurationImpl&&) = delete;
   ~SingletonComponentConfigurationImpl() override;
 
   /**
@@ -60,7 +65,8 @@ public:
    *
    * \param the bundle making the service request
    */
-  std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(const cppmicroservices::Bundle& bundle) /* noexcept */ override;
+  std::shared_ptr<ComponentInstance> CreateAndActivateComponentInstance(
+    const cppmicroservices::Bundle& bundle) /* noexcept */ override;
 
   /**
    * Method removes the singleton {@link ComponentInstance} object created by this object.
@@ -73,16 +79,18 @@ public:
    * This method always returns the same service implementation object.
    * A nullptr is returned if a service instance cannot be created or activated.
    */
-  cppmicroservices::InterfaceMapConstPtr GetService(const cppmicroservices::Bundle& bundle,
-                                                    const cppmicroservices::ServiceRegistrationBase& registration) override;
+  cppmicroservices::InterfaceMapConstPtr GetService(
+    const cppmicroservices::Bundle& bundle,
+    const cppmicroservices::ServiceRegistrationBase& registration) override;
 
   /**
    * Implements the {@link ServiceFactory#UngetService} interface. No-op since the
    * service is a \c shared_ptr
    */
-  void UngetService(const cppmicroservices::Bundle& bundle,
-                    const cppmicroservices::ServiceRegistrationBase& registration,
-                    const cppmicroservices::InterfaceMapConstPtr& service) override;
+  void UngetService(
+    const cppmicroservices::Bundle& bundle,
+    const cppmicroservices::ServiceRegistrationBase& registration,
+    const cppmicroservices::InterfaceMapConstPtr& service) override;
 
   /**
    * Calls the service component's bind method while performing a dynamic rebind.
@@ -91,7 +99,8 @@ public:
    * \param ref is the service reference to the target service to bind. A default
    *  constructed \c ServiceReferenceBase denotes that there is no service to bind.
    */
-  void BindReference(const std::string& refName, const ServiceReferenceBase& ref) override;
+  void BindReference(const std::string& refName,
+                     const ServiceReferenceBase& ref) override;
 
   /**
    * Calls the service component's unbind method while performing a dynamic rebind.
@@ -99,15 +108,20 @@ public:
    * \param refName is the name of the reference as defined in the SCR JSON
    * \param ref is the service reference to the target service to unbind. A default
    *  constructed \c ServiceReferenceBase denotes that there is no service to unbind.
-   */  
-  void UnbindReference(const std::string& refName, const ServiceReferenceBase& ref) override;
+   */
+  void UnbindReference(const std::string& refName,
+                       const ServiceReferenceBase& ref) override;
 
 private:
-  FRIEND_TEST(SingletonComponentConfigurationTest, TestConcurrentCreateAndActivateComponentInstance);
-  FRIEND_TEST(SingletonComponentConfigurationTest, TestCreateAndActivateComponentInstance);
-  FRIEND_TEST(SingletonComponentConfigurationTest, TestDestroyComponentInstances);
+  FRIEND_TEST(SingletonComponentConfigurationTest,
+              TestConcurrentCreateAndActivateComponentInstance);
+  FRIEND_TEST(SingletonComponentConfigurationTest,
+              TestCreateAndActivateComponentInstance);
+  FRIEND_TEST(SingletonComponentConfigurationTest,
+              TestDestroyComponentInstances);
   FRIEND_TEST(SingletonComponentConfigurationTest, TestGetService);
-  FRIEND_TEST(SingletonComponentConfigurationTest, TestDestroyComponentInstances_DeactivateFailure);
+  FRIEND_TEST(SingletonComponentConfigurationTest,
+              TestDestroyComponentInstances_DeactivateFailure);
 
   /**
    * Set the member data, only used in tests
@@ -124,7 +138,8 @@ private:
    */
   std::shared_ptr<ComponentInstance> GetComponentInstance();
 
-  Guarded<InstanceContextPair> data; ///< singleton pair of component instance and context associated with this configuration
+  Guarded<InstanceContextPair>
+    data; ///< singleton pair of component instance and context associated with this configuration
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
@@ -85,9 +85,9 @@ void CCActiveState::Rebind(ComponentConfigurationImpl& mgr,
       } catch (const std::exception&) {
         mgr.GetLogger()->Log(
           cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-          "Exception while dynamically binding a reference. ", std::current_exception());
+          "Exception while dynamically binding a reference. ",
+          std::current_exception());
       }
-      
     }
 
     if (svcRefToUnbind) {

--- a/compendium/DeclarativeServices/src/manager/states/CCActiveState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCActiveState.hpp
@@ -23,8 +23,8 @@
 #ifndef CCActiveState_hpp
 #define CCActiveState_hpp
 
-#include "CCSatisfiedState.hpp"
 #include "../ConcurrencyUtil.hpp"
+#include "CCSatisfiedState.hpp"
 
 #include "cppmicroservices/detail/CounterLatch.h"
 
@@ -32,13 +32,12 @@ using cppmicroservices::service::component::runtime::dto::ComponentState;
 
 namespace cppmicroservices {
 namespace scrimpl {
-    
+
 /**
  * This class represents the {\code ComponentState::ACTIVE} state of a
  * component configuration.
  */
-class CCActiveState final
-  : public CCSatisfiedState
+class CCActiveState final : public CCSatisfiedState
 {
 public:
   CCActiveState();
@@ -48,12 +47,12 @@ public:
   CCActiveState(CCActiveState&&) = delete;
   CCActiveState& operator=(CCActiveState&&) = delete;
 
-  void Register(ComponentConfigurationImpl&) override
-  {
+  void Register(ComponentConfigurationImpl&) override{
     // no-op, already resolved
   };
-  std::shared_ptr<ComponentInstance> Activate(ComponentConfigurationImpl& mgr,
-                                              const cppmicroservices::Bundle& clientBundle) override;
+  std::shared_ptr<ComponentInstance> Activate(
+    ComponentConfigurationImpl& mgr,
+    const cppmicroservices::Bundle& clientBundle) override;
 
   /**
    * Rebind to a target service. This operation does not transition to another state.
@@ -74,10 +73,8 @@ public:
    */
   ComponentState GetValue() const override { return ComponentState::ACTIVE; }
 
-  void WaitForTransitionTask() override
-  {
-    latch.Wait();
-  }
+  void WaitForTransitionTask() override { latch.Wait(); }
+
 private:
   detail::CounterLatch latch;
 };

--- a/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.cpp
@@ -21,9 +21,9 @@
   =============================================================================*/
 
 #include "CCRegisteredState.hpp"
-#include "CCUnsatisfiedReferenceState.hpp"
-#include "CCActiveState.hpp"
 #include "../ComponentConfigurationImpl.hpp"
+#include "CCActiveState.hpp"
+#include "CCUnsatisfiedReferenceState.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -37,26 +37,24 @@ CCRegisteredState::CCRegisteredState()
 
 CCRegisteredState::CCRegisteredState(std::future<void> blockUntil)
   : ready(std::move(blockUntil))
-{
-}
+{}
 
-std::shared_ptr<ComponentInstance> CCRegisteredState::Activate(ComponentConfigurationImpl& mgr,
-                                                               const cppmicroservices::Bundle& clientBundle)
+std::shared_ptr<ComponentInstance> CCRegisteredState::Activate(
+  ComponentConfigurationImpl& mgr,
+  const cppmicroservices::Bundle& clientBundle)
 {
   auto activeState = std::make_shared<CCActiveState>();
   auto currState = shared_from_this();
   bool success = false;
-  while(!success && currState->GetValue() == ComponentState::SATISFIED)
-  {
+  while (!success && currState->GetValue() == ComponentState::SATISFIED) {
     success = mgr.CompareAndSetState(&currState, activeState);
   };
 
-  if(success)
-  {
+  if (success) {
     auto instance = activeState->Activate(mgr, clientBundle);
-    if(!instance)
-    {
-      auto state = std::dynamic_pointer_cast<ComponentConfigurationState>(activeState);
+    if (!instance) {
+      auto state =
+        std::dynamic_pointer_cast<ComponentConfigurationState>(activeState);
       mgr.CompareAndSetState(&state, std::make_shared<CCRegisteredState>());
     }
     return instance;
@@ -65,4 +63,3 @@ std::shared_ptr<ComponentInstance> CCRegisteredState::Activate(ComponentConfigur
 }
 }
 }
-

--- a/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.hpp
@@ -35,8 +35,7 @@ namespace scrimpl {
  * component configuration. This state indicates that the component's service
  * is registered with the framework
  */
-class CCRegisteredState final
-  : public CCSatisfiedState
+class CCRegisteredState final : public CCSatisfiedState
 {
 public:
   CCRegisteredState();
@@ -47,20 +46,22 @@ public:
   CCRegisteredState(CCRegisteredState&&) = delete;
   CCRegisteredState& operator=(CCRegisteredState&&) = delete;
 
-  void Register(ComponentConfigurationImpl& /*mgr*/) override {
+  void Register(ComponentConfigurationImpl& /*mgr*/) override{
     // no-op, already resolved
   };
 
   /**
    * This method is used to trigger a transition from current state to \c ACTIVE state
    */
-  std::shared_ptr<ComponentInstance> Activate(ComponentConfigurationImpl& mgr,
-                                              const cppmicroservices::Bundle& clientBundle) override;
+  std::shared_ptr<ComponentInstance> Activate(
+    ComponentConfigurationImpl& mgr,
+    const cppmicroservices::Bundle& clientBundle) override;
 
   /**
    * Method blocks the current thread until the stored future is ready
    */
   void WaitForTransitionTask() override { ready.get(); }
+
 private:
   std::future<void> ready;
 };

--- a/compendium/DeclarativeServices/src/manager/states/CCSatisfiedState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCSatisfiedState.cpp
@@ -21,8 +21,8 @@
   =============================================================================*/
 
 #include "CCSatisfiedState.hpp"
-#include "CCUnsatisfiedReferenceState.hpp"
 #include "../ComponentConfigurationImpl.hpp"
+#include "CCUnsatisfiedReferenceState.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -32,16 +32,18 @@ CCSatisfiedState::CCSatisfiedState() = default;
 void CCSatisfiedState::Deactivate(ComponentConfigurationImpl& mgr)
 {
   auto currentState = shared_from_this();
-  std::packaged_task<void(void)> task([&mgr](){
-                                        mgr.UnregisterService();
-                                        mgr.DestroyComponentInstances();
-                                      });
-  auto unsatisfiedState = std::make_shared<CCUnsatisfiedReferenceState>(task.get_future().share());
-  while(currentState->GetValue() != service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE)
-  {
-    if(mgr.CompareAndSetState(&currentState, unsatisfiedState))
-    {
-      currentState->WaitForTransitionTask(); // wait for the previous transition to finish
+  std::packaged_task<void(void)> task([&mgr]() {
+    mgr.UnregisterService();
+    mgr.DestroyComponentInstances();
+  });
+  auto unsatisfiedState =
+    std::make_shared<CCUnsatisfiedReferenceState>(task.get_future().share());
+  while (
+    currentState->GetValue() !=
+    service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE) {
+    if (mgr.CompareAndSetState(&currentState, unsatisfiedState)) {
+      currentState
+        ->WaitForTransitionTask(); // wait for the previous transition to finish
       task();
       break;
     }

--- a/compendium/DeclarativeServices/src/manager/states/CCUnsatisfiedReferenceState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCUnsatisfiedReferenceState.hpp
@@ -42,9 +42,11 @@ public:
   explicit CCUnsatisfiedReferenceState(std::shared_future<void> blockUntil);
   ~CCUnsatisfiedReferenceState() override = default;
   CCUnsatisfiedReferenceState(const CCUnsatisfiedReferenceState&) = delete;
-  CCUnsatisfiedReferenceState& operator=(const CCUnsatisfiedReferenceState&) = delete;
+  CCUnsatisfiedReferenceState& operator=(const CCUnsatisfiedReferenceState&) =
+    delete;
   CCUnsatisfiedReferenceState(CCUnsatisfiedReferenceState&&) = delete;
-  CCUnsatisfiedReferenceState& operator=(CCUnsatisfiedReferenceState&&) = delete;
+  CCUnsatisfiedReferenceState& operator=(CCUnsatisfiedReferenceState&&) =
+    delete;
 
   /**
    * This method will set handle the operations for transitioning the state
@@ -55,8 +57,9 @@ public:
   /**
    * Calling an Activate transition on UNSATISFIED_REFERENCE state is a no-op
    */
-  std::shared_ptr<ComponentInstance> Activate(ComponentConfigurationImpl& /*mgr*/,
-                                              const cppmicroservices::Bundle& /*clientBundle*/) override
+  std::shared_ptr<ComponentInstance> Activate(
+    ComponentConfigurationImpl& /*mgr*/,
+    const cppmicroservices::Bundle& /*clientBundle*/) override
   {
     return nullptr;
   };
@@ -66,7 +69,8 @@ public:
    * UNSATISFIED_REFERENCE state. This method does wait for the state transition (possibly triggered
    * by another thread) to finish. 
    */
-  void Deactivate(ComponentConfigurationImpl& /*mgr*/) override {
+  void Deactivate(ComponentConfigurationImpl& /*mgr*/) override
+  {
     // wait for the transition to finish
     WaitForTransitionTask();
   };
@@ -84,9 +88,13 @@ public:
    * Returns {\code ComponentState::UNSATISFIED_REFERENCE} to indicate the
    * state represented by this object
    */
-  ComponentState GetValue() const override { return ComponentState::UNSATISFIED_REFERENCE; }
+  ComponentState GetValue() const override
+  {
+    return ComponentState::UNSATISFIED_REFERENCE;
+  }
 
   void WaitForTransitionTask() override { ready.get(); }
+
 private:
   std::shared_future<void> ready;
 };

--- a/compendium/DeclarativeServices/src/manager/states/CMDisabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMDisabledState.cpp
@@ -33,14 +33,15 @@ CMDisabledState::CMDisabledState()
 {
   // Initialization with a valid future is required to facilitate a request
   // to DISABLE a ComponentManager whose initial state is DISABLED
-  std::packaged_task<void()> task([](){ /*empty task*/ });
+  std::packaged_task<void()> task([]() { /*empty task*/ });
   fut = task.get_future().share();
   task();
 }
 
 std::shared_future<void> CMDisabledState::Enable(ComponentManagerImpl& cm)
 {
-  auto currentState = shared_from_this(); // assume this object is the current state object.
+  auto currentState =
+    shared_from_this(); // assume this object is the current state object.
   return cm.PostAsyncDisabledToEnabled(currentState);
 }
 
@@ -51,7 +52,8 @@ std::shared_future<void> CMDisabledState::Disable(ComponentManagerImpl& /*cm*/)
 }
 
 // There are no configurations for a disabled state. Equivalent to a no-op.
-std::vector<std::shared_ptr<ComponentConfiguration>> CMDisabledState::GetConfigurations(const ComponentManagerImpl&) const
+std::vector<std::shared_ptr<ComponentConfiguration>>
+CMDisabledState::GetConfigurations(const ComponentManagerImpl&) const
 {
   return {};
 }

--- a/compendium/DeclarativeServices/src/manager/states/CMDisabledState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMDisabledState.hpp
@@ -24,9 +24,9 @@
 #define CMDisabledState_hpp
 
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
 #include "ComponentManagerState.hpp"
 
@@ -36,8 +36,7 @@ namespace scrimpl {
 /**
  * This class represents the disabled state of {\code ComponentManagerImpl}
  */
-class CMDisabledState final
-  : public ComponentManagerState
+class CMDisabledState final : public ComponentManagerState
 {
 public:
   /**
@@ -55,7 +54,8 @@ public:
    *        the task performed when the ComponentManager changes it's state from
    *        \c CMEnabledState to this object.
    */
-  explicit CMDisabledState(std::shared_future<void> fut) : fut(std::move(fut)) {};
+  explicit CMDisabledState(std::shared_future<void> fut)
+    : fut(std::move(fut)){};
   ~CMDisabledState() override = default;
   CMDisabledState(const CMDisabledState&) = delete;
   CMDisabledState& operator=(const CMDisabledState&) = delete;
@@ -91,7 +91,8 @@ public:
    * Returns an empty vector because there are no configurations associated
    * with a disabled state
    */
-  std::vector<std::shared_ptr<ComponentConfiguration>> GetConfigurations(const ComponentManagerImpl& cm) const override;
+  std::vector<std::shared_ptr<ComponentConfiguration>> GetConfigurations(
+    const ComponentManagerImpl& cm) const override;
 
   /**
    * Returns false indicating this is not the ENABLED state
@@ -106,10 +107,8 @@ public:
    * spawned to delete the component configuration objects created
    * when the component was enabled.
    */
-  std::shared_future<void> GetFuture() const override
-  {
-    return fut;
-  }
+  std::shared_future<void> GetFuture() const override { return fut; }
+
 private:
   FRIEND_TEST(CMDisabledStateTest, Ctor);
   std::shared_future<void> fut; ///< future associated with the transition task

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
@@ -24,22 +24,21 @@
 #define CMEnabledState_hpp
 
 #if defined(USING_GTEST)
-#include "gtest/gtest_prod.h"
+#  include "gtest/gtest_prod.h"
 #else
-#define FRIEND_TEST(x, y)
+#  define FRIEND_TEST(x, y)
 #endif
-#include "cppmicroservices/logservice/LogService.hpp"
-#include "ComponentManagerState.hpp"
 #include "../../ComponentRegistry.hpp"
 #include "../../metadata/ComponentMetadata.hpp"
+#include "ComponentManagerState.hpp"
+#include "cppmicroservices/logservice/LogService.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
 class ComponentConfigurationImpl;
 
-class CMEnabledState final
-  : public ComponentManagerState
+class CMEnabledState final : public ComponentManagerState
 {
 public:
   /**
@@ -50,7 +49,9 @@ public:
    *        this object. The transition task associated with the change from this
    *        state to the next \c CMDisabledState has to wait on this future.
    */
-  explicit CMEnabledState(std::shared_future<void> fut) : fut(std::move(fut)) {}
+  explicit CMEnabledState(std::shared_future<void> fut)
+    : fut(std::move(fut))
+  {}
   ~CMEnabledState() override = default;
   CMEnabledState(const CMEnabledState&) = delete;
   CMEnabledState& operator=(const CMEnabledState&) = delete;
@@ -81,7 +82,8 @@ public:
    * \param cm is the component manager
    * \return a vector of configurations for the given component manager
    */
-  std::vector<std::shared_ptr<ComponentConfiguration>> GetConfigurations(const ComponentManagerImpl& cm) const override;
+  std::vector<std::shared_ptr<ComponentConfiguration>> GetConfigurations(
+    const ComponentManagerImpl& cm) const override;
 
   /**
    * Always returns true since this state represents an Enabled state
@@ -94,10 +96,7 @@ public:
   /**
    * Returns the future associated with the transition into this state
    */
-  std::shared_future<void> GetFuture() const override
-  {
-    return fut;
-  }
+  std::shared_future<void> GetFuture() const override { return fut; }
 
   /**
    * Helper function used to create configuration objects for the
@@ -109,10 +108,11 @@ public:
    * \param registry is the runtime's component registry
    * \param logger is the runtime's logger
    */
-  void CreateConfigurations(std::shared_ptr<const metadata::ComponentMetadata> compDesc,
-                            const cppmicroservices::Bundle& bundle,
-                            std::shared_ptr<const ComponentRegistry> registry,
-                            std::shared_ptr<logservice::LogService> logger);
+  void CreateConfigurations(
+    std::shared_ptr<const metadata::ComponentMetadata> compDesc,
+    const cppmicroservices::Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<logservice::LogService> logger);
 
   /**
    * Helper function used to remove all the configuration objects created by this state.
@@ -128,8 +128,10 @@ public:
   FRIEND_TEST(CMEnabledStateTest, TestCreateConfigurationsAsync);
   FRIEND_TEST(CMEnabledStateTest, TestCreateConfigurations);
 
-  std::shared_future<void> fut; ///< future object to represent the transition task associated with this state.
-  std::vector<std::shared_ptr<ComponentConfigurationImpl>> configurations; ///< configurations created by this state object
+  std::shared_future<void>
+    fut; ///< future object to represent the transition task associated with this state.
+  std::vector<std::shared_ptr<ComponentConfigurationImpl>>
+    configurations; ///< configurations created by this state object
 };
 }
 }

--- a/compendium/DeclarativeServices/src/manager/states/ComponentConfigurationState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/ComponentConfigurationState.hpp
@@ -23,18 +23,18 @@
 #ifndef ComponentConfigurationState_hpp
 #define ComponentConfigurationState_hpp
 
-#include <string>
-#include <vector>
-#include <memory>
-#include <future>
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/ServiceReference.h"
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp"
 #include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
+#include "cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp"
 
-using cppmicroservices::service::component::runtime::dto::ComponentState;
 using cppmicroservices::service::component::detail::ComponentInstance;
+using cppmicroservices::service::component::runtime::dto::ComponentState;
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -43,15 +43,18 @@ class ComponentConfigurationImpl;
 /**
  * Interface for state objects used in {@link ComponentConfigurationImpl} class
  */
-class ComponentConfigurationState : public std::enable_shared_from_this<ComponentConfigurationState>
+class ComponentConfigurationState
+  : public std::enable_shared_from_this<ComponentConfigurationState>
 {
 public:
   ComponentConfigurationState() = default;
   virtual ~ComponentConfigurationState() = default;
   ComponentConfigurationState(const ComponentConfigurationState&) = delete;
-  ComponentConfigurationState& operator=(const ComponentConfigurationState&) = delete;
+  ComponentConfigurationState& operator=(const ComponentConfigurationState&) =
+    delete;
   ComponentConfigurationState(ComponentConfigurationState&&) = delete;
-  ComponentConfigurationState& operator=(ComponentConfigurationState&&) = delete;
+  ComponentConfigurationState& operator=(ComponentConfigurationState&&) =
+    delete;
 
   /**
    * Implementation must handle the transition from \c UNSATISFIED_REFERENCE to \c SATISFIED
@@ -66,8 +69,9 @@ public:
    * \param mgr is the {@link ComponentConfigurationImpl} object whose state needs to change
    * \param clientBundle is the bundle responsible for triggering the state change
    */
-  virtual std::shared_ptr<ComponentInstance> Activate(ComponentConfigurationImpl& mgr,
-                                                      const cppmicroservices::Bundle& clientBundle) = 0;
+  virtual std::shared_ptr<ComponentInstance> Activate(
+    ComponentConfigurationImpl& mgr,
+    const cppmicroservices::Bundle& clientBundle) = 0;
 
   /**
    * Implementation must handle the transition from \c SATISFIED or \c ACTIVE to \c UNSATISFIED_REFERENCE

--- a/compendium/DeclarativeServices/src/manager/states/ComponentManagerState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/ComponentManagerState.hpp
@@ -23,10 +23,10 @@
 #ifndef ComponentManagerState_hpp
 #define ComponentManagerState_hpp
 
+#include <future>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <future>
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -67,7 +67,8 @@ public:
    * Implementation returns a \c std::vector of configurations created for
    * the component passed as parameter
    */
-  virtual std::vector<std::shared_ptr<ComponentConfiguration>> GetConfigurations(const ComponentManagerImpl& cm) const = 0;
+  virtual std::vector<std::shared_ptr<ComponentConfiguration>>
+  GetConfigurations(const ComponentManagerImpl& cm) const = 0;
 
   /**
    * Implementation returns a \c std::shared_future object representing the async

--- a/compendium/DeclarativeServices/src/metadata/ComponentMetadata.hpp
+++ b/compendium/DeclarativeServices/src/metadata/ComponentMetadata.hpp
@@ -24,11 +24,11 @@
 #define COMPONENTMETADATA_HPP
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-#include "ServiceMetadata.hpp"
 #include "ReferenceMetadata.hpp"
+#include "ServiceMetadata.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -47,8 +47,8 @@ struct ComponentMetadata
   {}
 
   std::string name;
-  bool enabled{true};
-  bool immediate{false};
+  bool enabled{ true };
+  bool immediate{ false };
   std::string implClassName;
   std::string activateMethodName;
   std::string deactivateMethodName;

--- a/compendium/DeclarativeServices/src/metadata/MetadataParser.hpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParser.hpp
@@ -23,9 +23,8 @@
 #ifndef METADATAPARSER_HPP
 #define METADATAPARSER_HPP
 
-#include "Util.hpp"
 #include "ComponentMetadata.hpp"
-
+#include "Util.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -59,7 +58,10 @@ public:
    * @param anymap An @c AnyMap representation of the service description
    * @returns a vector of shared_ptrs to each parsed @c ComponentMetadata
    */
-  virtual std::vector<std::shared_ptr<ComponentMetadata>> ParseAndGetComponentsMetadata(const cppmicroservices::AnyMap& anymap) const = 0;
+  virtual std::vector<std::shared_ptr<ComponentMetadata>>
+  ParseAndGetComponentsMetadata(
+    const cppmicroservices::AnyMap& anymap) const = 0;
+
 protected:
   MetadataParser() = default;
 };

--- a/compendium/DeclarativeServices/src/metadata/MetadataParserFactory.hpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParserFactory.hpp
@@ -41,14 +41,16 @@ public:
    * @returns an unique_ptr to the created @c MetadataParser object
    * @throws std::runtime_error if the version isn't supported
    */
-  static std::unique_ptr<MetadataParser> Create(uint64_t version, std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+  static std::unique_ptr<MetadataParser> Create(
+    uint64_t version,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger)
   {
-    switch (version)
-    {
+    switch (version) {
       case 1:
         return std::make_unique<MetadataParserImplV1>(logger);
       default:
-        throw std::runtime_error("Unsupported manifest file version '" + std::to_string(version) + "'");
+        throw std::runtime_error("Unsupported manifest file version '" +
+                                 std::to_string(version) + "'");
         return nullptr;
     }
   }
@@ -58,4 +60,3 @@ public:
 }
 }
 #endif //METADATAPARSERFACTORY_HPP
-

--- a/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
@@ -20,10 +20,10 @@
 
   =============================================================================*/
 
-#include "cppmicroservices/Bundle.h"
-#include "ComponentMetadata.hpp"
 #include "MetadataParserImpl.hpp"
+#include "ComponentMetadata.hpp"
 #include "Util.hpp"
+#include "cppmicroservices/Bundle.h"
 
 #include <iterator>
 
@@ -33,60 +33,70 @@ namespace cppmicroservices {
 namespace scrimpl {
 namespace metadata {
 
-ServiceMetadata MetadataParserImplV1::CreateServiceMetadata(const AnyMap& metadata) const
+ServiceMetadata MetadataParserImplV1::CreateServiceMetadata(
+  const AnyMap& metadata) const
 {
   ServiceMetadata serviceMetadata{};
 
   // service.interfaces (Mandatory)
-  const auto interfaces = ObjectValidator(metadata, "interfaces").GetValue<std::vector<cppmicroservices::Any>>();
+  const auto interfaces = ObjectValidator(metadata, "interfaces")
+                            .GetValue<std::vector<cppmicroservices::Any>>();
   std::transform(std::begin(interfaces),
                  std::end(interfaces),
                  std::back_inserter(serviceMetadata.interfaces),
-                 [](const auto& interface) { return ObjectValidator(interface).GetValue<std::string>(); });
+                 [](const auto& interface) {
+                   return ObjectValidator(interface).GetValue<std::string>();
+                 });
 
   // service.scope
   const auto object = ObjectValidator(metadata, "scope", /*isOptional=*/true);
-  object.AssignValueTo(serviceMetadata.scope, /*choices=*/ ServiceMetadata::Scopes);
+  object.AssignValueTo(serviceMetadata.scope,
+                       /*choices=*/ServiceMetadata::Scopes);
 
   return serviceMetadata;
 }
 
-ReferenceMetadata MetadataParserImplV1::CreateReferenceMetadata(const AnyMap& metadata) const
+ReferenceMetadata MetadataParserImplV1::CreateReferenceMetadata(
+  const AnyMap& metadata) const
 {
   ReferenceMetadata refMetadata{};
 
   // reference.interface (Mandatory)
-  ObjectValidator(metadata, "interface").AssignValueTo(refMetadata.interfaceName);
+  ObjectValidator(metadata, "interface")
+    .AssignValueTo(refMetadata.interfaceName);
 
   // reference.name (Mandatory)
   ObjectValidator(metadata, "name").AssignValueTo(refMetadata.name);
 
   // reference.cardinality
   auto object = ObjectValidator(metadata, "cardinality", /*isOptional=*/true);
-  object.AssignValueTo(refMetadata.cardinality, /*choices=*/ ReferenceMetadata::Cardinalities);
+  object.AssignValueTo(refMetadata.cardinality,
+                       /*choices=*/ReferenceMetadata::Cardinalities);
   std::tie(refMetadata.minCardinality, refMetadata.maxCardinality) =
     GetReferenceCardinalityExtents(refMetadata.cardinality);
 
   // reference.policy
   object = ObjectValidator(metadata, "policy", /*isOptional=*/true);
-  object.AssignValueTo(refMetadata.policy, /*choices=*/ ReferenceMetadata::Policies);
+  object.AssignValueTo(refMetadata.policy,
+                       /*choices=*/ReferenceMetadata::Policies);
 
   // reference.policy-option
   object = ObjectValidator(metadata, "policy-option", /*isOptional=*/true);
-  object.AssignValueTo(refMetadata.policyOption, /*choices=*/ ReferenceMetadata::PolicyOptions);
+  object.AssignValueTo(refMetadata.policyOption,
+                       /*choices=*/ReferenceMetadata::PolicyOptions);
 
   // reference.target
-  ObjectValidator(metadata, "target", /*isOptional=*/true).AssignValueTo(refMetadata.target);
+  ObjectValidator(metadata, "target", /*isOptional=*/true)
+    .AssignValueTo(refMetadata.target);
 
   return refMetadata;
 }
 
-std::vector<ReferenceMetadata>
-MetadataParserImplV1::CreateReferenceMetadatas(const std::vector<cppmicroservices::Any>& refs) const
+std::vector<ReferenceMetadata> MetadataParserImplV1::CreateReferenceMetadatas(
+  const std::vector<cppmicroservices::Any>& refs) const
 {
   std::vector<ReferenceMetadata> refMetadatas;
-  for (const auto& ref : refs)
-  {
+  for (const auto& ref : refs) {
     auto metadata = ObjectValidator(ref).GetValue<AnyMap>();
     refMetadatas.emplace_back(CreateReferenceMetadata(metadata));
   }
@@ -99,33 +109,37 @@ MetadataParserImplV1::CreateComponentMetadata(const AnyMap& metadata) const
   auto compMetadata = std::make_shared<ComponentMetadata>();
 
   // component.implementation-class (Mandatory)
-  ObjectValidator(metadata, "implementation-class").AssignValueTo(compMetadata->implClassName);
+  ObjectValidator(metadata, "implementation-class")
+    .AssignValueTo(compMetadata->implClassName);
 
   // component.immediate
   compMetadata->immediate = true;
-  const bool serviceSpecified = ObjectValidator(metadata, "service", /*isOptional=*/true).KeyExists();
+  const bool serviceSpecified =
+    ObjectValidator(metadata, "service", /*isOptional=*/true).KeyExists();
   auto object = ObjectValidator(metadata, "immediate", /*isOptional=*/true);
-  const bool isImmediate = (object.KeyExists()) ? object.GetValue<bool>() : !serviceSpecified;
-  if(!serviceSpecified && !isImmediate)
-  {
-    throw std::runtime_error("Invalid value specified for the name 'immediate'.");
+  const bool isImmediate =
+    (object.KeyExists()) ? object.GetValue<bool>() : !serviceSpecified;
+  if (!serviceSpecified && !isImmediate) {
+    throw std::runtime_error(
+      "Invalid value specified for the name 'immediate'.");
   }
-  compMetadata->immediate = (!serviceSpecified || (serviceSpecified && isImmediate));
+  compMetadata->immediate =
+    (!serviceSpecified || (serviceSpecified && isImmediate));
 
   // component.enabled
-  ObjectValidator(metadata, "enabled", /*isOptional=*/true).AssignValueTo(compMetadata->enabled);
+  ObjectValidator(metadata, "enabled", /*isOptional=*/true)
+    .AssignValueTo(compMetadata->enabled);
 
   // component.name
   compMetadata->name = compMetadata->implClassName;
-  ObjectValidator(metadata, "name", /*isOptional=*/true).AssignValueTo(compMetadata->name);
+  ObjectValidator(metadata, "name", /*isOptional=*/true)
+    .AssignValueTo(compMetadata->name);
 
   // component.properties
   object = ObjectValidator(metadata, "properties", /*isOptional=*/true);
-  if (object.KeyExists())
-  {
+  if (object.KeyExists()) {
     const auto props = object.GetValue<AnyMap>();
-    for(const auto& prop : props)
-    {
+    for (const auto& prop : props) {
       compMetadata->properties.insert(prop);
     }
   }
@@ -133,17 +147,17 @@ MetadataParserImplV1::CreateComponentMetadata(const AnyMap& metadata) const
   // component.service
   compMetadata->serviceMetadata = {};
   object = ObjectValidator(metadata, "service", /*isOptional=*/true);
-  if (object.KeyExists())
-  {
-    compMetadata->serviceMetadata = CreateServiceMetadata(object.GetValue<AnyMap>());
+  if (object.KeyExists()) {
+    compMetadata->serviceMetadata =
+      CreateServiceMetadata(object.GetValue<AnyMap>());
   }
 
   // component.references
   compMetadata->refsMetadata = {};
   object = ObjectValidator(metadata, "references", /*isOptional=*/true);
-  if (object.KeyExists())
-  {
-    compMetadata->refsMetadata = CreateReferenceMetadatas(object.GetValue<std::vector<cppmicroservices::Any>>());
+  if (object.KeyExists()) {
+    compMetadata->refsMetadata = CreateReferenceMetadatas(
+      object.GetValue<std::vector<cppmicroservices::Any>>());
   }
 
   return compMetadata;
@@ -153,21 +167,19 @@ std::vector<std::shared_ptr<ComponentMetadata>>
 MetadataParserImplV1::ParseAndGetComponentsMetadata(const AnyMap& scrmap) const
 {
   std::vector<std::shared_ptr<ComponentMetadata>> componentsMetadata;
-  const auto components = ObjectValidator(scrmap, "components").GetValue<std::vector<cppmicroservices::Any>>();
+  const auto components = ObjectValidator(scrmap, "components")
+                            .GetValue<std::vector<cppmicroservices::Any>>();
   std::size_t index = 0;
-  for (const auto& component : components)
-  {
+  for (const auto& component : components) {
     const auto componentMap = ObjectValidator(component).GetValue<AnyMap>();
     // Log the exception if the component can't be parsed and process the next
     // component
-    try
-    {
+    try {
       componentsMetadata.emplace_back(CreateComponentMetadata(componentMap));
-    }
-    catch (std::exception& ex)
-    {
+    } catch (std::exception& ex) {
       std::string msg = std::string(ex.what());
-      msg += " Could not load the component with index: " + std::to_string(index);
+      msg +=
+        " Could not load the component with index: " + std::to_string(index);
       logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, msg);
     }
     ++index;

--- a/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.hpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.hpp
@@ -32,14 +32,13 @@ namespace metadata {
 /*
  * Represents a concrete implementation (Version 1) of the MetadataParser
  */
-class MetadataParserImplV1
-  : public MetadataParser
+class MetadataParserImplV1 : public MetadataParser
 {
 public:
-  MetadataParserImplV1(std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+  MetadataParserImplV1(
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger)
     : logger(std::move(logger))
-  {
-  }
+  {}
 
   MetadataParserImplV1(const MetadataParserImplV1&) = delete;
   MetadataParserImplV1& operator=(const MetadataParserImplV1&) = delete;
@@ -61,8 +60,8 @@ public:
    *             key @c "references" in the manifest)
    * @returns a vector of @c ReferenceMetadata objects
    */
-  std::vector<ReferenceMetadata>
-  CreateReferenceMetadatas(const std::vector<cppmicroservices::Any>& refs) const;
+  std::vector<ReferenceMetadata> CreateReferenceMetadatas(
+    const std::vector<cppmicroservices::Any>& refs) const;
 
   /*
    * @brief Parse and return the ReferenceMetadata object
@@ -76,14 +75,16 @@ public:
    * @param metadata An element in the array of the key "components" in the manifest
    * @returns the shared_ptr to a @c ComponentMetadata object
    */
-  std::shared_ptr<ComponentMetadata> CreateComponentMetadata(const AnyMap& metadata) const;
+  std::shared_ptr<ComponentMetadata> CreateComponentMetadata(
+    const AnyMap& metadata) const;
 
   /*
    * @brief Parse and return the vector of ComponentMetadata's
    * @param metadata The value of the key "scr" in the manifest
    * @returns the vector of shared_ptrs to the created @ComponentMetadata objects
    */
-  std::vector<std::shared_ptr<ComponentMetadata>> ParseAndGetComponentsMetadata(const AnyMap& scrmap) const override;
+  std::vector<std::shared_ptr<ComponentMetadata>> ParseAndGetComponentsMetadata(
+    const AnyMap& scrmap) const override;
 
 private:
   std::shared_ptr<cppmicroservices::logservice::LogService> logger;

--- a/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.cpp
+++ b/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.cpp
@@ -27,45 +27,53 @@ namespace cppmicroservices {
 namespace scrimpl {
 namespace metadata {
 
-const std::vector<std::string> ReferenceMetadata::Cardinalities = {"0..1", "1..1", "0..n", "1..n"};
-const std::vector<std::string> ReferenceMetadata::Policies = {"static", "dynamic"};
-const std::vector<std::string> ReferenceMetadata::PolicyOptions = {"greedy", "reluctant"};
-const std::vector<std::string> ReferenceMetadata::Scopes = {"bundle", "prototype", "prototype-required"};
+const std::vector<std::string> ReferenceMetadata::Cardinalities = { "0..1",
+                                                                    "1..1",
+                                                                    "0..n",
+                                                                    "1..n" };
+const std::vector<std::string> ReferenceMetadata::Policies = { "static",
+                                                               "dynamic" };
+const std::vector<std::string> ReferenceMetadata::PolicyOptions = {
+  "greedy",
+  "reluctant"
+};
+const std::vector<std::string> ReferenceMetadata::Scopes = {
+  "bundle",
+  "prototype",
+  "prototype-required"
+};
 
-std::tuple<std::size_t, std::size_t> GetReferenceCardinalityExtents(const std::string& cardinality)
+std::tuple<std::size_t, std::size_t> GetReferenceCardinalityExtents(
+  const std::string& cardinality)
 {
   std::size_t minCardinality = 1;
   std::size_t maxCardinality = 1;
   auto cardinalities = ReferenceMetadata::Cardinalities;
-  auto it = std::find(std::begin(cardinalities), std::end(cardinalities), cardinality);
-  if (it == std::end(cardinalities))
-  {
-    std::string msg = cardinality + " is not a valid ReferenceCardinality string";
+  auto it =
+    std::find(std::begin(cardinalities), std::end(cardinalities), cardinality);
+  if (it == std::end(cardinalities)) {
+    std::string msg =
+      cardinality + " is not a valid ReferenceCardinality string";
     throw std::out_of_range(msg);
   }
   auto index = std::distance(std::begin(cardinalities), it);
-  switch (index)
-  {
-    case 0:
-    {
+  switch (index) {
+    case 0: {
       minCardinality = 0;
       maxCardinality = 1;
       break;
     }
-    case 1:
-    {
+    case 1: {
       minCardinality = 1;
       maxCardinality = 1;
       break;
     }
-    case 2:
-    {
+    case 2: {
       minCardinality = 0;
       maxCardinality = std::numeric_limits<std::size_t>::max();
       break;
     }
-    case 3:
-    {
+    case 3: {
       minCardinality = 1;
       maxCardinality = std::numeric_limits<std::size_t>::max();
       break;

--- a/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.hpp
+++ b/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.hpp
@@ -23,16 +23,16 @@
 #ifndef REFERENCEMETADATA_HPP
 #define REFERENCEMETADATA_HPP
 
-#include <string>
-#include <map>
-#include <vector>
 #include <iostream>
+#include <map>
+#include <string>
 #include <tuple>
+#include <vector>
 
+#include "Util.hpp"
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/LDAPFilter.h"
-#include "Util.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {
@@ -59,8 +59,8 @@ struct ReferenceMetadata
   std::string policy;
   std::string policyOption;
   std::string scope;
-  std::size_t minCardinality{1};
-  std::size_t maxCardinality{1};
+  std::size_t minCardinality{ 1 };
+  std::size_t maxCardinality{ 1 };
 
   static const std::vector<std::string> Cardinalities;
   static const std::vector<std::string> Policies;
@@ -78,7 +78,8 @@ struct ReferenceMetadata
  * @throws std::out_of_range error if @p cardinality is not found in the
  *         global @c ReferenceMetadata::Cardinalities
  */
-std::tuple<std::size_t, std::size_t> GetReferenceCardinalityExtents(const std::string& cardinality);
+std::tuple<std::size_t, std::size_t> GetReferenceCardinalityExtents(
+  const std::string& cardinality);
 
 }
 }

--- a/compendium/DeclarativeServices/src/metadata/ServiceMetadata.cpp
+++ b/compendium/DeclarativeServices/src/metadata/ServiceMetadata.cpp
@@ -26,7 +26,9 @@ namespace cppmicroservices {
 namespace scrimpl {
 namespace metadata {
 
-const std::vector<std::string> ServiceMetadata::Scopes = {"bundle", "prototype", "singleton"};
+const std::vector<std::string> ServiceMetadata::Scopes = { "bundle",
+                                                           "prototype",
+                                                           "singleton" };
 
 }
 }

--- a/compendium/DeclarativeServices/src/metadata/ServiceMetadata.hpp
+++ b/compendium/DeclarativeServices/src/metadata/ServiceMetadata.hpp
@@ -28,9 +28,9 @@
 
 #include <iostream>
 
+#include "Util.hpp"
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/Constants.h"
-#include "Util.hpp"
 
 namespace cppmicroservices {
 namespace scrimpl {

--- a/compendium/DeclarativeServices/src/metadata/Util.cpp
+++ b/compendium/DeclarativeServices/src/metadata/Util.cpp
@@ -22,44 +22,50 @@
 
 #include "Util.hpp"
 
-namespace cppmicroservices { namespace scrimpl { namespace util {
+namespace cppmicroservices {
+namespace scrimpl {
+namespace util {
 
 // @brief Throws if the container T is of type @c Any or @c string or @c AnyMap and it's empty
-template <>
-void ThrowIfEmpty(const std::vector<cppmicroservices::Any>& value, const std::string& key)
+template<>
+void ThrowIfEmpty(const std::vector<cppmicroservices::Any>& value,
+                  const std::string& key)
 {
   ThrowIfEmptyHelper(value, key);
 }
-  
-template <>
+
+template<>
 void ThrowIfEmpty(const std::string& value, const std::string& key)
 {
   ThrowIfEmptyHelper(value, key);
 }
-  
-template <>
+
+template<>
 void ThrowIfEmpty(const cppmicroservices::AnyMap& value, const std::string& key)
 {
   ThrowIfEmptyHelper(value, key);
 }
 
-template <>
-void ThrowIfValueAbsentInChoices(const std::string& inValue, const std::vector<std::string>& choices)
+template<>
+void ThrowIfValueAbsentInChoices(const std::string& inValue,
+                                 const std::vector<std::string>& choices)
 {
   std::string value = inValue;
 #if _WIN32
   std::transform(value.begin(), value.end(), value.begin(), tolower);
 #else
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<unsigned char>(std::tolower(static_cast<unsigned char>(c))); });
+  std::transform(
+    value.begin(), value.end(), value.begin(), [](unsigned char c) {
+      return static_cast<unsigned char>(
+        std::tolower(static_cast<unsigned char>(c)));
+    });
 #endif
   if (!choices.empty() &&
-      std::find(choices.begin(), choices.end(), value) == choices.end())
-  {
+      std::find(choices.begin(), choices.end(), value) == choices.end()) {
     std::ostringstream stream;
     stream << "Invalid value '" + value + "'. ";
     stream << "The valid choices are : [";
-    for (auto c = std::begin(choices); c < std::end(choices) - 1; ++c)
-    {
+    for (auto c = std::begin(choices); c < std::end(choices) - 1; ++c) {
       stream << *c << ", ";
     }
     stream << choices.back() << "].";
@@ -67,4 +73,6 @@ void ThrowIfValueAbsentInChoices(const std::string& inValue, const std::vector<s
   }
 }
 
-}}}
+}
+}
+}

--- a/compendium/DeclarativeServices/test/ActivatorTest.cpp
+++ b/compendium/DeclarativeServices/test/ActivatorTest.cpp
@@ -20,17 +20,17 @@
 
   =============================================================================*/
 
+#include <algorithm>
 #include <cstdio>
 #include <iostream>
-#include <algorithm>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/FrameworkFactory.h"
+#include "../src/SCRActivator.hpp"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/BundleImport.h"
 #include "cppmicroservices/Constants.h"
-#include "../src/SCRActivator.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 #include "Mocks.hpp"
 
@@ -39,24 +39,20 @@
 
 using cppmicroservices::scrimpl::SCRActivator;
 
-namespace cppmicroservices{
+namespace cppmicroservices {
 namespace scrimpl {
 
 // The fixture for testing class SCRActivator.
-class ActivatorTest
-  : public ::testing::Test
+class ActivatorTest : public ::testing::Test
 {
 protected:
   ActivatorTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
-      
+  {}
+
   virtual ~ActivatorTest() = default;
 
-  virtual void SetUp()
-  {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
   virtual void TearDown()
   {
@@ -65,6 +61,7 @@ protected:
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
@@ -72,40 +69,39 @@ private:
 TEST_F(ActivatorTest, VerifySCRService)
 {
   EXPECT_NO_THROW({
-      auto bundleContext = GetFramework().GetBundleContext();
-      auto allBundles = bundleContext.GetBundles();
-      EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
-      cppmicroservices::Bundle selfBundle;
-      for (const auto& bundle : allBundles)
-      {
-        if (bundle.GetSymbolicName() == str(US_BUNDLE_NAME))
-        {
-          selfBundle = bundle;
-          break;
-        }
+    auto bundleContext = GetFramework().GetBundleContext();
+    auto allBundles = bundleContext.GetBundles();
+    EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
+    cppmicroservices::Bundle selfBundle;
+    for (const auto& bundle : allBundles) {
+      if (bundle.GetSymbolicName() == str(US_BUNDLE_NAME)) {
+        selfBundle = bundle;
+        break;
       }
-      if (selfBundle)
-      {
-        selfBundle.Start();
-        EXPECT_EQ(selfBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE);
-        auto selfContext = selfBundle.GetBundleContext();
-        EXPECT_EQ(selfBundle.GetRegisteredServices().size(), static_cast<size_t>(1));
-        cppmicroservices::ServiceReference<ServiceComponentRuntime> serviceRef = bundleContext.GetServiceReference<ServiceComponentRuntime>();
-        std::shared_ptr<ServiceComponentRuntime> service = bundleContext.GetService<ServiceComponentRuntime>(serviceRef);
-        EXPECT_NE(service.get(), nullptr);
-      }
-    });
+    }
+    if (selfBundle) {
+      selfBundle.Start();
+      EXPECT_EQ(selfBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE);
+      auto selfContext = selfBundle.GetBundleContext();
+      EXPECT_EQ(selfBundle.GetRegisteredServices().size(),
+                static_cast<size_t>(1));
+      cppmicroservices::ServiceReference<ServiceComponentRuntime> serviceRef =
+        bundleContext.GetServiceReference<ServiceComponentRuntime>();
+      std::shared_ptr<ServiceComponentRuntime> service =
+        bundleContext.GetService<ServiceComponentRuntime>(serviceRef);
+      EXPECT_NE(service.get(), nullptr);
+    }
+  });
 }
 
-TEST_F(ActivatorTest, VerifyConcurrentStartStop) {
+TEST_F(ActivatorTest, VerifyConcurrentStartStop)
+{
   auto bundleContext = GetFramework().GetBundleContext();
   auto allBundles = bundleContext.GetBundles();
   EXPECT_EQ(allBundles.size(), static_cast<size_t>(2));
   cppmicroservices::Bundle selfBundle;
-  for(auto bundle : allBundles)
-  {
-    if(bundle.GetSymbolicName() == xstr(US_BUNDLE_NAME))
-    {
+  for (auto bundle : allBundles) {
+    if (bundle.GetSymbolicName() == xstr(US_BUNDLE_NAME)) {
       selfBundle = bundle;
       break;
     }
@@ -116,30 +112,25 @@ TEST_F(ActivatorTest, VerifyConcurrentStartStop) {
   std::vector<std::promise<void>> readies(numCalls);
   std::vector<std::future<void>> bundle_state_changes(numCalls);
   try {
-    for(int i =0; i<numCalls; i++)
-    {
-      bundle_state_changes[i] = std::async(std::launch::async,
-                                           [&selfBundle, ready, &readies, i]()
-                                           {
-                                             readies[i].set_value();
-                                             ready.wait();
-                                             ((i%2) ? selfBundle.Start() :selfBundle.Stop());
-                                           });
+    for (int i = 0; i < numCalls; i++) {
+      bundle_state_changes[i] =
+        std::async(std::launch::async, [&selfBundle, ready, &readies, i]() {
+          readies[i].set_value();
+          ready.wait();
+          ((i % 2) ? selfBundle.Start() : selfBundle.Stop());
+        });
     }
 
-    for(int i =0; i< numCalls; i++)
-    {
+    for (int i = 0; i < numCalls; i++) {
       readies[i].get_future().wait();
     }
     go.set_value();
-    for(int i =0; i< numCalls; i++)
-    {
+    for (int i = 0; i < numCalls; i++) {
       bundle_state_changes[i].wait();
     }
-  }
-  catch(const std::exception& e)
-  {
-    EXPECT_TRUE(false) << "Error: exception received ... " << e.what() << std::endl;
+  } catch (const std::exception& e) {
+    EXPECT_TRUE(false) << "Error: exception received ... " << e.what()
+                       << std::endl;
     go.set_value();
     throw std::current_exception();
   }

--- a/compendium/DeclarativeServices/test/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/Mocks.hpp
@@ -22,68 +22,93 @@
 
 #ifndef __MOCKS_HPP__
 #define __MOCKS_HPP__
-#include "gmock/gmock.h"
-#include <cppmicroservices/ServiceFactory.h>
 #include "../src/ComponentRegistry.hpp"
-#include "../src/manager/ComponentManager.hpp"
-#include "../src/manager/ComponentManagerImpl.hpp"
-#include "../src/manager/states/ComponentManagerState.hpp"
-#include "../src/manager/ReferenceManager.hpp"
-#include "../src/manager/ReferenceManagerImpl.hpp"
 #include "../src/manager/ComponentConfiguration.hpp"
 #include "../src/manager/ComponentConfigurationImpl.hpp"
+#include "../src/manager/ComponentManager.hpp"
+#include "../src/manager/ComponentManagerImpl.hpp"
+#include "../src/manager/ReferenceManager.hpp"
+#include "../src/manager/ReferenceManagerImpl.hpp"
 #include "../src/manager/states/ComponentConfigurationState.hpp"
+#include "../src/manager/states/ComponentManagerState.hpp"
+#include "gmock/gmock.h"
+#include <cppmicroservices/ServiceFactory.h>
 
 namespace cppmicroservices {
 namespace scrimpl {
 namespace dummy {
 
-struct ServiceImpl {};
-struct Reference1 {};
-struct Reference2 {};
-struct Reference3 {};
+struct ServiceImpl
+{};
+struct Reference1
+{};
+struct Reference2
+{};
+struct Reference3
+{};
 
 } // namespace dummy
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4373)
+#  pragma warning(push)
+#  pragma warning(disable : 4373)
 #endif
 
 /**
  * This class is used in tests where the logger is required and the test
  * needs to verify what is sent to the logger
  */
-class MockLogger
-  : public cppmicroservices::logservice::LogService
+class MockLogger : public cppmicroservices::logservice::LogService
 {
 public:
-  MOCK_METHOD2(Log, void(cppmicroservices::logservice::SeverityLevel, const std::string&));
-  MOCK_METHOD3(Log, void(cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr));
-  MOCK_METHOD3(Log, void(const cppmicroservices::ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&));
-  MOCK_METHOD4(Log, void(const cppmicroservices::ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr));
+  MOCK_METHOD2(Log,
+               void(cppmicroservices::logservice::SeverityLevel,
+                    const std::string&));
+  MOCK_METHOD3(Log,
+               void(cppmicroservices::logservice::SeverityLevel,
+                    const std::string&,
+                    const std::exception_ptr));
+  MOCK_METHOD3(Log,
+               void(const cppmicroservices::ServiceReferenceBase&,
+                    cppmicroservices::logservice::SeverityLevel,
+                    const std::string&));
+  MOCK_METHOD4(Log,
+               void(const cppmicroservices::ServiceReferenceBase&,
+                    cppmicroservices::logservice::SeverityLevel,
+                    const std::string&,
+                    const std::exception_ptr));
 };
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#  pragma warning(pop)
 #endif
 
 /**
  * This class is used in tests where the logger is required but the test
  * does not care if anything is actually sent to the logger
  */
-class FakeLogger
-  : public cppmicroservices::logservice::LogService
+class FakeLogger : public cppmicroservices::logservice::LogService
 {
 public:
-  void Log(cppmicroservices::logservice::SeverityLevel, const std::string&) override {}
-  void Log(cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr) override {}
-  void Log(const ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&) override {}
-  void Log(const ServiceReferenceBase&, cppmicroservices::logservice::SeverityLevel, const std::string&, const std::exception_ptr) override {}
+  void Log(cppmicroservices::logservice::SeverityLevel,
+           const std::string&) override
+  {}
+  void Log(cppmicroservices::logservice::SeverityLevel,
+           const std::string&,
+           const std::exception_ptr) override
+  {}
+  void Log(const ServiceReferenceBase&,
+           cppmicroservices::logservice::SeverityLevel,
+           const std::string&) override
+  {}
+  void Log(const ServiceReferenceBase&,
+           cppmicroservices::logservice::SeverityLevel,
+           const std::string&,
+           const std::exception_ptr) override
+  {}
 };
 
-class MockComponentManager
-  : public ComponentManager
+class MockComponentManager : public ComponentManager
 {
 public:
   MOCK_CONST_METHOD0(GetName, std::string(void));
@@ -93,34 +118,42 @@ public:
   MOCK_CONST_METHOD0(IsEnabled, bool(void));
   MOCK_METHOD0(Enable, std::shared_future<void>(void));
   MOCK_METHOD0(Disable, std::shared_future<void>(void));
-  MOCK_CONST_METHOD0(GetComponentConfigurations, std::vector<std::shared_ptr<ComponentConfiguration>>());
-  MOCK_CONST_METHOD0(GetMetadata, std::shared_ptr<const metadata::ComponentMetadata>());
+  MOCK_CONST_METHOD0(GetComponentConfigurations,
+                     std::vector<std::shared_ptr<ComponentConfiguration>>());
+  MOCK_CONST_METHOD0(GetMetadata,
+                     std::shared_ptr<const metadata::ComponentMetadata>());
 };
 
-class MockComponentRegistry
-  : public ComponentRegistry
+class MockComponentRegistry : public ComponentRegistry
 {
 public:
-  MOCK_CONST_METHOD0(GetComponentManagers, std::vector<std::shared_ptr<ComponentManager>>());
-  MOCK_CONST_METHOD1(GetComponentManagers, std::vector<std::shared_ptr<ComponentManager>>(unsigned long));
-  MOCK_CONST_METHOD2(GetComponentManager, std::shared_ptr<ComponentManager>(unsigned long, const std::string&));
-  MOCK_METHOD1(AddComponentManager, bool(const std::shared_ptr<ComponentManager>&));
-  MOCK_METHOD1(RemoveComponentManager, void(const std::shared_ptr<ComponentManager>&));
+  MOCK_CONST_METHOD0(GetComponentManagers,
+                     std::vector<std::shared_ptr<ComponentManager>>());
+  MOCK_CONST_METHOD1(
+    GetComponentManagers,
+    std::vector<std::shared_ptr<ComponentManager>>(unsigned long));
+  MOCK_CONST_METHOD2(GetComponentManager,
+                     std::shared_ptr<ComponentManager>(unsigned long,
+                                                       const std::string&));
+  MOCK_METHOD1(AddComponentManager,
+               bool(const std::shared_ptr<ComponentManager>&));
+  MOCK_METHOD1(RemoveComponentManager,
+               void(const std::shared_ptr<ComponentManager>&));
 };
 
-class MockComponentManagerState
-  : public ComponentManagerState
+class MockComponentManagerState : public ComponentManagerState
 {
 public:
-  MOCK_METHOD1(Enable, std::shared_future<void>(ComponentManagerImpl& ));
+  MOCK_METHOD1(Enable, std::shared_future<void>(ComponentManagerImpl&));
   MOCK_METHOD1(Disable, std::shared_future<void>(ComponentManagerImpl&));
   MOCK_CONST_METHOD1(IsEnabled, bool(const ComponentManagerImpl&));
-  MOCK_CONST_METHOD1(GetConfigurations, std::vector<std::shared_ptr<ComponentConfiguration>>(const ComponentManagerImpl&));
+  MOCK_CONST_METHOD1(GetConfigurations,
+                     std::vector<std::shared_ptr<ComponentConfiguration>>(
+                       const ComponentManagerImpl&));
   MOCK_CONST_METHOD0(GetFuture, std::shared_future<void>());
 };
 
-class MockReferenceManager
-  : public ReferenceManager
+class MockReferenceManager : public ReferenceManager
 {
 public:
   MOCK_CONST_METHOD0(GetReferenceName, std::string(void));
@@ -128,69 +161,90 @@ public:
   MOCK_CONST_METHOD0(GetLDAPString, std::string(void));
   MOCK_CONST_METHOD0(IsSatisfied, bool(void));
   MOCK_CONST_METHOD0(IsOptional, bool(void));
-  MOCK_CONST_METHOD0(GetBoundReferences, std::set<cppmicroservices::ServiceReferenceBase>());
-  MOCK_CONST_METHOD0(GetTargetReferences, std::set<cppmicroservices::ServiceReferenceBase>());
-  MOCK_METHOD1(RegisterListener, cppmicroservices::ListenerTokenId(std::function<void(const RefChangeNotification&)>));
+  MOCK_CONST_METHOD0(GetBoundReferences,
+                     std::set<cppmicroservices::ServiceReferenceBase>());
+  MOCK_CONST_METHOD0(GetTargetReferences,
+                     std::set<cppmicroservices::ServiceReferenceBase>());
+  MOCK_METHOD1(RegisterListener,
+               cppmicroservices::ListenerTokenId(
+                 std::function<void(const RefChangeNotification&)>));
   MOCK_METHOD1(UnregisterListener, void(cppmicroservices::ListenerTokenId));
   MOCK_METHOD0(StopTracking, void(void));
 };
 
-class MockReferenceManagerBaseImpl
-  : public ReferenceManagerBaseImpl
+class MockReferenceManagerBaseImpl : public ReferenceManagerBaseImpl
 {
 public:
-  MockReferenceManagerBaseImpl(const metadata::ReferenceMetadata& metadata
-                               , const cppmicroservices::BundleContext& bc
-                               , std::shared_ptr<cppmicroservices::logservice::LogService> logger
-                               , const std::string& configName)
+  MockReferenceManagerBaseImpl(
+    const metadata::ReferenceMetadata& metadata,
+    const cppmicroservices::BundleContext& bc,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+    const std::string& configName)
     : ReferenceManagerBaseImpl(metadata, bc, logger, configName)
   {}
-  
+
   MOCK_CONST_METHOD0(GetReferenceName, std::string(void));
   MOCK_CONST_METHOD0(GetReferenceScope, std::string(void));
   MOCK_CONST_METHOD0(GetLDAPString, std::string(void));
   MOCK_CONST_METHOD0(IsSatisfied, bool(void));
   MOCK_CONST_METHOD0(IsOptional, bool(void));
-  MOCK_CONST_METHOD0(GetBoundReferences, std::set<cppmicroservices::ServiceReferenceBase>());
-  MOCK_CONST_METHOD0(GetTargetReferences, std::set<cppmicroservices::ServiceReferenceBase>());
-  MOCK_METHOD1(RegisterListener, cppmicroservices::ListenerTokenId(std::function<void(const RefChangeNotification&)>));
+  MOCK_CONST_METHOD0(GetBoundReferences,
+                     std::set<cppmicroservices::ServiceReferenceBase>());
+  MOCK_CONST_METHOD0(GetTargetReferences,
+                     std::set<cppmicroservices::ServiceReferenceBase>());
+  MOCK_METHOD1(RegisterListener,
+               cppmicroservices::ListenerTokenId(
+                 std::function<void(const RefChangeNotification&)>));
   MOCK_METHOD1(UnregisterListener, void(cppmicroservices::ListenerTokenId));
   MOCK_METHOD0(StopTracking, void(void));
 };
 
-class MockComponentConfiguration
-  : public ComponentConfiguration
+class MockComponentConfiguration : public ComponentConfiguration
 {
 public:
-  MOCK_CONST_METHOD0(GetProperties,std::unordered_map<std::string, cppmicroservices::Any>(void));
-  MOCK_CONST_METHOD0(GetAllDependencyManagers, std::vector<std::shared_ptr<ReferenceManager>>(void));
-  MOCK_CONST_METHOD1(GetDependencyManager, std::shared_ptr<ReferenceManager>(const std::string&));
-  MOCK_CONST_METHOD0(GetServiceReference, cppmicroservices::ServiceReferenceBase(void));
-  MOCK_CONST_METHOD0(GetRegistry, std::shared_ptr<const ComponentRegistry>(void));
+  MOCK_CONST_METHOD0(
+    GetProperties,
+    std::unordered_map<std::string, cppmicroservices::Any>(void));
+  MOCK_CONST_METHOD0(GetAllDependencyManagers,
+                     std::vector<std::shared_ptr<ReferenceManager>>(void));
+  MOCK_CONST_METHOD1(GetDependencyManager,
+                     std::shared_ptr<ReferenceManager>(const std::string&));
+  MOCK_CONST_METHOD0(GetServiceReference,
+                     cppmicroservices::ServiceReferenceBase(void));
+  MOCK_CONST_METHOD0(GetRegistry,
+                     std::shared_ptr<const ComponentRegistry>(void));
   MOCK_CONST_METHOD0(GetBundle, cppmicroservices::Bundle(void));
   MOCK_CONST_METHOD0(GetId, unsigned long(void));
   MOCK_CONST_METHOD0(GetConfigState, ComponentState(void));
 };
 
-class MockFactory
-  : public cppmicroservices::ServiceFactory
+class MockFactory : public cppmicroservices::ServiceFactory
 {
 public:
-  MOCK_METHOD2(GetService, InterfaceMapConstPtr(const cppmicroservices::Bundle &,
-                                                const cppmicroservices::ServiceRegistrationBase &));
-  MOCK_METHOD3(UngetService, void(const cppmicroservices::Bundle &,
-                                  const cppmicroservices::ServiceRegistrationBase &,
-                                  const InterfaceMapConstPtr &));
+  MOCK_METHOD2(
+    GetService,
+    InterfaceMapConstPtr(const cppmicroservices::Bundle&,
+                         const cppmicroservices::ServiceRegistrationBase&));
+  MOCK_METHOD3(UngetService,
+               void(const cppmicroservices::Bundle&,
+                    const cppmicroservices::ServiceRegistrationBase&,
+                    const InterfaceMapConstPtr&));
 };
 
-class MockComponentConfigurationState
-  : public ComponentConfigurationState
+class MockComponentConfigurationState : public ComponentConfigurationState
 {
 public:
   MOCK_METHOD1(Register, void(ComponentConfigurationImpl&));
-  MOCK_METHOD2(Activate, std::shared_ptr<ComponentInstance>(ComponentConfigurationImpl&, const cppmicroservices::Bundle&));
+  MOCK_METHOD2(
+    Activate,
+    std::shared_ptr<ComponentInstance>(ComponentConfigurationImpl&,
+                                       const cppmicroservices::Bundle&));
   MOCK_METHOD1(Deactivate, void(ComponentConfigurationImpl&));
-  MOCK_METHOD4(Rebind, void(ComponentConfigurationImpl&, const std::string&, const ServiceReference<void>&, const ServiceReference<void>&));
+  MOCK_METHOD4(Rebind,
+               void(ComponentConfigurationImpl&,
+                    const std::string&,
+                    const ServiceReference<void>&,
+                    const ServiceReference<void>&));
   MOCK_CONST_METHOD0(GetValue, ComponentState(void));
   MOCK_METHOD0(WaitForTransitionTask, void());
 };
@@ -199,44 +253,57 @@ class MockComponentInstance
   : public service::component::detail::ComponentInstance
 {
 public:
-  MOCK_METHOD1(CreateInstanceAndBindReferences, void(const std::shared_ptr<service::component::ComponentContext>&));
+  MOCK_METHOD1(
+    CreateInstanceAndBindReferences,
+    void(const std::shared_ptr<service::component::ComponentContext>&));
   MOCK_METHOD0(UnbindReferences, void(void));
   MOCK_METHOD0(Activate, void(void));
   MOCK_METHOD0(Deactivate, void(void));
   MOCK_METHOD0(Modified, void(void));
-  MOCK_METHOD2(InvokeUnbindMethod, void(const std::string &, const cppmicroservices::ServiceReferenceBase&));
-  MOCK_METHOD2(InvokeBindMethod, void(const std::string &, const cppmicroservices::ServiceReferenceBase &));
+  MOCK_METHOD2(InvokeUnbindMethod,
+               void(const std::string&,
+                    const cppmicroservices::ServiceReferenceBase&));
+  MOCK_METHOD2(InvokeBindMethod,
+               void(const std::string&,
+                    const cppmicroservices::ServiceReferenceBase&));
   MOCK_METHOD0(GetInterfaceMap, cppmicroservices::InterfaceMapPtr(void));
 };
 
-class MockComponentContextImpl
-  : public ComponentContextImpl
+class MockComponentContextImpl : public ComponentContextImpl
 {
 public:
-  MockComponentContextImpl(const std::weak_ptr<ComponentConfiguration>& cm) : ComponentContextImpl(cm) {}
-  MOCK_CONST_METHOD0(GetProperties, std::unordered_map<std::string, cppmicroservices::Any>(void));
+  MockComponentContextImpl(const std::weak_ptr<ComponentConfiguration>& cm)
+    : ComponentContextImpl(cm)
+  {}
+  MOCK_CONST_METHOD0(
+    GetProperties,
+    std::unordered_map<std::string, cppmicroservices::Any>(void));
   MOCK_CONST_METHOD0(GetBundleContext, cppmicroservices::BundleContext(void));
   MOCK_CONST_METHOD0(GetUsingBundle, cppmicroservices::Bundle(void));
   MOCK_METHOD1(EnableComponent, void(const std::string&));
   MOCK_METHOD1(DisableComponent, void(const std::string&));
-  MOCK_CONST_METHOD0(GetServiceReference, cppmicroservices::ServiceReferenceBase(void));
-  MOCK_CONST_METHOD2(LocateService, std::shared_ptr<void>(const std::string&, const std::string&));
-  MOCK_CONST_METHOD2(LocateServices, std::vector<std::shared_ptr<void>>(const std::string&, const std::string&));
+  MOCK_CONST_METHOD0(GetServiceReference,
+                     cppmicroservices::ServiceReferenceBase(void));
+  MOCK_CONST_METHOD2(LocateService,
+                     std::shared_ptr<void>(const std::string&,
+                                           const std::string&));
+  MOCK_CONST_METHOD2(LocateServices,
+                     std::vector<std::shared_ptr<void>>(const std::string&,
+                                                        const std::string&));
 };
 
-class MockComponentManagerImpl
-  : public ComponentManagerImpl
+class MockComponentManagerImpl : public ComponentManagerImpl
 {
 public:
-  MockComponentManagerImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                           std::shared_ptr<const ComponentRegistry> registry,
-                           BundleContext bundleContext,
-                           std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-      std::shared_ptr<boost::asio::thread_pool> pool)
+  MockComponentManagerImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    std::shared_ptr<const ComponentRegistry> registry,
+    BundleContext bundleContext,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+    std::shared_ptr<boost::asio::thread_pool> pool)
     : ComponentManagerImpl(metadata, registry, bundleContext, logger, pool)
     , statechangecount(0)
-  {
-  }
+  {}
   virtual ~MockComponentManagerImpl() = default;
   void SetState(const std::shared_ptr<ComponentManagerState>& newState)
   {
@@ -244,56 +311,62 @@ public:
     ComponentManagerImpl::CompareAndSetState(&currentState, newState);
   }
 
-  MOCK_CONST_METHOD0(GetComponentConfigurations, std::vector<std::shared_ptr<ComponentConfiguration>>());
+  MOCK_CONST_METHOD0(GetComponentConfigurations,
+                     std::vector<std::shared_ptr<ComponentConfiguration>>());
 
-  bool CompareAndSetState(std::shared_ptr<ComponentManagerState>* expectedState,
-                          std::shared_ptr<ComponentManagerState> desiredState) override
+  bool CompareAndSetState(
+    std::shared_ptr<ComponentManagerState>* expectedState,
+    std::shared_ptr<ComponentManagerState> desiredState) override
   {
-    bool superresult = ComponentManagerImpl::CompareAndSetState(expectedState, desiredState);
+    bool superresult =
+      ComponentManagerImpl::CompareAndSetState(expectedState, desiredState);
     statechangecount += superresult ? 1 : 0;
     return superresult;
   }
 
-  void ResetCounter() {
-    statechangecount = 0;
-  }
+  void ResetCounter() { statechangecount = 0; }
   // count the number of successful state swaps. One successful state transition = 2 atomic state swaps
   std::atomic<int> statechangecount;
 };
 
-class MockComponentConfigurationImpl
-  : public ComponentConfigurationImpl
+class MockComponentConfigurationImpl : public ComponentConfigurationImpl
 {
 public:
-  MockComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                                 const Bundle& bundle,
-                                 std::shared_ptr<const ComponentRegistry> registry,
-                                 std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+  MockComponentConfigurationImpl(
+    std::shared_ptr<const metadata::ComponentMetadata> metadata,
+    const Bundle& bundle,
+    std::shared_ptr<const ComponentRegistry> registry,
+    std::shared_ptr<cppmicroservices::logservice::LogService> logger)
     : ComponentConfigurationImpl(metadata, bundle, registry, logger)
     , statechangecount(0)
   {}
   virtual ~MockComponentConfigurationImpl() = default;
   MOCK_METHOD0(GetFactory, std::shared_ptr<ServiceFactory>(void));
-  MOCK_METHOD1(CreateAndActivateComponentInstance, std::shared_ptr<ComponentInstance>(const cppmicroservices::Bundle&));
-  MOCK_METHOD1(UnbindAndDeactivateComponentInstance, void(std::shared_ptr<ComponentInstance>));
+  MOCK_METHOD1(
+    CreateAndActivateComponentInstance,
+    std::shared_ptr<ComponentInstance>(const cppmicroservices::Bundle&));
+  MOCK_METHOD1(UnbindAndDeactivateComponentInstance,
+               void(std::shared_ptr<ComponentInstance>));
   MOCK_METHOD0(DestroyComponentInstances, void());
-  MOCK_METHOD2(BindReference, void(const std::string&, const ServiceReferenceBase&));
-  MOCK_METHOD2(UnbindReference, void(const std::string&, const ServiceReferenceBase&));
+  MOCK_METHOD2(BindReference,
+               void(const std::string&, const ServiceReferenceBase&));
+  MOCK_METHOD2(UnbindReference,
+               void(const std::string&, const ServiceReferenceBase&));
   void SetState(const std::shared_ptr<ComponentConfigurationState>& newState)
   {
     ComponentConfigurationImpl::SetState(newState);
   }
 
-  bool CompareAndSetState(std::shared_ptr<ComponentConfigurationState>* expectedState,
-                          std::shared_ptr<ComponentConfigurationState> desiredState) override
+  bool CompareAndSetState(
+    std::shared_ptr<ComponentConfigurationState>* expectedState,
+    std::shared_ptr<ComponentConfigurationState> desiredState) override
   {
-    bool superresult = ComponentConfigurationImpl::CompareAndSetState(expectedState, desiredState);
+    bool superresult = ComponentConfigurationImpl::CompareAndSetState(
+      expectedState, desiredState);
     statechangecount += superresult ? 1 : 0;
     return superresult;
   }
-  void ResetCounter() {
-    statechangecount = 0;
-  }
+  void ResetCounter() { statechangecount = 0; }
   // count the number of successful state swaps. One successful state transition = 2 atomic state swaps
   std::atomic<int> statechangecount;
 };

--- a/compendium/DeclarativeServices/test/SCRLoggerTest.cpp
+++ b/compendium/DeclarativeServices/test/SCRLoggerTest.cpp
@@ -21,16 +21,16 @@
   =============================================================================*/
 
 #include <chrono>
-#include <thread>
-#include <memory>
 #include <future>
+#include <memory>
+#include <thread>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/BundleContext.h"
-#include "Mocks.hpp"
 #include "../src/SCRLogger.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 using cppmicroservices::logservice::LogService;
 using cppmicroservices::logservice::SeverityLevel;
@@ -39,24 +39,24 @@ namespace cppmicroservices {
 namespace scrimpl {
 
 // The fixture for testing class SCRLogger.
-class SCRLoggerTest
-  : public ::testing::Test
+class SCRLoggerTest : public ::testing::Test
 {
 protected:
-  SCRLoggerTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  SCRLoggerTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
   virtual ~SCRLoggerTest() = default;
 
-  virtual void SetUp() {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
@@ -68,67 +68,83 @@ TEST_F(SCRLoggerTest, VerifyWithoutLoggerService)
   cppmicroservices::ServiceReferenceU dummyRef;
   // check that calling log method is safe even if a LogService is unavailable
   EXPECT_NO_THROW({
-      logger.Log(SeverityLevel::LOG_DEBUG, "sample log message");
-      logger.Log(SeverityLevel::LOG_DEBUG, "sample log message", std::make_exception_ptr(std::runtime_error("error occured")));
-      logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message");
-      logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message", std::make_exception_ptr(std::runtime_error("error occured")));
-    });
+    logger.Log(SeverityLevel::LOG_DEBUG, "sample log message");
+    logger.Log(SeverityLevel::LOG_DEBUG,
+               "sample log message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
+    logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message");
+    logger.Log(dummyRef,
+               SeverityLevel::LOG_DEBUG,
+               "sample log message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
+  });
 }
 
 TEST_F(SCRLoggerTest, VerifyWithLoggerService)
 {
   EXPECT_NO_THROW({
-      // Register a mock logger implementaion
-      auto mockLogger = std::make_shared<MockLogger>();
-      auto bundleContext = GetFramework().GetBundleContext();
-      auto reg = bundleContext.RegisterService<LogService>(mockLogger);
-      // set expectations
-      EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(1);
-      EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_ERROR, testing::_, testing::_))
-        .Times(1);
-      EXPECT_CALL(*(mockLogger.get()), Log(testing::_, SeverityLevel::LOG_WARNING, testing::_))
-        .Times(1);
-      EXPECT_CALL(*(mockLogger.get()), Log(testing::_, SeverityLevel::LOG_ERROR, testing::_, testing::_))
-        .Times(1);
-      // exercise methods on instance of SCRLogger
-      cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
-      logger.Log(SeverityLevel::LOG_DEBUG, "some sample debug message");
-      logger.Log(SeverityLevel::LOG_ERROR, "some sample error message", std::make_exception_ptr(std::runtime_error("error occured")));
-      cppmicroservices::ServiceReferenceU dummyRef;
-      logger.Log(dummyRef, SeverityLevel::LOG_WARNING, "some sample warning message");
-      logger.Log(dummyRef, SeverityLevel::LOG_ERROR, "some sample error message with service reference", std::make_exception_ptr(std::runtime_error("error occured")));
-    });
+    // Register a mock logger implementaion
+    auto mockLogger = std::make_shared<MockLogger>();
+    auto bundleContext = GetFramework().GetBundleContext();
+    auto reg = bundleContext.RegisterService<LogService>(mockLogger);
+    // set expectations
+    EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(1);
+    EXPECT_CALL(*(mockLogger.get()),
+                Log(SeverityLevel::LOG_ERROR, testing::_, testing::_))
+      .Times(1);
+    EXPECT_CALL(*(mockLogger.get()),
+                Log(testing::_, SeverityLevel::LOG_WARNING, testing::_))
+      .Times(1);
+    EXPECT_CALL(
+      *(mockLogger.get()),
+      Log(testing::_, SeverityLevel::LOG_ERROR, testing::_, testing::_))
+      .Times(1);
+    // exercise methods on instance of SCRLogger
+    cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
+    logger.Log(SeverityLevel::LOG_DEBUG, "some sample debug message");
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "some sample error message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
+    cppmicroservices::ServiceReferenceU dummyRef;
+    logger.Log(
+      dummyRef, SeverityLevel::LOG_WARNING, "some sample warning message");
+    logger.Log(dummyRef,
+               SeverityLevel::LOG_ERROR,
+               "some sample error message with service reference",
+               std::make_exception_ptr(std::runtime_error("error occured")));
+  });
 }
 
 TEST_F(SCRLoggerTest, VerifyLoggerServiceStaticBinding)
 {
   EXPECT_NO_THROW({
-      auto mockLogger1 = std::make_shared<MockLogger>();
-      auto mockLogger2 = std::make_shared<MockLogger>();
-      auto mockLogger3 = std::make_shared<MockLogger>();
-      // setup expectations.
-      // mockLogger1 received first two calls because it is registered first.
-      // mockLogger2 does not receive any calls because it is never bound to SCRLogger.
-      // mockLogger3 receives 1 call because it is registered after mockLogger1 is unbound.
-      EXPECT_CALL(*(mockLogger1.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(2);
-      EXPECT_CALL(*(mockLogger2.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-        .Times(0);
-      EXPECT_CALL(*(mockLogger3.get()), Log(SeverityLevel::LOG_DEBUG, "3. sample debug message"))
-        .Times(1);
-      auto bundleContext = GetFramework().GetBundleContext();
-      cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
-      auto reg1 = bundleContext.RegisterService<LogService>(mockLogger1);
-      auto reg2 = bundleContext.RegisterService<LogService>(mockLogger2);
-      logger.Log(SeverityLevel::LOG_DEBUG, "1. sample debug message");
-      logger.Log(SeverityLevel::LOG_DEBUG, "2. sample debug message");
-      reg1.Unregister();
-      auto reg3 = bundleContext.RegisterService<LogService>(mockLogger3);
-      logger.Log(SeverityLevel::LOG_DEBUG, "3. sample debug message");
-      reg2.Unregister();
-      reg3.Unregister();
-    });
+    auto mockLogger1 = std::make_shared<MockLogger>();
+    auto mockLogger2 = std::make_shared<MockLogger>();
+    auto mockLogger3 = std::make_shared<MockLogger>();
+    // setup expectations.
+    // mockLogger1 received first two calls because it is registered first.
+    // mockLogger2 does not receive any calls because it is never bound to SCRLogger.
+    // mockLogger3 receives 1 call because it is registered after mockLogger1 is unbound.
+    EXPECT_CALL(*(mockLogger1.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(2);
+    EXPECT_CALL(*(mockLogger2.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
+      .Times(0);
+    EXPECT_CALL(*(mockLogger3.get()),
+                Log(SeverityLevel::LOG_DEBUG, "3. sample debug message"))
+      .Times(1);
+    auto bundleContext = GetFramework().GetBundleContext();
+    cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
+    auto reg1 = bundleContext.RegisterService<LogService>(mockLogger1);
+    auto reg2 = bundleContext.RegisterService<LogService>(mockLogger2);
+    logger.Log(SeverityLevel::LOG_DEBUG, "1. sample debug message");
+    logger.Log(SeverityLevel::LOG_DEBUG, "2. sample debug message");
+    reg1.Unregister();
+    auto reg3 = bundleContext.RegisterService<LogService>(mockLogger3);
+    logger.Log(SeverityLevel::LOG_DEBUG, "3. sample debug message");
+    reg2.Unregister();
+    reg3.Unregister();
+  });
 }
 
 TEST_F(SCRLoggerTest, VerifyMultiThreadedAccess)
@@ -136,65 +152,59 @@ TEST_F(SCRLoggerTest, VerifyMultiThreadedAccess)
   // log from multiple threads while one thread is continously registering
   // and unregistering the log service.
   EXPECT_NO_THROW({
-      auto bundleContext = GetFramework().GetBundleContext();
-      cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
-      std::promise<void> startPromise;
-      std::shared_future<void> start(startPromise.get_future());
-      std::promise<void> stopPromise;
-      std::shared_future<void> stop(stopPromise.get_future());
-      int numThreads = 20;
-      std::vector<std::promise<void>> readies(numThreads);
-      std::vector<std::future<void>> logging_futures(numThreads);
-      try
-      {
-        for(int i =0; i<numThreads; i++)
-        {
-          // launch a task to continously log until stop signal is received
-          logging_futures[i] = std::async(std::launch::async,
-                                          [&logger, i, start, stop, &readies]() {
-                                            readies[i].set_value();
-                                            start.wait();
-                                            do
-                                            {
-                                              logger.Log(SeverityLevel::LOG_DEBUG, "sample debug message");
-                                            }while(stop.wait_for(std::chrono::milliseconds(1)) != std::future_status::ready);
-                                          });
-        }
-        for(int i =0; i< numThreads; i++)
-        {
-          readies[i].get_future().wait();
-        }
-        startPromise.set_value();
-        // on a separate thread, register and unregister mock logger service.
-        auto serviceReg = std::async(std::launch::async,
-                                     [start, stop, &bundleContext]() {
-                                       start.wait();
-                                       auto mockLogger = std::make_shared<MockLogger>();
-                                       EXPECT_CALL(*(mockLogger.get()), Log(SeverityLevel::LOG_DEBUG, testing::_))
-                                         .Times(testing::AtLeast(1));
-                                       do
-                                       {
-                                         auto reg1 = bundleContext.RegisterService<LogService>(mockLogger);
-                                         std::this_thread::sleep_for(std::chrono::seconds(1));
-                                         reg1.Unregister();
-                                       }while(stop.wait_for(std::chrono::milliseconds(1)) != std::future_status::ready);
-                                     });
-        std::this_thread::sleep_for(std::chrono::seconds(30));
-        stopPromise.set_value(); // stop all threads
-        serviceReg.get();
-        for(int i =0; i< numThreads; i++)
-        {
-          logging_futures[i].get();
-        }
+    auto bundleContext = GetFramework().GetBundleContext();
+    cppmicroservices::scrimpl::SCRLogger logger(bundleContext);
+    std::promise<void> startPromise;
+    std::shared_future<void> start(startPromise.get_future());
+    std::promise<void> stopPromise;
+    std::shared_future<void> stop(stopPromise.get_future());
+    int numThreads = 20;
+    std::vector<std::promise<void>> readies(numThreads);
+    std::vector<std::future<void>> logging_futures(numThreads);
+    try {
+      for (int i = 0; i < numThreads; i++) {
+        // launch a task to continously log until stop signal is received
+        logging_futures[i] =
+          std::async(std::launch::async, [&logger, i, start, stop, &readies]() {
+            readies[i].set_value();
+            start.wait();
+            do {
+              logger.Log(SeverityLevel::LOG_DEBUG, "sample debug message");
+            } while (stop.wait_for(std::chrono::milliseconds(1)) !=
+                     std::future_status::ready);
+          });
       }
-      catch(...)
-      {
-        startPromise.set_value();
-        stopPromise.set_value();
-        throw;
+      for (int i = 0; i < numThreads; i++) {
+        readies[i].get_future().wait();
       }
-    });
-  
+      startPromise.set_value();
+      // on a separate thread, register and unregister mock logger service.
+      auto serviceReg =
+        std::async(std::launch::async, [start, stop, &bundleContext]() {
+          start.wait();
+          auto mockLogger = std::make_shared<MockLogger>();
+          EXPECT_CALL(*(mockLogger.get()),
+                      Log(SeverityLevel::LOG_DEBUG, testing::_))
+            .Times(testing::AtLeast(1));
+          do {
+            auto reg1 = bundleContext.RegisterService<LogService>(mockLogger);
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            reg1.Unregister();
+          } while (stop.wait_for(std::chrono::milliseconds(1)) !=
+                   std::future_status::ready);
+        });
+      std::this_thread::sleep_for(std::chrono::seconds(30));
+      stopPromise.set_value(); // stop all threads
+      serviceReg.get();
+      for (int i = 0; i < numThreads; i++) {
+        logging_futures[i].get();
+      }
+    } catch (...) {
+      startPromise.set_value();
+      stopPromise.set_value();
+      throw;
+    }
+  });
 }
 }
 }

--- a/compendium/DeclarativeServices/test/TestBindingPolicies.cpp
+++ b/compendium/DeclarativeServices/test/TestBindingPolicies.cpp
@@ -33,14 +33,13 @@
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
+#include "../src/SCRLogger.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
-#include "../src/SCRLogger.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 #include "TestUtils.hpp"
 
 namespace scr = cppmicroservices::service::component::runtime;
-
 
 namespace {
 // convenience function to get the SCR service
@@ -70,8 +69,7 @@ void CheckComponentConfigurationState(
 }
 
 namespace test {
-class InterfaceImpl
-  : public Interface1
+class InterfaceImpl : public Interface1
 {
 public:
   InterfaceImpl(std::string str)
@@ -195,18 +193,17 @@ INSTANTIATE_TEST_SUITE_P(
   BindingPolicyTest,
   testing::Values(
     Policy{ "static",
-               "greedy",
-               typeid(ReferenceManagerBaseImpl::BindingPolicyStaticGreedy) },
+            "greedy",
+            typeid(ReferenceManagerBaseImpl::BindingPolicyStaticGreedy) },
     Policy{ "static",
-               "reluctant",
-               typeid(ReferenceManagerBaseImpl::BindingPolicyStaticReluctant) },
+            "reluctant",
+            typeid(ReferenceManagerBaseImpl::BindingPolicyStaticReluctant) },
     Policy{ "dynamic",
-               "greedy",
-               typeid(ReferenceManagerBaseImpl::BindingPolicyDynamicGreedy) },
-    Policy{
-      "dynamic",
-      "reluctant",
-      typeid(ReferenceManagerBaseImpl::BindingPolicyDynamicReluctant) }));
+            "greedy",
+            typeid(ReferenceManagerBaseImpl::BindingPolicyDynamicGreedy) },
+    Policy{ "dynamic",
+            "reluctant",
+            typeid(ReferenceManagerBaseImpl::BindingPolicyDynamicReluctant) }));
 
 TEST_P(BindingPolicyTest, TestPolicyCreation)
 {
@@ -240,9 +237,9 @@ TEST_P(BindingPolicyTest, InvalidServiceReference)
   auto bindingPolicy = ReferenceManagerBaseImpl::CreateBindingPolicy(
     *mgr, fakeMetadata.policy, fakeMetadata.policyOption);
 
-  EXPECT_CALL(*mockLogger.get(),
-              Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                  testing::_))
+  EXPECT_CALL(
+    *mockLogger.get(),
+    Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, testing::_))
     .Times(1);
 
   EXPECT_NO_THROW(bindingPolicy->ServiceAdded(ServiceReferenceU()));
@@ -254,32 +251,40 @@ INSTANTIATE_TEST_SUITE_P(
   testing::Values(
     DynamicRefPolicy{
       "TestBundleDSDRMU",
-      "ServiceComponentDynamicReluctantMandatoryUnary depends on ServiceComponentDynamicReluctantMandatoryUnary Interface1",
+      "ServiceComponentDynamicReluctantMandatoryUnary depends on "
+      "ServiceComponentDynamicReluctantMandatoryUnary Interface1",
       "",
       "sample::ServiceComponentDynamicReluctantMandatoryUnary",
       false,
-      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicReluctantMandatoryUnary Interface1")) },
+      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+        "ServiceComponentDynamicReluctantMandatoryUnary Interface1")) },
     DynamicRefPolicy{
       "TestBundleDSDGMU",
-      "ServiceComponentDynamicGreedyMandatoryUnary depends on ServiceComponentDynamicGreedyMandatoryUnary Interface1",
+      "ServiceComponentDynamicGreedyMandatoryUnary depends on "
+      "ServiceComponentDynamicGreedyMandatoryUnary Interface1",
       "",
       "sample::ServiceComponentDynamicGreedyMandatoryUnary",
       false,
-      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicGreedyMandatoryUnary Interface1")) },
+      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+        "ServiceComponentDynamicGreedyMandatoryUnary Interface1")) },
     DynamicRefPolicy{
       "TestBundleDSDROU",
-      "ServiceComponentDynamicReluctantOptionalUnary depends on ServiceComponentDynamicReluctantOptionalUnary Interface1",
+      "ServiceComponentDynamicReluctantOptionalUnary depends on "
+      "ServiceComponentDynamicReluctantOptionalUnary Interface1",
       "ServiceComponentDynamicReluctantOptionalUnary depends on ",
       "sample::ServiceComponentDynamicReluctantOptionalUnary",
       true,
-      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicReluctantOptionalUnary Interface1")) },
+      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+        "ServiceComponentDynamicReluctantOptionalUnary Interface1")) },
     DynamicRefPolicy{
       "TestBundleDSDGOU",
-      "ServiceComponentDynamicGreedyOptionalUnary depends on ServiceComponentDynamicGreedyOptionalUnary Interface1",
+      "ServiceComponentDynamicGreedyOptionalUnary depends on "
+      "ServiceComponentDynamicGreedyOptionalUnary Interface1",
       "ServiceComponentDynamicGreedyOptionalUnary depends on ",
       "sample::ServiceComponentDynamicGreedyOptionalUnary",
       true,
-      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicGreedyOptionalUnary Interface1")) }));
+      MakeInterfaceMap<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+        "ServiceComponentDynamicGreedyOptionalUnary Interface1")) }));
 
 // test binding a service under the following reference policy, reference policy options and cardinality
 // Cardinality: 0..1, 1..1
@@ -298,7 +303,8 @@ TEST_P(DynamicRefPolicyTest, TestBindingWithDynamicPolicyOptions)
 
   if (param.optional) {
     EXPECT_TRUE(bc.GetServiceReference<test::Interface2>())
-      << "Service must be available before it's dependency because the dependency is optional";
+      << "Service must be available before it's dependency because the "
+         "dependency is optional";
   } else {
     EXPECT_FALSE(bc.GetServiceReference<test::Interface2>())
       << "Service must not be available before it's dependency";
@@ -310,25 +316,22 @@ TEST_P(DynamicRefPolicyTest, TestBindingWithDynamicPolicyOptions)
     param.implClassName,
     ((param.optional) ? scr::dto::ComponentState::ACTIVE
                       : scr::dto::ComponentState::UNSATISFIED_REFERENCE));
- 
+
   // register the dependent service to trigger the bind
   auto depSvcReg = bc.RegisterService(param.interfaceMap);
   ASSERT_TRUE(depSvcReg);
 
-  CheckComponentConfigurationState(
-    dsRuntimeService,
-    testBundle,
-    param.implClassName,
-    scr::dto::ComponentState::ACTIVE);
-  
+  CheckComponentConfigurationState(dsRuntimeService,
+                                   testBundle,
+                                   param.implClassName,
+                                   scr::dto::ComponentState::ACTIVE);
+
   auto svcRef = bc.GetServiceReference<test::Interface2>();
   ASSERT_TRUE(svcRef);
   auto svc = bc.GetService<test::Interface2>(svcRef);
   ASSERT_TRUE(svc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    param.verificationMessage,
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ(param.verificationMessage, svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -352,7 +355,7 @@ TEST_P(DynamicRefPolicyTest, TestBindingWithDynamicPolicyOptions)
 }
 
 // test error handling and logging when the bind and unbind methods throw an exception
-// this test ensures that exception handling when binding and unbinding for both 
+// this test ensures that exception handling when binding and unbinding for both
 // 0..1 and 1..1 cardinalities works.
 //
 // According to OSGi Compendium Release 7 Sections 112.5.10 and 112.5.18, if a
@@ -382,7 +385,7 @@ TEST_F(BindingPolicyTest, TestDynamicBindUnBindExceptionHandling)
   auto testBundle = test::InstallAndStartBundle(bc, "TestBindUnbindThrows");
   EXPECT_TRUE(bc.GetServiceReference<test::Interface2>())
     << "Service must be available before it's dependency";
-  
+
   auto dsRuntimeService = GetServiceComponentRuntime(bc);
 
   CheckComponentConfigurationState(
@@ -437,7 +440,7 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyMandatoryUnaryReBind)
   auto testBundle = test::InstallAndStartBundle(bc, "TestBundleDSDGMU");
   EXPECT_FALSE(bc.GetServiceReference<test::Interface2>())
     << "Service must not be available before it's dependency";
-  
+
   auto dsRuntimeService = GetServiceComponentRuntime(bc);
 
   CheckComponentConfigurationState(
@@ -447,7 +450,9 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyMandatoryUnaryReBind)
     scr::dto::ComponentState::UNSATISFIED_REFERENCE);
 
   // register the dependent service to trigger a bind
-  auto depSvcReg = bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicGreedyMandatoryUnary Interface1"));
+  auto depSvcReg =
+    bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+      "ServiceComponentDynamicGreedyMandatoryUnary Interface1"));
   ASSERT_TRUE(depSvcReg);
 
   CheckComponentConfigurationState(
@@ -460,8 +465,10 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyMandatoryUnaryReBind)
   ASSERT_TRUE(svcRef);
   auto svc = bc.GetService<test::Interface2>(svcRef);
   ASSERT_TRUE(svc);
-  EXPECT_NO_THROW(svc->ExtendedDescription()); 
-  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on ServiceComponentDynamicGreedyMandatoryUnary Interface1", svc->ExtendedDescription().c_str())
+  EXPECT_NO_THROW(svc->ExtendedDescription());
+  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on "
+               "ServiceComponentDynamicGreedyMandatoryUnary Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -471,9 +478,9 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyMandatoryUnaryReBind)
     { { Constants::SERVICE_RANKING, Any(10000) } });
   ASSERT_TRUE(higherRankedSvc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicGreedyMandatoryUnary depends on higher ranked Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on higher "
+               "ranked Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -483,25 +490,26 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyMandatoryUnaryReBind)
     { { Constants::SERVICE_RANKING, Any(1) } });
   ASSERT_TRUE(lowerRankedSvc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicGreedyMandatoryUnary depends on higher ranked Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on higher "
+               "ranked Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
   // unregistering the higher ranked service should cause a re-bind to the lower ranked service.
   higherRankedSvc.Unregister();
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicGreedyMandatoryUnary depends on lower ranked Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on lower "
+               "ranked Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
   // unregistering the lower ranked service should cause a re-bind to the last registered service.
   lowerRankedSvc.Unregister();
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on ServiceComponentDynamicGreedyMandatoryUnary Interface1",
+  EXPECT_STREQ("ServiceComponentDynamicGreedyMandatoryUnary depends on "
+               "ServiceComponentDynamicGreedyMandatoryUnary Interface1",
                svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
@@ -526,10 +534,10 @@ TEST_F(BindingPolicyTest, TestDynamicGreedyOptionalUnaryReBind)
   auto testBundle = test::InstallAndStartBundle(bc, "TestBundleDSDGOU");
   EXPECT_TRUE(bc.GetServiceReference<test::Interface2>())
     << "Service should be available before it's dependency";
-  
+
   auto dsRuntimeService = GetServiceComponentRuntime(bc);
 
-   CheckComponentConfigurationState(
+  CheckComponentConfigurationState(
     dsRuntimeService,
     testBundle,
     "sample::ServiceComponentDynamicGreedyOptionalUnary",
@@ -631,7 +639,7 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantMandatoryUnaryReBind)
   auto testBundle = test::InstallAndStartBundle(bc, "TestBundleDSDRMU");
   EXPECT_FALSE(bc.GetServiceReference<test::Interface2>())
     << "Service must not be available before it's dependency";
-  
+
   auto dsRuntimeService = GetServiceComponentRuntime(bc);
 
   CheckComponentConfigurationState(
@@ -641,8 +649,9 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantMandatoryUnaryReBind)
     scr::dto::ComponentState::UNSATISFIED_REFERENCE);
 
   // register the dependent service to trigger the bind
-  auto depSvcReg = bc.RegisterService<test::Interface1>(
-    std::make_shared<test::InterfaceImpl>("ServiceComponentDynamicReluctantMandatoryUnary Interface1"));
+  auto depSvcReg =
+    bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>(
+      "ServiceComponentDynamicReluctantMandatoryUnary Interface1"));
   ASSERT_TRUE(depSvcReg);
 
   CheckComponentConfigurationState(
@@ -656,9 +665,9 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantMandatoryUnaryReBind)
   auto svc = bc.GetService<test::Interface2>(svcRef);
   ASSERT_TRUE(svc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicReluctantMandatoryUnary depends on ServiceComponentDynamicReluctantMandatoryUnary Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on "
+               "ServiceComponentDynamicReluctantMandatoryUnary Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -668,7 +677,8 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantMandatoryUnaryReBind)
     { { Constants::SERVICE_RANKING, Any(10000) } });
   ASSERT_TRUE(higherRankedSvc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on ServiceComponentDynamicReluctantMandatoryUnary Interface1",
+  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on "
+               "ServiceComponentDynamicReluctantMandatoryUnary Interface1",
                svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
@@ -679,27 +689,28 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantMandatoryUnaryReBind)
     { { Constants::SERVICE_RANKING, Any(1) } });
   ASSERT_TRUE(lowerRankedSvc);
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicReluctantMandatoryUnary depends on ServiceComponentDynamicReluctantMandatoryUnary Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on "
+               "ServiceComponentDynamicReluctantMandatoryUnary Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
   // unregistering the bound service should cause a re-bind to the higher ranked service.
   depSvcReg.Unregister();
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on higher "
-               "ranked Interface1",
-               svc->ExtendedDescription().c_str())
+  EXPECT_STREQ(
+    "ServiceComponentDynamicReluctantMandatoryUnary depends on higher "
+    "ranked Interface1",
+    svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
   // unregistering the higher ranked service should cause a re-bind to the lower ranked service.
   higherRankedSvc.Unregister();
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicReluctantMandatoryUnary depends on lower ranked Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicReluctantMandatoryUnary depends on "
+               "lower ranked Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -720,7 +731,7 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantOptionalUnaryReBind)
   auto testBundle = test::InstallAndStartBundle(bc, "TestBundleDSDROU");
   EXPECT_TRUE(bc.GetServiceReference<test::Interface2>())
     << "Service should be available before it's dependency";
-  
+
   auto dsRuntimeService = GetServiceComponentRuntime(bc);
 
   CheckComponentConfigurationState(
@@ -790,10 +801,9 @@ TEST_F(BindingPolicyTest, TestDynamicReluctantOptionalUnaryReBind)
   // since the lower ranked service wasn't bound.
   higherRankedSvc.Unregister();
   EXPECT_NO_THROW(svc->ExtendedDescription());
-  EXPECT_STREQ(
-    "ServiceComponentDynamicReluctantOptionalUnary depends on "
-    "ServiceComponentDynamicReluctantOptionalUnary Interface1",
-    svc->ExtendedDescription().c_str())
+  EXPECT_STREQ("ServiceComponentDynamicReluctantOptionalUnary depends on "
+               "ServiceComponentDynamicReluctantOptionalUnary Interface1",
+               svc->ExtendedDescription().c_str())
     << "String value returned was not expected. Was the correct service "
        "dependency bound?";
 
@@ -860,7 +870,6 @@ TEST_F(BindingPolicyTest, TestConcurrentBindUnbind)
   EXPECT_TRUE(std::all_of(
     results.cbegin(), results.cend(), [](bool result) { return result; }));
   testBundle.Stop();
-  
 }
 
 }

--- a/compendium/DeclarativeServices/test/TestCCActiveState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCActiveState.cpp
@@ -20,29 +20,29 @@
 
   =============================================================================*/
 
-#include <memory>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <random>
 
-#include "Mocks.hpp"
-#include "ConcurrencyTestUtil.hpp"
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
 #include "../src/manager/states/CCActiveState.hpp"
+#include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 typedef std::chrono::time_point<std::chrono::system_clock> TimePoint;
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class CCActiveStateTest
-  : public ::testing::Test
+class CCActiveStateTest : public ::testing::Test
 {
 protected:
-  CCActiveStateTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  CCActiveStateTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
   virtual ~CCActiveStateTest() = default;
 
   virtual void SetUp()
@@ -51,10 +51,8 @@ protected:
     auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
     auto mockRegistry = std::make_shared<MockComponentRegistry>();
     auto fakeLogger = std::make_shared<FakeLogger>();
-    mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                      framework,
-                                                                      mockRegistry,
-                                                                      fakeLogger);
+    mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, framework, mockRegistry, fakeLogger);
   }
 
   virtual void TearDown()
@@ -79,9 +77,7 @@ TEST_F(CCActiveStateTest, TestRegister)
   auto state = std::make_shared<CCActiveState>();
   mockCompConfig->SetState(state);
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
-  EXPECT_NO_THROW({
-      state->Register(*mockCompConfig);
-    });
+  EXPECT_NO_THROW({ state->Register(*mockCompConfig); });
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
   EXPECT_EQ(mockCompConfig->GetState(), state);
 }
@@ -95,9 +91,9 @@ TEST_F(CCActiveStateTest, TestActivate)
     .Times(1)
     .WillOnce(testing::Return(std::make_shared<MockComponentInstance>()));
   EXPECT_NO_THROW({
-      auto inst = state->Activate(*mockCompConfig, framework);
-      EXPECT_NE(inst, nullptr);
-    });
+    auto inst = state->Activate(*mockCompConfig, framework);
+    EXPECT_NE(inst, nullptr);
+  });
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
   EXPECT_EQ(mockCompConfig->GetState(), state);
 }
@@ -108,10 +104,10 @@ TEST_F(CCActiveStateTest, TestActivateWithInvalidLatch)
   mockCompConfig->SetState(state);
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
   EXPECT_NO_THROW({
-      state->WaitForTransitionTask();
-      auto inst = state->Activate(*mockCompConfig, framework);
-      EXPECT_EQ(inst, nullptr);
-    });
+    state->WaitForTransitionTask();
+    auto inst = state->Activate(*mockCompConfig, framework);
+    EXPECT_EQ(inst, nullptr);
+  });
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
   EXPECT_EQ(mockCompConfig->GetState(), state);
 }
@@ -122,17 +118,16 @@ TEST_F(CCActiveStateTest, TestConcurrentActivate)
   mockCompConfig->SetState(state);
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
   EXPECT_CALL(*mockCompConfig, CreateAndActivateComponentInstance(testing::_))
-    .WillRepeatedly(testing::Invoke([](const Bundle&) {
-                                      return std::make_shared<MockComponentInstance>();
-                                    }));
-  std::function<std::shared_ptr<ComponentInstance>()> func = [&](){
-                                                               return state->Activate(*mockCompConfig, framework);
-                                                             };
+    .WillRepeatedly(testing::Invoke(
+      [](const Bundle&) { return std::make_shared<MockComponentInstance>(); }));
+  std::function<std::shared_ptr<ComponentInstance>()> func = [&]() {
+    return state->Activate(*mockCompConfig, framework);
+  };
   auto results = ConcurrentInvoke(func);
   auto resultSize = results.size();
   // eliminate duplicates
-  auto it = std::unique (results.begin(), results.end());
-  results.resize(std::distance(results.begin(),it));
+  auto it = std::unique(results.begin(), results.end());
+  results.resize(std::distance(results.begin(), it));
   EXPECT_EQ(resultSize, results.size());
 
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
@@ -143,13 +138,11 @@ TEST_F(CCActiveStateTest, TestDeactivate)
 {
   auto state = std::make_shared<CCActiveState>();
   mockCompConfig->SetState(state);
-  EXPECT_CALL(*mockCompConfig, DestroyComponentInstances())
-    .Times(1);
+  EXPECT_CALL(*mockCompConfig, DestroyComponentInstances()).Times(1);
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
-  EXPECT_NO_THROW({
-      state->Deactivate(*mockCompConfig);
-    });
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_NO_THROW({ state->Deactivate(*mockCompConfig); });
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_NE(mockCompConfig->GetState(), state);
 }
 
@@ -157,15 +150,15 @@ TEST_F(CCActiveStateTest, TestConcurrentDeactivate)
 {
   auto state = std::make_shared<CCActiveState>();
   mockCompConfig->SetState(state);
-  EXPECT_CALL(*mockCompConfig, DestroyComponentInstances())
-    .Times(1);
+  EXPECT_CALL(*mockCompConfig, DestroyComponentInstances()).Times(1);
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
-  std::function<bool()> func = [&](){
-                                 state->Deactivate(*mockCompConfig);
-                                 return true;
-                               };
+  std::function<bool()> func = [&]() {
+    state->Deactivate(*mockCompConfig);
+    return true;
+  };
   auto results = ConcurrentInvoke(func);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_NE(mockCompConfig->GetState(), state);
 }
 
@@ -176,33 +169,30 @@ TEST_F(CCActiveStateTest, TestConcurrentActivateDeactivate)
   std::atomic<int> activeInstanceCount;
   EXPECT_CALL(*mockCompConfig, DestroyComponentInstances())
     .Times(1)
-    .WillOnce(testing::Invoke([&]() {
-                                activeInstanceCount = 0;
-                              }));
+    .WillOnce(testing::Invoke([&]() { activeInstanceCount = 0; }));
   EXPECT_CALL(*mockCompConfig, CreateAndActivateComponentInstance(testing::_))
     .WillRepeatedly(testing::Invoke([&](const Bundle&) {
-                                      activeInstanceCount++;
-                                      return std::make_shared<MockComponentInstance>();
-                                    }));
+      activeInstanceCount++;
+      return std::make_shared<MockComponentInstance>();
+    }));
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
-  std::function<std::pair<TimePoint,bool>()> func = [&](){
-                                                      std::random_device rd;
-                                                      std::mt19937 gen(rd());
-                                                      std::uniform_int_distribution<unsigned int> dis;
-                                                      int randVal = dis(gen);
-                                                      if(randVal & 0x1)
-                                                      {
-                                                        auto inst = state->Activate(*mockCompConfig, Bundle());
-                                                        return std::make_pair(std::chrono::system_clock::now(), inst ? true : false);
-                                                      }
-                                                      else
-                                                      {
-                                                        state->Deactivate(*mockCompConfig);
-                                                        return std::make_pair(std::chrono::system_clock::now(),false);
-                                                      }
-                                                    };
+  std::function<std::pair<TimePoint, bool>()> func = [&]() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<unsigned int> dis;
+    int randVal = dis(gen);
+    if (randVal & 0x1) {
+      auto inst = state->Activate(*mockCompConfig, Bundle());
+      return std::make_pair(std::chrono::system_clock::now(),
+                            inst ? true : false);
+    } else {
+      state->Deactivate(*mockCompConfig);
+      return std::make_pair(std::chrono::system_clock::now(), false);
+    }
+  };
   auto results = ConcurrentInvoke(func);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_NE(mockCompConfig->GetState(), state);
   EXPECT_EQ(activeInstanceCount, 0);
 }

--- a/compendium/DeclarativeServices/test/TestCCUnsatisfiedReferenceState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCUnsatisfiedReferenceState.cpp
@@ -20,42 +20,41 @@
 
   =============================================================================*/
 
-#include <memory>
 #include <future>
 #include <iostream>
+#include <memory>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
 #include "../src/manager/states/CCUnsatisfiedReferenceState.hpp"
-#include "Mocks.hpp"
 #include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class CCUnsatisfiedReferenceStateTest
-  : public ::testing::Test
+class CCUnsatisfiedReferenceStateTest : public ::testing::Test
 {
 protected:
   CCUnsatisfiedReferenceStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  {}
   virtual ~CCUnsatisfiedReferenceStateTest() = default;
 
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     framework.Start();
     auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
     mockMetadata->serviceMetadata.interfaces.push_back("Service::Interface");
     auto mockRegistry = std::make_shared<MockComponentRegistry>();
     auto fakeLogger = std::make_shared<FakeLogger>();
-    mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                      framework,
-                                                                      mockRegistry,
-                                                                      fakeLogger);
+    mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, framework, mockRegistry, fakeLogger);
   }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     mockCompConfig.reset();
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
@@ -75,12 +74,14 @@ TEST_F(CCUnsatisfiedReferenceStateTest, TestActivate)
 {
   auto state = std::make_shared<CCUnsatisfiedReferenceState>();
   mockCompConfig->SetState(state);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_NO_THROW({
-      auto inst = state->Activate(*mockCompConfig, framework);
-      EXPECT_EQ(inst, nullptr);
-    });
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+    auto inst = state->Activate(*mockCompConfig, framework);
+    EXPECT_EQ(inst, nullptr);
+  });
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_EQ(mockCompConfig->GetState(), state);
 }
 
@@ -88,11 +89,11 @@ TEST_F(CCUnsatisfiedReferenceStateTest, TestDeactivate)
 {
   auto state = std::make_shared<CCUnsatisfiedReferenceState>();
   mockCompConfig->SetState(state);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
-  EXPECT_NO_THROW({
-      state->Deactivate(*mockCompConfig);
-    });
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_NO_THROW({ state->Deactivate(*mockCompConfig); });
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_EQ(mockCompConfig->GetState(), state);
 }
 
@@ -100,51 +101,57 @@ TEST_F(CCUnsatisfiedReferenceStateTest, TestRegister)
 {
   auto state = std::make_shared<CCUnsatisfiedReferenceState>();
   mockCompConfig->SetState(state);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_CALL(*mockCompConfig, GetFactory())
     .WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
-  EXPECT_NO_THROW({
-      state->Register(*mockCompConfig);
-    });
+  EXPECT_NO_THROW({ state->Register(*mockCompConfig); });
   EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::SATISFIED);
   EXPECT_NE(mockCompConfig->GetState(), state);
-  EXPECT_EQ(framework.GetBundleContext().GetServiceReferences("Service::Interface").size(), 1u);
+  EXPECT_EQ(framework.GetBundleContext()
+              .GetServiceReferences("Service::Interface")
+              .size(),
+            1u);
 }
 
 TEST_F(CCUnsatisfiedReferenceStateTest, TestRegister_Failure)
 {
   auto state = std::make_shared<CCUnsatisfiedReferenceState>();
   mockCompConfig->SetState(state);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_CALL(*mockCompConfig, GetFactory())
     .WillRepeatedly(testing::Return(nullptr));
-  EXPECT_NO_THROW({
-      state->Register(*mockCompConfig);
-    });
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
-  EXPECT_EQ(framework.GetBundleContext().GetServiceReferences("Service::Interface").size(), 0u);
+  EXPECT_NO_THROW({ state->Register(*mockCompConfig); });
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(framework.GetBundleContext()
+              .GetServiceReferences("Service::Interface")
+              .size(),
+            0u);
 }
 
 TEST_F(CCUnsatisfiedReferenceStateTest, TestConcurrentRegister)
 {
   auto state = std::make_shared<CCUnsatisfiedReferenceState>();
   mockCompConfig->SetState(state);
-  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_CALL(*mockCompConfig, GetFactory())
     .WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
   std::function<ComponentState()> func = [&state, this]() {
-                                           EXPECT_NO_THROW({
-                                               state->Register(*mockCompConfig);
-                                             });
-                                           return mockCompConfig->GetConfigState();
-                                         };
+    EXPECT_NO_THROW({ state->Register(*mockCompConfig); });
+    return mockCompConfig->GetConfigState();
+  };
   std::vector<ComponentState> resultVec = ConcurrentInvoke(func);
-  for(auto result : resultVec)
-  {
+  for (auto result : resultVec) {
     EXPECT_EQ(result, ComponentState::SATISFIED);
   }
   EXPECT_NE(mockCompConfig->GetState(), state);
-  EXPECT_EQ(framework.GetBundleContext().GetServiceReferences("Service::Interface").size(), 1u);
+  EXPECT_EQ(framework.GetBundleContext()
+              .GetServiceReferences("Service::Interface")
+              .size(),
+            1u);
 }
 }
 }

--- a/compendium/DeclarativeServices/test/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentConfigurationImpl.cpp
@@ -22,17 +22,17 @@
 
 #include <random>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/ServiceInterface.h"
 #include "../src/manager/ComponentConfigurationImpl.hpp"
-#include "Mocks.hpp"
-#include "ConcurrencyTestUtil.hpp"
-#include "../src/manager/states/CCUnsatisfiedReferenceState.hpp"
-#include "../src/manager/states/CCRegisteredState.hpp"
-#include "../src/manager/states/CCActiveState.hpp"
 #include "../src/manager/ReferenceManager.hpp"
+#include "../src/manager/states/CCActiveState.hpp"
+#include "../src/manager/states/CCRegisteredState.hpp"
+#include "../src/manager/states/CCUnsatisfiedReferenceState.hpp"
+#include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/ServiceInterface.h"
 
 #include "TestUtils.hpp"
 #include <TestInterfaces/Interfaces.hpp>
@@ -42,25 +42,25 @@ using cppmicroservices::service::component::ComponentContext;
 namespace cppmicroservices {
 namespace scrimpl {
 
-class ComponentConfigurationImplTest
-  : public ::testing::Test
+class ComponentConfigurationImplTest : public ::testing::Test
 {
 protected:
-  ComponentConfigurationImplTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {
-  }
+  ComponentConfigurationImplTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
 
   virtual ~ComponentConfigurationImplTest() = default;
 
-  virtual void SetUp() {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
@@ -70,34 +70,33 @@ TEST_F(ComponentConfigurationImplTest, VerifyCtor)
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  EXPECT_THROW({
-      auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(nullptr,
-                                                                              GetFramework(),
-                                                                              mockRegistry,
-                                                                              fakeLogger);
-    }, std::invalid_argument);
-  EXPECT_THROW({
-      auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                              GetFramework(),
-                                                                              nullptr,
-                                                                              fakeLogger);
-    }, std::invalid_argument);
-  EXPECT_THROW({
-      auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                              GetFramework(),
-                                                                              mockRegistry,
-                                                                              nullptr);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+    {
+      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+        nullptr, GetFramework(), mockRegistry, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+        mockMetadata, GetFramework(), nullptr, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+        mockMetadata, GetFramework(), mockRegistry, nullptr);
+    },
+    std::invalid_argument);
 
   EXPECT_NO_THROW({
-      auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                              GetFramework(),
-                                                                              mockRegistry,
-                                                                              fakeLogger);
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
-      EXPECT_EQ(fakeCompConfig->regManager, nullptr);
-      EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
-    });
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
+    EXPECT_EQ(fakeCompConfig->regManager, nullptr);
+    EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
+  });
 }
 
 TEST_F(ComponentConfigurationImplTest, VerifyUniqueId)
@@ -107,15 +106,12 @@ TEST_F(ComponentConfigurationImplTest, VerifyUniqueId)
   auto fakeLogger = std::make_shared<FakeLogger>();
   std::set<unsigned long> idSet;
   const size_t iterCount = 10;
-  for(size_t i =0; i < iterCount; ++i)
-  {
+  for (size_t i = 0; i < iterCount; ++i) {
     EXPECT_NO_THROW({
-        auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                                GetFramework(),
-                                                                                mockRegistry,
-                                                                                fakeLogger);
-        idSet.insert(fakeCompConfig->GetId());
-      });
+      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+        mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+      idSet.insert(fakeCompConfig->GetId());
+    });
   }
   EXPECT_EQ(idSet.size(), iterCount);
 }
@@ -130,7 +126,9 @@ TEST_F(ComponentConfigurationImplTest, VerifyRefSatisfied)
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
+  mockMetadata->serviceMetadata.interfaces = {
+    us_service_interface_iid<dummy::ServiceImpl>()
+  };
   auto refMgr1 = std::make_shared<MockReferenceManager>();
   auto refMgr2 = std::make_shared<MockReferenceManager>();
   auto refMgr3 = std::make_shared<MockReferenceManager>();
@@ -138,17 +136,17 @@ TEST_F(ComponentConfigurationImplTest, VerifyRefSatisfied)
     .WillRepeatedly(testing::Return(true)); // simulate pre-existing reference
   EXPECT_CALL(*refMgr2, IsSatisfied())
     .Times(1)
-    .WillOnce(testing::Return(true));       // simulate reference that becomes available
+    .WillOnce(
+      testing::Return(true)); // simulate reference that becomes available
   EXPECT_CALL(*refMgr3, IsSatisfied())
     .Times(1)
-    .WillOnce(testing::Return(false));      // simulate reference that is unavailable when ref2 is satisfied
+    .WillOnce(testing::Return(
+      false)); // simulate reference that is unavailable when ref2 is satisfied
   auto mockFactory = std::make_shared<MockFactory>();
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
   auto bc = GetFramework().GetBundleContext();
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   EXPECT_CALL(*fakeCompConfig, GetFactory())
     .Times(1)
     .WillOnce(testing::Return(mockFactory));
@@ -156,16 +154,21 @@ TEST_F(ComponentConfigurationImplTest, VerifyRefSatisfied)
   fakeCompConfig->referenceManagers.insert(std::make_pair("ref1", refMgr1));
   fakeCompConfig->referenceManagers.insert(std::make_pair("ref2", refMgr2));
   fakeCompConfig->referenceManagers.insert(std::make_pair("ref3", refMgr3));
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   // callback from refMgr2
   fakeCompConfig->RefSatisfied("ref2");
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   // callback from refMgr3
   fakeCompConfig->RefSatisfied("ref3");
   EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
   EXPECT_EQ(fakeCompConfig->GetServiceReference().operator bool(), true);
-  EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(mockMetadata->serviceMetadata.interfaces.at(0)), true);
-  fakeCompConfig->referenceManagers.clear(); // remove the mock reference managers
+  EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(
+              mockMetadata->serviceMetadata.interfaces.at(0)),
+            true);
+  fakeCompConfig->referenceManagers
+    .clear(); // remove the mock reference managers
 }
 
 TEST_F(ComponentConfigurationImplTest, VerifyRefUnsatisfied)
@@ -174,32 +177,39 @@ TEST_F(ComponentConfigurationImplTest, VerifyRefUnsatisfied)
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
 
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
-  auto mockStatisfiedState = std::make_shared<MockComponentConfigurationState>();
-  auto mockUnsatisfiedState = std::make_shared<MockComponentConfigurationState>();
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+  auto mockStatisfiedState =
+    std::make_shared<MockComponentConfigurationState>();
+  auto mockUnsatisfiedState =
+    std::make_shared<MockComponentConfigurationState>();
   EXPECT_CALL(*mockStatisfiedState, GetValue())
     .Times(2)
-    .WillRepeatedly(testing::Return(service::component::runtime::dto::ComponentState::SATISFIED));
+    .WillRepeatedly(testing::Return(
+      service::component::runtime::dto::ComponentState::SATISFIED));
   EXPECT_CALL(*mockStatisfiedState, Deactivate(testing::_))
     .Times(1)
-    .WillRepeatedly(testing::Invoke([&](ComponentConfigurationImpl& config){
-                                      config.state = mockUnsatisfiedState;
-                                    }));
+    .WillRepeatedly(testing::Invoke([&](ComponentConfigurationImpl& config) {
+      config.state = mockUnsatisfiedState;
+    }));
   EXPECT_CALL(*mockUnsatisfiedState, GetValue())
     .Times(1)
-    .WillRepeatedly(testing::Return(service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE));
+    .WillRepeatedly(testing::Return(
+      service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE));
   auto refMgr1 = std::make_shared<MockReferenceManager>();
   fakeCompConfig->referenceManagers.insert(std::make_pair("ref1", refMgr1));
   fakeCompConfig->state = mockStatisfiedState;
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), service::component::runtime::dto::ComponentState::SATISFIED);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            service::component::runtime::dto::ComponentState::SATISFIED);
   fakeCompConfig->RefUnsatisfied("invalid_refname");
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), service::component::runtime::dto::ComponentState::SATISFIED);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            service::component::runtime::dto::ComponentState::SATISFIED);
   fakeCompConfig->RefUnsatisfied("ref1");
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE);
-  fakeCompConfig->referenceManagers.clear(); // remove the mock reference managers
+  EXPECT_EQ(
+    fakeCompConfig->GetConfigState(),
+    service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE);
+  fakeCompConfig->referenceManagers
+    .clear(); // remove the mock reference managers
 }
 
 TEST_F(ComponentConfigurationImplTest, VerifyRefChangedState)
@@ -212,15 +222,19 @@ TEST_F(ComponentConfigurationImplTest, VerifyRefChangedState)
   // and a reference to the same service interface will not cause a state change.
   scrimpl::metadata::ReferenceMetadata refMetadata{};
   refMetadata.interfaceName = "dummy::ServiceImpl";
-  mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
+  mockMetadata->serviceMetadata.interfaces = {
+    us_service_interface_iid<dummy::ServiceImpl>()
+  };
   mockMetadata->refsMetadata.push_back(refMetadata);
   auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
     mockMetadata, GetFramework(), mockRegistry, fakeLogger);
 
-  auto reg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
-    std::make_shared<dummy::ServiceImpl>());
+  auto reg =
+    GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
+      std::make_shared<dummy::ServiceImpl>());
 
-  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+  EXPECT_EQ(
+    fakeCompConfig->GetConfigState(),
     service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE);
   reg.Unregister();
 }
@@ -233,11 +247,10 @@ TEST_F(ComponentConfigurationImplTest, VerifyRegister)
   // Test if a call to Register will change the state when the component
   // does not provide a service.
   {
-    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                            GetFramework(),
-                                                                            mockRegistry,
-                                                                            fakeLogger);
-    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
     EXPECT_EQ(fakeCompConfig->regManager, nullptr);
     EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
     EXPECT_NO_THROW(fakeCompConfig->Register());
@@ -247,48 +260,54 @@ TEST_F(ComponentConfigurationImplTest, VerifyRegister)
   // Test if a call to Register will change the state when the component
   // provides a service.
   {
-    mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
+    mockMetadata->serviceMetadata.interfaces = {
+      us_service_interface_iid<dummy::ServiceImpl>()
+    };
     auto mockFactory = std::make_shared<MockFactory>();
-    auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                            GetFramework(),
-                                                                            mockRegistry,
-                                                                            fakeLogger);
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
     EXPECT_CALL(*fakeCompConfig, GetFactory())
       .Times(1)
       .WillRepeatedly(testing::Return(mockFactory));
-    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
     EXPECT_NE(fakeCompConfig->regManager, nullptr);
     EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
     EXPECT_NO_THROW(fakeCompConfig->Register());
     EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
     EXPECT_EQ(fakeCompConfig->GetServiceReference().operator bool(), true);
-    EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(us_service_interface_iid<dummy::ServiceImpl>()), true);
+    EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(
+                us_service_interface_iid<dummy::ServiceImpl>()),
+              true);
   }
   // Test if a call to Register will change the state when the component
   // provides a service and component is immediate type.
   // For immediate component, a call to Register will result in immediate activation
   {
-    mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
+    mockMetadata->serviceMetadata.interfaces = {
+      us_service_interface_iid<dummy::ServiceImpl>()
+    };
     mockMetadata->immediate = true;
     auto mockFactory = std::make_shared<MockFactory>();
     auto mockCompInstance = std::make_shared<MockComponentInstance>();
-    auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                            GetFramework(),
-                                                                            mockRegistry,
-                                                                            fakeLogger);
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
     EXPECT_CALL(*fakeCompConfig, GetFactory())
       .Times(1)
       .WillRepeatedly(testing::Return(mockFactory));
     EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
       .Times(1)
       .WillRepeatedly(testing::Return(mockCompInstance));
-    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
     EXPECT_NE(fakeCompConfig->regManager, nullptr);
     EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
     EXPECT_NO_THROW(fakeCompConfig->Register());
     EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
     EXPECT_EQ(fakeCompConfig->GetServiceReference().operator bool(), true);
-    EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(us_service_interface_iid<dummy::ServiceImpl>()), true);
+    EXPECT_EQ(fakeCompConfig->GetServiceReference().IsConvertibleTo(
+                us_service_interface_iid<dummy::ServiceImpl>()),
+              true);
   }
 }
 
@@ -298,21 +317,20 @@ TEST_F(ComponentConfigurationImplTest, VerifyStateChangeDelegation)
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto mockState = std::make_shared<MockComponentConfigurationState>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   fakeCompConfig->state = mockState;
-  ComponentConfigurationImpl& fakeCompConfigBase = *(std::dynamic_pointer_cast<ComponentConfigurationImpl>(fakeCompConfig));
-  EXPECT_CALL(*mockState, Register(testing::Ref(fakeCompConfigBase)))
-    .Times(1);
-  EXPECT_CALL(*mockState, Activate(testing::Ref(fakeCompConfigBase), GetFramework()))
+  ComponentConfigurationImpl& fakeCompConfigBase =
+    *(std::dynamic_pointer_cast<ComponentConfigurationImpl>(fakeCompConfig));
+  EXPECT_CALL(*mockState, Register(testing::Ref(fakeCompConfigBase))).Times(1);
+  EXPECT_CALL(*mockState,
+              Activate(testing::Ref(fakeCompConfigBase), GetFramework()))
     .Times(1);
   EXPECT_CALL(*mockState, Deactivate(testing::Ref(fakeCompConfigBase)))
     .Times(1);
-  EXPECT_CALL(*mockState, GetValue())
-    .Times(1);
+  EXPECT_CALL(*mockState, GetValue()).Times(1);
   fakeCompConfig->Register();
   fakeCompConfig->Activate(GetFramework());
   fakeCompConfig->Deactivate();
@@ -324,10 +342,8 @@ TEST_F(ComponentConfigurationImplTest, VerifyActivate_Success)
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   fakeCompConfig->state = std::make_shared<CCRegisteredState>();
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
   EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -344,10 +360,8 @@ TEST_F(ComponentConfigurationImplTest, VerifyActivate_Failure)
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
   // Test for exception from user code
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   fakeCompConfig->state = std::make_shared<CCRegisteredState>();
   EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
   EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -362,41 +376,38 @@ TEST_F(ComponentConfigurationImplTest, VerifyDeactivate)
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   auto activeState = std::make_shared<CCActiveState>();
   fakeCompConfig->state = activeState;
   EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
-  EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances())
-    .Times(1);
+  EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances()).Times(1);
   EXPECT_NO_THROW(fakeCompConfig->Deactivate());
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
 }
 
-bool ValidateStateSequence(const std::vector<std::pair<ComponentState,ComponentState>>& stateArr
-                          )
+bool ValidateStateSequence(
+  const std::vector<std::pair<ComponentState, ComponentState>>& stateArr)
 {
   bool foundInvalidTransition = false;
   auto vecSize = stateArr.size();
-  for(size_t i = 0; i < vecSize && !foundInvalidTransition; ++i)
-  {
+  for (size_t i = 0; i < vecSize && !foundInvalidTransition; ++i) {
     auto currState = stateArr[i].first;
     auto nextState = stateArr[i].second;
-    switch(currState)
-    {
-      case service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE:
-        if(nextState == service::component::runtime::dto::ComponentState::ACTIVE)
-        {
+    switch (currState) {
+      case service::component::runtime::dto::ComponentState::
+        UNSATISFIED_REFERENCE:
+        if (nextState ==
+            service::component::runtime::dto::ComponentState::ACTIVE) {
           foundInvalidTransition = true;
         }
         break;
       case service::component::runtime::dto::ComponentState::SATISFIED:
         break;
       case service::component::runtime::dto::ComponentState::ACTIVE:
-        if(nextState == service::component::runtime::dto::ComponentState::SATISFIED)
-        {
+        if (nextState ==
+            service::component::runtime::dto::ComponentState::SATISFIED) {
           foundInvalidTransition = true;
         }
         break;
@@ -413,44 +424,50 @@ TEST_F(ComponentConfigurationImplTest, VerifyConcurrentRegisterDeactivate)
   // - zero registrations if the current state is UNSATISFIED_REFERENCE
   // ensure there are zero objects of ComponentInstance
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
-  mockMetadata->serviceMetadata.interfaces = { "ServiceInterface", "interface" };
+  mockMetadata->serviceMetadata.interfaces = { "ServiceInterface",
+                                               "interface" };
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  auto  fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   EXPECT_CALL(*fakeCompConfig, GetFactory())
     .WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
-  EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(fakeCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
   EXPECT_NE(fakeCompConfig->regManager, nullptr);
-  std::function<std::pair<ComponentState, ComponentState>()> func = [&fakeCompConfig]() {
-                                                                      std::random_device rd;
-                                                                      std::mt19937 gen(rd());
-                                                                      std::uniform_int_distribution<unsigned int> dis;
-                                                                      int randVal = dis(gen);
-                                                                      auto prevState = fakeCompConfig->GetConfigState();
-                                                                      if(randVal & 0x1)
-                                                                      {
-                                                                        fakeCompConfig->Register();
-                                                                      }
-                                                                      else
-                                                                      {
-                                                                        fakeCompConfig->Deactivate();
-                                                                      }
-                                                                      auto currentState = fakeCompConfig->GetConfigState();
-                                                                      return std::make_pair(prevState, currentState);
-                                                                    };
+  std::function<std::pair<ComponentState, ComponentState>()> func =
+    [&fakeCompConfig]() {
+      std::random_device rd;
+      std::mt19937 gen(rd());
+      std::uniform_int_distribution<unsigned int> dis;
+      int randVal = dis(gen);
+      auto prevState = fakeCompConfig->GetConfigState();
+      if (randVal & 0x1) {
+        fakeCompConfig->Register();
+      } else {
+        fakeCompConfig->Deactivate();
+      }
+      auto currentState = fakeCompConfig->GetConfigState();
+      return std::make_pair(prevState, currentState);
+    };
 
   auto results = ConcurrentInvoke(func);
   EXPECT_TRUE(ValidateStateSequence(results));
-  if(fakeCompConfig->GetConfigState() == service::component::runtime::dto::ComponentState::SATISFIED)
-  {
-    EXPECT_EQ(GetFramework().GetBundleContext().GetServiceReferences("interface").size(), 1u);
-  }
-  else if(fakeCompConfig->GetConfigState() == service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE)
-  {
-    EXPECT_EQ(GetFramework().GetBundleContext().GetServiceReferences("interface").size(), 0u);
+  if (fakeCompConfig->GetConfigState() ==
+      service::component::runtime::dto::ComponentState::SATISFIED) {
+    EXPECT_EQ(GetFramework()
+                .GetBundleContext()
+                .GetServiceReferences("interface")
+                .size(),
+              1u);
+  } else if (fakeCompConfig->GetConfigState() ==
+             service::component::runtime::dto::ComponentState::
+               UNSATISFIED_REFERENCE) {
+    EXPECT_EQ(GetFramework()
+                .GetBundleContext()
+                .GetServiceReferences("interface")
+                .size(),
+              0u);
   }
 }
 
@@ -460,14 +477,13 @@ TEST_F(ComponentConfigurationImplTest, VerifyConcurrentActivateDeactivate)
   // ensure there the current state is UNSATISFIED_REFERENCE
   // ensure there are zero objects of ComponentInstance
   auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
-  mockMetadata->serviceMetadata.interfaces = { "ServiceInterface", "interface" };
+  mockMetadata->serviceMetadata.interfaces = { "ServiceInterface",
+                                               "interface" };
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
-  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                          GetFramework(),
-                                                                          mockRegistry,
-                                                                          fakeLogger);
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
   EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
     .WillRepeatedly(testing::Return(mockCompInstance));
   EXPECT_CALL(*fakeCompConfig, GetFactory())
@@ -475,23 +491,21 @@ TEST_F(ComponentConfigurationImplTest, VerifyConcurrentActivateDeactivate)
   fakeCompConfig->Register();
   EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
   auto clientBundle = GetFramework();
-  std::function<std::pair<ComponentState,ComponentState>()> func = [&fakeCompConfig, &clientBundle]() {
-                                                                     std::random_device rd;
-                                                                     std::mt19937 gen(rd());
-                                                                     std::uniform_int_distribution<unsigned int> dis;
-                                                                     int randVal = dis(gen);
-                                                                     auto prevState = fakeCompConfig->GetConfigState();
-                                                                     if(randVal & 0x1)
-                                                                     {
-                                                                       fakeCompConfig->Activate(clientBundle);
-                                                                     }
-                                                                     else
-                                                                     {
-                                                                       fakeCompConfig->Deactivate();
-                                                                     }
-                                                                     auto currentState = fakeCompConfig->GetConfigState();
-                                                                     return std::make_pair(prevState, currentState);
-                                                                   };
+  std::function<std::pair<ComponentState, ComponentState>()> func =
+    [&fakeCompConfig, &clientBundle]() {
+      std::random_device rd;
+      std::mt19937 gen(rd());
+      std::uniform_int_distribution<unsigned int> dis;
+      int randVal = dis(gen);
+      auto prevState = fakeCompConfig->GetConfigState();
+      if (randVal & 0x1) {
+        fakeCompConfig->Activate(clientBundle);
+      } else {
+        fakeCompConfig->Deactivate();
+      }
+      auto currentState = fakeCompConfig->GetConfigState();
+      return std::make_pair(prevState, currentState);
+    };
   auto results = ConcurrentInvoke(func);
   EXPECT_TRUE(ValidateStateSequence(results));
 }
@@ -499,79 +513,79 @@ TEST_F(ComponentConfigurationImplTest, VerifyConcurrentActivateDeactivate)
 TEST_F(ComponentConfigurationImplTest, VerifyImmediateComponent)
 {
   EXPECT_NO_THROW({
-      auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
-      mockMetadata->immediate = true;
-      auto mockRegistry = std::make_shared<MockComponentRegistry>();
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      auto mockCompInstance = std::make_shared<MockComponentInstance>();
-      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                             GetFramework(),
-                                                                             mockRegistry,
-                                                                             fakeLogger);
-      EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
-        .Times(2)
-        .WillRepeatedly(testing::Return(mockCompInstance));
-      fakeCompConfig->Initialize();
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
-      EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances())
-        .Times(1);
-      fakeCompConfig->Deactivate();
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
-      fakeCompConfig->Register();
-      // since its an immediate component, it gets activated on call to Register.
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
-    });
+    auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
+    mockMetadata->immediate = true;
+    auto mockRegistry = std::make_shared<MockComponentRegistry>();
+    auto fakeLogger = std::make_shared<FakeLogger>();
+    auto mockCompInstance = std::make_shared<MockComponentInstance>();
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+    EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
+      .Times(2)
+      .WillRepeatedly(testing::Return(mockCompInstance));
+    fakeCompConfig->Initialize();
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
+    EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances()).Times(1);
+    fakeCompConfig->Deactivate();
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
+    fakeCompConfig->Register();
+    // since its an immediate component, it gets activated on call to Register.
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
+  });
 }
 
 TEST_F(ComponentConfigurationImplTest, VerifyDelayedComponent)
 {
   EXPECT_NO_THROW({
-      auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
-      auto mockRegistry = std::make_shared<MockComponentRegistry>();
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      auto mockCompInstance = std::make_shared<MockComponentInstance>();
-      auto mockFactory = std::make_shared<MockFactory>();
+    auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
+    auto mockRegistry = std::make_shared<MockComponentRegistry>();
+    auto fakeLogger = std::make_shared<FakeLogger>();
+    auto mockCompInstance = std::make_shared<MockComponentInstance>();
+    auto mockFactory = std::make_shared<MockFactory>();
 
-      mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
-      mockMetadata->immediate = false;
-      auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                             GetFramework(),
-                                                                             mockRegistry,
-                                                                             fakeLogger);
-      EXPECT_CALL(*fakeCompConfig, GetFactory())
-        .Times(testing::AtLeast(1)) // 2
-        .WillRepeatedly(testing::Return(mockFactory));
-      fakeCompConfig->Initialize();
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
-      EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
-        .Times(testing::AtLeast(1)) // 2
-        .WillRepeatedly(testing::Return(mockCompInstance));
-      fakeCompConfig->Activate(GetFramework());
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
-      EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances())
-        .Times(1);
-      fakeCompConfig->Deactivate();
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
-      fakeCompConfig->Register();
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
-      auto bc = GetFramework().GetBundleContext();
-      auto sRef = bc.GetServiceReference<dummy::ServiceImpl>();
-      ASSERT_EQ(sRef.operator bool(), true);
-      ASSERT_EQ(sRef, fakeCompConfig->GetServiceReference());
-      auto mockServiceImpl = std::make_shared<dummy::ServiceImpl>();
-      InterfaceMapPtr instanceMap = MakeInterfaceMap<dummy::ServiceImpl>(mockServiceImpl);
-      EXPECT_CALL(*mockFactory, GetService(testing::_, testing::_))
-        .Times(1)
-        .WillRepeatedly(testing::Invoke([&](const cppmicroservices::Bundle &b,
-                                            const cppmicroservices::ServiceRegistrationBase&){
-                                          fakeCompConfig->Activate(b);
-                                          return instanceMap;
-                                        }));
-      EXPECT_CALL(*mockFactory, UngetService(testing::_, testing::_, testing::_));
-      auto service = bc.GetService<dummy::ServiceImpl>(sRef);
-      EXPECT_NE(service, nullptr);
-      EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
-    });
+    mockMetadata->serviceMetadata.interfaces = {
+      us_service_interface_iid<dummy::ServiceImpl>()
+    };
+    mockMetadata->immediate = false;
+    auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+      mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+    EXPECT_CALL(*fakeCompConfig, GetFactory())
+      .Times(testing::AtLeast(1)) // 2
+      .WillRepeatedly(testing::Return(mockFactory));
+    fakeCompConfig->Initialize();
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
+    EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
+      .Times(testing::AtLeast(1)) // 2
+      .WillRepeatedly(testing::Return(mockCompInstance));
+    fakeCompConfig->Activate(GetFramework());
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
+    EXPECT_CALL(*fakeCompConfig, DestroyComponentInstances()).Times(1);
+    fakeCompConfig->Deactivate();
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
+    fakeCompConfig->Register();
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
+    auto bc = GetFramework().GetBundleContext();
+    auto sRef = bc.GetServiceReference<dummy::ServiceImpl>();
+    ASSERT_EQ(sRef.operator bool(), true);
+    ASSERT_EQ(sRef, fakeCompConfig->GetServiceReference());
+    auto mockServiceImpl = std::make_shared<dummy::ServiceImpl>();
+    InterfaceMapPtr instanceMap =
+      MakeInterfaceMap<dummy::ServiceImpl>(mockServiceImpl);
+    EXPECT_CALL(*mockFactory, GetService(testing::_, testing::_))
+      .Times(1)
+      .WillRepeatedly(
+        testing::Invoke([&](const cppmicroservices::Bundle& b,
+                            const cppmicroservices::ServiceRegistrationBase&) {
+          fakeCompConfig->Activate(b);
+          return instanceMap;
+        }));
+    EXPECT_CALL(*mockFactory, UngetService(testing::_, testing::_, testing::_));
+    auto service = bc.GetService<dummy::ServiceImpl>(sRef);
+    EXPECT_NE(service, nullptr);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
+  });
 }
 
 TEST_F(ComponentConfigurationImplTest, TestGetDependencyManagers)
@@ -582,7 +596,9 @@ TEST_F(ComponentConfigurationImplTest, TestGetDependencyManagers)
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
   auto mockFactory = std::make_shared<MockFactory>();
 
-  mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
+  mockMetadata->serviceMetadata.interfaces = {
+    us_service_interface_iid<dummy::ServiceImpl>()
+  };
   mockMetadata->immediate = false;
   metadata::ReferenceMetadata rm1;
   rm1.name = "Foo";
@@ -592,11 +608,10 @@ TEST_F(ComponentConfigurationImplTest, TestGetDependencyManagers)
   rm2.interfaceName = "sample::Bar";
   mockMetadata->refsMetadata.push_back(rm1);
   mockMetadata->refsMetadata.push_back(rm2);
-  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                         GetFramework(),
-                                                                         mockRegistry,
-                                                                         fakeLogger);
-  EXPECT_EQ(fakeCompConfig->GetAllDependencyManagers().size(), mockMetadata->refsMetadata.size());
+  auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(
+    mockMetadata, GetFramework(), mockRegistry, fakeLogger);
+  EXPECT_EQ(fakeCompConfig->GetAllDependencyManagers().size(),
+            mockMetadata->refsMetadata.size());
   EXPECT_NE(fakeCompConfig->GetDependencyManager("Foo"), nullptr);
   EXPECT_NE(fakeCompConfig->GetDependencyManager("Bar"), nullptr);
 }
@@ -605,7 +620,8 @@ TEST_F(ComponentConfigurationImplTest, TestComponentWithUniqueName)
 {
 #if defined(US_BUILD_SHARED_LIBS)
   auto dsPluginPath = test::GetDSRuntimePluginFilePath();
-  auto dsbundles = GetFramework().GetBundleContext().InstallBundles(dsPluginPath);
+  auto dsbundles =
+    GetFramework().GetBundleContext().InstallBundles(dsPluginPath);
   ASSERT_EQ(dsbundles.size(), 1);
   for (auto& bundle : dsbundles) {
     ASSERT_TRUE(bundle);
@@ -613,11 +629,13 @@ TEST_F(ComponentConfigurationImplTest, TestComponentWithUniqueName)
   }
 #endif
 
-  auto testBundle = test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI8");
+  auto testBundle = test::InstallAndStartBundle(
+    GetFramework().GetBundleContext(), "TestBundleDSTOI8");
   ASSERT_TRUE(testBundle);
   ASSERT_EQ(testBundle.GetSymbolicName(), "TestBundleDSTOI8");
 
-  auto svcRef = testBundle.GetBundleContext().GetServiceReference<test::Interface1>();
+  auto svcRef =
+    testBundle.GetBundleContext().GetServiceReference<test::Interface1>();
   ASSERT_TRUE(svcRef);
   auto svc = testBundle.GetBundleContext().GetService<test::Interface1>(svcRef);
   EXPECT_NE(svc, nullptr);

--- a/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
@@ -20,96 +20,111 @@
 
   =============================================================================*/
 
-#include <chrono>
-#include <vector>
-#include <string>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <future>
+#include <string>
+#include <vector>
 
-#include "gmock/gmock.h"
+#include "../src/ComponentContextImpl.hpp"
 #include "Mocks.hpp"
+#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include "cppmicroservices/servicecomponent/ComponentException.hpp"
+#include "gmock/gmock.h"
 #include <cppmicroservices/Constants.h>
 #include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
 #include <cppmicroservices/FrameworkEvent.h>
-#include "cppmicroservices/servicecomponent/ComponentException.hpp"
-#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
-#include "../src/ComponentContextImpl.hpp"
+#include <cppmicroservices/FrameworkFactory.h>
 
-using cppmicroservices::service::component::ComponentContext;
-using cppmicroservices::service::component::ComponentException;
-using cppmicroservices::scrimpl::metadata::ComponentMetadata;
-using cppmicroservices::Constants::SCOPE_SINGLETON;
 using cppmicroservices::Constants::SCOPE_BUNDLE;
 using cppmicroservices::Constants::SCOPE_PROTOTYPE;
-using cppmicroservices::service::component::ComponentConstants::REFERENCE_SCOPE_PROTOTYPE_REQUIRED;
+using cppmicroservices::Constants::SCOPE_SINGLETON;
+using cppmicroservices::scrimpl::metadata::ComponentMetadata;
+using cppmicroservices::service::component::ComponentContext;
+using cppmicroservices::service::component::ComponentException;
+using cppmicroservices::service::component::ComponentConstants::
+  REFERENCE_SCOPE_PROTOTYPE_REQUIRED;
 
 namespace cppmicroservices {
 namespace scrimpl {
 
 // The fixture for testing class ComponentContextImpl.
-class ComponentContextImplTest
-  : public ::testing::Test
+class ComponentContextImplTest : public ::testing::Test
 {
 protected:
-  ComponentContextImplTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  ComponentContextImplTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
   virtual ~ComponentContextImplTest() = default;
 
-  virtual void SetUp() {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
 
-namespace test
-{
-struct Foo{};
-struct Bar{};
+namespace test {
+struct Foo
+{};
+struct Bar
+{};
 }
 
 TEST_F(ComponentContextImplTest, VerifyInvalidCtor)
 {
-  EXPECT_THROW({
-      std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(std::weak_ptr<ComponentConfiguration>());
-    }, ComponentException);
-  EXPECT_THROW({
-      std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(std::weak_ptr<ComponentConfiguration>(), GetFramework());
-    }, ComponentException);
+  EXPECT_THROW(
+    {
+      std::shared_ptr<ComponentContext> ctxt =
+        std::make_shared<ComponentContextImpl>(
+          std::weak_ptr<ComponentConfiguration>());
+    },
+    ComponentException);
+  EXPECT_THROW(
+    {
+      std::shared_ptr<ComponentContext> ctxt =
+        std::make_shared<ComponentContextImpl>(
+          std::weak_ptr<ComponentConfiguration>(), GetFramework());
+    },
+    ComponentException);
 }
 
-auto anyMapComparator = [](const std::pair<std::string, cppmicroservices::Any>& x,
-                           const std::pair<std::string, cppmicroservices::Any>& y) -> bool {
-                          auto ret = ((x.first == y.first) && (x.second.ToStringNoExcept() == y.second.ToStringNoExcept()));
-                          return ret;
-                        };
+auto anyMapComparator =
+  [](const std::pair<std::string, cppmicroservices::Any>& x,
+     const std::pair<std::string, cppmicroservices::Any>& y) -> bool {
+  auto ret = ((x.first == y.first) &&
+              (x.second.ToStringNoExcept() == y.second.ToStringNoExcept()));
+  return ret;
+};
 
 TEST_F(ComponentContextImplTest, VerifyComponentProperties)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   std::unordered_map<std::string, cppmicroservices::Any> fakeProps;
   fakeProps["foo"] = std::string("bar");
   EXPECT_CALL(*mockConfig, GetProperties())
     .Times(1)
     .WillRepeatedly(testing::Return(fakeProps));
-  EXPECT_NO_THROW(
-    {
-      auto props = ctxt->GetProperties();
-      bool compresult = std::equal(props.begin(), props.end(),
-                                   fakeProps.begin(), fakeProps.end(),
-                                   anyMapComparator);
-      EXPECT_EQ(compresult, true);
-    });
+  EXPECT_NO_THROW({
+    auto props = ctxt->GetProperties();
+    bool compresult = std::equal(props.begin(),
+                                 props.end(),
+                                 fakeProps.begin(),
+                                 fakeProps.end(),
+                                 anyMapComparator);
+    EXPECT_EQ(compresult, true);
+  });
 }
 
 TEST_F(ComponentContextImplTest, VerifyLocateService)
@@ -117,8 +132,11 @@ TEST_F(ComponentContextImplTest, VerifyLocateService)
   auto mockConfig = std::make_shared<MockComponentConfiguration>();
   auto fooServ = std::make_shared<test::Foo>();
   auto mockRefMgrFoo = std::make_shared<MockReferenceManager>();
-  auto reg = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
-  std::set<cppmicroservices::ServiceReferenceBase> refsSet = { reg.GetReference() };
+  auto reg =
+    GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
+  std::set<cppmicroservices::ServiceReferenceBase> refsSet = {
+    reg.GetReference()
+  };
   EXPECT_CALL(*mockRefMgrFoo, GetBoundReferences())
     .Times(1)
     .WillRepeatedly(testing::Return(refsSet));
@@ -130,163 +148,155 @@ TEST_F(ComponentContextImplTest, VerifyLocateService)
     .WillRepeatedly(testing::Return(cppmicroservices::Constants::SCOPE_BUNDLE));
   EXPECT_CALL(*mockConfig, GetBundle())
     .WillRepeatedly(testing::Return(GetFramework()));
-  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{mockRefMgrFoo};
+  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{ mockRefMgrFoo };
   EXPECT_CALL(*mockConfig, GetAllDependencyManagers())
     .Times(1)
     .WillRepeatedly(testing::Return(depMgrs));
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
-  EXPECT_NO_THROW(
-    {
-      auto serv = ctxt->LocateService<test::Foo>("foo");
-      EXPECT_EQ(serv, fooServ); // test with correct type and name
-      auto serv1 = ctxt->LocateService<test::Foo>("bar");
-      EXPECT_EQ(serv1, nullptr); // test with correct type and wrong name
-      auto serv2 = ctxt->LocateService<test::Bar>("foo");
-      EXPECT_EQ(serv2, nullptr); // test with wrong type and correct name
-    });
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
+  EXPECT_NO_THROW({
+    auto serv = ctxt->LocateService<test::Foo>("foo");
+    EXPECT_EQ(serv, fooServ); // test with correct type and name
+    auto serv1 = ctxt->LocateService<test::Foo>("bar");
+    EXPECT_EQ(serv1, nullptr); // test with correct type and wrong name
+    auto serv2 = ctxt->LocateService<test::Bar>("foo");
+    EXPECT_EQ(serv2, nullptr); // test with wrong type and correct name
+  });
 }
-
 
 /**
  * This test point creates mutiple component configs per available bundle and
  * calls LocateService multiple times on each ComponentContext
  */
-TEST_F(ComponentContextImplTest, DISABLED_VerifyLocateServiceWithReferenceScopes)
+TEST_F(ComponentContextImplTest,
+       DISABLED_VerifyLocateServiceWithReferenceScopes)
 {
   size_t iterCount = 4ul;
   size_t componentInstanceCount = 3ul;
   auto bc = GetFramework().GetBundleContext();
   auto bundles = bc.GetBundles();
-  auto VerifyLocateServiceWithScopes =
-    [&](std::string referenceScope,
-        std::string publishedScope,
-        size_t expectedServiceInstanceCount)
-    {
-      auto mockConfig = std::make_shared<MockComponentConfiguration>();
-      
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      metadata::ReferenceMetadata fakeRefMetadata;
-      fakeRefMetadata.name = "foo";
-      fakeRefMetadata.interfaceName = us_service_interface_iid<dummy::ServiceImpl>();
-      fakeRefMetadata.scope = referenceScope;
-      
-      std::set<std::shared_ptr<dummy::ServiceImpl>> instances;
-      
-      // publish a service
-      auto mockServiceFactory = std::make_shared<MockFactory>();
-      InterfaceMapConstPtr singletonInstance = MakeInterfaceMap<dummy::ServiceImpl>(std::make_shared<dummy::ServiceImpl>());
-      EXPECT_CALL(*mockServiceFactory, GetService(testing::_, testing::_)).WillRepeatedly(testing::Invoke([&](const cppmicroservices::Bundle&,
-                                                                                                              const cppmicroservices::ServiceRegistrationBase&) {
-                                                                                                            if(publishedScope == SCOPE_SINGLETON)
-                                                                                                            {
-                                                                                                              return singletonInstance;
-                                                                                                            }
-                                                                                                            else
-                                                                                                            {
-                                                                                                              InterfaceMapConstPtr iMap = MakeInterfaceMap<dummy::ServiceImpl>(std::make_shared<dummy::ServiceImpl>());
-                                                                                                              return iMap;
-                                                                                                            }
-                                                                                                          }));
-      
-      EXPECT_CALL(*mockServiceFactory, UngetService(testing::_, testing::_, testing::_))
-        .WillRepeatedly(testing::Invoke([&](const cppmicroservices::Bundle&,
-                                            const cppmicroservices::ServiceRegistrationBase&,
-                                            const cppmicroservices::InterfaceMapConstPtr& service){
-                                          //std::cout << "Unget called from bundle id " << bundle.GetBundleId() << std::endl;
-                                          if(publishedScope == SCOPE_SINGLETON)
-                                          {
-                                            ASSERT_EQ(service, singletonInstance);
-                                          }
-                                        }));
-      
-      auto sReg = bc.RegisterService<dummy::ServiceImpl>(ToFactory(mockServiceFactory), {{cppmicroservices::Constants::SERVICE_SCOPE, Any(publishedScope)}});
+  auto VerifyLocateServiceWithScopes = [&](
+                                         std::string referenceScope,
+                                         std::string publishedScope,
+                                         size_t expectedServiceInstanceCount) {
+    auto mockConfig = std::make_shared<MockComponentConfiguration>();
 
-      for(auto& bundle : bundles)
-      {
-        bundle.Start(); // In case the pkgtest bundle is not started
-        auto bundleContext = bundle.GetBundleContext();
-        auto mockRefMgrFoo = std::make_shared<ReferenceManagerImpl>(fakeRefMetadata
-                                                                    , bundleContext
-                                                                    , fakeLogger
-                                                                    , "foobar");
-        std::vector<std::shared_ptr<ReferenceManager>> depMgrs{mockRefMgrFoo};
-        EXPECT_CALL(*mockConfig, GetAllDependencyManagers()).WillRepeatedly(testing::Return(depMgrs));
-        EXPECT_CALL(*mockConfig, GetBundle()).WillRepeatedly(testing::Return(bundle));
-        
-        // component context has 1:1 relation with component instance, so we
-        // use the context to validate the number of instances of a reference
-        std::vector<std::shared_ptr<ComponentContext>> contexts;
-        for(size_t i =0; i<componentInstanceCount; i++)
-        {
-          contexts.push_back(std::make_shared<ComponentContextImpl>(mockConfig));
-        }
-        
-        for(size_t i =0; i<iterCount; i++)
-        {
-          for(auto ctxt : contexts)
-          {
-            auto serviceObj = ctxt->LocateService<dummy::ServiceImpl>("foo");
-            if(serviceObj)
-            {
-              instances.insert(serviceObj);
-            }
+    auto fakeLogger = std::make_shared<FakeLogger>();
+    metadata::ReferenceMetadata fakeRefMetadata;
+    fakeRefMetadata.name = "foo";
+    fakeRefMetadata.interfaceName =
+      us_service_interface_iid<dummy::ServiceImpl>();
+    fakeRefMetadata.scope = referenceScope;
+
+    std::set<std::shared_ptr<dummy::ServiceImpl>> instances;
+
+    // publish a service
+    auto mockServiceFactory = std::make_shared<MockFactory>();
+    InterfaceMapConstPtr singletonInstance =
+      MakeInterfaceMap<dummy::ServiceImpl>(
+        std::make_shared<dummy::ServiceImpl>());
+    EXPECT_CALL(*mockServiceFactory, GetService(testing::_, testing::_))
+      .WillRepeatedly(
+        testing::Invoke([&](const cppmicroservices::Bundle&,
+                            const cppmicroservices::ServiceRegistrationBase&) {
+          if (publishedScope == SCOPE_SINGLETON) {
+            return singletonInstance;
+          } else {
+            InterfaceMapConstPtr iMap = MakeInterfaceMap<dummy::ServiceImpl>(
+              std::make_shared<dummy::ServiceImpl>());
+            return iMap;
+          }
+        }));
+
+    EXPECT_CALL(*mockServiceFactory,
+                UngetService(testing::_, testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke(
+        [&](const cppmicroservices::Bundle&,
+            const cppmicroservices::ServiceRegistrationBase&,
+            const cppmicroservices::InterfaceMapConstPtr& service) {
+          //std::cout << "Unget called from bundle id " << bundle.GetBundleId() << std::endl;
+          if (publishedScope == SCOPE_SINGLETON) {
+            ASSERT_EQ(service, singletonInstance);
+          }
+        }));
+
+    auto sReg = bc.RegisterService<dummy::ServiceImpl>(
+      ToFactory(mockServiceFactory),
+      { { cppmicroservices::Constants::SERVICE_SCOPE, Any(publishedScope) } });
+
+    for (auto& bundle : bundles) {
+      bundle.Start(); // In case the pkgtest bundle is not started
+      auto bundleContext = bundle.GetBundleContext();
+      auto mockRefMgrFoo = std::make_shared<ReferenceManagerImpl>(
+        fakeRefMetadata, bundleContext, fakeLogger, "foobar");
+      std::vector<std::shared_ptr<ReferenceManager>> depMgrs{ mockRefMgrFoo };
+      EXPECT_CALL(*mockConfig, GetAllDependencyManagers())
+        .WillRepeatedly(testing::Return(depMgrs));
+      EXPECT_CALL(*mockConfig, GetBundle())
+        .WillRepeatedly(testing::Return(bundle));
+
+      // component context has 1:1 relation with component instance, so we
+      // use the context to validate the number of instances of a reference
+      std::vector<std::shared_ptr<ComponentContext>> contexts;
+      for (size_t i = 0; i < componentInstanceCount; i++) {
+        contexts.push_back(std::make_shared<ComponentContextImpl>(mockConfig));
+      }
+
+      for (size_t i = 0; i < iterCount; i++) {
+        for (auto ctxt : contexts) {
+          auto serviceObj = ctxt->LocateService<dummy::ServiceImpl>("foo");
+          if (serviceObj) {
+            instances.insert(serviceObj);
           }
         }
       }
-      EXPECT_TRUE(std::none_of(instances.begin(), instances.end(), [](const std::shared_ptr<dummy::ServiceImpl>& sObj){ return (sObj == nullptr); }));
-      EXPECT_EQ(instances.size(), expectedServiceInstanceCount);
-      sReg.Unregister();
-    };
-  
+    }
+    EXPECT_TRUE(
+      std::none_of(instances.begin(),
+                   instances.end(),
+                   [](const std::shared_ptr<dummy::ServiceImpl>& sObj) {
+                     return (sObj == nullptr);
+                   }));
+    EXPECT_EQ(instances.size(), expectedServiceInstanceCount);
+    sReg.Unregister();
+  };
+
   // See https://osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#service.component-reference.scope
   // If the reference scope is BUNDLE, and service is published with SINGLETON
   // scope all component instances must receive the same instance of the reference
-  VerifyLocateServiceWithScopes(SCOPE_BUNDLE,
-                                SCOPE_SINGLETON,
-                                1ul);
+  VerifyLocateServiceWithScopes(SCOPE_BUNDLE, SCOPE_SINGLETON, 1ul);
   // If the reference scope is BUNDLE, and service is published with BUNDLE
   // scope all component instances within the same bundle must receive the
   // same instance of the reference. Components from different bundles must
   // receive distinct instances
-  VerifyLocateServiceWithScopes(SCOPE_BUNDLE,
-                                SCOPE_BUNDLE,
-                                bundles.size());
+  VerifyLocateServiceWithScopes(SCOPE_BUNDLE, SCOPE_BUNDLE, bundles.size());
   // If the reference scope is BUNDLE, and service is published with PROTOTYPE
   // this is no different from the case where the service is published with
   // BUNDLE scope
-  VerifyLocateServiceWithScopes(SCOPE_BUNDLE,
-                                SCOPE_PROTOTYPE,
-                                bundles.size());
+  VerifyLocateServiceWithScopes(SCOPE_BUNDLE, SCOPE_PROTOTYPE, bundles.size());
 
   // If the reference scope is PROTOTYPE, and service is published with SINGLETON
   // scope all component instances must receive the same instance of the reference
-  VerifyLocateServiceWithScopes(SCOPE_PROTOTYPE,
-                                SCOPE_SINGLETON,
-                                1ul);
+  VerifyLocateServiceWithScopes(SCOPE_PROTOTYPE, SCOPE_SINGLETON, 1ul);
   // If the reference scope is PROTOTYPE, and service is published with BUNDLE
   // scope all component instances within the same bundle must receive the
   // same instance of the reference. Components from different bundles must
   // receive distinct instances
-  VerifyLocateServiceWithScopes(SCOPE_PROTOTYPE,
-                                SCOPE_BUNDLE,
-                                bundles.size());
+  VerifyLocateServiceWithScopes(SCOPE_PROTOTYPE, SCOPE_BUNDLE, bundles.size());
   // If the reference scope is PROTOTYPE, and service is published with PROTOTYPE
   // scope each component instance must receive a unique instance of the reference
   // service
-  VerifyLocateServiceWithScopes(SCOPE_PROTOTYPE,
-                                SCOPE_PROTOTYPE,
-                                bundles.size() * componentInstanceCount);
+  VerifyLocateServiceWithScopes(
+    SCOPE_PROTOTYPE, SCOPE_PROTOTYPE, bundles.size() * componentInstanceCount);
 
   // If the reference scope is PROTOTYPE_REQUIRED, and service is published
   // with SINGLETON scope, the reference remains unsatisfied
-  VerifyLocateServiceWithScopes(REFERENCE_SCOPE_PROTOTYPE_REQUIRED,
-                                SCOPE_SINGLETON,
-                                0ul);
+  VerifyLocateServiceWithScopes(
+    REFERENCE_SCOPE_PROTOTYPE_REQUIRED, SCOPE_SINGLETON, 0ul);
   // If the reference scope is PROTOTYPE_REQUIRED, and service is published
   // with BUNDLE scope, the reference remains unsatisfied
-  VerifyLocateServiceWithScopes(REFERENCE_SCOPE_PROTOTYPE_REQUIRED,
-                                SCOPE_BUNDLE,
-                                0ul);
+  VerifyLocateServiceWithScopes(
+    REFERENCE_SCOPE_PROTOTYPE_REQUIRED, SCOPE_BUNDLE, 0ul);
   // If the reference scope is PROTOTYPE_REQUIRED, and service is published
   // with PROTOTYPE scope each component instance must receive a unique
   // instance of the reference service
@@ -300,10 +310,13 @@ TEST_F(ComponentContextImplTest, VerifyLocateServiceWithHighestRank)
   auto mockConfig = std::make_shared<MockComponentConfiguration>();
   auto fooServ = std::make_shared<test::Foo>();
   auto mockRefMgrFoo = std::make_shared<MockReferenceManager>();
-  auto reg = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
+  auto reg =
+    GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
   auto fooServ1 = std::make_shared<test::Foo>();
-  auto reg1 = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ1, {{cppmicroservices::Constants::SERVICE_RANKING, 20}});
-  auto refs = GetFramework().GetBundleContext().GetServiceReferences(us_service_interface_iid<test::Foo>());
+  auto reg1 = GetFramework().GetBundleContext().RegisterService<test::Foo>(
+    fooServ1, { { cppmicroservices::Constants::SERVICE_RANKING, 20 } });
+  auto refs = GetFramework().GetBundleContext().GetServiceReferences(
+    us_service_interface_iid<test::Foo>());
   std::set<cppmicroservices::ServiceReferenceBase> refsSet;
   refsSet.insert(refs.begin(), refs.end());
   EXPECT_CALL(*mockRefMgrFoo, GetBoundReferences())
@@ -317,17 +330,17 @@ TEST_F(ComponentContextImplTest, VerifyLocateServiceWithHighestRank)
     .WillRepeatedly(testing::Return(cppmicroservices::Constants::SCOPE_BUNDLE));
   EXPECT_CALL(*mockConfig, GetBundle())
     .WillRepeatedly(testing::Return(GetFramework()));
-  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{mockRefMgrFoo};
+  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{ mockRefMgrFoo };
   EXPECT_CALL(*mockConfig, GetAllDependencyManagers())
     .Times(1)
     .WillRepeatedly(testing::Return(depMgrs));
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
-  EXPECT_NO_THROW(
-    {
-      auto service = ctxt->LocateService<test::Foo>("foo");
-      EXPECT_NE(service.get(), fooServ.get());
-      EXPECT_EQ(service.get(), fooServ1.get()); // test with correct type and name
-    });
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
+  EXPECT_NO_THROW({
+    auto service = ctxt->LocateService<test::Foo>("foo");
+    EXPECT_NE(service.get(), fooServ.get());
+    EXPECT_EQ(service.get(), fooServ1.get()); // test with correct type and name
+  });
 }
 
 TEST_F(ComponentContextImplTest, VerifyLocateServiceWithLowestId)
@@ -335,12 +348,15 @@ TEST_F(ComponentContextImplTest, VerifyLocateServiceWithLowestId)
   auto mockConfig = std::make_shared<MockComponentConfiguration>();
   auto mockRefMgrFoo = std::make_shared<MockReferenceManager>();
   auto fooServ = std::make_shared<test::Foo>();
-  auto reg = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
+  auto reg =
+    GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
   auto fooServ1 = std::make_shared<test::Foo>();
-  auto reg1 = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ1);
+  auto reg1 =
+    GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ1);
 
   std::vector<cppmicroservices::ServiceReferenceBase> refArr;
-  auto refs = GetFramework().GetBundleContext().GetServiceReferences(us_service_interface_iid<test::Foo>());
+  auto refs = GetFramework().GetBundleContext().GetServiceReferences(
+    us_service_interface_iid<test::Foo>());
   std::set<cppmicroservices::ServiceReferenceBase> refsSet;
   refsSet.insert(refs.begin(), refs.end());
   EXPECT_CALL(*mockRefMgrFoo, GetBoundReferences())
@@ -354,17 +370,17 @@ TEST_F(ComponentContextImplTest, VerifyLocateServiceWithLowestId)
     .WillRepeatedly(testing::Return(cppmicroservices::Constants::SCOPE_BUNDLE));
   EXPECT_CALL(*mockConfig, GetBundle())
     .WillRepeatedly(testing::Return(GetFramework()));
-  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{mockRefMgrFoo};
+  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{ mockRefMgrFoo };
   EXPECT_CALL(*mockConfig, GetAllDependencyManagers())
     .Times(1)
     .WillRepeatedly(testing::Return(depMgrs));
 
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
-  EXPECT_NO_THROW(
-    {
-      auto service = ctxt->LocateService<test::Foo>("foo");
-      EXPECT_EQ(service, fooServ); // test with correct type and name
-    });
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
+  EXPECT_NO_THROW({
+    auto service = ctxt->LocateService<test::Foo>("foo");
+    EXPECT_EQ(service, fooServ); // test with correct type and name
+  });
 }
 
 TEST_F(ComponentContextImplTest, VerifyLocateServices)
@@ -372,10 +388,13 @@ TEST_F(ComponentContextImplTest, VerifyLocateServices)
   auto mockConfig = std::make_shared<MockComponentConfiguration>();
   auto fooServ = std::make_shared<test::Foo>();
   auto mockRefMgrFoo = std::make_shared<MockReferenceManager>();
-  auto reg = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
+  auto reg =
+    GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ);
   auto fooServ1 = std::make_shared<test::Foo>();
-  auto reg1 = GetFramework().GetBundleContext().RegisterService<test::Foo>(fooServ1, {{cppmicroservices::Constants::SERVICE_RANKING, 20}});
-  auto refs = GetFramework().GetBundleContext().GetServiceReferences(us_service_interface_iid<test::Foo>());
+  auto reg1 = GetFramework().GetBundleContext().RegisterService<test::Foo>(
+    fooServ1, { { cppmicroservices::Constants::SERVICE_RANKING, 20 } });
+  auto refs = GetFramework().GetBundleContext().GetServiceReferences(
+    us_service_interface_iid<test::Foo>());
   std::set<cppmicroservices::ServiceReferenceBase> refsSet;
   refsSet.insert(refs.begin(), refs.end());
   EXPECT_CALL(*mockRefMgrFoo, GetBoundReferences())
@@ -389,56 +408,78 @@ TEST_F(ComponentContextImplTest, VerifyLocateServices)
     .WillRepeatedly(testing::Return(cppmicroservices::Constants::SCOPE_BUNDLE));
   EXPECT_CALL(*mockConfig, GetBundle())
     .WillRepeatedly(testing::Return(GetFramework()));
-  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{mockRefMgrFoo};
+  std::vector<std::shared_ptr<ReferenceManager>> depMgrs{ mockRefMgrFoo };
   EXPECT_CALL(*mockConfig, GetAllDependencyManagers())
     .Times(1)
     .WillRepeatedly(testing::Return(depMgrs));
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   EXPECT_NO_THROW({
-      auto services = ctxt->LocateServices<test::Foo>("foo");
-      EXPECT_EQ(services.size(), refs.size()); // test with correct type and name
-    });
+    auto services = ctxt->LocateServices<test::Foo>("foo");
+    EXPECT_EQ(services.size(), refs.size()); // test with correct type and name
+  });
 }
 
 TEST_F(ComponentContextImplTest, VerifyUsingBundle)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
   // The context created without a usingBundle will always return an invalid bundle.
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   EXPECT_EQ(ctxt->GetUsingBundle().operator bool(), false);
 
   // The context created with a usingBundle must return the passed argument.
-  std::shared_ptr<ComponentContext> ctxt1 = std::make_shared<ComponentContextImpl>(mockConfig,
-                                                                                   GetFramework());
+  std::shared_ptr<ComponentContext> ctxt1 =
+    std::make_shared<ComponentContextImpl>(mockConfig, GetFramework());
   EXPECT_EQ(ctxt1->GetUsingBundle().operator bool(), true);
   EXPECT_EQ(ctxt1->GetUsingBundle(), GetFramework());
 }
 
 TEST_F(ComponentContextImplTest, VerifyEnableComponent)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockConfig, GetBundle()).Times(1).WillRepeatedly(testing::Return(GetFramework()));
-  EXPECT_CALL(*mockConfig, GetRegistry()).Times(1).WillRepeatedly(testing::Return(mockRegistry));
-  EXPECT_CALL(*mockRegistry, GetComponentManager(GetFramework().GetBundleId(),"comp::name")).Times(1).WillRepeatedly(testing::Return(mockCompMgr));
+  EXPECT_CALL(*mockConfig, GetBundle())
+    .Times(1)
+    .WillRepeatedly(testing::Return(GetFramework()));
+  EXPECT_CALL(*mockConfig, GetRegistry())
+    .Times(1)
+    .WillRepeatedly(testing::Return(mockRegistry));
+  EXPECT_CALL(*mockRegistry,
+              GetComponentManager(GetFramework().GetBundleId(), "comp::name"))
+    .Times(1)
+    .WillRepeatedly(testing::Return(mockCompMgr));
   EXPECT_CALL(*mockCompMgr, Enable()).Times(1);
   ctxt->EnableComponent("comp::name");
 }
 
 TEST_F(ComponentContextImplTest, VerifyEnableComponentEmptyArg)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
   auto mockCompMgr1 = std::make_shared<MockComponentManager>();
   auto mockCompMgr2 = std::make_shared<MockComponentManager>();
-  std::vector<std::shared_ptr<ComponentManager>> compmgrs = { mockCompMgr, mockCompMgr1, mockCompMgr2 };
-  EXPECT_CALL(*mockConfig, GetBundle()).Times(1).WillRepeatedly(testing::Return(GetFramework()));
-  EXPECT_CALL(*mockConfig, GetRegistry()).Times(1).WillRepeatedly(testing::Return(mockRegistry));
-  EXPECT_CALL(*mockRegistry, GetComponentManagers(GetFramework().GetBundleId())).Times(1).WillRepeatedly(testing::Return(compmgrs));
+  std::vector<std::shared_ptr<ComponentManager>> compmgrs = { mockCompMgr,
+                                                              mockCompMgr1,
+                                                              mockCompMgr2 };
+  EXPECT_CALL(*mockConfig, GetBundle())
+    .Times(1)
+    .WillRepeatedly(testing::Return(GetFramework()));
+  EXPECT_CALL(*mockConfig, GetRegistry())
+    .Times(1)
+    .WillRepeatedly(testing::Return(mockRegistry));
+  EXPECT_CALL(*mockRegistry, GetComponentManagers(GetFramework().GetBundleId()))
+    .Times(1)
+    .WillRepeatedly(testing::Return(compmgrs));
   EXPECT_CALL(*mockCompMgr, Enable()).Times(1);
   EXPECT_CALL(*mockCompMgr1, Enable()).Times(1);
   EXPECT_CALL(*mockCompMgr2, Enable()).Times(1);
@@ -447,22 +488,33 @@ TEST_F(ComponentContextImplTest, VerifyEnableComponentEmptyArg)
 
 TEST_F(ComponentContextImplTest, VerifyDisableComponent)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
-  std::shared_ptr<ComponentContext> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  std::shared_ptr<ComponentContext> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockConfig, GetBundle()).Times(1).WillRepeatedly(testing::Return(GetFramework()));
-  EXPECT_CALL(*mockConfig, GetRegistry()).Times(1).WillRepeatedly(testing::Return(mockRegistry));
-  EXPECT_CALL(*mockRegistry, GetComponentManager(GetFramework().GetBundleId(),"comp::name")).Times(1).WillRepeatedly(testing::Return(mockCompMgr));
+  EXPECT_CALL(*mockConfig, GetBundle())
+    .Times(1)
+    .WillRepeatedly(testing::Return(GetFramework()));
+  EXPECT_CALL(*mockConfig, GetRegistry())
+    .Times(1)
+    .WillRepeatedly(testing::Return(mockRegistry));
+  EXPECT_CALL(*mockRegistry,
+              GetComponentManager(GetFramework().GetBundleId(), "comp::name"))
+    .Times(1)
+    .WillRepeatedly(testing::Return(mockCompMgr));
   EXPECT_CALL(*mockCompMgr, Disable()).Times(1);
   ctxt->DisableComponent("comp::name");
 }
 
 TEST_F(ComponentContextImplTest, VerifyInvalidate)
 {
-  auto mockConfig = std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
+  auto mockConfig =
+    std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
   // The context created without a usingBundle will always return an invalid bundle.
-  std::shared_ptr<ComponentContextImpl> ctxt = std::make_shared<ComponentContextImpl>(mockConfig);
+  std::shared_ptr<ComponentContextImpl> ctxt =
+    std::make_shared<ComponentContextImpl>(mockConfig);
   EXPECT_CALL(*mockConfig, GetBundle())
     .WillRepeatedly(testing::Return(GetFramework()));
   EXPECT_EQ(ctxt->GetBundleContext().operator bool(), true);

--- a/compendium/DeclarativeServices/test/TestComponentDescription.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentDescription.cpp
@@ -20,49 +20,64 @@
 
 =============================================================================*/
 
-#include "gtest/gtest.h"
 #include "TestFixture.hpp"
+#include "gtest/gtest.h"
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace test
+namespace test {
+/**
+ * Verify a component with default name(=implementation class name) is loaded properly
+ */
+TEST_F(tServiceComponent, testComponentLoad_DefaultComponentName) //DS_TOI_2
 {
-  /**
-   * Verify a component with default name(=implementation class name) is loaded properly
-   */
-  TEST_F(tServiceComponent, testComponentLoad_DefaultComponentName) //DS_TOI_2
-  {
-    cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSTOI2");
-    scr::dto::ComponentDescriptionDTO compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent2");
-    EXPECT_EQ(compDescDTO.name, compDescDTO.implementationClass) << "component name and implementation class must be different";
-    EXPECT_EQ(compDescDTO.implementationClass, "sample::ServiceComponent2") << "Implementation class in the returned component description must be sample::ServiceComponent2";
-    auto fut = dsRuntimeService->EnableComponent(compDescDTO);
-    fut.get();
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state reported by the runtime service must match the initial state in component description";
-    auto bc = framework.GetBundleContext();
-    auto sRef = bc.GetServiceReference<test::Interface1>();
-    EXPECT_TRUE(static_cast<bool>(sRef));
-    auto service = bc.GetService(sRef);
-    EXPECT_NE(service, nullptr);
-    testBundle.Stop();
-  }
+  cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSTOI2");
+  scr::dto::ComponentDescriptionDTO compDescDTO =
+    dsRuntimeService->GetComponentDescriptionDTO(testBundle,
+                                                 "sample::ServiceComponent2");
+  EXPECT_EQ(compDescDTO.name, compDescDTO.implementationClass)
+    << "component name and implementation class must be different";
+  EXPECT_EQ(compDescDTO.implementationClass, "sample::ServiceComponent2")
+    << "Implementation class in the returned component description must be "
+       "sample::ServiceComponent2";
+  auto fut = dsRuntimeService->EnableComponent(compDescDTO);
+  fut.get();
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto bc = framework.GetBundleContext();
+  auto sRef = bc.GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef));
+  auto service = bc.GetService(sRef);
+  EXPECT_NE(service, nullptr);
+  testBundle.Stop();
+}
 
-  /**
-   * Verify a component with custom name is loaded properly
-   */
-  TEST_F(tServiceComponent, testComponentLoad_CustomComponentName) //DS_TOI_3
-  {
-    cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSTOI3");
-    scr::dto::ComponentDescriptionDTO compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sampleServiceComponent");
-    EXPECT_NE(compDescDTO.name, compDescDTO.implementationClass) << "component name and implementation class must be different";
-    EXPECT_EQ(compDescDTO.name, "sampleServiceComponent") << "Name in the returned component description must be sampleServiceComponent";
-    EXPECT_EQ(compDescDTO.implementationClass, "sample::ServiceComponent3") << "Implementation class in the returned component description must be sample::ServiceComponent3";
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state reported by the runtime service must match the initial state in component description";
-    auto bc = framework.GetBundleContext();
-    auto sRef = bc.GetServiceReference<test::Interface1>();
-    EXPECT_TRUE(static_cast<bool>(sRef));
-    auto service = bc.GetService(sRef);
-    EXPECT_NE(service, nullptr);
-    testBundle.Stop();
-  }
+/**
+ * Verify a component with custom name is loaded properly
+ */
+TEST_F(tServiceComponent, testComponentLoad_CustomComponentName) //DS_TOI_3
+{
+  cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSTOI3");
+  scr::dto::ComponentDescriptionDTO compDescDTO =
+    dsRuntimeService->GetComponentDescriptionDTO(testBundle,
+                                                 "sampleServiceComponent");
+  EXPECT_NE(compDescDTO.name, compDescDTO.implementationClass)
+    << "component name and implementation class must be different";
+  EXPECT_EQ(compDescDTO.name, "sampleServiceComponent")
+    << "Name in the returned component description must be "
+       "sampleServiceComponent";
+  EXPECT_EQ(compDescDTO.implementationClass, "sample::ServiceComponent3")
+    << "Implementation class in the returned component description must be "
+       "sample::ServiceComponent3";
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto bc = framework.GetBundleContext();
+  auto sRef = bc.GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef));
+  auto service = bc.GetService(sRef);
+  EXPECT_NE(service, nullptr);
+  testBundle.Stop();
+}
 }

--- a/compendium/DeclarativeServices/test/TestComponentInitialState.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentInitialState.cpp
@@ -20,49 +20,66 @@
 
 =============================================================================*/
 
-#include "gtest/gtest.h"
 #include "TestFixture.hpp"
+#include "gtest/gtest.h"
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace test
+namespace test {
+/**
+ * Verify state changes for a component with initial state as ENABLED
+ */
+TEST_F(tServiceComponent, testInitialEnabled) //testDS_TOI_1
 {
-  /**
-   * Verify state changes for a component with initial state as ENABLED
-   */
-  TEST_F(tServiceComponent, testInitialEnabled) //testDS_TOI_1
-  {
-    std::string testBundleName("TestBundleDSTOI1");
-    cppmicroservices::Bundle testBundle = StartTestBundle(testBundleName);
-    scr::dto::ComponentDescriptionDTO compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent");
-    EXPECT_EQ(compDescDTO.name, "sample::ServiceComponent") << "Name in the returned component description must be sample::ServiceComponentImpl";
-    EXPECT_EQ(compDescDTO.defaultEnabled, true) << "Component's initial state in component description must be ENABLED";
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state reported by the runtime service must match the initial state in component description";
-    auto sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-    EXPECT_TRUE(static_cast<bool>(sRef));
-    auto fut = dsRuntimeService->DisableComponent(compDescDTO);
-    EXPECT_NO_THROW(fut.get());
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), false) << "current state must be DISABLED after call to DisableComponent";
-    EXPECT_FALSE(static_cast<bool>(sRef));
-  }
+  std::string testBundleName("TestBundleDSTOI1");
+  cppmicroservices::Bundle testBundle = StartTestBundle(testBundleName);
+  scr::dto::ComponentDescriptionDTO compDescDTO =
+    dsRuntimeService->GetComponentDescriptionDTO(testBundle,
+                                                 "sample::ServiceComponent");
+  EXPECT_EQ(compDescDTO.name, "sample::ServiceComponent")
+    << "Name in the returned component description must be "
+       "sample::ServiceComponentImpl";
+  EXPECT_EQ(compDescDTO.defaultEnabled, true)
+    << "Component's initial state in component description must be ENABLED";
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto sRef =
+    framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef));
+  auto fut = dsRuntimeService->DisableComponent(compDescDTO);
+  EXPECT_NO_THROW(fut.get());
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), false)
+    << "current state must be DISABLED after call to DisableComponent";
+  EXPECT_FALSE(static_cast<bool>(sRef));
+}
 
-  /**
-   * Verify state changes for a component with initial state as DISABLED
-   */
-  TEST_F(tServiceComponent, testInitialDisabled) //testDS_TOI_2
-  {
-    std::string testBundleName("TestBundleDSTOI2");
-    cppmicroservices::Bundle testBundle = StartTestBundle(testBundleName);
-    scr::dto::ComponentDescriptionDTO compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent2");
-    EXPECT_EQ(compDescDTO.name, "sample::ServiceComponent2") << "Name in the returned component description must be sample::ServiceComponentImpl";
-    EXPECT_EQ(compDescDTO.defaultEnabled, false) << "Component's initial state in component description must be DISABLED";
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), false) << "current state reported by the runtime service must match the initial state in component description";
-    auto sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-    EXPECT_FALSE(static_cast<bool>(sRef));
-    auto fut = dsRuntimeService->EnableComponent(compDescDTO);
-    EXPECT_NO_THROW(fut.get());
-    EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state must be ENABLED after call to EnableComponent";
-    sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-    EXPECT_TRUE(static_cast<bool>(sRef));
-  }
+/**
+ * Verify state changes for a component with initial state as DISABLED
+ */
+TEST_F(tServiceComponent, testInitialDisabled) //testDS_TOI_2
+{
+  std::string testBundleName("TestBundleDSTOI2");
+  cppmicroservices::Bundle testBundle = StartTestBundle(testBundleName);
+  scr::dto::ComponentDescriptionDTO compDescDTO =
+    dsRuntimeService->GetComponentDescriptionDTO(testBundle,
+                                                 "sample::ServiceComponent2");
+  EXPECT_EQ(compDescDTO.name, "sample::ServiceComponent2")
+    << "Name in the returned component description must be "
+       "sample::ServiceComponentImpl";
+  EXPECT_EQ(compDescDTO.defaultEnabled, false)
+    << "Component's initial state in component description must be DISABLED";
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), false)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto sRef =
+    framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_FALSE(static_cast<bool>(sRef));
+  auto fut = dsRuntimeService->EnableComponent(compDescDTO);
+  EXPECT_NO_THROW(fut.get());
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state must be ENABLED after call to EnableComponent";
+  sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef));
+}
 }

--- a/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentLifecycle.cpp
@@ -20,17 +20,16 @@
 
 =============================================================================*/
 
-#include "gtest/gtest.h"
 #include "TestFixture.hpp"
-#include "TestUtils.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "TestUtils.hpp"
 #include "cppmicroservices/ServiceEvent.h"
+#include "gtest/gtest.h"
 
-namespace sc  = cppmicroservices::service::component;
+namespace sc = cppmicroservices::service::component;
 namespace scr = cppmicroservices::service::component::runtime;
 
-namespace test
-{
+namespace test {
 /**
  * Verify a component that implements Activate & Deactivate methods receives
  * the callbacks
@@ -45,10 +44,12 @@ TEST_F(tServiceComponent, testLifeCycleHooks) //DS_TOI_10
   ASSERT_TRUE(static_cast<bool>(sRef));
   auto service = ctxt.GetService<test::LifeCycleValidation>(sRef);
   ASSERT_NE(service, nullptr);
-  EXPECT_TRUE(service->IsActivated()) << "service component instance must have received the Activate callback";
+  EXPECT_TRUE(service->IsActivated())
+    << "service component instance must have received the Activate callback";
 
   // Use DS runtime service to validate the component state
-  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent10");
+  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent10");
   auto compConfigs = dsRuntimeService->GetComponentConfigurationDTOs(compDesc);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";
   EXPECT_EQ(compConfigs.at(0).state, scr::dto::ComponentState::ACTIVE);
@@ -56,14 +57,18 @@ TEST_F(tServiceComponent, testLifeCycleHooks) //DS_TOI_10
   // Disable the component which should remove the corresponding configuration
   auto fut = dsRuntimeService->DisableComponent(compDesc);
   EXPECT_NO_THROW(fut.get());
-  EXPECT_TRUE(service->IsDeactivated()) << "service component instance must have received the Deactivate callback";
+  EXPECT_TRUE(service->IsDeactivated())
+    << "service component instance must have received the Deactivate callback";
   compConfigs = dsRuntimeService->GetComponentConfigurationDTOs(compDesc);
-  EXPECT_EQ(compConfigs.size(), 0ul) << "No configurations must exist after the component is disbled";
+  EXPECT_EQ(compConfigs.size(), 0ul)
+    << "No configurations must exist after the component is disbled";
 
   // stop the bundle
   testBundle.Stop();
-  compDesc = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent10");
-  EXPECT_EQ(compDesc.name, "") << "Component must not be found after bundle is stopped";
+  compDesc = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent10");
+  EXPECT_EQ(compDesc.name, "")
+    << "Component must not be found after bundle is stopped";
 }
 
 /**
@@ -76,11 +81,15 @@ TEST_F(tServiceComponent, testThrowingLifeCycleHooks) //DS_TOI_9
   auto sRef = ctxt.GetServiceReference<test::LifeCycleValidation>();
   ASSERT_TRUE(static_cast<bool>(sRef));
   auto service = ctxt.GetService<test::LifeCycleValidation>(sRef);
-  EXPECT_EQ(service, nullptr) << "Service object must be nullptr since the service component should have thrown an exception when activated";
-  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent9");
+  EXPECT_EQ(service, nullptr)
+    << "Service object must be nullptr since the service component should have "
+       "thrown an exception when activated";
+  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent9");
   auto compConfigs = dsRuntimeService->GetComponentConfigurationDTOs(compDesc);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";
-  EXPECT_EQ(compConfigs.at(0).state, scr::dto::ComponentState::SATISFIED) << "state must be SATISFIED, and never progresses to ACTIVE";
+  EXPECT_EQ(compConfigs.at(0).state, scr::dto::ComponentState::SATISFIED)
+    << "state must be SATISFIED, and never progresses to ACTIVE";
 }
 
 /**
@@ -90,46 +99,55 @@ TEST_F(tServiceComponent, testThrowingLifeCycleHooks) //DS_TOI_9
 TEST_F(tServiceComponent, testImmediateComponent_LifeCycle) // DS_TOI_51
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI5");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent5");
-  auto compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent5");
+  auto compConfigDTOs =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(compConfigDTOs.size(), 1ul);
-  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
   auto ctxt = framework.GetBundleContext();
   auto sRef = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef)) << "Service must not be available before it's dependency";
+  EXPECT_FALSE(static_cast<bool>(sRef))
+    << "Service must not be available before it's dependency";
   auto depBundle = StartTestBundle("TestBundleDSTOI1");
 
   // wait for the asynchronous task to take effect
-  auto result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-                                         {
-                                             compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-                                         }
-                                         , [&compConfigDTOs]()->bool
-                                           {
-                                               return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
-                                           });
+  auto result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
+    });
 
-  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE after the dependency became available";
+  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE "
+                         "after the dependency became available";
   auto sRef1 = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_TRUE(static_cast<bool>(sRef1)) << "Service must be available after it's dependency is available";
+  EXPECT_TRUE(static_cast<bool>(sRef1))
+    << "Service must be available after it's dependency is available";
   auto service = ctxt.GetService<test::Interface2>(sRef1);
 
   ASSERT_NE(service, nullptr);
-  EXPECT_NO_THROW(service->ExtendedDescription()) << "Throws if the dependency could not be found";
+  EXPECT_NO_THROW(service->ExtendedDescription())
+    << "Throws if the dependency could not be found";
   depBundle.Stop();
-  
-  result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-                                    {
-                                      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-                                    }
-                                    , [&compConfigDTOs]()->bool
-                                      {
-                                          return compConfigDTOs.at(0).state == scr::dto::ComponentState::UNSATISFIED_REFERENCE;
-                                      });
-  
-  ASSERT_TRUE(result) << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after the dependency was removed";
+
+  result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state ==
+             scr::dto::ComponentState::UNSATISFIED_REFERENCE;
+    });
+
+  ASSERT_TRUE(result)
+    << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after "
+       "the dependency was removed";
   auto sRef2 = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef2)) << "Service must not be available after it's dependency is removed";
+  EXPECT_FALSE(static_cast<bool>(sRef2))
+    << "Service must not be available after it's dependency is removed";
 }
 
 /**
@@ -139,40 +157,53 @@ TEST_F(tServiceComponent, testImmediateComponent_LifeCycle) // DS_TOI_51
 TEST_F(tServiceComponent, testImmediateComponent_LifeCycle_Dynamic) // DS_TOI_51
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI7");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent7");
-  auto compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent7");
+  auto compConfigDTOs =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(compConfigDTOs.size(), 1ul);
-  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
   auto ctxt = framework.GetBundleContext();
   auto sRef = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef)) << "Service must not be available before it's dependency";
+  EXPECT_FALSE(static_cast<bool>(sRef))
+    << "Service must not be available before it's dependency";
   auto depBundle = StartTestBundle("TestBundleDSTOI1");
 
   // wait for the asynchronous task to take effect
-  auto result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
-                                           compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-                                         },
-    [&compConfigDTOs]()->bool {
+  auto result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
       return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
     });
 
-  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE after the dependency became available";
+  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE "
+                         "after the dependency became available";
   auto sRef1 = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_TRUE(static_cast<bool>(sRef1)) << "Service must be available after it's dependency is available";
+  EXPECT_TRUE(static_cast<bool>(sRef1))
+    << "Service must be available after it's dependency is available";
   auto service = ctxt.GetService<test::Interface2>(sRef1);
 
   ASSERT_NE(service, nullptr);
-  EXPECT_NO_THROW(service->ExtendedDescription()) << "Throws if the dependency could not be found";
+  EXPECT_NO_THROW(service->ExtendedDescription())
+    << "Throws if the dependency could not be found";
   depBundle.Stop();
-  result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
-                                      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-                                    },
-    [&compConfigDTOs]()->bool {
-      return compConfigDTOs.at(0).state == scr::dto::ComponentState::UNSATISFIED_REFERENCE;
+  result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state ==
+             scr::dto::ComponentState::UNSATISFIED_REFERENCE;
     });
-  ASSERT_TRUE(result) << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after the dependency was removed";
+  ASSERT_TRUE(result)
+    << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after "
+       "the dependency was removed";
   auto sRef2 = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef2)) << "Service must not be available after it's dependency is removed";
+  EXPECT_FALSE(static_cast<bool>(sRef2))
+    << "Service must not be available after it's dependency is removed";
 }
 
 /**
@@ -184,14 +215,18 @@ TEST_F(tServiceComponent, testImmediateComponent_LifeCycle_Dynamic) // DS_TOI_51
 TEST_F(tServiceComponent, testDelayedComponent_LifeCycle) //DS_TOI_52 //DS_TOI_6
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI6");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent6");
-  auto compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent6");
+  auto compConfigDTOs =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(compConfigDTOs.size(), 1ul);
-  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
   auto ctxt = framework.GetBundleContext();
   auto sRef = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef)) << "Service must not be available before it's dependency";
-  
+  EXPECT_FALSE(static_cast<bool>(sRef))
+    << "Service must not be available before it's dependency";
+
   auto result = isBundleLoadedInThisProcess("TestBundleDSTOI6");
   EXPECT_FALSE(result) << "library must not be available";
 
@@ -200,23 +235,22 @@ TEST_F(tServiceComponent, testDelayedComponent_LifeCycle) //DS_TOI_52 //DS_TOI_6
   bool serviceRegistered = false;
   bool serviceUnregistered = false;
   // add a listener
-  auto token = ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
-//      std::cout << evt << std::endl;
-//      std::cout << GetServiceInterface(evt.GetServiceReference()) << ", " << us_service_interface_iid<test::Interface2>() << std::endl;
-                                         if (evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_REGISTERED &&
-                                             evt.GetServiceReference().IsConvertibleTo(us_service_interface_iid<test::Interface2>()))
-                                         {
-                                           std::lock_guard<std::mutex> lk(mtx);
-                                           serviceRegistered = true;
-                                           cv.notify_all();
-                                         }
-                                       });
+  auto token = ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent&
+                                             evt) {
+    //      std::cout << evt << std::endl;
+    //      std::cout << GetServiceInterface(evt.GetServiceReference()) << ", " << us_service_interface_iid<test::Interface2>() << std::endl;
+    if (evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_REGISTERED &&
+        evt.GetServiceReference().IsConvertibleTo(
+          us_service_interface_iid<test::Interface2>())) {
+      std::lock_guard<std::mutex> lk(mtx);
+      serviceRegistered = true;
+      cv.notify_all();
+    }
+  });
   auto depBundle = StartTestBundle("TestBundleDSTOI1");
   {
     std::unique_lock<std::mutex> lk(mtx);
-    cv.wait(lk, [&serviceRegistered]() {
-                  return serviceRegistered == true;
-                });
+    cv.wait(lk, [&serviceRegistered]() { return serviceRegistered == true; });
     ctxt.RemoveListener(std::move(token));
   }
 
@@ -227,149 +261,173 @@ TEST_F(tServiceComponent, testDelayedComponent_LifeCycle) //DS_TOI_52 //DS_TOI_6
   EXPECT_FALSE(result) << "library must not be available";
 
   auto sRef1 = ctxt.GetServiceReference<test::Interface2>();
-  ASSERT_TRUE(static_cast<bool>(sRef1)) << "Service must be available after it's dependency is available";
+  ASSERT_TRUE(static_cast<bool>(sRef1))
+    << "Service must be available after it's dependency is available";
   auto service = ctxt.GetService<test::Interface2>(sRef1);
   ASSERT_NE(service, nullptr);
   compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
-  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::ACTIVE) << "State must be ACTIVE after call to GetService";
-  EXPECT_NO_THROW(service->ExtendedDescription()) << "Throws if the dependency could not be found";
+  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::ACTIVE)
+    << "State must be ACTIVE after call to GetService";
+  EXPECT_NO_THROW(service->ExtendedDescription())
+    << "Throws if the dependency could not be found";
 
   result = isBundleLoadedInThisProcess("TestBundleDSTOI6");
   EXPECT_TRUE(result) << "library must be available";
 
-  auto token1 = ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
-                                          //std::cout << evt << std::endl;
-                                          auto sRef = evt.GetServiceReference();
-                                          if (evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_UNREGISTERING &&
-                                              test::GetServiceId(sRef) == test::GetServiceId(sRef1))
-                                          {
-                                            std::lock_guard<std::mutex> lk(mtx1);
-                                            serviceUnregistered = true;
-                                            cv1.notify_all();
-                                          }
-                                        });
-    
+  auto token1 =
+    ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
+      //std::cout << evt << std::endl;
+      auto sRef = evt.GetServiceReference();
+      if (evt.GetType() ==
+            cppmicroservices::ServiceEvent::SERVICE_UNREGISTERING &&
+          test::GetServiceId(sRef) == test::GetServiceId(sRef1)) {
+        std::lock_guard<std::mutex> lk(mtx1);
+        serviceUnregistered = true;
+        cv1.notify_all();
+      }
+    });
+
   depBundle.Stop();
   {
     std::unique_lock<std::mutex> lk(mtx1);
-    cv1.wait(lk, [&serviceUnregistered]() {
-                   return serviceUnregistered == true;
-                 });
+    cv1.wait(lk,
+             [&serviceUnregistered]() { return serviceUnregistered == true; });
     ctxt.RemoveListener(std::move(token1));
   }
 
   compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
-  EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
   auto sRef2 = ctxt.GetServiceReference<test::Interface2>();
-  EXPECT_FALSE(static_cast<bool>(sRef2)) << "Service must not be available after it's dependency is removed";
+  EXPECT_FALSE(static_cast<bool>(sRef2))
+    << "Service must not be available after it's dependency is removed";
 }
 
 TEST_F(tServiceComponent, testDependencyInjection) // DS_TOI_18
 {
-    auto testBundle = StartTestBundle("TestBundleDSTOI18");
-    auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent18");
-    auto compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
-    EXPECT_EQ(compConfigDTOs.size(), 1ul);
-    EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
-    
-    auto ctxt = framework.GetBundleContext();
-    auto sRef = ctxt.GetServiceReference<test::Interface3>();
-    EXPECT_FALSE(static_cast<bool>(sRef)) << "Service must not be available before it's dependency";
-    
-    auto depBundle = StartTestBundle("TestBundleDSTOI1");
-    
-    // wait for the asynchronous task to take effect
-    auto result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-    {
-        compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-    }
-    , [&compConfigDTOs]()->bool
-    {
-        return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
+  auto testBundle = StartTestBundle("TestBundleDSTOI18");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent18");
+  auto compConfigDTOs =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  EXPECT_EQ(compConfigDTOs.size(), 1ul);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+
+  auto ctxt = framework.GetBundleContext();
+  auto sRef = ctxt.GetServiceReference<test::Interface3>();
+  EXPECT_FALSE(static_cast<bool>(sRef))
+    << "Service must not be available before it's dependency";
+
+  auto depBundle = StartTestBundle("TestBundleDSTOI1");
+
+  // wait for the asynchronous task to take effect
+  auto result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
     });
 
-    ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE after the dependency became available";
-    auto sRef1 = ctxt.GetServiceReference<test::Interface3>();
-    EXPECT_TRUE(static_cast<bool>(sRef1)) << "Service must be available after it's dependency is available";
-    auto service = ctxt.GetService<test::Interface3>(sRef1);
-    ASSERT_NE(service, nullptr);
-    
-    //Verify Constructor Injection
-    ASSERT_TRUE(service->isDependencyInjected()) << "Constructor based dependency injection failed";
-    
-    depBundle.Stop();
-    result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-    {
-        compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-    }
-    , [&compConfigDTOs]()->bool
-    {
-        return compConfigDTOs.at(0).state == scr::dto::ComponentState::UNSATISFIED_REFERENCE;
+  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE "
+                         "after the dependency became available";
+  auto sRef1 = ctxt.GetServiceReference<test::Interface3>();
+  EXPECT_TRUE(static_cast<bool>(sRef1))
+    << "Service must be available after it's dependency is available";
+  auto service = ctxt.GetService<test::Interface3>(sRef1);
+  ASSERT_NE(service, nullptr);
+
+  //Verify Constructor Injection
+  ASSERT_TRUE(service->isDependencyInjected())
+    << "Constructor based dependency injection failed";
+
+  depBundle.Stop();
+  result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state ==
+             scr::dto::ComponentState::UNSATISFIED_REFERENCE;
     });
 
-    ASSERT_TRUE(result) << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after the dependency was removed";
-    auto sRef2 = ctxt.GetServiceReference<test::Interface3>();
-    EXPECT_FALSE(static_cast<bool>(sRef2)) << "Service must not be available after it's dependency is removed";
+  ASSERT_TRUE(result)
+    << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after "
+       "the dependency was removed";
+  auto sRef2 = ctxt.GetServiceReference<test::Interface3>();
+  EXPECT_FALSE(static_cast<bool>(sRef2))
+    << "Service must not be available after it's dependency is removed";
 }
 
 TEST_F(tServiceComponent, testServiceDependency_LDAPFilter) // DS_TOI_19
 {
-    auto testBundle = StartTestBundle("TestBundleDSTOI19");
-    auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent19");
-    auto compConfigDTOs = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
-    EXPECT_EQ(compConfigDTOs.size(), 1ul);
-    EXPECT_EQ(compConfigDTOs.at(0).state, scr::dto::ComponentState::UNSATISFIED_REFERENCE);
-    auto ctxt = framework.GetBundleContext();
-    auto sRef = ctxt.GetServiceReference<test::Interface2>();
-    EXPECT_FALSE(static_cast<bool>(sRef)) << "Service must not be available before it's dependency";
-    
-    //start non-matching bundle
-    auto depBundle1 = StartTestBundle("TestBundleDSTOI1");
-    auto sRef1 = ctxt.GetServiceReference<test::Interface2>();
-    EXPECT_FALSE(static_cast<bool>(sRef1)) << "Service must not be available as this dependency does not match the filter";
+  auto testBundle = StartTestBundle("TestBundleDSTOI19");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent19");
+  auto compConfigDTOs =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  EXPECT_EQ(compConfigDTOs.size(), 1ul);
+  EXPECT_EQ(compConfigDTOs.at(0).state,
+            scr::dto::ComponentState::UNSATISFIED_REFERENCE);
+  auto ctxt = framework.GetBundleContext();
+  auto sRef = ctxt.GetServiceReference<test::Interface2>();
+  EXPECT_FALSE(static_cast<bool>(sRef))
+    << "Service must not be available before it's dependency";
 
-    //start matching bundle
-    auto depBundle2 = StartTestBundle("TestBundleDSTOI12");
-    auto result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-    {
-        compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-    }
-    , [&compConfigDTOs]()->bool
-    {
-        return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
+  //start non-matching bundle
+  auto depBundle1 = StartTestBundle("TestBundleDSTOI1");
+  auto sRef1 = ctxt.GetServiceReference<test::Interface2>();
+  EXPECT_FALSE(static_cast<bool>(sRef1))
+    << "Service must not be available as this dependency does not match the "
+       "filter";
+
+  //start matching bundle
+  auto depBundle2 = StartTestBundle("TestBundleDSTOI12");
+  auto result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state == scr::dto::ComponentState::ACTIVE;
     });
 
-    ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE after the dependency became available";
-    auto sRef2 = ctxt.GetServiceReference<test::Interface2>();
-    EXPECT_TRUE(static_cast<bool>(sRef2)) << "Service must be available after it's dependency is available";
-    auto service = ctxt.GetService<test::Interface2>(sRef2);
-    ASSERT_NE(service, nullptr);
-    EXPECT_NO_THROW(service->ExtendedDescription()) << "Throws if the dependency could not be found";
-    
+  ASSERT_TRUE(result) << "Timed out waiting for state to change to ACTIVE "
+                         "after the dependency became available";
+  auto sRef2 = ctxt.GetServiceReference<test::Interface2>();
+  EXPECT_TRUE(static_cast<bool>(sRef2))
+    << "Service must be available after it's dependency is available";
+  auto service = ctxt.GetService<test::Interface2>(sRef2);
+  ASSERT_NE(service, nullptr);
+  EXPECT_NO_THROW(service->ExtendedDescription())
+    << "Throws if the dependency could not be found";
 
-    //stop non matching bundle
-    depBundle1.Stop();
-    sRef1 = ctxt.GetServiceReference<test::Interface2>();
-    EXPECT_TRUE(static_cast<bool>(sRef1)) << "Service must be available as the removed dependency does not match the filter";
-    service = ctxt.GetService<test::Interface2>(sRef1);
-    ASSERT_NE(service, nullptr);
+  //stop non matching bundle
+  depBundle1.Stop();
+  sRef1 = ctxt.GetServiceReference<test::Interface2>();
+  EXPECT_TRUE(static_cast<bool>(sRef1))
+    << "Service must be available as the removed dependency does not match the "
+       "filter";
+  service = ctxt.GetService<test::Interface2>(sRef1);
+  ASSERT_NE(service, nullptr);
 
-
-    //stop matching bundle
-    depBundle2.Stop();
-    result = RepeatTaskUntilOrTimeout([&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]()
-    {
-        compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
-    }
-    , [&compConfigDTOs]()->bool
-    {
-        return compConfigDTOs.at(0).state == scr::dto::ComponentState::UNSATISFIED_REFERENCE;
+  //stop matching bundle
+  depBundle2.Stop();
+  result = RepeatTaskUntilOrTimeout(
+    [&compConfigDTOs, service = this->dsRuntimeService, &compDescDTO]() {
+      compConfigDTOs = service->GetComponentConfigurationDTOs(compDescDTO);
+    },
+    [&compConfigDTOs]() -> bool {
+      return compConfigDTOs.at(0).state ==
+             scr::dto::ComponentState::UNSATISFIED_REFERENCE;
     });
 
-    ASSERT_TRUE(result) << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after the dependency was removed";
-    sRef2 = ctxt.GetServiceReference<test::Interface2>();
-    EXPECT_FALSE(static_cast<bool>(sRef2)) << "Service must not be available after it's dependency is removed";
+  ASSERT_TRUE(result)
+    << "Timed out waiting for state to change to UNSATISFIED_REFERENCE after "
+       "the dependency was removed";
+  sRef2 = ctxt.GetServiceReference<test::Interface2>();
+  EXPECT_FALSE(static_cast<bool>(sRef2))
+    << "Service must not be available after it's dependency is removed";
 }
-
 
 }

--- a/compendium/DeclarativeServices/test/TestComponentManagerDisabledState.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerDisabledState.cpp
@@ -20,37 +20,37 @@
 
   =============================================================================*/
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
 #include "../src/manager/states/CMDisabledState.hpp"
-#include "Mocks.hpp"
 #include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class CMDisabledStateTest
-  : public ::testing::Test
+class CMDisabledStateTest : public ::testing::Test
 {
 protected:
-  CMDisabledStateTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  CMDisabledStateTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
   virtual ~CMDisabledStateTest() = default;
 
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     framework.Start();
     auto fakeLogger = std::make_shared<FakeLogger>();
     auto compDesc = std::make_shared<metadata::ComponentMetadata>();
     auto mockRegistry = std::make_shared<MockComponentRegistry>();
-    auto pool = std::make_shared <boost::asio::thread_pool>(1);
-    compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                         mockRegistry,
-                                                         framework.GetBundleContext(),
-                                                         fakeLogger, pool);
+    auto pool = std::make_shared<boost::asio::thread_pool>(1);
+    compMgr = std::make_shared<MockComponentManagerImpl>(
+      compDesc, mockRegistry, framework.GetBundleContext(), fakeLogger, pool);
   }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     compMgr.reset();
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
@@ -64,16 +64,20 @@ TEST_F(CMDisabledStateTest, Ctor)
 {
   // default contructor
   EXPECT_NO_THROW({
-      auto disabledState = std::make_shared<CMDisabledState>();
-      EXPECT_TRUE(disabledState->fut.valid());
-      disabledState->fut.get();
-    });
+    auto disabledState = std::make_shared<CMDisabledState>();
+    EXPECT_TRUE(disabledState->fut.valid());
+    disabledState->fut.get();
+  });
 
   // constructor with a future
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMDisabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMDisabledState>(prom.get_future().share());
   EXPECT_TRUE(enabledState->fut.valid());
-  EXPECT_EQ(enabledState->fut.wait_for(std::chrono::microseconds(1)), std::future_status::timeout) << "The future member of CMDisabledState must not be ready until the corresponding promise is set";
+  EXPECT_EQ(enabledState->fut.wait_for(std::chrono::microseconds(1)),
+            std::future_status::timeout)
+    << "The future member of CMDisabledState must not be ready until the "
+       "corresponding promise is set";
   prom.set_value();
   enabledState->fut.get();
 }
@@ -81,16 +85,18 @@ TEST_F(CMDisabledStateTest, Ctor)
 TEST_F(CMDisabledStateTest, TestIsEnabled)
 {
   auto enabledState = std::make_shared<CMDisabledState>();
-  EXPECT_FALSE(enabledState->IsEnabled(*compMgr)) << "CMDisabledState must always return false for IsEnabled";
+  EXPECT_FALSE(enabledState->IsEnabled(*compMgr))
+    << "CMDisabledState must always return false for IsEnabled";
 }
 
 TEST_F(CMDisabledStateTest, GetConfigurations)
 {
   EXPECT_NO_THROW({
-      auto disabledState = std::make_shared<CMDisabledState>();
-      auto configs = disabledState->GetConfigurations(*compMgr);
-      EXPECT_TRUE(configs.empty()) << "Component Configurations must not exist in a disabled state.";
-    });
+    auto disabledState = std::make_shared<CMDisabledState>();
+    auto configs = disabledState->GetConfigurations(*compMgr);
+    EXPECT_TRUE(configs.empty())
+      << "Component Configurations must not exist in a disabled state.";
+  });
 }
 
 TEST_F(CMDisabledStateTest, TestDisable)
@@ -98,10 +104,12 @@ TEST_F(CMDisabledStateTest, TestDisable)
   auto disabledState = std::make_shared<CMDisabledState>();
   compMgr->SetState(disabledState);
   EXPECT_NO_THROW({
-      auto fut = disabledState->Disable(*compMgr);
-      EXPECT_TRUE(fut.valid()) << "A call to ComponentManager::Disable must always return a valid future";
-      EXPECT_FALSE(compMgr->IsEnabled()) << "ComponentManager must be DISABLED after a call to Disable";
-    });
+    auto fut = disabledState->Disable(*compMgr);
+    EXPECT_TRUE(fut.valid()) << "A call to ComponentManager::Disable must "
+                                "always return a valid future";
+    EXPECT_FALSE(compMgr->IsEnabled())
+      << "ComponentManager must be DISABLED after a call to Disable";
+  });
 }
 
 TEST_F(CMDisabledStateTest, TestConcurrentDisable)
@@ -110,17 +118,18 @@ TEST_F(CMDisabledStateTest, TestConcurrentDisable)
   compMgr->SetState(disabledState);
   // Invoke "Disable" from multiple threads
   std::function<std::shared_future<void>()> func = [&disabledState, this]() {
-                                                     return disabledState->Disable(*compMgr);
-                                                   };
-  std::vector<std::shared_future<void>> futVec = ConcurrentInvoke<std::shared_future<void>>(func);
-  EXPECT_FALSE(compMgr->IsEnabled()) << "ComponentManager state must be DISABLED after concurrent calls to Disable";
+    return disabledState->Disable(*compMgr);
+  };
+  std::vector<std::shared_future<void>> futVec =
+    ConcurrentInvoke<std::shared_future<void>>(func);
+  EXPECT_FALSE(compMgr->IsEnabled())
+    << "ComponentManager state must be DISABLED after concurrent calls to "
+       "Disable";
   // check if the futures returned from concurrent invocation are all valid
-  for(auto fut : futVec)
-  {
-    EXPECT_TRUE(fut.valid()) << "All futures returned from concurrent calls to Disable must be valid";
-    EXPECT_NO_THROW({
-        fut.get();
-      });
+  for (auto fut : futVec) {
+    EXPECT_TRUE(fut.valid())
+      << "All futures returned from concurrent calls to Disable must be valid";
+    EXPECT_NO_THROW({ fut.get(); });
   }
 }
 
@@ -129,11 +138,11 @@ TEST_F(CMDisabledStateTest, TestEnable)
   auto disabledState = std::make_shared<CMDisabledState>();
   compMgr->SetState(disabledState);
   auto fut = disabledState->Enable(*compMgr);
-  EXPECT_TRUE(fut.valid()) << "A call to ComponentManager::Enable must always return a valid future";
-  EXPECT_NO_THROW({
-      fut.get();
-    });
-  EXPECT_TRUE(compMgr->IsEnabled()) << "ComponentManager must be ENABLED after a call to Enable";
+  EXPECT_TRUE(fut.valid())
+    << "A call to ComponentManager::Enable must always return a valid future";
+  EXPECT_NO_THROW({ fut.get(); });
+  EXPECT_TRUE(compMgr->IsEnabled())
+    << "ComponentManager must be ENABLED after a call to Enable";
 }
 
 TEST_F(CMDisabledStateTest, TestConcurrentEnable)
@@ -142,19 +151,18 @@ TEST_F(CMDisabledStateTest, TestConcurrentEnable)
   compMgr->SetState(disabledState);
   // Invoke "Enable" from multiple threads
   std::function<std::shared_future<void>()> func = [&disabledState, this]() {
-                                                     return disabledState->Enable(*(this->compMgr));
-                                                   };
-  std::vector<std::shared_future<void>> futVec = ConcurrentInvoke<std::shared_future<void>>(func);
-  EXPECT_TRUE(compMgr->IsEnabled()) << "ComponentManager state must be ENABLED after concurrent calls to Enable";
+    return disabledState->Enable(*(this->compMgr));
+  };
+  std::vector<std::shared_future<void>> futVec =
+    ConcurrentInvoke<std::shared_future<void>>(func);
+  EXPECT_TRUE(compMgr->IsEnabled()) << "ComponentManager state must be ENABLED "
+                                       "after concurrent calls to Enable";
   // check if the futures returned from concurrent invocation are all valid
-  for(auto fut : futVec)
-  {
-    EXPECT_TRUE(fut.valid()) << "All futures returned from concurrent calls to Enable must be valid";
-    EXPECT_NO_THROW({
-        fut.get();
-      });
+  for (auto fut : futVec) {
+    EXPECT_TRUE(fut.valid())
+      << "All futures returned from concurrent calls to Enable must be valid";
+    EXPECT_NO_THROW({ fut.get(); });
   }
 }
 }
 }
-

--- a/compendium/DeclarativeServices/test/TestComponentManagerEnabledState.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerEnabledState.cpp
@@ -20,41 +20,41 @@
 
   =============================================================================*/
 
-#include <memory>
 #include <future>
 #include <iostream>
+#include <memory>
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
 #include "../src/manager/states/CMEnabledState.hpp"
-#include "Mocks.hpp"
 #include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class CMEnabledStateTest
-  : public ::testing::Test
+class CMEnabledStateTest : public ::testing::Test
 {
 protected:
-  CMEnabledStateTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  CMEnabledStateTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
   virtual ~CMEnabledStateTest() = default;
 
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     framework.Start();
     auto fakeLogger = std::make_shared<FakeLogger>();
     auto compDesc = std::make_shared<metadata::ComponentMetadata>();
     auto mockRegistry = std::make_shared<MockComponentRegistry>();
     auto pool = std::make_shared<boost::asio::thread_pool>(1);
-    compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                         mockRegistry,
-                                                         framework.GetBundleContext(),
-                                                         fakeLogger, pool);
+    compMgr = std::make_shared<MockComponentManagerImpl>(
+      compDesc, mockRegistry, framework.GetBundleContext(), fakeLogger, pool);
   }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     compMgr.reset();
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
@@ -67,38 +67,52 @@ protected:
 TEST_F(CMEnabledStateTest, TestCtor)
 {
   EXPECT_NO_THROW({
-      std::promise<void> prom;
-      auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
-      EXPECT_TRUE(enabledState->fut.valid()) << "The future member of CMEnabledState must be valid";
-      EXPECT_EQ(enabledState->fut.wait_for(std::chrono::microseconds(1)), std::future_status::timeout) << "The future member of CMEnabledState must not be ready until the corresponding promise is set";
-      prom.set_value();
-      enabledState->fut.get();
-    });
+    std::promise<void> prom;
+    auto enabledState =
+      std::make_shared<CMEnabledState>(prom.get_future().share());
+    EXPECT_TRUE(enabledState->fut.valid())
+      << "The future member of CMEnabledState must be valid";
+    EXPECT_EQ(enabledState->fut.wait_for(std::chrono::microseconds(1)),
+              std::future_status::timeout)
+      << "The future member of CMEnabledState must not be ready until the "
+         "corresponding promise is set";
+    prom.set_value();
+    enabledState->fut.get();
+  });
 }
 
 TEST_F(CMEnabledStateTest, TestIsEnabled)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
-  EXPECT_TRUE(enabledState->IsEnabled(*compMgr)) << "CMEnabledState must always return true for IsEnabled";
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
+  EXPECT_TRUE(enabledState->IsEnabled(*compMgr))
+    << "CMEnabledState must always return true for IsEnabled";
 }
 
 TEST_F(CMEnabledStateTest, TestGetConfigurations)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
-  enabledState->configurations = { std::make_shared<MockComponentConfigurationImpl>(compMgr->GetMetadata(),
-                                                                                    framework,
-                                                                                    compMgr->GetRegistry(),
-                                                                                    compMgr->GetLogger()) };
-  auto fut = std::async(std::launch::async, [&](){
-                                              return enabledState->GetConfigurations(*compMgr);
-                                            });
-  EXPECT_NE(fut.wait_for(std::chrono::milliseconds::zero()), std::future_status::ready) << "The call to GetConfigurations must not return until the promise is set";
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
+  enabledState->configurations = {
+    std::make_shared<MockComponentConfigurationImpl>(compMgr->GetMetadata(),
+                                                     framework,
+                                                     compMgr->GetRegistry(),
+                                                     compMgr->GetLogger())
+  };
+  auto fut = std::async(std::launch::async, [&]() {
+    return enabledState->GetConfigurations(*compMgr);
+  });
+  EXPECT_NE(fut.wait_for(std::chrono::milliseconds::zero()),
+            std::future_status::ready)
+    << "The call to GetConfigurations must not return until the promise is set";
   prom.set_value();
   auto configs = fut.get();
-  EXPECT_EQ(configs.size(), 1ul) << "GetConfigurations must return the stored configuration";
-  enabledState->configurations.clear(); // remove the inserted mock configuration
+  EXPECT_EQ(configs.size(), 1ul)
+    << "GetConfigurations must return the stored configuration";
+  enabledState->configurations
+    .clear(); // remove the inserted mock configuration
 }
 
 /**
@@ -110,10 +124,13 @@ TEST_F(CMEnabledStateTest, TestGetConfigurations)
 TEST_F(CMEnabledStateTest, TestEnable)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
   compMgr->SetState(enabledState);
   auto fut = enabledState->Enable(*compMgr);
-  EXPECT_NE(fut.wait_for(std::chrono::milliseconds::zero()), std::future_status::ready) << "Future returned from Enable must not be ready until the promise is set";
+  EXPECT_NE(fut.wait_for(std::chrono::milliseconds::zero()),
+            std::future_status::ready)
+    << "Future returned from Enable must not be ready until the promise is set";
   prom.set_value();
   EXPECT_NO_THROW(fut.get());
 }
@@ -121,20 +138,22 @@ TEST_F(CMEnabledStateTest, TestEnable)
 TEST_F(CMEnabledStateTest, TestConcurrentEnable)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
   compMgr->SetState(enabledState);
   prom.set_value();
   EXPECT_TRUE(compMgr->IsEnabled());
   // Invoke "Enable" from multiple threads
   std::function<std::shared_future<void>()> func = [enabledState, this]() {
-                                                     return enabledState->Enable(*(this->compMgr));
-                                                   };
+    return enabledState->Enable(*(this->compMgr));
+  };
   std::vector<std::shared_future<void>> futVec = ConcurrentInvoke(func);
-  EXPECT_TRUE(compMgr->IsEnabled()) << "ComponentManager must still be ENABLED after concurrent calls to Enable";
+  EXPECT_TRUE(compMgr->IsEnabled()) << "ComponentManager must still be ENABLED "
+                                       "after concurrent calls to Enable";
   // check if the futures returned from concurrent invocation are all valid
-  for(auto& fut : futVec)
-  {
-    EXPECT_TRUE(fut.valid()) << "All futures returned from concurrent calls to Enable must be valid";
+  for (auto& fut : futVec) {
+    EXPECT_TRUE(fut.valid())
+      << "All futures returned from concurrent calls to Enable must be valid";
     EXPECT_NO_THROW(fut.get());
   }
 }
@@ -142,33 +161,38 @@ TEST_F(CMEnabledStateTest, TestConcurrentEnable)
 TEST_F(CMEnabledStateTest, TestDisable)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
   prom.set_value();
   compMgr->SetState(enabledState);
   EXPECT_TRUE(compMgr->IsEnabled());
   auto fut = enabledState->Disable(*compMgr);
-  EXPECT_TRUE(fut.valid()) << "A call to ComponentManager::Enable must always return a valid future";
+  EXPECT_TRUE(fut.valid())
+    << "A call to ComponentManager::Enable must always return a valid future";
   EXPECT_NO_THROW(fut.get());
-  EXPECT_FALSE(compMgr->IsEnabled()) << "ComponentManager must be DISABLED after a call to Disable";
+  EXPECT_FALSE(compMgr->IsEnabled())
+    << "ComponentManager must be DISABLED after a call to Disable";
 }
 
 TEST_F(CMEnabledStateTest, TestConcurrentDisable)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
   compMgr->SetState(enabledState);
   prom.set_value();
   EXPECT_TRUE(compMgr->IsEnabled());
   // Invoke "Disable" from multiple threads
   std::function<std::shared_future<void>()> func = [enabledState, this]() {
-                                                     return enabledState->Disable(*(this->compMgr));
-                                                   };
+    return enabledState->Disable(*(this->compMgr));
+  };
   std::vector<std::shared_future<void>> futVec = ConcurrentInvoke(func);
-  EXPECT_FALSE(compMgr->IsEnabled()) << "ComponentManager must be DISABLED after concurrent calls to Disable";
+  EXPECT_FALSE(compMgr->IsEnabled())
+    << "ComponentManager must be DISABLED after concurrent calls to Disable";
   // check if the futures returned from concurrent invocation are all valid
-  for(auto& fut : futVec)
-  {
-    EXPECT_TRUE(fut.valid()) << "All futures returned from concurrent calls to Disable must be valid";
+  for (auto& fut : futVec) {
+    EXPECT_TRUE(fut.valid())
+      << "All futures returned from concurrent calls to Disable must be valid";
     EXPECT_NO_THROW(fut.get());
   }
 }
@@ -176,18 +200,22 @@ TEST_F(CMEnabledStateTest, TestConcurrentDisable)
 TEST_F(CMEnabledStateTest, TestCreateConfigurations)
 {
   std::promise<void> prom;
-  auto enabledState = std::make_shared<CMEnabledState>(prom.get_future().share());
+  auto enabledState =
+    std::make_shared<CMEnabledState>(prom.get_future().share());
   compMgr->SetState(enabledState);
   prom.set_value();
-  EXPECT_EQ(enabledState->configurations.size(), 0ul) << "Initial number of configurations is zero";
+  EXPECT_EQ(enabledState->configurations.size(), 0ul)
+    << "Initial number of configurations is zero";
   EXPECT_NO_THROW({
-      enabledState->CreateConfigurations(compMgr->GetMetadata(),
-                                         compMgr->GetBundle(),
-                                         compMgr->GetRegistry(),
-                                         compMgr->GetLogger());
-    });
-  EXPECT_EQ(enabledState->configurations.size(), 1ul) << "Must have a configuration created after call to CreateConfigurations";
-  enabledState->configurations.clear(); // remove configs due to the call to the private method.
+    enabledState->CreateConfigurations(compMgr->GetMetadata(),
+                                       compMgr->GetBundle(),
+                                       compMgr->GetRegistry(),
+                                       compMgr->GetLogger());
+  });
+  EXPECT_EQ(enabledState->configurations.size(), 1ul)
+    << "Must have a configuration created after call to CreateConfigurations";
+  enabledState->configurations
+    .clear(); // remove configs due to the call to the private method.
 }
 }
 }

--- a/compendium/DeclarativeServices/test/TestComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerImpl.cpp
@@ -20,23 +20,23 @@
 
   =============================================================================*/
 
+#include <algorithm>
 #include <cstdio>
 #include <iostream>
-#include <algorithm>
 #include <random>
 
 #include "cppmicroservices/Any.h"
+#include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/Framework.h"
 #include "cppmicroservices/FrameworkEvent.h"
 #include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/BundleContext.h"
 
 #include "../src/manager/ComponentManagerImpl.hpp"
 #include "../src/manager/states/ComponentManagerState.hpp"
 #include "../src/metadata/ComponentMetadata.hpp"
 
-#include "Mocks.hpp"
 #include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
 
 using cppmicroservices::Any;
 using cppmicroservices::Bundle;
@@ -94,22 +94,26 @@ TEST(ComponentManagerImplTest, Ctor)
 }
 
 // The fixture for testing class ComponentManagerImpl.
-class ComponentManagerImplParameterizedTest : public ::testing::TestWithParam<std::shared_ptr<metadata::ComponentMetadata>> {
+class ComponentManagerImplParameterizedTest
+  : public ::testing::TestWithParam<
+      std::shared_ptr<metadata::ComponentMetadata>>
+{
 protected:
   ComponentManagerImplParameterizedTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {
-  }
+  {}
 
   virtual ~ComponentManagerImplParameterizedTest() = default;
 
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     framework.Start();
     fakeLogger = std::make_shared<FakeLogger>();
     mockRegistry = std::make_shared<MockComponentRegistry>();
   }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     fakeLogger.reset();
     mockRegistry.reset();
     framework.Stop();
@@ -124,101 +128,126 @@ protected:
 TEST_P(ComponentManagerImplParameterizedTest, VerifyInitialize)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<ComponentManagerImpl>(compDesc,
-                                                        mockRegistry,
-                                                        framework.GetBundleContext(),
-                                                        fakeLogger, std::make_shared<boost::asio::thread_pool>(1));
-  EXPECT_EQ(compMgr->IsEnabled(), false) << "Illegal state before Initialization";
+  auto compMgr = std::make_shared<ComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
+    fakeLogger,
+    std::make_shared<boost::asio::thread_pool>(1));
+  EXPECT_EQ(compMgr->IsEnabled(), false)
+    << "Illegal state before Initialization";
   compMgr->Initialize();
-  EXPECT_EQ(compMgr->IsEnabled(), compMgr->GetMetadata()->enabled) << "Illegal state after Initialization";
+  EXPECT_EQ(compMgr->IsEnabled(), compMgr->GetMetadata()->enabled)
+    << "Illegal state after Initialization";
 }
 
 TEST_P(ComponentManagerImplParameterizedTest, VerifyEnable)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<ComponentManagerImpl>(compDesc,
-                                                        mockRegistry,
-                                                        framework.GetBundleContext(),
+  auto compMgr = std::make_shared<ComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
   EXPECT_NO_THROW({
-      compMgr->Initialize();
-      compMgr->Enable();
-      EXPECT_EQ(compMgr->IsEnabled(), true) << "State expected to be ENABLED";
-      compMgr->Enable(); // enabling an already enabled component results in no state change
-      EXPECT_EQ(compMgr->IsEnabled(), true) << "State expected to stay as ENABLED";
-    });
+    compMgr->Initialize();
+    compMgr->Enable();
+    EXPECT_EQ(compMgr->IsEnabled(), true) << "State expected to be ENABLED";
+    compMgr
+      ->Enable(); // enabling an already enabled component results in no state change
+    EXPECT_EQ(compMgr->IsEnabled(), true)
+      << "State expected to stay as ENABLED";
+  });
 }
 
 TEST_P(ComponentManagerImplParameterizedTest, VerifyDisable)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<ComponentManagerImpl>(compDesc,
-                                                        mockRegistry,
-                                                        framework.GetBundleContext(),
+  auto compMgr = std::make_shared<ComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
   EXPECT_NO_THROW({
-      compMgr->Initialize();
-      compMgr->Disable();
-      EXPECT_EQ(compMgr->IsEnabled(), false) << "State expected to be DISABLED";
-      compMgr->Disable(); // Disabling an already disabled component results in no state change
-      EXPECT_EQ(compMgr->IsEnabled(), false) << "State expected to stay as DISABLED";
-    });
+    compMgr->Initialize();
+    compMgr->Disable();
+    EXPECT_EQ(compMgr->IsEnabled(), false) << "State expected to be DISABLED";
+    compMgr
+      ->Disable(); // Disabling an already disabled component results in no state change
+    EXPECT_EQ(compMgr->IsEnabled(), false)
+      << "State expected to stay as DISABLED";
+  });
 }
 
 TEST_P(ComponentManagerImplParameterizedTest, VerifyStateChangeCount)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
-                                                            fakeLogger, std::make_shared<boost::asio::thread_pool>(1));
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
+    fakeLogger,
+    std::make_shared<boost::asio::thread_pool>(1));
   EXPECT_NO_THROW({
-      compMgr->Initialize();
-      compMgr->ResetCounter();
-      auto wasEnabled = compMgr->IsEnabled();
-      compMgr->Disable();
-      EXPECT_EQ(compMgr->statechangecount, wasEnabled ? 1 : 0) << "Unexpected number of state changes during a call to Disable a ComponentManager";
-      EXPECT_EQ(compMgr->IsEnabled(), false) << "ComponentManager must be in DISABLED state after a call to Disable";
-    });
+    compMgr->Initialize();
+    compMgr->ResetCounter();
+    auto wasEnabled = compMgr->IsEnabled();
+    compMgr->Disable();
+    EXPECT_EQ(compMgr->statechangecount, wasEnabled ? 1 : 0)
+      << "Unexpected number of state changes during a call to Disable a "
+         "ComponentManager";
+    EXPECT_EQ(compMgr->IsEnabled(), false)
+      << "ComponentManager must be in DISABLED state after a call to Disable";
+  });
 }
 
 TEST_P(ComponentManagerImplParameterizedTest, VerifySequentialStateChange)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
   EXPECT_NO_THROW({
-
-      auto prevState = compMgr->IsEnabled();
-      compMgr->Initialize();
-      // Initialize will swicth to enabled only if "enabled" is set in the comp description
-      // two atomic swaps per state change.
-      EXPECT_EQ(compMgr->statechangecount, compMgr->GetMetadata()->enabled ? 1 : 0) << "Unexpected number of state changes during a call to Initialize a ComponentManager";
-      prevState = compMgr->IsEnabled();
-      compMgr->ResetCounter();
-      compMgr->Disable();
-      EXPECT_EQ(compMgr->IsEnabled(), false) << "ComponentManager must be in DISABLED state after a call to Disable";
-      EXPECT_EQ(compMgr->statechangecount, prevState ? 1 : 0) << "Unexpected number of state changes during a call to Disable a ComponentManager";
-      compMgr->ResetCounter();
-      prevState = compMgr->IsEnabled();
-      compMgr->Enable();
-      EXPECT_EQ(compMgr->statechangecount, !prevState ? 1 : 0) << "Unexpected number of state changes during a call to Enable a ComponentManager";
-      EXPECT_EQ(compMgr->IsEnabled(), true) << "ComponentManager must be in ENABLED state after a call to Enable";
-      compMgr->ResetCounter();
-    });
+    auto prevState = compMgr->IsEnabled();
+    compMgr->Initialize();
+    // Initialize will swicth to enabled only if "enabled" is set in the comp description
+    // two atomic swaps per state change.
+    EXPECT_EQ(compMgr->statechangecount,
+              compMgr->GetMetadata()->enabled ? 1 : 0)
+      << "Unexpected number of state changes during a call to Initialize a "
+         "ComponentManager";
+    prevState = compMgr->IsEnabled();
+    compMgr->ResetCounter();
+    compMgr->Disable();
+    EXPECT_EQ(compMgr->IsEnabled(), false)
+      << "ComponentManager must be in DISABLED state after a call to Disable";
+    EXPECT_EQ(compMgr->statechangecount, prevState ? 1 : 0)
+      << "Unexpected number of state changes during a call to Disable a "
+         "ComponentManager";
+    compMgr->ResetCounter();
+    prevState = compMgr->IsEnabled();
+    compMgr->Enable();
+    EXPECT_EQ(compMgr->statechangecount, !prevState ? 1 : 0)
+      << "Unexpected number of state changes during a call to Enable a "
+         "ComponentManager";
+    EXPECT_EQ(compMgr->IsEnabled(), true)
+      << "ComponentManager must be in ENABLED state after a call to Enable";
+    compMgr->ResetCounter();
+  });
 }
 
 TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentEnable)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
 
@@ -228,16 +257,19 @@ TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentEnable)
 
   // test concurrent calls to "enable" from multiple threads
   std::function<std::shared_future<void>()> func = [compMgr]() {
-                                                     return compMgr->Enable();
-                                                   };
+    return compMgr->Enable();
+  };
   std::vector<std::shared_future<void>> results = ConcurrentInvoke(func);
 
   // verify component manager is disabled and the manager has performed two atomic state change operations for the disable operation.
-  EXPECT_EQ(compMgr->IsEnabled(), true) << "ComponentManager must be in ENABLED state after a call to Enable";
-  EXPECT_EQ(compMgr->statechangecount, 1) << "Unexpected number of state changes after concurrent calls to Enable a ComponentManager";
-  for(auto& fut : results)
-  {
-    EXPECT_EQ(fut.valid(), true) << "A valid future is expected as a return value from ComponentManager::Enable";
+  EXPECT_EQ(compMgr->IsEnabled(), true)
+    << "ComponentManager must be in ENABLED state after a call to Enable";
+  EXPECT_EQ(compMgr->statechangecount, 1)
+    << "Unexpected number of state changes after concurrent calls to Enable a "
+       "ComponentManager";
+  for (auto& fut : results) {
+    EXPECT_EQ(fut.valid(), true) << "A valid future is expected as a return "
+                                    "value from ComponentManager::Enable";
     fut.wait();
   }
 }
@@ -245,9 +277,10 @@ TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentEnable)
 TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentDisable)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
 
@@ -257,16 +290,19 @@ TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentDisable)
 
   // test concurrent calls to "disable" from multiple threads
   std::function<std::shared_future<void>()> func = [compMgr]() {
-                                                     return compMgr->Disable();
-                                                   };
+    return compMgr->Disable();
+  };
   std::vector<std::shared_future<void>> results = ConcurrentInvoke(func);
 
   // verify component manager is disabled and the manager has performed two atomic state change operations for the disable operation.
-  EXPECT_EQ(compMgr->IsEnabled(), false) << "ComponentManager must be in DISABLED state after a call to Disable";
-  EXPECT_EQ(compMgr->statechangecount, 1) << "Unexpected number of state changes after concurrent calls to Disable a ComponentManager";
-  for(auto& fut : results)
-  {
-    EXPECT_EQ(fut.valid(), true) << "A valid future is expected as a return value from ComponentManager::Disable";
+  EXPECT_EQ(compMgr->IsEnabled(), false)
+    << "ComponentManager must be in DISABLED state after a call to Disable";
+  EXPECT_EQ(compMgr->statechangecount, 1)
+    << "Unexpected number of state changes after concurrent calls to Disable a "
+       "ComponentManager";
+  for (auto& fut : results) {
+    EXPECT_EQ(fut.valid(), true) << "A valid future is expected as a return "
+                                    "value from ComponentManager::Disable";
     fut.wait();
   }
 }
@@ -274,29 +310,28 @@ TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentDisable)
 TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentEnableDisable)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
   compMgr->Initialize();
   // test concurrent calls to enable and disable from multiple threads
   std::function<std::shared_future<void>()> func = [compMgr]() mutable {
-                                                     std::vector<std::shared_future<void>> futVec;
-                                                     std::random_device rd;
-                                                     std::mt19937 gen(rd());
-                                                     std::uniform_int_distribution<unsigned int> dis(20,50);
-                                                     int randVal = dis(gen); // random number in range [20, 50)
-                                                     for(int i =0; i < randVal; ++i)
-                                                     {
-                                                       futVec.push_back(((i & 0x1) ? compMgr->Disable() : compMgr->Enable()));
-                                                     }
-                                                     return futVec.back();
-                                                   };
+    std::vector<std::shared_future<void>> futVec;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<unsigned int> dis(20, 50);
+    int randVal = dis(gen); // random number in range [20, 50)
+    for (int i = 0; i < randVal; ++i) {
+      futVec.push_back(((i & 0x1) ? compMgr->Disable() : compMgr->Enable()));
+    }
+    return futVec.back();
+  };
   std::vector<std::shared_future<void>> results = ConcurrentInvoke(func);
 
-  for(auto& fut : results)
-  {
+  for (auto& fut : results) {
     EXPECT_EQ(fut.valid(), true);
     fut.get();
   }
@@ -305,13 +340,16 @@ TEST_P(ComponentManagerImplParameterizedTest, VerifyConcurrentEnableDisable)
 TEST_P(ComponentManagerImplParameterizedTest, TestAccumulateFutures)
 {
   auto compDesc = GetParam();
-  auto compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
-                                                            mockRegistry,
-                                                            framework.GetBundleContext(),
+  auto compMgr = std::make_shared<MockComponentManagerImpl>(
+    compDesc,
+    mockRegistry,
+    framework.GetBundleContext(),
     fakeLogger,
     std::make_shared<boost::asio::thread_pool>(1));
 
-  EXPECT_EQ(compMgr->disableFutures.size(), 0ul) << "Disabled futures list must be empty before any calls to AccumulateFuture method";
+  EXPECT_EQ(compMgr->disableFutures.size(), 0ul)
+    << "Disabled futures list must be empty before any calls to "
+       "AccumulateFuture method";
   std::promise<void> p1;
   compMgr->AccumulateFuture(p1.get_future().share());
   EXPECT_EQ(compMgr->disableFutures.size(), 1ul);
@@ -337,8 +375,9 @@ TEST_P(ComponentManagerImplParameterizedTest, TestAccumulateFutures)
 /**
  * Util method to create component descriptions used for parametrized tests for ComponentManagerImpl
  */
-std::shared_ptr<metadata::ComponentMetadata> CreateComponentMetadata(const std::string& implClassName,
-                                                                     bool defaultEnabled)
+std::shared_ptr<metadata::ComponentMetadata> CreateComponentMetadata(
+  const std::string& implClassName,
+  bool defaultEnabled)
 {
   auto compDesc = std::make_shared<metadata::ComponentMetadata>();
   compDesc->name = compDesc->implClassName = implClassName;
@@ -347,9 +386,10 @@ std::shared_ptr<metadata::ComponentMetadata> CreateComponentMetadata(const std::
   return compDesc;
 }
 
-INSTANTIATE_TEST_SUITE_P(ComponentManagerParameterized, ComponentManagerImplParameterizedTest,
-                        testing::Values(CreateComponentMetadata("foo", false)/* default disabled */,
-                                        CreateComponentMetadata("bar", true) /* default enabled */));
+INSTANTIATE_TEST_SUITE_P(
+  ComponentManagerParameterized,
+  ComponentManagerImplParameterizedTest,
+  testing::Values(CreateComponentMetadata("foo", false) /* default disabled */,
+                  CreateComponentMetadata("bar", true) /* default enabled */));
 }
 }
-

--- a/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
@@ -20,24 +20,24 @@
 
   =============================================================================*/
 
-#include <chrono>
-#include <algorithm>
-#include <vector>
-#include <memory>
-#include <random>
-#include "gmock/gmock.h"
-#include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
-#include <cppmicroservices/FrameworkEvent.h>
-#include <cppmicroservices/BundleContext.h>
 #include "../src/ComponentRegistry.hpp"
-#include "../src/manager/ComponentManager.hpp"
 #include "../src/manager/ComponentConfiguration.hpp"
+#include "../src/manager/ComponentManager.hpp"
 #include "../src/metadata/ComponentMetadata.hpp"
 #include "Mocks.hpp"
+#include "gmock/gmock.h"
+#include <algorithm>
+#include <chrono>
+#include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
+#include <memory>
+#include <random>
+#include <vector>
 using cppmicroservices::Bundle;
-using cppmicroservices::scrimpl::ComponentManager;
 using cppmicroservices::scrimpl::ComponentConfiguration;
+using cppmicroservices::scrimpl::ComponentManager;
 using cppmicroservices::scrimpl::ComponentRegistry;
 using cppmicroservices::scrimpl::metadata::ComponentMetadata;
 
@@ -54,14 +54,15 @@ std::string GenRandomString()
   return tempName;
 }
 
-class FakeComponentManager
-  : public ComponentManager
+class FakeComponentManager : public ComponentManager
 {
 public:
-  FakeComponentManager() : ComponentManager()
-                         ,mBundleId(++id)
-                         ,mName(GenRandomString()) { }
-  ~FakeComponentManager() {};
+  FakeComponentManager()
+    : ComponentManager()
+    , mBundleId(++id)
+    , mName(GenRandomString())
+  {}
+  ~FakeComponentManager(){};
   unsigned long GetBundleId() const override { return mBundleId; }
   std::string GetName() const override { return mName; }
   MOCK_CONST_METHOD0(GetBundle, Bundle(void));
@@ -69,8 +70,12 @@ public:
   MOCK_CONST_METHOD0(IsEnabled, bool(void));
   MOCK_METHOD0(Enable, std::shared_future<void>(void));
   MOCK_METHOD0(Disable, std::shared_future<void>(void));
-  MOCK_CONST_METHOD0(GetComponentConfigurations,std::vector<std::shared_ptr<ComponentConfiguration>>(void));
-  MOCK_CONST_METHOD0(GetMetadata, std::shared_ptr<const ComponentMetadata>(void));
+  MOCK_CONST_METHOD0(
+    GetComponentConfigurations,
+    std::vector<std::shared_ptr<ComponentConfiguration>>(void));
+  MOCK_CONST_METHOD0(GetMetadata,
+                     std::shared_ptr<const ComponentMetadata>(void));
+
 private:
   long mBundleId;
   std::string mName;
@@ -80,14 +85,13 @@ private:
 std::atomic<long> FakeComponentManager::id(0);
 
 // The fixture for testing class ComponentRegistry.
-class ComponentRegistryTest
-  : public ::testing::Test
+class ComponentRegistryTest : public ::testing::Test
 {
 protected:
   ComponentRegistryTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
     , registry(std::make_shared<ComponentRegistry>())
-  { }
+  {}
   virtual ~ComponentRegistryTest() = default;
 
   virtual void SetUp()
@@ -106,6 +110,7 @@ protected:
 
   cppmicroservices::Framework& GetFramework() { return framework; }
   std::shared_ptr<ComponentRegistry> GetRegistry() { return registry; }
+
 private:
   cppmicroservices::Framework framework;
   std::shared_ptr<ComponentRegistry> registry;
@@ -115,8 +120,12 @@ TEST_F(ComponentRegistryTest, VerifyAddComponentManager)
 {
   auto registry = GetRegistry();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr, GetBundleId()).Times(1).WillOnce(testing::Return(121));
-  EXPECT_CALL(*mockCompMgr, GetName()).Times(1).WillOnce(testing::Return(std::string("Foo")));
+  EXPECT_CALL(*mockCompMgr, GetBundleId())
+    .Times(1)
+    .WillOnce(testing::Return(121));
+  EXPECT_CALL(*mockCompMgr, GetName())
+    .Times(1)
+    .WillOnce(testing::Return(std::string("Foo")));
   EXPECT_EQ(registry->Count(), 0ul);
   registry->AddComponentManager(mockCompMgr);
   EXPECT_EQ(registry->Count(), 1ul);
@@ -126,14 +135,26 @@ TEST_F(ComponentRegistryTest, VerifyGetComponentManager)
 {
   auto registry = GetRegistry();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr, GetBundleId()).Times(1).WillOnce(testing::Return(121));
-  EXPECT_CALL(*mockCompMgr, GetName()).Times(1).WillOnce(testing::Return(std::string("Foo")));
+  EXPECT_CALL(*mockCompMgr, GetBundleId())
+    .Times(1)
+    .WillOnce(testing::Return(121));
+  EXPECT_CALL(*mockCompMgr, GetName())
+    .Times(1)
+    .WillOnce(testing::Return(std::string("Foo")));
   auto mockCompMgr1 = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr1, GetBundleId()).Times(1).WillOnce(testing::Return(121));
-  EXPECT_CALL(*mockCompMgr1, GetName()).Times(1).WillOnce(testing::Return(std::string("Bar")));
+  EXPECT_CALL(*mockCompMgr1, GetBundleId())
+    .Times(1)
+    .WillOnce(testing::Return(121));
+  EXPECT_CALL(*mockCompMgr1, GetName())
+    .Times(1)
+    .WillOnce(testing::Return(std::string("Bar")));
   auto mockCompMgr2 = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr2, GetBundleId()).Times(1).WillOnce(testing::Return(122));
-  EXPECT_CALL(*mockCompMgr2, GetName()).Times(1).WillOnce(testing::Return(std::string("Foo")));
+  EXPECT_CALL(*mockCompMgr2, GetBundleId())
+    .Times(1)
+    .WillOnce(testing::Return(122));
+  EXPECT_CALL(*mockCompMgr2, GetName())
+    .Times(1)
+    .WillOnce(testing::Return(std::string("Foo")));
   EXPECT_EQ(registry->Count(), 0ul);
   registry->AddComponentManager(mockCompMgr);
   registry->AddComponentManager(mockCompMgr1);
@@ -148,8 +169,12 @@ TEST_F(ComponentRegistryTest, VerifyRemoveComponentManager)
 {
   auto registry = GetRegistry();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr, GetBundleId()).Times(2).WillRepeatedly(testing::Return(121));
-  EXPECT_CALL(*mockCompMgr, GetName()).Times(2).WillRepeatedly(testing::Return(std::string("Foo")));
+  EXPECT_CALL(*mockCompMgr, GetBundleId())
+    .Times(2)
+    .WillRepeatedly(testing::Return(121));
+  EXPECT_CALL(*mockCompMgr, GetName())
+    .Times(2)
+    .WillRepeatedly(testing::Return(std::string("Foo")));
   registry->AddComponentManager(mockCompMgr);
   EXPECT_EQ(registry->Count(), 1ul);
   registry->RemoveComponentManager(mockCompMgr);
@@ -160,8 +185,12 @@ TEST_F(ComponentRegistryTest, VerifyRemoveComponentManagerByIdName)
 {
   auto registry = GetRegistry();
   auto mockCompMgr = std::make_shared<MockComponentManager>();
-  EXPECT_CALL(*mockCompMgr, GetBundleId()).Times(1).WillOnce(testing::Return(121));
-  EXPECT_CALL(*mockCompMgr, GetName()).Times(1).WillOnce(testing::Return(std::string("Foo")));
+  EXPECT_CALL(*mockCompMgr, GetBundleId())
+    .Times(1)
+    .WillOnce(testing::Return(121));
+  EXPECT_CALL(*mockCompMgr, GetName())
+    .Times(1)
+    .WillOnce(testing::Return(std::string("Foo")));
   registry->AddComponentManager(mockCompMgr);
   EXPECT_EQ(registry->Count(), 1ul);
   registry->RemoveComponentManager(121, "Foo");
@@ -174,84 +203,78 @@ TEST_F(ComponentRegistryTest, VerifyConcurrentAddsRemoves)
   size_t expected_count(0);
   std::set<std::pair<long, std::string>> randomComps;
   std::mutex compNameMutex; // protects changes to randomComps & expected_count
-      
+
   {
     std::promise<void> go;
-    try
-    { // Add Elements concurrently
+    try { // Add Elements concurrently
       std::shared_future<void> ready(go.get_future());
       std::size_t numCalls = 20;
       std::vector<std::promise<void>> readies(numCalls);
       std::vector<std::future<void>> registry_adds(numCalls);
-      for(std::size_t i =0; i<numCalls; i++)
-      {
-        registry_adds[i] = std::async(std::launch::async,
-                                      [registry, ready, &readies, i, &expected_count, &compNameMutex, &randomComps]()
-                                      {
-                                        readies[i].set_value();
-                                        std::shared_ptr<ComponentManager> cm(std::make_shared<FakeComponentManager>());
-                                        ready.wait();
-                                        if(registry->AddComponentManager(cm))
-                                        {
-                                          std::lock_guard<std::mutex> lock(compNameMutex);
-                                          randomComps.insert(std::make_pair(cm->GetBundleId(),cm->GetName()));
-                                          expected_count++;
-                                        }
-                                      });
+      for (std::size_t i = 0; i < numCalls; i++) {
+        registry_adds[i] =
+          std::async(std::launch::async,
+                     [registry,
+                      ready,
+                      &readies,
+                      i,
+                      &expected_count,
+                      &compNameMutex,
+                      &randomComps]() {
+                       readies[i].set_value();
+                       std::shared_ptr<ComponentManager> cm(
+                         std::make_shared<FakeComponentManager>());
+                       ready.wait();
+                       if (registry->AddComponentManager(cm)) {
+                         std::lock_guard<std::mutex> lock(compNameMutex);
+                         randomComps.insert(
+                           std::make_pair(cm->GetBundleId(), cm->GetName()));
+                         expected_count++;
+                       }
+                     });
       }
 
-      for(std::size_t i =0; i< numCalls; i++)
-      {
+      for (std::size_t i = 0; i < numCalls; i++) {
         readies[i].get_future().wait();
       }
 
       go.set_value();
 
-      for(std::size_t i =0; i< numCalls; i++)
-      {
+      for (std::size_t i = 0; i < numCalls; i++) {
         registry_adds[i].get();
       }
-    }
-    catch(...)
-    {
+    } catch (...) {
       go.set_value();
       throw;
     }
 
     std::promise<void> go2;
-    try
-    { // Remove elements concurrently
+    try { // Remove elements concurrently
       std::shared_future<void> ready2(go2.get_future());
       std::size_t numCalls = randomComps.size();
       std::vector<std::promise<void>> readies2(numCalls);
       std::vector<std::future<void>> registry_removes(numCalls);
-      std::size_t i =0;
-      for(auto pair : randomComps)
-      {
-        registry_removes[i] = std::async(std::launch::async,
-                                         [registry, ready2, &readies2, i, pair]()
-                                         {
-                                           readies2[i].set_value();
-                                           ready2.wait();
-                                           registry->RemoveComponentManager(pair.first, pair.second);
-                                         });
+      std::size_t i = 0;
+      for (auto pair : randomComps) {
+        registry_removes[i] = std::async(
+          std::launch::async, [registry, ready2, &readies2, i, pair]() {
+            readies2[i].set_value();
+            ready2.wait();
+            registry->RemoveComponentManager(pair.first, pair.second);
+          });
         i++;
       }
-      for(std::size_t i =0; i< numCalls; i++)
-      {
+      for (std::size_t i = 0; i < numCalls; i++) {
         readies2[i].get_future().wait();
       }
 
       go2.set_value();
 
-      for(std::size_t i =0; i< numCalls; i++)
-      {
+      for (std::size_t i = 0; i < numCalls; i++) {
         registry_removes[i].get();
       }
       EXPECT_EQ(registry->Count(), 0ul);
-    }
-    catch(...)
-    {
+    } catch (...) {
       go2.set_value();
       throw;
     }

--- a/compendium/DeclarativeServices/test/TestDictionary.cpp
+++ b/compendium/DeclarativeServices/test/TestDictionary.cpp
@@ -20,81 +20,82 @@
 
 =============================================================================*/
 
-#include "gtest/gtest.h"
-#include "cppmicroservices/Constants.h"
-#include "cppmicroservices/ServiceEvent.h"
-#include "TestFixture.hpp"
-#include "TestUtils.hpp"
 #include "IDictionaryService/IDictionaryService.hpp"
 #include "ISpellCheckService/ISpellCheckService.hpp"
+#include "TestFixture.hpp"
+#include "TestUtils.hpp"
+#include "cppmicroservices/Constants.h"
+#include "cppmicroservices/ServiceEvent.h"
+#include "gtest/gtest.h"
 
-namespace test
-{
+namespace test {
 
-  /**
+/**
    * Verify Spellcheck service works as expected with a Dictionary service from a
    * DS bundle and a non-DS bundle
    */
-  TEST_F(tServiceComponent, DISABLED_testDictionaryExample) //DS_TOI_50
-  {
+TEST_F(tServiceComponent, DISABLED_testDictionaryExample) //DS_TOI_50
+{
 
-    auto ctxt = framework.GetBundleContext();
+  auto ctxt = framework.GetBundleContext();
 
-    // try DS spellchecker with DS dictionary
-    EXPECT_TRUE(ctxt.GetServiceReferences<test::IDictionaryService>().empty());
-    auto frenchDictDSBundle = StartTestBundle("DSFrenchDictionary");
-    EXPECT_EQ(ctxt.GetServiceReferences<test::IDictionaryService>().size(), 1ul);
-    EXPECT_TRUE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
-    auto spellcheckerBundle = StartTestBundle("DSSpellChecker");
-    EXPECT_FALSE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
-    auto spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
-    auto service = ctxt.GetService<test::ISpellCheckService>(spellCheckRef);
-    ASSERT_NE(service, nullptr);
-    auto spellCheckServiceId = GetServiceId(spellCheckRef);
-    EXPECT_TRUE(service->Check("bienvenue au tutoriel micro services").empty());
-    EXPECT_FALSE(service->Check("bienvenue au tutoriel microservices").empty());
-    EXPECT_TRUE(service->Check("bienvenue au").empty()); // verify partial string
+  // try DS spellchecker with DS dictionary
+  EXPECT_TRUE(ctxt.GetServiceReferences<test::IDictionaryService>().empty());
+  auto frenchDictDSBundle = StartTestBundle("DSFrenchDictionary");
+  EXPECT_EQ(ctxt.GetServiceReferences<test::IDictionaryService>().size(), 1ul);
+  EXPECT_TRUE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
+  auto spellcheckerBundle = StartTestBundle("DSSpellChecker");
+  EXPECT_FALSE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
+  auto spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
+  auto service = ctxt.GetService<test::ISpellCheckService>(spellCheckRef);
+  ASSERT_NE(service, nullptr);
+  auto spellCheckServiceId = GetServiceId(spellCheckRef);
+  EXPECT_TRUE(service->Check("bienvenue au tutoriel micro services").empty());
+  EXPECT_FALSE(service->Check("bienvenue au tutoriel microservices").empty());
+  EXPECT_TRUE(service->Check("bienvenue au").empty()); // verify partial string
 
-    // register service listener and wait for SERVICE_UNREGISTERING event for SpellCheck service
-    std::mutex mtx;
-    std::condition_variable cv;
-    auto token = ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
-      if((evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_UNREGISTERING) &&
-         (spellCheckServiceId == GetServiceId(evt.GetServiceReference())))
-      {
+  // register service listener and wait for SERVICE_UNREGISTERING event for SpellCheck service
+  std::mutex mtx;
+  std::condition_variable cv;
+  auto token =
+    ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
+      if ((evt.GetType() ==
+           cppmicroservices::ServiceEvent::SERVICE_UNREGISTERING) &&
+          (spellCheckServiceId == GetServiceId(evt.GetServiceReference()))) {
         std::unique_lock<std::mutex> lk(mtx);
         cv.notify_all();
       }
     });
-    frenchDictDSBundle.Stop(); // remove the dependency for spellchecker
-    {
-      std::unique_lock<std::mutex> lk(mtx);
-      bool result = cv.wait_for(lk, std::chrono::milliseconds(30000), [&ctxt]() -> bool {
-        return static_cast<bool>(ctxt.GetServiceReference<test::ISpellCheckService>()) == false;
+  frenchDictDSBundle.Stop(); // remove the dependency for spellchecker
+  {
+    std::unique_lock<std::mutex> lk(mtx);
+    bool result =
+      cv.wait_for(lk, std::chrono::milliseconds(30000), [&ctxt]() -> bool {
+        return static_cast<bool>(
+                 ctxt.GetServiceReference<test::ISpellCheckService>()) == false;
       });
-      ctxt.RemoveListener(std::move(token));
-      ASSERT_TRUE(result);
-      EXPECT_TRUE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
-      spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
-      EXPECT_FALSE(static_cast<bool>(spellCheckRef));
-    }
-
-    spellcheckerBundle.Stop();
-
-
-    // try the DS spell checker with a non-DS dictionary
-    spellcheckerBundle.Start(); // restart the bundle to re-use it, since the
-                                // default binding policy is static reluctant.
+    ctxt.RemoveListener(std::move(token));
+    ASSERT_TRUE(result);
     EXPECT_TRUE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
-    EXPECT_TRUE(ctxt.GetServiceReferences<test::IDictionaryService>().empty());
+    spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
+    EXPECT_FALSE(static_cast<bool>(spellCheckRef));
+  }
 
-    // register service listener and wait for SERVICE_REGISTERED event for SpellCheck service
-    std::mutex mtx1;
-    std::condition_variable cv1;
-    auto token1 = ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
-      if(evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_REGISTERED &&
-         evt.GetServiceReference().GetBundle() == spellcheckerBundle)
-      {
+  spellcheckerBundle.Stop();
+
+  // try the DS spell checker with a non-DS dictionary
+  spellcheckerBundle.Start(); // restart the bundle to re-use it, since the
+                              // default binding policy is static reluctant.
+  EXPECT_TRUE(ctxt.GetServiceReferences<test::ISpellCheckService>().empty());
+  EXPECT_TRUE(ctxt.GetServiceReferences<test::IDictionaryService>().empty());
+
+  // register service listener and wait for SERVICE_REGISTERED event for SpellCheck service
+  std::mutex mtx1;
+  std::condition_variable cv1;
+  auto token1 =
+    ctxt.AddServiceListener([&](const cppmicroservices::ServiceEvent& evt) {
+      if (evt.GetType() == cppmicroservices::ServiceEvent::SERVICE_REGISTERED &&
+          evt.GetServiceReference().GetBundle() == spellcheckerBundle) {
         {
           std::unique_lock<std::mutex> lk(mtx1);
         }
@@ -102,26 +103,30 @@ namespace test
       }
     });
 
-    auto englishDictDSBundle = StartTestBundle("EnglishDictionary");
-    EXPECT_EQ(ctxt.GetServiceReferences<test::IDictionaryService>().size(), 1ul);
-    {
-      std::unique_lock<std::mutex> lk(mtx1);
-      auto result = cv1.wait_for(lk, std::chrono::milliseconds(30000), [&ctxt]() -> bool {
-        return static_cast<bool>(ctxt.GetServiceReference<test::ISpellCheckService>());
+  auto englishDictDSBundle = StartTestBundle("EnglishDictionary");
+  EXPECT_EQ(ctxt.GetServiceReferences<test::IDictionaryService>().size(), 1ul);
+  {
+    std::unique_lock<std::mutex> lk(mtx1);
+    auto result =
+      cv1.wait_for(lk, std::chrono::milliseconds(30000), [&ctxt]() -> bool {
+        return static_cast<bool>(
+          ctxt.GetServiceReference<test::ISpellCheckService>());
       });
-      ctxt.RemoveListener(std::move(token1));
-      ASSERT_TRUE(result);
-      spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
-      ASSERT_TRUE(static_cast<bool>(spellCheckRef));
-      service = ctxt.GetService<test::ISpellCheckService>(spellCheckRef);
-    }
-
-    ASSERT_NE(service, nullptr);
-    EXPECT_TRUE(service->Check("welcome to micro services tutorial").empty());
-    auto misspelledWords = service->Check("welcome to microservices tutorial page");
-    EXPECT_FALSE(misspelledWords.empty());
-    auto expectedWords = { "microservices", "page" };
-    EXPECT_TRUE(std::equal(misspelledWords.begin(), misspelledWords.end(), expectedWords.begin()));
-    EXPECT_TRUE(service->Check("welcome micro").empty()); // verify partial string
+    ctxt.RemoveListener(std::move(token1));
+    ASSERT_TRUE(result);
+    spellCheckRef = ctxt.GetServiceReference<test::ISpellCheckService>();
+    ASSERT_TRUE(static_cast<bool>(spellCheckRef));
+    service = ctxt.GetService<test::ISpellCheckService>(spellCheckRef);
   }
+
+  ASSERT_NE(service, nullptr);
+  EXPECT_TRUE(service->Check("welcome to micro services tutorial").empty());
+  auto misspelledWords =
+    service->Check("welcome to microservices tutorial page");
+  EXPECT_FALSE(misspelledWords.empty());
+  auto expectedWords = { "microservices", "page" };
+  EXPECT_TRUE(std::equal(
+    misspelledWords.begin(), misspelledWords.end(), expectedWords.begin()));
+  EXPECT_TRUE(service->Check("welcome micro").empty()); // verify partial string
+}
 }

--- a/compendium/DeclarativeServices/test/TestFixture.hpp
+++ b/compendium/DeclarativeServices/test/TestFixture.hpp
@@ -26,21 +26,20 @@
 #include "gtest/gtest.h"
 
 #include <cppmicroservices/Bundle.h>
-#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/Framework.h>
 #include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/FrameworkFactory.h>
 
-#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
 #include "TestUtils.hpp"
 
 namespace test {
 
 namespace scr = cppmicroservices::service::component::runtime;
-  
 
 /**
  * Test Fixture used for several test points. The setup method installs and starts
@@ -48,16 +47,14 @@ namespace scr = cppmicroservices::service::component::runtime;
  * test bundles.
  * This class also provides convenience methods to start a specific test bundle 
  */
-class tServiceComponent
-  : public testing::Test
+class tServiceComponent : public testing::Test
 {
 public:
   tServiceComponent()
     : ::testing::Test()
     , framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {
-  }
-  
+  {}
+
   void SetUp() override
   {
     framework.Start();
@@ -66,11 +63,10 @@ public:
 #if defined(US_BUILD_SHARED_LIBS)
     auto dsPluginPath = test::GetDSRuntimePluginFilePath();
     auto dsbundles = context.InstallBundles(dsPluginPath);
-    for (auto& bundle : dsbundles)
-    {
+    for (auto& bundle : dsbundles) {
       bundle.Start();
     }
-    
+
     test::InstallLib(context, "DSFrenchDictionary");
     test::InstallLib(context, "EnglishDictionary");
     test::InstallLib(context, "TestBundleDSTOI1");
@@ -90,11 +86,11 @@ public:
 #endif
 
 #ifndef US_BUILD_SHARED_LIBS
-    auto dsbundles= context.GetBundles();
-    for (auto& bundle : dsbundles)
-    {
-      try { bundle.Start(); }
-      catch (std::exception& e) {
+    auto dsbundles = context.GetBundles();
+    for (auto& bundle : dsbundles) {
+      try {
+        bundle.Start();
+      } catch (std::exception& e) {
         std::cerr << "    " << e.what();
       }
       std::cerr << std::endl;
@@ -117,11 +113,9 @@ public:
     auto context = framework.GetBundleContext();
     auto bundles = context.GetBundles();
 
-    for (auto& bundle : bundles)
-    {
+    for (auto& bundle : bundles) {
       auto bundleSymbolicName = bundle.GetSymbolicName();
-      if (symbolicName == bundleSymbolicName)
-      {
+      if (symbolicName == bundleSymbolicName) {
         return bundle;
       }
     }
@@ -133,7 +127,8 @@ public:
     cppmicroservices::Bundle testBundle = GetTestBundle(symName);
     EXPECT_EQ(static_cast<bool>(testBundle), true);
     testBundle.Start();
-    EXPECT_EQ(testBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE) << " failed to start bundle with symbolic name"+symName;
+    EXPECT_EQ(testBundle.GetState(), cppmicroservices::Bundle::STATE_ACTIVE)
+      << " failed to start bundle with symbolic name" + symName;
     return testBundle;
   }
   std::shared_ptr<scr::ServiceComponentRuntime> dsRuntimeService;

--- a/compendium/DeclarativeServices/test/TestMetadataParserFactory.cpp
+++ b/compendium/DeclarativeServices/test/TestMetadataParserFactory.cpp
@@ -19,22 +19,24 @@
   limitations under the License.
 
   =============================================================================*/
-#include "gtest/gtest.h"
-#include "../src/metadata/MetadataParserFactory.hpp"
 #include "../src/metadata/MetadataParser.hpp"
+#include "../src/metadata/MetadataParserFactory.hpp"
 #include "Mocks.hpp"
+#include "gtest/gtest.h"
 
 using namespace cppmicroservices;
 
-namespace cppmicroservices { namespace scrimpl { namespace metadata {
+namespace cppmicroservices {
+namespace scrimpl {
+namespace metadata {
 
 TEST(MetadataParserTest, ManifestVersionInvalid)
 {
   auto logger = std::make_shared<FakeLogger>();
-  EXPECT_THROW(MetadataParserFactory::Create(0, logger);
-               , std::runtime_error);
-  EXPECT_THROW(MetadataParserFactory::Create(2, logger);
-               , std::runtime_error);
+  EXPECT_THROW(MetadataParserFactory::Create(0, logger);, std::runtime_error);
+  EXPECT_THROW(MetadataParserFactory::Create(2, logger);, std::runtime_error);
 }
 
-}}} // namespaces
+}
+}
+} // namespaces

--- a/compendium/DeclarativeServices/test/TestMetadataParserImplV1.cpp
+++ b/compendium/DeclarativeServices/test/TestMetadataParserImplV1.cpp
@@ -19,12 +19,12 @@
   limitations under the License.
 
   =============================================================================*/
-#include "Mocks.hpp"
-#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "../src/metadata/MetadataParserFactory.hpp"
 #include "../src/metadata/MetadataParserImpl.hpp"
 #include "../src/metadata/ReferenceMetadata.hpp"
 #include "../src/metadata/Util.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "gtest/gtest.h"
 #include <cppmicroservices/Framework.h>
 #include <cppmicroservices/FrameworkEvent.h>

--- a/compendium/DeclarativeServices/test/TestReferenceMetadataParserV1.cpp
+++ b/compendium/DeclarativeServices/test/TestReferenceMetadataParserV1.cpp
@@ -300,16 +300,17 @@ INSTANTIATE_TEST_SUITE_P(
                                       "",
                                       1,
                                       1),
-    ReferenceMetadataParserValidState(9,
-                                      "com.bar.foo",
-                                      "foo",
-                                      "0..n",
-                                      "dynamic",
-                                      "greedy",
-                                      "bundle",
-                                      "LDAP",
-                                      0,
-                                      std::numeric_limits<std::size_t>::max())));
+    ReferenceMetadataParserValidState(
+      9,
+      "com.bar.foo",
+      "foo",
+      "0..n",
+      "dynamic",
+      "greedy",
+      "bundle",
+      "LDAP",
+      0,
+      std::numeric_limits<std::size_t>::max())));
 
 // For the metadata in InvalidInputs corresponding to metadataIndex,
 // we expect the exception message output by the Metadata Parser to be

--- a/compendium/DeclarativeServices/test/TestReferenceSelfSatisfyDeadLock.cpp
+++ b/compendium/DeclarativeServices/test/TestReferenceSelfSatisfyDeadLock.cpp
@@ -24,16 +24,16 @@
 
 #include <gtest/gtest.h>
 
+#include <TestInterfaces/Interfaces.hpp>
 #include <cppmicroservices/Bundle.h>
-#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/Framework.h>
 #include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/FrameworkFactory.h>
 #include <cppmicroservices/ServiceTracker.h>
-#include <cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp>
 #include <cppmicroservices/servicecomponent/ComponentConstants.hpp>
-#include <TestInterfaces/Interfaces.hpp>
+#include <cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp>
 
 #include "TestUtils.hpp"
 
@@ -46,11 +46,12 @@ namespace test {
  *
  * A failure will result in a deadlock.
  */
-TEST(tServiceComponentRuntime, testReferenceSelfSatisfyDeadlock) {
+TEST(tServiceComponentRuntime, testReferenceSelfSatisfyDeadlock)
+{
   auto framework = cppmicroservices::FrameworkFactory().NewFramework();
   framework.Start();
   EXPECT_TRUE(framework);
-    
+
   auto dsPluginPath = test::GetDSRuntimePluginFilePath();
   auto dsbundles = framework.GetBundleContext().InstallBundles(dsPluginPath);
   for (auto& bundle : dsbundles) {
@@ -60,10 +61,12 @@ TEST(tServiceComponentRuntime, testReferenceSelfSatisfyDeadlock) {
   // The names of the bundles do matter here. The bundle containing the dependency MUST
   // be stopped after the one providing the dependency. CppMicroServices stores bundles
   // in sorted order by path.
-  auto bundleB = test::InstallAndStartBundle(framework.GetBundleContext(), "TestBundleDSb");
+  auto bundleB =
+    test::InstallAndStartBundle(framework.GetBundleContext(), "TestBundleDSb");
   ASSERT_TRUE(bundleB);
   bundleB.Start();
-  auto bundleA = test::InstallAndStartBundle(framework.GetBundleContext(), "TestBundleDSa");
+  auto bundleA =
+    test::InstallAndStartBundle(framework.GetBundleContext(), "TestBundleDSa");
   ASSERT_TRUE(bundleA);
   bundleA.Start();
 

--- a/compendium/DeclarativeServices/test/TestRegistrationManager.cpp
+++ b/compendium/DeclarativeServices/test/TestRegistrationManager.cpp
@@ -20,29 +20,29 @@
 
   =============================================================================*/
 
+#include <algorithm>
 #include <cstdio>
 #include <iostream>
-#include <algorithm>
 
 #include "Mocks.hpp"
 
-#include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
-#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/Bundle.h>
 #include <cppmicroservices/BundleContext.h>
 #include <cppmicroservices/BundleImport.h>
 #include <cppmicroservices/Constants.h>
-#include <cppmicroservices/Bundle.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
 #include <cppmicroservices/ServiceRegistration.h>
 #include <cppmicroservices/ServiceTracker.h>
 
-#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "../src/manager/RegistrationManager.hpp"
+#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 
-using cppmicroservices::Constants::SERVICE_SCOPE;
 using cppmicroservices::Constants::SCOPE_BUNDLE;
-using cppmicroservices::Constants::SCOPE_SINGLETON;
 using cppmicroservices::Constants::SCOPE_PROTOTYPE;
+using cppmicroservices::Constants::SCOPE_SINGLETON;
+using cppmicroservices::Constants::SERVICE_SCOPE;
 using cppmicroservices::service::component::ComponentConstants::COMPONENT_ID;
 using cppmicroservices::service::component::ComponentConstants::COMPONENT_NAME;
 
@@ -50,21 +50,23 @@ namespace cppmicroservices {
 namespace scrimpl {
 
 class MockService
-  : public dummy::Reference1, public dummy::Reference2
-{
-};
+  : public dummy::Reference1
+  , public dummy::Reference2
+{};
 
-class MockServiceFactory
-  : public cppmicroservices::ServiceFactory
+class MockServiceFactory : public cppmicroservices::ServiceFactory
 {
 public:
-  MockServiceFactory() : callcount(0) {};
-  virtual ~MockServiceFactory() {};
-  virtual cppmicroservices::InterfaceMapConstPtr GetService(const cppmicroservices::Bundle&,
-                                                            const cppmicroservices::ServiceRegistrationBase&)
+  MockServiceFactory()
+    : callcount(0){};
+  virtual ~MockServiceFactory(){};
+  virtual cppmicroservices::InterfaceMapConstPtr GetService(
+    const cppmicroservices::Bundle&,
+    const cppmicroservices::ServiceRegistrationBase&)
   {
     callcount++;
-    return cppmicroservices::MakeInterfaceMap<MockService>(std::make_shared<MockService>());
+    return cppmicroservices::MakeInterfaceMap<MockService>(
+      std::make_shared<MockService>());
   }
 
   virtual void UngetService(const cppmicroservices::Bundle&,
@@ -83,19 +85,16 @@ enum RegState
 };
 
 // The fixture for testing class RegistrationManager.
-class RegistrationManagerTest
-  : public ::testing::Test
+class RegistrationManagerTest : public ::testing::Test
 {
 protected:
-  RegistrationManagerTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  RegistrationManagerTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
 
   virtual ~RegistrationManagerTest() = default;
 
-  virtual void SetUp()
-  {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
   virtual void TearDown()
   {
@@ -104,6 +103,7 @@ protected:
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
@@ -111,84 +111,113 @@ private:
 TEST_F(RegistrationManagerTest, VerifyConstructor)
 {
   auto fakeLogger = std::make_shared<FakeLogger>();
-  std::vector<std::string> services {"Foo", "Bar"};
+  std::vector<std::string> services{ "Foo", "Bar" };
   auto bc = GetFramework().GetBundleContext();
   // invalid bundle context
-  EXPECT_THROW({
-      RegistrationManager rm(BundleContext(), services, SCOPE_SINGLETON, fakeLogger);
-    }, std::invalid_argument) << "Invalid bundle context must result in a throw";
+  EXPECT_THROW(
+    {
+      RegistrationManager rm(
+        BundleContext(), services, SCOPE_SINGLETON, fakeLogger);
+    },
+    std::invalid_argument)
+    << "Invalid bundle context must result in a throw";
   // invalid service interfaces vector
-  EXPECT_THROW({
-      RegistrationManager rm(bc, {}, SCOPE_SINGLETON, fakeLogger);
-    }, std::invalid_argument) << "Empty services param must result in a throw";
+  EXPECT_THROW({ RegistrationManager rm(bc, {}, SCOPE_SINGLETON, fakeLogger); },
+               std::invalid_argument)
+    << "Empty services param must result in a throw";
   // invalid service scope
-  EXPECT_THROW({
-      RegistrationManager rm(bc, services, "fuzzy", fakeLogger);
-    }, std::invalid_argument) << "Invalid service scope must result in a throw";
+  EXPECT_THROW({ RegistrationManager rm(bc, services, "fuzzy", fakeLogger); },
+               std::invalid_argument)
+    << "Invalid service scope must result in a throw";
   // invalid logger
-  EXPECT_THROW({
-      RegistrationManager rm(bc, services, SCOPE_SINGLETON, nullptr);
-    }, std::invalid_argument) << "Invalid logger must result in a throw";
+  EXPECT_THROW(
+    { RegistrationManager rm(bc, services, SCOPE_SINGLETON, nullptr); },
+    std::invalid_argument)
+    << "Invalid logger must result in a throw";
 
   EXPECT_NO_THROW({
-      RegistrationManager rm(bc, services, SCOPE_SINGLETON, fakeLogger);
-    }) << "No throw expected when all params are valid";
+    RegistrationManager rm(bc, services, SCOPE_SINGLETON, fakeLogger);
+  }) << "No throw expected when all params are valid";
 }
 
 TEST_F(RegistrationManagerTest, VerifyUnregister)
 {
   auto fakeLogger = std::make_shared<FakeLogger>();
-  std::vector<std::string> services {"Foo", "Bar"};
+  std::vector<std::string> services{ "Foo", "Bar" };
   auto bc = GetFramework().GetBundleContext();
   {
     // Unregister without register
     RegistrationManager rm(bc, services, SCOPE_SINGLETON, fakeLogger);
-    EXPECT_THROW({
-        rm.UnregisterService();
-      }, std::logic_error) << "Cannot unregister if not registered by this registration manager";
+    EXPECT_THROW({ rm.UnregisterService(); }, std::logic_error)
+      << "Cannot unregister if not registered by this registration manager";
   }
 
   {
     // register then unregister
     RegistrationManager rm(bc, services, SCOPE_SINGLETON, fakeLogger);
-    std::shared_ptr<ServiceFactory> mockServiceFactory = std::make_shared<MockFactory>();
+    std::shared_ptr<ServiceFactory> mockServiceFactory =
+      std::make_shared<MockFactory>();
     rm.serviceReg = bc.RegisterService<dummy::Reference1>(mockServiceFactory);
-    EXPECT_TRUE(rm.IsServiceRegistered()) << "state must be REGISTERED after call to RegisterService";
-    EXPECT_NO_THROW({
-        rm.UnregisterService();
-      });
-    EXPECT_FALSE(rm.IsServiceRegistered()) << "state must be UNREGISTERED after call to UnregisterService";
+    EXPECT_TRUE(rm.IsServiceRegistered())
+      << "state must be REGISTERED after call to RegisterService";
+    EXPECT_NO_THROW({ rm.UnregisterService(); });
+    EXPECT_FALSE(rm.IsServiceRegistered())
+      << "state must be UNREGISTERED after call to UnregisterService";
 
     // unregister after an unregister
-    EXPECT_THROW({
-        rm.UnregisterService();
-      }, std::logic_error) << "Unregistering an already unregistered service must throw";
+    EXPECT_THROW({ rm.UnregisterService(); }, std::logic_error)
+      << "Unregistering an already unregistered service must throw";
   }
 }
 
 TEST_F(RegistrationManagerTest, VerifyRegisterService)
 {
   auto fakeLogger = std::make_shared<FakeLogger>();
-  std::vector<std::string> services {us_service_interface_iid<dummy::Reference1>(), us_service_interface_iid<dummy::Reference2>()};
+  std::vector<std::string> services{
+    us_service_interface_iid<dummy::Reference1>(),
+    us_service_interface_iid<dummy::Reference2>()
+  };
   auto bc = GetFramework().GetBundleContext();
   RegistrationManager rm(bc, services, SCOPE_SINGLETON, fakeLogger);
   auto mockServiceFactory = std::make_shared<MockFactory>();
-  EXPECT_FALSE(rm.IsServiceRegistered()) << "Initial state must be UNREGISTERED";
-  EXPECT_FALSE(static_cast<bool>(rm.GetServiceReference())) << "Initial call to GetServiceReference must return invalid ServiceReference object";
+  EXPECT_FALSE(rm.IsServiceRegistered())
+    << "Initial state must be UNREGISTERED";
+  EXPECT_FALSE(static_cast<bool>(rm.GetServiceReference()))
+    << "Initial call to GetServiceReference must return invalid "
+       "ServiceReference object";
   ServiceProperties props;
   props.insert(std::make_pair(COMPONENT_NAME, Any(std::string("name"))));
   props.insert(std::make_pair(COMPONENT_ID, Any(978723ul)));
-  EXPECT_TRUE(rm.RegisterService(std::dynamic_pointer_cast<ServiceFactory>(mockServiceFactory), props)) << "RegisterService must return true";
-  EXPECT_TRUE(rm.IsServiceRegistered()) << "state must be REGISTERED after call to RegisterService";
-  cppmicroservices::ServiceReference<dummy::Reference1> sRef1 = bc.GetServiceReference<dummy::Reference1>();
+  EXPECT_TRUE(rm.RegisterService(
+    std::dynamic_pointer_cast<ServiceFactory>(mockServiceFactory), props))
+    << "RegisterService must return true";
+  EXPECT_TRUE(rm.IsServiceRegistered())
+    << "state must be REGISTERED after call to RegisterService";
+  cppmicroservices::ServiceReference<dummy::Reference1> sRef1 =
+    bc.GetServiceReference<dummy::Reference1>();
   // Verify service is registered
-  EXPECT_EQ(rm.GetServiceReference(), sRef1) << "service reference stored in the registration manager must be the same as the one retrieved from the framework for 'dummy::Reference1' interface";
-  EXPECT_TRUE(sRef1.IsConvertibleTo(services.at(0))) << "Retrieved service reference must be convertible to 'dummy::Reference1' interface";
-  EXPECT_TRUE(rm.RegisterService(std::dynamic_pointer_cast<ServiceFactory>(mockServiceFactory), props)) << "A second call to RegisterService must return true without actually performing a service registration";
-  cppmicroservices::ServiceReference<dummy::Reference2> sRef2 = bc.GetServiceReference<dummy::Reference2>();
-  EXPECT_EQ(rm.GetServiceReference(), sRef2) << "service reference stored in the registration manager must be the same as the one retrieved from the framework for 'dummy::Reference2' interface";
-  EXPECT_TRUE(sRef2.IsConvertibleTo(services.at(0))) << "Retrieved service reference must be convertible to 'dummy::Reference2' interface";
-  InterfaceMapPtr iMap = MakeInterfaceMap<dummy::Reference2, dummy::Reference1>(std::make_shared<MockService>());
+  EXPECT_EQ(rm.GetServiceReference(), sRef1)
+    << "service reference stored in the registration manager must be the same "
+       "as the one retrieved from the framework for 'dummy::Reference1' "
+       "interface";
+  EXPECT_TRUE(sRef1.IsConvertibleTo(services.at(0)))
+    << "Retrieved service reference must be convertible to 'dummy::Reference1' "
+       "interface";
+  EXPECT_TRUE(rm.RegisterService(
+    std::dynamic_pointer_cast<ServiceFactory>(mockServiceFactory), props))
+    << "A second call to RegisterService must return true without actually "
+       "performing a service registration";
+  cppmicroservices::ServiceReference<dummy::Reference2> sRef2 =
+    bc.GetServiceReference<dummy::Reference2>();
+  EXPECT_EQ(rm.GetServiceReference(), sRef2)
+    << "service reference stored in the registration manager must be the same "
+       "as the one retrieved from the framework for 'dummy::Reference2' "
+       "interface";
+  EXPECT_TRUE(sRef2.IsConvertibleTo(services.at(0)))
+    << "Retrieved service reference must be convertible to 'dummy::Reference2' "
+       "interface";
+  InterfaceMapPtr iMap = MakeInterfaceMap<dummy::Reference2, dummy::Reference1>(
+    std::make_shared<MockService>());
   EXPECT_CALL(*mockServiceFactory, GetService(testing::_, testing::_))
     .Times(1)
     .WillOnce(testing::Return(iMap));
@@ -196,13 +225,17 @@ TEST_F(RegistrationManagerTest, VerifyRegisterService)
   EXPECT_FALSE(service2 == nullptr);
   auto service1 = bc.GetService<dummy::Reference1>(sRef1);
   EXPECT_FALSE(service1 == nullptr);
-  EXPECT_CALL(*mockServiceFactory, UngetService(testing::_, testing::_, testing::_))
+  EXPECT_CALL(*mockServiceFactory,
+              UngetService(testing::_, testing::_, testing::_))
     .Times(1);
   // Verify service properties
   // All services are registered with a factory
-  EXPECT_EQ(sRef1.GetProperty(SERVICE_SCOPE).ToString(), SCOPE_SINGLETON) << "Service scope must be SINGLETON";
-  EXPECT_EQ(sRef1.GetProperty(COMPONENT_NAME).ToString(), "name") << "Service must have a 'COMPONENT_NAME' property with value 'name'";
-  EXPECT_EQ(any_cast<unsigned long>(sRef1.GetProperty(COMPONENT_ID)), 978723ul) << "Service must have a 'COMPONENT_ID' property with value '978723'";
+  EXPECT_EQ(sRef1.GetProperty(SERVICE_SCOPE).ToString(), SCOPE_SINGLETON)
+    << "Service scope must be SINGLETON";
+  EXPECT_EQ(sRef1.GetProperty(COMPONENT_NAME).ToString(), "name")
+    << "Service must have a 'COMPONENT_NAME' property with value 'name'";
+  EXPECT_EQ(any_cast<unsigned long>(sRef1.GetProperty(COMPONENT_ID)), 978723ul)
+    << "Service must have a 'COMPONENT_ID' property with value '978723'";
 }
 }
 }

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
@@ -20,39 +20,34 @@
 
   =============================================================================*/
 
-#include <iostream>
 #include <gtest/gtest.h>
+#include <iostream>
 
 #include <cppmicroservices/Bundle.h>
-#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/BundleEvent.h>
 #include <cppmicroservices/Framework.h>
 #include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/FrameworkFactory.h>
 
-#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
-#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
-#include "TestUtils.hpp"
 #include "DSTestingConfig.h"
+#include "TestUtils.hpp"
+#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
 namespace scr = cppmicroservices::service::component::runtime;
 
-namespace test
-{
-class TestServiceComponentRuntime
-  : public ::testing::Test
+namespace test {
+class TestServiceComponentRuntime : public ::testing::Test
 {
 protected:
   TestServiceComponentRuntime()
     : ::testing::Test()
     , framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  {}
   virtual ~TestServiceComponentRuntime() = default;
 
-  virtual void SetUp()
-  {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
   virtual void TearDown()
   {
@@ -83,7 +78,8 @@ TEST_F(TestServiceComponentRuntime, testServiceAvailability)
 {
   auto dsPluginPath = GetDSRuntimePluginFilePath();
   auto bundles = framework.GetBundleContext().InstallBundles(dsPluginPath);
-  EXPECT_EQ(bundles.size(), 1ul) << "DS Runtime bundle found at" << dsPluginPath;
+  EXPECT_EQ(bundles.size(), 1ul)
+    << "DS Runtime bundle found at" << dsPluginPath;
   for (auto bundle : bundles) {
     bundle.Start();
   }

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
@@ -20,36 +20,36 @@
 
   =============================================================================*/
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/BundleContext.h"
-#include "Mocks.hpp"
 #include "../src/ServiceComponentRuntimeImpl.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
 // The fixture for testing class ServiceComponentRuntimeImpl.
-class ServiceComponentRuntimeImplTest
-  : public ::testing::Test
+class ServiceComponentRuntimeImplTest : public ::testing::Test
 {
 protected:
-  ServiceComponentRuntimeImplTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {
-  }
+  ServiceComponentRuntimeImplTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
 
   virtual ~ServiceComponentRuntimeImplTest() = default;
 
-  virtual void SetUp() {
-    framework.Start();
-  }
+  virtual void SetUp() { framework.Start(); }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
   }
 
   cppmicroservices::Framework& GetFramework() { return framework; }
+
 private:
   cppmicroservices::Framework framework;
 };
@@ -58,29 +58,31 @@ TEST_F(ServiceComponentRuntimeImplTest, Validate_Ctor)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  EXPECT_THROW({
-      ServiceComponentRuntimeImpl service(BundleContext(),
-                                          mockRegistry,
-                                          fakeLogger);
-    }, std::invalid_argument);
-  EXPECT_THROW({
-      ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                          nullptr,
-                                          fakeLogger);
-    }, std::invalid_argument);
-  EXPECT_THROW({
-      ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                          mockRegistry,
-                                          nullptr);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+    {
+      ServiceComponentRuntimeImpl service(
+        BundleContext(), mockRegistry, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      ServiceComponentRuntimeImpl service(
+        GetFramework().GetBundleContext(), nullptr, fakeLogger);
+    },
+    std::invalid_argument);
+  EXPECT_THROW(
+    {
+      ServiceComponentRuntimeImpl service(
+        GetFramework().GetBundleContext(), mockRegistry, nullptr);
+    },
+    std::invalid_argument);
   EXPECT_NO_THROW({
-      ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                          mockRegistry,
-                                          fakeLogger);
-      EXPECT_EQ(service.scrContext, GetFramework().GetBundleContext());
-      EXPECT_EQ(service.registry, mockRegistry);
-      EXPECT_EQ(service.logger, fakeLogger);
-    });
+    ServiceComponentRuntimeImpl service(
+      GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
+    EXPECT_EQ(service.scrContext, GetFramework().GetBundleContext());
+    EXPECT_EQ(service.registry, mockRegistry);
+    EXPECT_EQ(service.logger, fakeLogger);
+  });
 }
 
 TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTO)
@@ -92,10 +94,10 @@ TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTO)
   fakeCompDesc->name = "componentname";
   metadata::ReferenceMetadata refData;
   fakeCompDesc->refsMetadata.push_back(refData);
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
-  EXPECT_CALL(*mockRegistry, GetComponentManager(GetFramework().GetBundleId(), "Foo::Bar"))
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
+  EXPECT_CALL(*mockRegistry,
+              GetComponentManager(GetFramework().GetBundleId(), "Foo::Bar"))
     .Times(1)
     .WillRepeatedly(testing::Return(mockCompMgr));
   EXPECT_CALL(*mockCompMgr, GetMetadata())
@@ -105,30 +107,33 @@ TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTO)
     .Times(1)
     .WillRepeatedly(testing::Return(GetFramework().GetBundleId()));
   EXPECT_NO_THROW({
-      auto compDesc = service.GetComponentDescriptionDTO(GetFramework(), "Foo::Bar");
-      EXPECT_EQ(compDesc.name, "componentname");
-      EXPECT_EQ(compDesc.references.size(), 1u);
-    });
+    auto compDesc =
+      service.GetComponentDescriptionDTO(GetFramework(), "Foo::Bar");
+    EXPECT_EQ(compDesc.name, "componentname");
+    EXPECT_EQ(compDesc.references.size(), 1u);
+  });
 
-  EXPECT_CALL(*mockRegistry, GetComponentManager(GetFramework().GetBundleId(), "FooBar"))
+  EXPECT_CALL(*mockRegistry,
+              GetComponentManager(GetFramework().GetBundleId(), "FooBar"))
     .Times(1)
     .WillRepeatedly(testing::Throw(std::out_of_range("Invalid Component")));
   EXPECT_NO_THROW({
-      auto compDesc = service.GetComponentDescriptionDTO(GetFramework(), "FooBar");
-      EXPECT_EQ(compDesc.name, "");
-    });
+    auto compDesc =
+      service.GetComponentDescriptionDTO(GetFramework(), "FooBar");
+    EXPECT_EQ(compDesc.name, "");
+  });
 }
 
-TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTOs_EmptyArg)
+TEST_F(ServiceComponentRuntimeImplTest,
+       Validate_GetComponentDescriptionDTOs_EmptyArg)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   auto mgr1 = std::make_shared<MockComponentManager>();
   auto mgr2 = std::make_shared<MockComponentManager>();
-  std::vector<std::shared_ptr<ComponentManager>> mgrs {mgr1, mgr2};
+  std::vector<std::shared_ptr<ComponentManager>> mgrs{ mgr1, mgr2 };
   EXPECT_CALL(*mockRegistry, GetComponentManagers())
     .Times(2)
     .WillOnce(testing::Return(std::vector<std::shared_ptr<ComponentManager>>{}))
@@ -142,27 +147,26 @@ TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTOs_Emp
 
   // check against empty registry
   EXPECT_NO_THROW({
-      auto compDTOs = service.GetComponentDescriptionDTOs({});
-      EXPECT_EQ(compDTOs.size(), 0u);
-    });
+    auto compDTOs = service.GetComponentDescriptionDTOs({});
+    EXPECT_EQ(compDTOs.size(), 0u);
+  });
 
   // check against registry with valid elements
   EXPECT_NO_THROW({
-      auto compDTOs = service.GetComponentDescriptionDTOs({});
-      EXPECT_EQ(compDTOs.size(), mgrs.size());
-    });
+    auto compDTOs = service.GetComponentDescriptionDTOs({});
+    EXPECT_EQ(compDTOs.size(), mgrs.size());
+  });
 }
 
 TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTOs)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   auto mgr1 = std::make_shared<MockComponentManager>();
   auto mgr2 = std::make_shared<MockComponentManager>();
-  std::vector<std::shared_ptr<ComponentManager>> mgrs {mgr1, mgr2};
+  std::vector<std::shared_ptr<ComponentManager>> mgrs{ mgr1, mgr2 };
   EXPECT_CALL(*mockRegistry, GetComponentManagers(GetFramework().GetBundleId()))
     .Times(1)
     .WillRepeatedly(testing::Return(mgrs));
@@ -173,14 +177,14 @@ TEST_F(ServiceComponentRuntimeImplTest, Validate_GetComponentDescriptionDTOs)
     .Times(1)
     .WillRepeatedly(testing::Return(nullptr));
   EXPECT_NO_THROW({
-      auto compDTOs = service.GetComponentDescriptionDTOs({GetFramework()});
-      EXPECT_EQ(compDTOs.size(), mgrs.size());
-    });
-//      This test point fails due to a crash in the core framework
-//      EXPECT_NO_THROW({
-//        auto compDTOs = service.GetComponentDescriptionDTOs({Bundle()});
-//        EXPECT_EQ(compDTOs.size(), 0UL);
-//      });
+    auto compDTOs = service.GetComponentDescriptionDTOs({ GetFramework() });
+    EXPECT_EQ(compDTOs.size(), mgrs.size());
+  });
+  //      This test point fails due to a crash in the core framework
+  //      EXPECT_NO_THROW({
+  //        auto compDTOs = service.GetComponentDescriptionDTOs({Bundle()});
+  //        EXPECT_EQ(compDTOs.size(), 0UL);
+  //      });
 }
 
 TEST_F(ServiceComponentRuntimeImplTest, GetComponentConfigurationDTOs)
@@ -190,55 +194,65 @@ TEST_F(ServiceComponentRuntimeImplTest, GetComponentConfigurationDTOs)
   compDescDTO.bundle.id = 21;
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   auto mockCompMgr = std::make_shared<MockComponentManager>();
   auto config1 = std::make_shared<MockComponentConfiguration>();
   auto config2 = std::make_shared<MockComponentConfiguration>();
-  std::vector<std::shared_ptr<ComponentConfiguration>> configs {config1, config2};
+  std::vector<std::shared_ptr<ComponentConfiguration>> configs{ config1,
+                                                                config2 };
   EXPECT_CALL(*mockRegistry, GetComponentManager(21, "FooBar"))
     .WillRepeatedly(testing::Return(mockCompMgr));
   EXPECT_CALL(*mockCompMgr, GetComponentConfigurations())
     .WillRepeatedly(testing::Return(configs));
   EXPECT_CALL(*mockCompMgr, GetMetadata())
     .WillRepeatedly(testing::Return(nullptr));
-  EXPECT_CALL(*config1, GetId())
-    .WillRepeatedly(testing::Return(100));
-  EXPECT_CALL(*config2, GetId())
-    .WillRepeatedly(testing::Return(200));
+  EXPECT_CALL(*config1, GetId()).WillRepeatedly(testing::Return(100));
+  EXPECT_CALL(*config2, GetId()).WillRepeatedly(testing::Return(200));
   std::unordered_map<std::string, cppmicroservices::Any> emptyProperties;
   EXPECT_CALL(*config1, GetProperties())
     .WillRepeatedly(testing::Return(emptyProperties));
   EXPECT_CALL(*config2, GetProperties())
     .WillRepeatedly(testing::Return(emptyProperties));
   EXPECT_CALL(*config1, GetConfigState())
-    .WillRepeatedly(testing::Return(service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE));
+    .WillRepeatedly(testing::Return(
+      service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE));
   EXPECT_CALL(*config2, GetConfigState())
-    .WillRepeatedly(testing::Return(service::component::runtime::dto::ComponentState::ACTIVE));
+    .WillRepeatedly(testing::Return(
+      service::component::runtime::dto::ComponentState::ACTIVE));
   auto refMgr1 = std::make_shared<MockReferenceManager>();
   auto refMgr2 = std::make_shared<MockReferenceManager>();
-  std::vector<std::shared_ptr<ReferenceManager>> refMgrs {refMgr1, refMgr2};
+  std::vector<std::shared_ptr<ReferenceManager>> refMgrs{ refMgr1, refMgr2 };
   EXPECT_CALL(*config1, GetAllDependencyManagers())
-    .WillRepeatedly(testing::Return(std::vector<std::shared_ptr<ReferenceManager>>{}));
+    .WillRepeatedly(
+      testing::Return(std::vector<std::shared_ptr<ReferenceManager>>{}));
   EXPECT_CALL(*config2, GetAllDependencyManagers())
     .WillRepeatedly(testing::Return(refMgrs));
   EXPECT_CALL(*refMgr1, IsSatisfied()).WillRepeatedly(testing::Return(false));
-  EXPECT_CALL(*refMgr1, GetReferenceName()).WillRepeatedly(testing::Return("ref1"));
-  EXPECT_CALL(*refMgr1, GetLDAPString()).WillRepeatedly(testing::Return("(OBJECTCLASS=ref1Impl)"));
+  EXPECT_CALL(*refMgr1, GetReferenceName())
+    .WillRepeatedly(testing::Return("ref1"));
+  EXPECT_CALL(*refMgr1, GetLDAPString())
+    .WillRepeatedly(testing::Return("(OBJECTCLASS=ref1Impl)"));
   EXPECT_CALL(*refMgr1, GetTargetReferences())
-    .WillRepeatedly(testing::Return(std::set<cppmicroservices::ServiceReferenceBase>{}));
+    .WillRepeatedly(
+      testing::Return(std::set<cppmicroservices::ServiceReferenceBase>{}));
   EXPECT_CALL(*refMgr2, IsSatisfied()).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(*refMgr2, GetReferenceName()).WillRepeatedly(testing::Return("ref2"));
-  EXPECT_CALL(*refMgr2, GetLDAPString()).WillRepeatedly(testing::Return("(OBJECTCLASS=ref2Impl)"));
+  EXPECT_CALL(*refMgr2, GetReferenceName())
+    .WillRepeatedly(testing::Return("ref2"));
+  EXPECT_CALL(*refMgr2, GetLDAPString())
+    .WillRepeatedly(testing::Return("(OBJECTCLASS=ref2Impl)"));
   EXPECT_CALL(*refMgr2, GetBoundReferences())
-    .WillRepeatedly(testing::Return(std::set<cppmicroservices::ServiceReferenceBase>{}));
+    .WillRepeatedly(
+      testing::Return(std::set<cppmicroservices::ServiceReferenceBase>{}));
   auto configDTOs = service.GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(configDTOs.size(), configs.size());
   EXPECT_EQ(configDTOs.at(0).id, 100ul);
   EXPECT_EQ(configDTOs.at(1).id, 200ul);
-  EXPECT_EQ(configDTOs.at(0).state, service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE);
-  EXPECT_EQ(configDTOs.at(1).state, service::component::runtime::dto::ComponentState::ACTIVE);
+  EXPECT_EQ(
+    configDTOs.at(0).state,
+    service::component::runtime::dto::ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_EQ(configDTOs.at(1).state,
+            service::component::runtime::dto::ComponentState::ACTIVE);
 
   // no matching component in the ComponentRegistry
   compDescDTO.name = "FooBar";
@@ -246,18 +260,17 @@ TEST_F(ServiceComponentRuntimeImplTest, GetComponentConfigurationDTOs)
   EXPECT_CALL(*mockRegistry, GetComponentManager(23, "FooBar"))
     .Times(1)
     .WillRepeatedly(testing::Throw(std::out_of_range("Unknown Component")));
-  EXPECT_THROW({
-      configDTOs = service.GetComponentConfigurationDTOs(compDescDTO);
-    }, std::out_of_range);
+  EXPECT_THROW(
+    { configDTOs = service.GetComponentConfigurationDTOs(compDescDTO); },
+    std::out_of_range);
 }
 
 TEST_F(ServiceComponentRuntimeImplTest, IsComponentEnabled)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   ComponentDescriptionDTO compDescDTO;
   compDescDTO.name = "FooBar";
   compDescDTO.bundle.id = 21;
@@ -283,9 +296,8 @@ TEST_F(ServiceComponentRuntimeImplTest, EnableComponent)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   ComponentDescriptionDTO compDescDTO;
   compDescDTO.name = "FooBar";
   compDescDTO.bundle.id = 21;
@@ -298,9 +310,7 @@ TEST_F(ServiceComponentRuntimeImplTest, EnableComponent)
   EXPECT_CALL(*mockCompMgr, Enable())
     .Times(1)
     .WillOnce(testing::Return(promise.get_future().share()));
-  EXPECT_NO_THROW({
-      auto fut = service.EnableComponent(compDescDTO);
-    });
+  EXPECT_NO_THROW({ auto fut = service.EnableComponent(compDescDTO); });
 
   compDescDTO.bundle.id = 23;
   EXPECT_CALL(*mockRegistry, GetComponentManager(23, "FooBar"))
@@ -313,9 +323,8 @@ TEST_F(ServiceComponentRuntimeImplTest, DisableComponent)
 {
   auto mockRegistry = std::make_shared<MockComponentRegistry>();
   auto fakeLogger = std::make_shared<FakeLogger>();
-  ServiceComponentRuntimeImpl service(GetFramework().GetBundleContext(),
-                                      mockRegistry,
-                                      fakeLogger);
+  ServiceComponentRuntimeImpl service(
+    GetFramework().GetBundleContext(), mockRegistry, fakeLogger);
   ComponentDescriptionDTO compDescDTO;
   compDescDTO.name = "FooBar";
   compDescDTO.bundle.id = 21;
@@ -328,9 +337,7 @@ TEST_F(ServiceComponentRuntimeImplTest, DisableComponent)
   EXPECT_CALL(*mockCompMgr, Disable())
     .Times(1)
     .WillOnce(testing::Return(promise.get_future().share()));
-  EXPECT_NO_THROW({
-      auto fut = service.DisableComponent(compDescDTO);
-    });
+  EXPECT_NO_THROW({ auto fut = service.DisableComponent(compDescDTO); });
 
   compDescDTO.bundle.id = 23;
   EXPECT_CALL(*mockRegistry, GetComponentManager(23, "FooBar"))
@@ -341,12 +348,14 @@ TEST_F(ServiceComponentRuntimeImplTest, DisableComponent)
 
 // declaration of the standalone helper functions defined in ServiceComponentRuntimeImpl.cpp
 framework::dto::BundleDTO ToDTO(const cppmicroservices::Bundle& bundle);
-framework::dto::ServiceReferenceDTO ToDTO(const cppmicroservices::ServiceReferenceBase& sRef);
+framework::dto::ServiceReferenceDTO ToDTO(
+  const cppmicroservices::ServiceReferenceBase& sRef);
 
 TEST_F(ServiceComponentRuntimeImplTest, TestBundleDTO)
 {
   auto bundleDTO = ToDTO(GetFramework());
-  EXPECT_EQ(bundleDTO.id, static_cast<unsigned long>(GetFramework().GetBundleId()));
+  EXPECT_EQ(bundleDTO.id,
+            static_cast<unsigned long>(GetFramework().GetBundleId()));
   EXPECT_EQ(bundleDTO.symbolicName, GetFramework().GetSymbolicName());
   EXPECT_EQ(bundleDTO.state, GetFramework().GetState());
   EXPECT_EQ(bundleDTO.version, GetFramework().GetVersion().ToString());
@@ -364,7 +373,8 @@ TEST_F(ServiceComponentRuntimeImplTest, TestServiceReferenceDTO)
   EXPECT_TRUE(static_cast<bool>(sRef));
   auto sRefDTO = ToDTO(sRef);
 
-  EXPECT_EQ(sRefDTO.bundle, static_cast<unsigned long>(sRef.GetBundle().GetBundleId()));
+  EXPECT_EQ(sRefDTO.bundle,
+            static_cast<unsigned long>(sRef.GetBundle().GetBundleId()));
   EXPECT_EQ(sRefDTO.properties.size(), sRef.GetPropertyKeys().size());
   EXPECT_EQ(sRefDTO.usingBundles.size(), sRef.GetUsingBundles().size());
 }

--- a/compendium/DeclarativeServices/test/TestServiceMetadataParserV1.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceMetadataParserV1.cpp
@@ -19,28 +19,25 @@
   limitations under the License.
 
   =============================================================================*/
-#include <cppmicroservices/FrameworkFactory.h>
-#include <cppmicroservices/FrameworkEvent.h>
-#include "gtest/gtest.h"
-#include "../src/metadata/ServiceMetadata.hpp"
-#include "../src/metadata/MetadataParserImpl.hpp"
 #include "../src/metadata/MetadataParserFactory.hpp"
+#include "../src/metadata/MetadataParserImpl.hpp"
+#include "../src/metadata/ServiceMetadata.hpp"
 #include "Mocks.hpp"
+#include "gtest/gtest.h"
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
 
+using cppmicroservices::AnyMap;
+using cppmicroservices::scrimpl::FakeLogger;
 using cppmicroservices::scrimpl::metadata::MetadataParserFactory;
 using cppmicroservices::scrimpl::metadata::MetadataParserImplV1;
 using cppmicroservices::scrimpl::metadata::ServiceMetadata;
-using cppmicroservices::AnyMap;
-using cppmicroservices::scrimpl::FakeLogger;
 
 namespace {
 // Classes derive from this to provide input test cases
 struct TestInputs
 {
-  const AnyMap& operator[](std::size_t i) const
-  {
-    return metadatas[i];
-  }
+  const AnyMap& operator[](std::size_t i) const { return metadatas[i]; }
 
   std::vector<AnyMap> metadatas;
 };
@@ -51,20 +48,28 @@ struct TestInputs
 // in the constructor.
 struct ServiceMetadataParserValidState
 {
-  ServiceMetadataParserValidState( std::size_t _metadataIndex, std::string _serviceScope, std::vector<std::string> _interfaces)
-    : metadataIndex(_metadataIndex),
-    serviceScope(_serviceScope),
-    interfaces(_interfaces) {}
+  ServiceMetadataParserValidState(std::size_t _metadataIndex,
+                                  std::string _serviceScope,
+                                  std::vector<std::string> _interfaces)
+    : metadataIndex(_metadataIndex)
+    , serviceScope(_serviceScope)
+    , interfaces(_interfaces)
+  {}
 
   std::size_t metadataIndex;
   std::string serviceScope;
   std::vector<std::string> interfaces;
 
-  friend std::ostream& operator<<(std::ostream& os, const ServiceMetadataParserValidState& obj)
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ServiceMetadataParserValidState& obj)
   {
-      os << "Metadata Index: " << obj.metadataIndex << " service scope: " << obj.serviceScope << " interfaces: [ ";
-      std::for_each(obj.interfaces.begin(), obj.interfaces.end(), [&os](const std::string& interface) {os << interface << " "; });
-      return os << "]\n";
+    os << "Metadata Index: " << obj.metadataIndex
+       << " service scope: " << obj.serviceScope << " interfaces: [ ";
+    std::for_each(
+      obj.interfaces.begin(),
+      obj.interfaces.end(),
+      [&os](const std::string& interface) { os << interface << " "; });
+    return os << "]\n";
   }
 };
 
@@ -73,12 +78,10 @@ class ValidServiceMetadataTest
 {
 public:
   std::shared_ptr<FakeLogger> GetLogger() { return logger; }
+
 protected:
   std::shared_ptr<FakeLogger> logger;
-  virtual void SetUp()
-  {
-    logger = std::make_shared<FakeLogger>();
-  }
+  virtual void SetUp() { logger = std::make_shared<FakeLogger>(); }
 };
 
 // Valid service metadata inputs
@@ -88,20 +91,30 @@ struct ValidInputs : public TestInputs
   {
     //  CheckWithInterfaceNoScope
     std::vector<cppmicroservices::Any> interfaces{
-      cppmicroservices::Any(std::string("Interface1")), cppmicroservices::Any(std::string("Interface2")) };
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { "interfaces" , cppmicroservices::Any(interfaces) } })));
+      cppmicroservices::Any(std::string("Interface1")),
+      cppmicroservices::Any(std::string("Interface2"))
+    };
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { "interfaces", cppmicroservices::Any(interfaces) } })));
 
     // CheckWithInterfaceAndScope_SINGLETON
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { "interfaces" , cppmicroservices::Any(interfaces) },
-                                                                                        { "scope" , cppmicroservices::Any(std::string("singleton")) } } )));
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { "interfaces", cppmicroservices::Any(interfaces) },
+          { "scope", cppmicroservices::Any(std::string("singleton")) } })));
 
     // CheckWithInterfaceAndScope_PROTOTYPE
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { "interfaces" , cppmicroservices::Any(interfaces) },
-                                                                                        { "scope" , cppmicroservices::Any(std::string("prototype")) } } )));
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { "interfaces", cppmicroservices::Any(interfaces) },
+          { "scope", cppmicroservices::Any(std::string("prototype")) } })));
 
     // CheckWithInterfaceAndScope_BUNDLE
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { "interfaces" , cppmicroservices::Any(interfaces) },
-                                                                                        { "scope" , cppmicroservices::Any(std::string("bundle")) } } )));
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { "interfaces", cppmicroservices::Any(interfaces) },
+          { "scope", cppmicroservices::Any(std::string("bundle")) } })));
   }
 };
 
@@ -116,13 +129,22 @@ TEST_P(ValidServiceMetadataTest, TestServiceMetadataSuccessModes)
   ASSERT_THAT(prop.interfaces, ::testing::ContainerEq(smvs.interfaces));
 }
 
-INSTANTIATE_TEST_SUITE_P(SuccessModes, ValidServiceMetadataTest,
-                        testing::Values(
-                          ServiceMetadataParserValidState(0, "singleton", {"Interface1", "Interface2"}),
-                          ServiceMetadataParserValidState(1, "singleton", {"Interface1", "Interface2"}),
-                          ServiceMetadataParserValidState(2, "prototype", {"Interface1", "Interface2"}),
-                          ServiceMetadataParserValidState(3, "bundle",    {"Interface1", "Interface2"})
-                        ));
+INSTANTIATE_TEST_SUITE_P(
+  SuccessModes,
+  ValidServiceMetadataTest,
+  testing::Values(
+    ServiceMetadataParserValidState(0,
+                                    "singleton",
+                                    { "Interface1", "Interface2" }),
+    ServiceMetadataParserValidState(1,
+                                    "singleton",
+                                    { "Interface1", "Interface2" }),
+    ServiceMetadataParserValidState(2,
+                                    "prototype",
+                                    { "Interface1", "Interface2" }),
+    ServiceMetadataParserValidState(3,
+                                    "bundle",
+                                    { "Interface1", "Interface2" })));
 
 // For the metadata in InvalidInputs corresponding to metadataIndex,
 // we expect the exception message output by the Metadata Parser to be
@@ -131,20 +153,27 @@ INSTANTIATE_TEST_SUITE_P(SuccessModes, ValidServiceMetadataTest,
 // mode is useful when we don't want to specify really long error messages)
 struct ServiceMetadataParserInvalidState
 {
-  ServiceMetadataParserInvalidState( std::size_t _metadataIndex, std::string _errorOutput, bool _isPartial = false)
-    : metadataIndex(_metadataIndex),
-    errorOutput(_errorOutput),
-    isPartial(_isPartial) {}
+  ServiceMetadataParserInvalidState(std::size_t _metadataIndex,
+                                    std::string _errorOutput,
+                                    bool _isPartial = false)
+    : metadataIndex(_metadataIndex)
+    , errorOutput(_errorOutput)
+    , isPartial(_isPartial)
+  {}
 
   std::size_t metadataIndex;
   std::string errorOutput;
   bool isPartial;
 
-  friend std::ostream& operator<<(std::ostream& os, const ServiceMetadataParserInvalidState& obj)
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ServiceMetadataParserInvalidState& obj)
   {
-    return os << "";return os << "Metadata Index: " << obj.metadataIndex << " error output: " << obj.errorOutput << "  Perform partial match: " << (obj.isPartial?"Yes":"No") << "\n";
+    return os << "";
+    return os << "Metadata Index: " << obj.metadataIndex
+              << " error output: " << obj.errorOutput
+              << "  Perform partial match: " << (obj.isPartial ? "Yes" : "No")
+              << "\n";
   }
-  
 };
 
 class InvalidServiceMetadataTest
@@ -152,35 +181,44 @@ class InvalidServiceMetadataTest
 {
 public:
   std::shared_ptr<FakeLogger> GetLogger() { return logger; }
+
 protected:
   std::shared_ptr<FakeLogger> logger;
-  virtual void SetUp()
-  {
-    logger = std::make_shared<FakeLogger>();
-  }
+  virtual void SetUp() { logger = std::make_shared<FakeLogger>(); }
 };
 
-struct InvalidInputs
-  : public TestInputs
+struct InvalidInputs : public TestInputs
 {
   InvalidInputs()
   {
     // ConstructorWithNoInterface
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { std::string("scope") , cppmicroservices::Any(std::string("prototype")) } } )));
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { std::string("scope"),
+            cppmicroservices::Any(std::string("prototype")) } })));
 
     // ConstructorWithInterfaceAndInvalidScope
-    std::vector<cppmicroservices::Any> interfaces{ cppmicroservices::Any(std::string("Interface1")),
-      cppmicroservices::Any(std::string("Interface2")) };
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { std::string("interfaces") , cppmicroservices::Any(interfaces) },
-                                                                                        { std::string("scope") , cppmicroservices::Any(std::string("foobar")) } })));
+    std::vector<cppmicroservices::Any> interfaces{
+      cppmicroservices::Any(std::string("Interface1")),
+      cppmicroservices::Any(std::string("Interface2"))
+    };
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { std::string("interfaces"), cppmicroservices::Any(interfaces) },
+          { std::string("scope"),
+            cppmicroservices::Any(std::string("foobar")) } })));
 
     // ConstructorWithInterfaceAndIllegalScope
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { std::string("interfaces") , cppmicroservices::Any(interfaces) },
-                                                                                        { std::string("scope") , cppmicroservices::Any(42) } })));
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { std::string("interfaces"), cppmicroservices::Any(interfaces) },
+          { std::string("scope"), cppmicroservices::Any(42) } })));
 
     // ConstructorWithIllegalInterface
-    interfaces = {cppmicroservices::Any(true)};
-    metadatas.push_back(AnyMap(std::unordered_map<std::string, cppmicroservices::Any>({ { std::string("interfaces") , cppmicroservices::Any(interfaces) } } )));
+    interfaces = { cppmicroservices::Any(true) };
+    metadatas.push_back(
+      AnyMap(std::unordered_map<std::string, cppmicroservices::Any>(
+        { { std::string("interfaces"), cppmicroservices::Any(interfaces) } })));
   }
 };
 
@@ -189,36 +227,38 @@ TEST_P(InvalidServiceMetadataTest, TestServiceMetadataFailureModes)
   ServiceMetadataParserInvalidState smis = GetParam();
   auto inputs = InvalidInputs();
   std::size_t i = smis.metadataIndex;
-  try
-  {
+  try {
     MetadataParserImplV1 metadataparser(GetLogger());
     auto sMetadata = metadataparser.CreateServiceMetadata(inputs[i]);
     FAIL() << "This failure suggests that parsing has succeeded. "
-      "Shouldn't happen for failure mode tests";
-  }
-  catch (const std::exception& err)
-  {
-    std::string exceptionMsg{err.what()};
-    if (!smis.isPartial)
-    {
+              "Shouldn't happen for failure mode tests";
+  } catch (const std::exception& err) {
+    std::string exceptionMsg{ err.what() };
+    if (!smis.isPartial) {
       ASSERT_THAT(exceptionMsg, ::testing::StrEq(smis.errorOutput));
-    }
-    else
-    {
+    } else {
       ASSERT_THAT(exceptionMsg, ::testing::HasSubstr(smis.errorOutput));
     }
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(FailureModes, InvalidServiceMetadataTest,
-                        testing::Values(
-                          ServiceMetadataParserInvalidState(0,
-                                                            "Missing key 'interfaces' in the manifest."),
-                          ServiceMetadataParserInvalidState(1,
-                                                            "Invalid value 'foobar'. The valid choices are : [bundle, prototype, singleton]."),
-                          ServiceMetadataParserInvalidState(2,
-                                                            "Unexpected type for the name 'scope'. Exception: cppmicroservices::BadAnyCastException", /*isPartial=*/true),
-                          ServiceMetadataParserInvalidState(3,
-                                                            "Exception: cppmicroservices::BadAnyCastException:", /*isPartial=*/true)
-                        ));
+INSTANTIATE_TEST_SUITE_P(
+  FailureModes,
+  InvalidServiceMetadataTest,
+  testing::Values(ServiceMetadataParserInvalidState(
+                    0,
+                    "Missing key 'interfaces' in the manifest."),
+                  ServiceMetadataParserInvalidState(
+                    1,
+                    "Invalid value 'foobar'. The valid choices are : [bundle, "
+                    "prototype, singleton]."),
+                  ServiceMetadataParserInvalidState(
+                    2,
+                    "Unexpected type for the name 'scope'. Exception: "
+                    "cppmicroservices::BadAnyCastException",
+                    /*isPartial=*/true),
+                  ServiceMetadataParserInvalidState(
+                    3,
+                    "Exception: cppmicroservices::BadAnyCastException:",
+                    /*isPartial=*/true)));
 }

--- a/compendium/DeclarativeServices/test/TestServiceProvider.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceProvider.cpp
@@ -20,15 +20,15 @@
 
 =============================================================================*/
 
-#include "gtest/gtest.h"
-#include "cppmicroservices/Constants.h"
-#include "cppmicroservices/ServiceObjects.h"
 #include "TestFixture.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/Constants.h"
+#include "cppmicroservices/ServiceObjects.h"
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include "gtest/gtest.h"
 
 #ifdef US_PLATFORM_POSIX
-#include <dlfcn.h>
+#  include <dlfcn.h>
 #endif
 
 namespace test {
@@ -42,14 +42,20 @@ namespace sc = cppmicroservices::service::component;
 TEST_F(tServiceComponent, testService) //DS_TOI_4
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI1");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent");
-  auto sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-  EXPECT_TRUE(static_cast<bool>(sRef)) << "valid service reference must be available after the bundle is started";
-  auto service = framework.GetBundleContext().GetService<test::Interface1>(sRef);
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent");
+  auto sRef =
+    framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef))
+    << "valid service reference must be available after the bundle is started";
+  auto service =
+    framework.GetBundleContext().GetService<test::Interface1>(sRef);
   EXPECT_NE(service, nullptr) << "a valid service instance must be available";
-  EXPECT_EQ(service->Description(), testBundle.GetSymbolicName()) << "service instance must return the symbolic name of the bundle that published the service";
+  EXPECT_EQ(service->Description(), testBundle.GetSymbolicName())
+    << "service instance must return the symbolic name of the bundle that "
+       "published the service";
 }
-  
+
 /**
  * Verify that a service published through DS
  * always has the properties COMP_ID & COMP_NAME
@@ -58,18 +64,28 @@ TEST_F(tServiceComponent, testDefaultServiceProperties) //DS_TOI_11
 {
   std::string testBundleName("TestBundleDSTOI1");
   auto testBundle = StartTestBundle(testBundleName);
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent");
-  EXPECT_EQ(compDescDTO.properties.size(), 0ul) << "componet description must not have any properties specified";
-  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state reported by the runtime service must match the initial state in component description";
-  auto sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-  EXPECT_TRUE(static_cast<bool>(sRef)) << "valid service reference must be available after the bundle is started";
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent");
+  EXPECT_EQ(compDescDTO.properties.size(), 0ul)
+    << "componet description must not have any properties specified";
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto sRef =
+    framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef))
+    << "valid service reference must be available after the bundle is started";
   auto compIdAny = sRef.GetProperty(sc::ComponentConstants::COMPONENT_ID);
-  EXPECT_FALSE(compIdAny.Empty()) << "COMP_ID property must exist for a service published by DS";
+  EXPECT_FALSE(compIdAny.Empty())
+    << "COMP_ID property must exist for a service published by DS";
   auto compNameAny = sRef.GetProperty(sc::ComponentConstants::COMPONENT_NAME);
-  EXPECT_FALSE(compNameAny.Empty()) << "COMP_NAME property must exist for a service published by DS";
-  EXPECT_EQ(compNameAny.ToStringNoExcept(), compDescDTO.name) << "value of COMP_NAME service property must match the value from the component description";
+  EXPECT_FALSE(compNameAny.Empty())
+    << "COMP_NAME property must exist for a service published by DS";
+  EXPECT_EQ(compNameAny.ToStringNoExcept(), compDescDTO.name)
+    << "value of COMP_NAME service property must match the value from the "
+       "component description";
 }
-  
+
 /**
  * verify that any properties specified in the component description file are
  * made available as service properties when it is published to the service registry.
@@ -77,34 +93,49 @@ TEST_F(tServiceComponent, testDefaultServiceProperties) //DS_TOI_11
 TEST_F(tServiceComponent, testCustomServiceProperties) //DS_TOI_12
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI12");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent12");
-  EXPECT_EQ(compDescDTO.properties.size(), 3ul) << "component description must have properties specified";
-  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true) << "current state reported by the runtime service must match the initial state in component description";
-  auto sRef = framework.GetBundleContext().GetServiceReference<test::Interface1>();
-  EXPECT_TRUE(static_cast<bool>(sRef)) << "valid service reference must be available after the bundle is started";
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent12");
+  EXPECT_EQ(compDescDTO.properties.size(), 3ul)
+    << "component description must have properties specified";
+  EXPECT_EQ(dsRuntimeService->IsComponentEnabled(compDescDTO), true)
+    << "current state reported by the runtime service must match the initial "
+       "state in component description";
+  auto sRef =
+    framework.GetBundleContext().GetServiceReference<test::Interface1>();
+  EXPECT_TRUE(static_cast<bool>(sRef))
+    << "valid service reference must be available after the bundle is started";
   auto compIdAny = sRef.GetProperty(sc::ComponentConstants::COMPONENT_ID);
-  EXPECT_FALSE(compIdAny.Empty()) << "COMP_ID property must exist for a service published by DS";
+  EXPECT_FALSE(compIdAny.Empty())
+    << "COMP_ID property must exist for a service published by DS";
   auto compNameAny = sRef.GetProperty(sc::ComponentConstants::COMPONENT_NAME);
-  EXPECT_FALSE(compNameAny.Empty()) << "COMP_NAME property must exist for a service published by DS";
-  EXPECT_EQ(compNameAny.ToStringNoExcept(), compDescDTO.name) << "value of COMP_NAME service property must match the value from the component description";
-    
+  EXPECT_FALSE(compNameAny.Empty())
+    << "COMP_NAME property must exist for a service published by DS";
+  EXPECT_EQ(compNameAny.ToStringNoExcept(), compDescDTO.name)
+    << "value of COMP_NAME service property must match the value from the "
+       "component description";
+
   // verify that all properties specified in the component description are in the service properties
-  for(auto prop : compDescDTO.properties)
-  {
+  for (auto prop : compDescDTO.properties) {
     auto propVal = sRef.GetProperty(prop.first);
-    EXPECT_FALSE(propVal.Empty()) << "Property from component description must be present in the service properties";
+    EXPECT_FALSE(propVal.Empty()) << "Property from component description must "
+                                     "be present in the service properties";
     EXPECT_EQ(propVal.Type(), prop.second.Type());
-    EXPECT_EQ(propVal.ToStringNoExcept(), prop.second.ToStringNoExcept()) << "Value of the service property must match the value specified in the component description";
+    EXPECT_EQ(propVal.ToStringNoExcept(), prop.second.ToStringNoExcept())
+      << "Value of the service property must match the value specified in the "
+         "component description";
   }
 
   // verify custom objects in service properties
   EXPECT_NO_THROW({
-      auto propObject = cppmicroservices::any_cast<cppmicroservices::AnyMap>(sRef.GetProperty("DummyAnyMap"));
-      EXPECT_EQ(propObject.AtCompoundKey("NestedMap.a").ToString(), "b");
-      EXPECT_EQ(cppmicroservices::any_cast<int>(propObject.AtCompoundKey("NestedVector.1")), 2);
-    });
+    auto propObject = cppmicroservices::any_cast<cppmicroservices::AnyMap>(
+      sRef.GetProperty("DummyAnyMap"));
+    EXPECT_EQ(propObject.AtCompoundKey("NestedMap.a").ToString(), "b");
+    EXPECT_EQ(cppmicroservices::any_cast<int>(
+                propObject.AtCompoundKey("NestedVector.1")),
+              2);
+  });
 }
-  
+
 /**
  * Verify a service specified with scope as SINGLETON in component description
  * is published with the correct scope and all calls to GetService return the
@@ -114,24 +145,30 @@ TEST_F(tServiceComponent, testSingletonScope) //DS_TOI_13
 {
   std::string testBundleName("TestBundleDSTOI1");
   auto testBundle = StartTestBundle(testBundleName);
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent");
   EXPECT_EQ(compDescDTO.scope, cppmicroservices::Constants::SCOPE_SINGLETON);
   auto ctxt = framework.GetBundleContext();
   auto sRef = ctxt.GetServiceReference<test::Interface1>();
   EXPECT_TRUE(static_cast<bool>(sRef));
-  auto serviceScope = sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
+  auto serviceScope =
+    sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
   EXPECT_EQ(compDescDTO.scope, serviceScope.ToStringNoExcept());
   auto serv = ctxt.GetService<test::Interface1>(sRef);
   EXPECT_NE(serv, nullptr);
   auto sRef1 = ctxt.GetServiceReference<test::Interface1>();
   auto serv1 = ctxt.GetService<test::Interface1>(sRef1);
   EXPECT_NE(serv1, nullptr);
-  EXPECT_EQ(serv.get(), serv1.get()) << "same service instance must be returned from all calls to GetService";
-  auto sRef2 = testBundle.GetBundleContext().GetServiceReference<test::Interface1>();
-  auto serv2 = testBundle.GetBundleContext().GetService<test::Interface1>(sRef2);
-  EXPECT_EQ(serv.get(), serv2.get()) << "same service instance must be returned from all calls to GetService";
+  EXPECT_EQ(serv.get(), serv1.get())
+    << "same service instance must be returned from all calls to GetService";
+  auto sRef2 =
+    testBundle.GetBundleContext().GetServiceReference<test::Interface1>();
+  auto serv2 =
+    testBundle.GetBundleContext().GetService<test::Interface1>(sRef2);
+  EXPECT_EQ(serv.get(), serv2.get())
+    << "same service instance must be returned from all calls to GetService";
 }
-  
+
 /**
  * Verify a service specified with scope as BUNDLE in component description
  * is published with the correct scope and calls to GetService from the same
@@ -142,36 +179,46 @@ TEST_F(tServiceComponent, testBundleScope) //DS_TOI_14
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI14");
   auto helperBundle = StartTestBundle("TestBundleDSTOI1");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent14");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent14");
   EXPECT_EQ(compDescDTO.scope, cppmicroservices::Constants::SCOPE_BUNDLE);
   auto ctxt = framework.GetBundleContext();
-  cppmicroservices::ServiceReference<test::Interface1> sRef = ctxt.GetServiceReference<test::Interface1>();
+  cppmicroservices::ServiceReference<test::Interface1> sRef =
+    ctxt.GetServiceReference<test::Interface1>();
   EXPECT_TRUE(static_cast<bool>(sRef));
-  auto serviceScope = sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
+  auto serviceScope =
+    sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
   EXPECT_EQ(compDescDTO.scope, serviceScope.ToStringNoExcept());
-    
-  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects = ctxt.GetServiceObjects(sRef);
+
+  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects =
+    ctxt.GetServiceObjects(sRef);
   size_t callCount = 10;
   size_t i = 0;
   std::set<std::shared_ptr<test::Interface1>> instanceSet;
-  for(;i < callCount; i++)
-  {
+  for (; i < callCount; i++) {
     instanceSet.emplace(serviceObjects.GetService());
   }
-    
+
   auto helperBundleCtxt = helperBundle.GetBundleContext();
   auto sRef1 = helperBundleCtxt.GetServiceReference<test::Interface1>();
-  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects1 = helperBundleCtxt.GetServiceObjects(sRef1);
+  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects1 =
+    helperBundleCtxt.GetServiceObjects(sRef1);
   callCount += 5;
-  for(;i < callCount; i++)
-  {
+  for (; i < callCount; i++) {
     instanceSet.emplace(serviceObjects1.GetService());
   }
-  EXPECT_TRUE(std::none_of(instanceSet.begin(), instanceSet.end(), [](const std::shared_ptr<test::Interface1>& service) { return service == nullptr; }));
-  EXPECT_EQ(instanceSet.size(), 2) << "number of service instances returned must be equal to the number of distinct contexts used to call GetService";
+  EXPECT_TRUE(
+    std::none_of(instanceSet.begin(),
+                 instanceSet.end(),
+                 [](const std::shared_ptr<test::Interface1>& service) {
+                   return service == nullptr;
+                 }));
+  EXPECT_EQ(instanceSet.size(), 2)
+    << "number of service instances returned must be equal to the number of "
+       "distinct contexts used to call GetService";
   instanceSet.clear();
 }
-  
+
 /**
  * Verify a service specified with scope as PROTOTYPE in component description
  * is published with the correct scope and calls to GetService always return a
@@ -181,36 +228,45 @@ TEST_F(tServiceComponent, testPrototypeScope) //DS_TOI_15
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI15");
   auto helperBundle = StartTestBundle("TestBundleDSTOI1");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent15");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent15");
   EXPECT_EQ(compDescDTO.scope, cppmicroservices::Constants::SCOPE_PROTOTYPE);
   auto ctxt = framework.GetBundleContext();
-  cppmicroservices::ServiceReference<test::Interface1> sRef = ctxt.GetServiceReference<test::Interface1>();
+  cppmicroservices::ServiceReference<test::Interface1> sRef =
+    ctxt.GetServiceReference<test::Interface1>();
   EXPECT_TRUE(static_cast<bool>(sRef));
-  auto serviceScope = sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
+  auto serviceScope =
+    sRef.GetProperty(cppmicroservices::Constants::SERVICE_SCOPE);
   EXPECT_EQ(compDescDTO.scope, serviceScope.ToStringNoExcept());
-    
-  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects = ctxt.GetServiceObjects(sRef);
+
+  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects =
+    ctxt.GetServiceObjects(sRef);
   size_t expectedInstanceCount = 10;
   size_t i = 0;
   std::set<std::shared_ptr<test::Interface1>> instanceSet;
-  for(;i < expectedInstanceCount; i++)
-  {
+  for (; i < expectedInstanceCount; i++) {
     instanceSet.emplace(serviceObjects.GetService());
   }
-    
+
   auto helperBundleCtxt = helperBundle.GetBundleContext();
   auto sRef1 = helperBundleCtxt.GetServiceReference<test::Interface1>();
-  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects1 = helperBundleCtxt.GetServiceObjects(sRef1);
+  cppmicroservices::ServiceObjects<test::Interface1> serviceObjects1 =
+    helperBundleCtxt.GetServiceObjects(sRef1);
   expectedInstanceCount += 5;
-  for(;i < expectedInstanceCount; i++)
-  {
+  for (; i < expectedInstanceCount; i++) {
     instanceSet.emplace(serviceObjects1.GetService());
   }
-  EXPECT_TRUE(std::none_of(instanceSet.begin(), instanceSet.end(), [](const std::shared_ptr<test::Interface1>& service) { return service == nullptr; }));
-  EXPECT_EQ(instanceSet.size(), expectedInstanceCount) << "service instances returned from calls to GetService must be unique";
+  EXPECT_TRUE(
+    std::none_of(instanceSet.begin(),
+                 instanceSet.end(),
+                 [](const std::shared_ptr<test::Interface1>& service) {
+                   return service == nullptr;
+                 }));
+  EXPECT_EQ(instanceSet.size(), expectedInstanceCount)
+    << "service instances returned from calls to GetService must be unique";
   instanceSet.clear();
 }
-  
+
 /**
  * Verify that a service with multiple interfaces in component description is
  * registered with all the interfaces specified
@@ -218,7 +274,8 @@ TEST_F(tServiceComponent, testPrototypeScope) //DS_TOI_15
 TEST_F(tServiceComponent, testMultipleInterfaces) //DS_TOI_16
 {
   auto testBundle = StartTestBundle("TestBundleDSTOI16");
-  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, "sample::ServiceComponent16");
+  auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
+    testBundle, "sample::ServiceComponent16");
   EXPECT_EQ(compDescDTO.serviceInterfaces.size(), 2ul);
   auto ctxt = framework.GetBundleContext();
 
@@ -231,6 +288,6 @@ TEST_F(tServiceComponent, testMultipleInterfaces) //DS_TOI_16
   EXPECT_TRUE(static_cast<bool>(sRef2));
   auto serv2 = ctxt.GetService<test::Interface2>(sRef2);
   EXPECT_NE(serv2, nullptr);
- }
+}
 
 }

--- a/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
@@ -20,24 +20,24 @@
 
   =============================================================================*/
 
-#include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
-#include "cppmicroservices/FrameworkEvent.h"
-#include "Mocks.hpp"
 #include "../src/manager/SingletonComponentConfiguration.hpp"
-#include "ConcurrencyTestUtil.hpp"
-#include "../src/manager/states/CCRegisteredState.hpp"
 #include "../src/manager/states/CCActiveState.hpp"
+#include "../src/manager/states/CCRegisteredState.hpp"
+#include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 
 namespace cppmicroservices {
 namespace scrimpl {
 
-class SingletonComponentConfigurationTest
-  : public ::testing::Test
+class SingletonComponentConfigurationTest : public ::testing::Test
 {
 protected:
-  SingletonComponentConfigurationTest() : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  { }
+  SingletonComponentConfigurationTest()
+    : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {}
 
   virtual ~SingletonComponentConfigurationTest() = default;
 
@@ -47,10 +47,8 @@ protected:
     auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
     auto mockRegistry = std::make_shared<MockComponentRegistry>();
     auto fakeLogger = std::make_shared<FakeLogger>();
-    obj = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
-                                                                framework,
-                                                                mockRegistry,
-                                                                fakeLogger);
+    obj = std::make_shared<SingletonComponentConfigurationImpl>(
+      mockMetadata, framework, mockRegistry, fakeLogger);
   }
 
   virtual void TearDown()
@@ -69,39 +67,49 @@ TEST_F(SingletonComponentConfigurationTest, TestGetFactory)
   EXPECT_NE(obj->GetFactory(), nullptr);
 }
 
-class MockComponentInstanceFactory {
+class MockComponentInstanceFactory
+{
 public:
   MOCK_METHOD0(CreateComponentInstance, ComponentInstance*());
   MOCK_METHOD1(DeleteComponentInstance, void(ComponentInstance*));
 };
 
-TEST_F(SingletonComponentConfigurationTest, TestCreateAndActivateComponentInstance)
+TEST_F(SingletonComponentConfigurationTest,
+       TestCreateAndActivateComponentInstance)
 {
   // calling CreateAndActivateComponentInstance multiple times must return the same instance
   MockComponentInstanceFactory mockCompFactory;
   auto mockInstance = new MockComponentInstance();
   obj->SetState(std::make_shared<CCRegisteredState>());
   auto nullInstance = obj->CreateAndActivateComponentInstance(framework);
-  EXPECT_EQ(nullInstance, nullptr) << "Return value must be nullptr when state is not ACTIVE";
+  EXPECT_EQ(nullInstance, nullptr)
+    << "Return value must be nullptr when state is not ACTIVE";
   obj->SetState(std::make_shared<CCActiveState>());
-  obj->SetComponentInstanceCreateDeleteMethods(std::bind(&MockComponentInstanceFactory::CreateComponentInstance, &mockCompFactory), std::bind(&MockComponentInstanceFactory::DeleteComponentInstance, &mockCompFactory, std::placeholders::_1));
+  obj->SetComponentInstanceCreateDeleteMethods(
+    std::bind(&MockComponentInstanceFactory::CreateComponentInstance,
+              &mockCompFactory),
+    std::bind(&MockComponentInstanceFactory::DeleteComponentInstance,
+              &mockCompFactory,
+              std::placeholders::_1));
   EXPECT_CALL(mockCompFactory, CreateComponentInstance())
     .Times(2)
     .WillOnce(testing::Throw(std::runtime_error("Some error in user code")))
     .WillOnce(testing::Return(mockInstance));
   EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_))
     .Times(1)
-    .WillOnce(testing::Invoke([](ComponentInstance* obj) {
-                                delete obj;
-                              }));
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_)).Times(1);
+    .WillOnce(testing::Invoke([](ComponentInstance* obj) { delete obj; }));
+  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+    .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
   auto instance0 = obj->CreateAndActivateComponentInstance(framework);
-  EXPECT_EQ(instance0, nullptr) << "Return value must be nullptr when an exception is thrown from user code";
+  EXPECT_EQ(instance0, nullptr) << "Return value must be nullptr when an "
+                                   "exception is thrown from user code";
   auto instance = obj->CreateAndActivateComponentInstance(framework);
-  EXPECT_NE(instance, nullptr) << "Return value must be non-null in ACTIVE state";
+  EXPECT_NE(instance, nullptr)
+    << "Return value must be non-null in ACTIVE state";
   auto instance1 = obj->CreateAndActivateComponentInstance(framework);
-  EXPECT_EQ(instance, instance1) << "Return values for repeated calls must be the same";
+  EXPECT_EQ(instance, instance1)
+    << "Return values for repeated calls must be the same";
 
   //clean-up injected mock objects
   {
@@ -111,34 +119,39 @@ TEST_F(SingletonComponentConfigurationTest, TestCreateAndActivateComponentInstan
   }
 }
 
-TEST_F(SingletonComponentConfigurationTest, TestConcurrentCreateAndActivateComponentInstance)
+TEST_F(SingletonComponentConfigurationTest,
+       TestConcurrentCreateAndActivateComponentInstance)
 {
   // calling CreateAndActivateComponentInstance from multiple threads must return the same instance
   MockComponentInstanceFactory mockCompFactory;
   auto mockInstance = new MockComponentInstance();
   obj->SetState(std::make_shared<CCActiveState>());
-  obj->SetComponentInstanceCreateDeleteMethods(std::bind(&MockComponentInstanceFactory::CreateComponentInstance, &mockCompFactory), std::bind(&MockComponentInstanceFactory::DeleteComponentInstance, &mockCompFactory, std::placeholders::_1));
+  obj->SetComponentInstanceCreateDeleteMethods(
+    std::bind(&MockComponentInstanceFactory::CreateComponentInstance,
+              &mockCompFactory),
+    std::bind(&MockComponentInstanceFactory::DeleteComponentInstance,
+              &mockCompFactory,
+              std::placeholders::_1));
   EXPECT_CALL(mockCompFactory, CreateComponentInstance())
     .Times(1)
     .WillOnce(testing::Return(mockInstance));
   EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_))
     .Times(1)
-    .WillOnce(testing::Invoke([](ComponentInstance* obj) {
-                                delete obj;
-                              }));
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_)).Times(1);
+    .WillOnce(testing::Invoke([](ComponentInstance* obj) { delete obj; }));
+  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+    .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
 
   std::function<std::shared_ptr<ComponentInstance>(void)> func = [&]() {
-                                                                   return obj->CreateAndActivateComponentInstance(framework);
-                                                                 };
+    return obj->CreateAndActivateComponentInstance(framework);
+  };
   auto results = ConcurrentInvoke(func);
-  if(!results.empty())
-  {
+  if (!results.empty()) {
     auto firstElement = results[0];
-    EXPECT_TRUE(std::all_of(results.begin(), results.end(), [&](auto const& elem) {
-                                                              return elem == firstElement;
-                                                            }));
+    EXPECT_TRUE(
+      std::all_of(results.begin(), results.end(), [&](auto const& elem) {
+        return elem == firstElement;
+      }));
   }
 
   // clean up injected mock objects
@@ -154,16 +167,23 @@ TEST_F(SingletonComponentConfigurationTest, TestGetService)
   MockComponentInstanceFactory mockCompFactory;
   auto mockInstance = std::make_shared<MockComponentInstance>();
   obj->SetState(std::make_shared<CCRegisteredState>());
-  obj->SetComponentInstanceCreateDeleteMethods(std::bind(&MockComponentInstanceFactory::CreateComponentInstance, &mockCompFactory), std::bind(&MockComponentInstanceFactory::DeleteComponentInstance, &mockCompFactory, std::placeholders::_1));
+  obj->SetComponentInstanceCreateDeleteMethods(
+    std::bind(&MockComponentInstanceFactory::CreateComponentInstance,
+              &mockCompFactory),
+    std::bind(&MockComponentInstanceFactory::DeleteComponentInstance,
+              &mockCompFactory,
+              std::placeholders::_1));
   EXPECT_CALL(mockCompFactory, CreateComponentInstance())
     .Times(1)
     .WillOnce(testing::Return(mockInstance.get()));
-  EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_))
-    .Times(1);
+  EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_)).Times(1);
   cppmicroservices::InterfaceMapPtr iMap;
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_)).Times(1);
+  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+    .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
-  EXPECT_CALL(*mockInstance, GetInterfaceMap()).Times(1).WillOnce(testing::Return(iMap));
+  EXPECT_CALL(*mockInstance, GetInterfaceMap())
+    .Times(1)
+    .WillOnce(testing::Return(iMap));
   auto service = obj->GetService(Bundle(), ServiceRegistrationU());
   EXPECT_EQ(obj->GetState()->GetValue(), ComponentState::ACTIVE);
   EXPECT_EQ(service, iMap);
@@ -180,7 +200,8 @@ TEST_F(SingletonComponentConfigurationTest, TestDestroyComponentInstances)
 {
   auto mockCompContext = std::make_shared<MockComponentContextImpl>(obj);
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
-  obj->SetComponentInstancePair(InstanceContextPair(mockCompInstance,mockCompContext));
+  obj->SetComponentInstancePair(
+    InstanceContextPair(mockCompInstance, mockCompContext));
   EXPECT_CALL(*mockCompInstance, Deactivate()).Times(1);
   EXPECT_NE(obj->GetComponentInstance(), nullptr);
   EXPECT_NE(obj->GetComponentContext(), nullptr);
@@ -190,11 +211,13 @@ TEST_F(SingletonComponentConfigurationTest, TestDestroyComponentInstances)
   EXPECT_EQ(obj->GetState()->GetValue(), ComponentState::UNSATISFIED_REFERENCE);
 }
 
-TEST_F(SingletonComponentConfigurationTest, TestDestroyComponentInstances_DeactivateFailure)
+TEST_F(SingletonComponentConfigurationTest,
+       TestDestroyComponentInstances_DeactivateFailure)
 {
   auto mockCompContext = std::make_shared<MockComponentContextImpl>(obj);
   auto mockCompInstance = std::make_shared<MockComponentInstance>();
-  obj->SetComponentInstancePair(InstanceContextPair(mockCompInstance,mockCompContext));
+  obj->SetComponentInstancePair(
+    InstanceContextPair(mockCompInstance, mockCompContext));
   std::string exceptionMsg("Deactivation failed with exception");
   EXPECT_CALL(*mockCompInstance, Deactivate())
     .Times(1)
@@ -208,4 +231,3 @@ TEST_F(SingletonComponentConfigurationTest, TestDestroyComponentInstances_Deacti
 }
 }
 }
-

--- a/compendium/DeclarativeServices/test/TestUtils.cpp
+++ b/compendium/DeclarativeServices/test/TestUtils.cpp
@@ -21,35 +21,32 @@
 =============================================================================*/
 
 #include "TestUtils.hpp"
+#include "DSTestingConfig.h"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/Constants.h"
+#include "cppmicroservices/util/Error.h"
 #include "cppmicroservices/util/FileSystem.h"
 #include <iostream>
-#include "DSTestingConfig.h"
-#include "cppmicroservices/util/Error.h"
 
 #if defined(US_PLATFORM_WINDOWS)
-  #include <Windows.h>
-  #include <psapi.h>
+#  include <Windows.h>
+#  include <psapi.h>
 #else
-  #include <fstream>
-  #include <unistd.h>
+#  include <fstream>
+#  include <unistd.h>
 #endif
 
 #if defined(US_PLATFORM_LINUX)
-  #include <linux/limits.h>
+#  include <linux/limits.h>
 #endif
 
 namespace {
 
 std::string PathToLib(const std::string& libName)
 {
-  return (cppmicroservices::testing::LIB_PATH
-          + cppmicroservices::util::DIR_SEP
-          + US_LIB_PREFIX
-          + libName
-          + US_LIB_POSTFIX
-          + US_LIB_EXT);
+  return (cppmicroservices::testing::LIB_PATH +
+          cppmicroservices::util::DIR_SEP + US_LIB_PREFIX + libName +
+          US_LIB_POSTFIX + US_LIB_EXT);
 }
 
 }
@@ -58,38 +55,37 @@ namespace test {
 
 void InstallLib(
 #if defined(US_BUILD_SHARED_LIBS)
-  ::cppmicroservices::BundleContext frameworkCtx
-  , const std::string& libName
+  ::cppmicroservices::BundleContext frameworkCtx,
+  const std::string& libName
 #else
-  ::cppmicroservices::BundleContext
-  , const std::string&
+  ::cppmicroservices::BundleContext,
+  const std::string&
 #endif
-  )
+)
 {
 #if defined(US_BUILD_SHARED_LIBS)
   frameworkCtx.InstallBundles(PathToLib(libName));
 #endif
 }
 
-cppmicroservices::Bundle InstallAndStartBundle(::cppmicroservices::BundleContext frameworkCtx, const std::string& libName)
+cppmicroservices::Bundle InstallAndStartBundle(
+  ::cppmicroservices::BundleContext frameworkCtx,
+  const std::string& libName)
 {
   std::vector<cppmicroservices::Bundle> bundles;
 
 #if defined(US_BUILD_SHARED_LIBS)
-  bundles = frameworkCtx.InstallBundles(cppmicroservices::testing::LIB_PATH
-        + cppmicroservices::util::DIR_SEP
-        + US_LIB_PREFIX
-        + libName
-        + US_LIB_POSTFIX
-        + US_LIB_EXT);
+  bundles = frameworkCtx.InstallBundles(
+    cppmicroservices::testing::LIB_PATH + cppmicroservices::util::DIR_SEP +
+    US_LIB_PREFIX + libName + US_LIB_POSTFIX + US_LIB_EXT);
 #else
   bundles = frameworkCtx.GetBundles();
 #endif
 
   for (auto b : bundles) {
     if (b.GetSymbolicName() == libName) {
-        b.Start();
-        return b;
+      b.Start();
+      return b;
     }
   }
   return {};
@@ -98,15 +94,12 @@ cppmicroservices::Bundle InstallAndStartBundle(::cppmicroservices::BundleContext
 long GetServiceId(const ::cppmicroservices::ServiceReferenceBase& sRef)
 {
   long serviceId = 0;
-  try 
-  {
-    if(sRef)
-    {
-      serviceId = cppmicroservices::any_cast<long int>(sRef.GetProperty(::cppmicroservices::Constants::SERVICE_ID));
+  try {
+    if (sRef) {
+      serviceId = cppmicroservices::any_cast<long int>(
+        sRef.GetProperty(::cppmicroservices::Constants::SERVICE_ID));
     }
-  }
-  catch (const std::exception& e)
-  {
+  } catch (const std::exception& e) {
     std::cout << "Exception: " << e.what() << std::endl;
     throw;
   }
@@ -115,7 +108,7 @@ long GetServiceId(const ::cppmicroservices::ServiceReferenceBase& sRef)
 
 std::string GetDSRuntimePluginFilePath()
 {
-  std::string libName { "DeclarativeServices" };
+  std::string libName{ "DeclarativeServices" };
 #if defined(US_PLATFORM_WINDOWS)
   libName += US_DeclarativeServices_VERSION_MAJOR;
 #endif
@@ -124,8 +117,8 @@ std::string GetDSRuntimePluginFilePath()
 
 std::string GetTestPluginsPath()
 {
-  return (cppmicroservices::testing::LIB_PATH
-          + cppmicroservices::util::DIR_SEP);
+  return (cppmicroservices::testing::LIB_PATH +
+          cppmicroservices::util::DIR_SEP);
 }
 
 void InstallAndStartDS(::cppmicroservices::BundleContext frameworkCtx)
@@ -148,72 +141,73 @@ bool isBundleLoadedInThisProcess(std::string bundleName)
 {
 #if defined(US_PLATFORM_WINDOWS)
 
-    HMODULE hMods[1024];
-    DWORD cbNeeded;
+  HMODULE hMods[1024];
+  DWORD cbNeeded;
 
-    HANDLE hProcess = GetCurrentProcess();
+  HANDLE hProcess = GetCurrentProcess();
 
-    if (!EnumProcessModules(hProcess, hMods, sizeof(hMods), &cbNeeded))
-    {
-        std::cout << "FAILURE:\n" << "EnumProcessModules failed : " << cppmicroservices::util::GetLastWin32ErrorStr() << std::endl;
-        SetLastError(0);
-        return false;
-    }
-
-    if ((sizeof(hMods) < cbNeeded))
-    {
-        std::cout << "WARNING:\n" << "EnumProcessModules : Size of array is too small to hold all module handles" << std::endl;
-    }
-
-    TCHAR szModName[MAX_PATH * 2];
-    std::size_t found;
-
-    for (unsigned int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
-    {
-        if (!GetModuleFileNameA(hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)))
-        {
-            std::cout << "WARNING:\n" << "GetModuleFileNameA failed :" << cppmicroservices::util::GetLastWin32ErrorStr() << std::endl;
-            SetLastError(0);
-        }
-
-        found = std::string(szModName).find(bundleName);
-        if (found != std::string::npos)
-        {
-            return true;
-        }
-    }
-
+  if (!EnumProcessModules(hProcess, hMods, sizeof(hMods), &cbNeeded)) {
+    std::cout << "FAILURE:\n"
+              << "EnumProcessModules failed : "
+              << cppmicroservices::util::GetLastWin32ErrorStr() << std::endl;
+    SetLastError(0);
     return false;
+  }
+
+  if ((sizeof(hMods) < cbNeeded)) {
+    std::cout << "WARNING:\n"
+              << "EnumProcessModules : Size of array is too small to hold all "
+                 "module handles"
+              << std::endl;
+  }
+
+  TCHAR szModName[MAX_PATH * 2];
+  std::size_t found;
+
+  for (unsigned int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++) {
+    if (!GetModuleFileNameA(
+          hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR))) {
+      std::cout << "WARNING:\n"
+                << "GetModuleFileNameA failed :"
+                << cppmicroservices::util::GetLastWin32ErrorStr() << std::endl;
+      SetLastError(0);
+    }
+
+    found = std::string(szModName).find(bundleName);
+    if (found != std::string::npos) {
+      return true;
+    }
+  }
+
+  return false;
 #else
-    auto pid_t = getpid();
-    std::string command("lsof -p " + std::to_string(pid_t));
-    FILE* fd = popen(command.c_str(), "r");
-    if (nullptr == fd)
-    {
-        std::cout << "FAILURE:\n" << "popen failed" << std::endl;
-        return false;
-    }
-
-    std::size_t found;
-    char buf[PATH_MAX];
-    while (nullptr != fgets(buf, PATH_MAX, fd))
-    {
-        found = std::string(buf).find(bundleName);
-        if (found != std::string::npos)
-        {
-            if(-1 == pclose(fd))
-            {
-                std::cout << "WARNING:\n" << "pclose failed"<< std::endl;
-            }
-            return true;
-        }
-    }
-
-    if(-1 == pclose(fd))
-    {
-        std::cout << "WARNING:\n" << "pclose failed"<< std::endl;
-    }
+  auto pid_t = getpid();
+  std::string command("lsof -p " + std::to_string(pid_t));
+  FILE* fd = popen(command.c_str(), "r");
+  if (nullptr == fd) {
+    std::cout << "FAILURE:\n"
+              << "popen failed" << std::endl;
     return false;
+  }
+
+  std::size_t found;
+  char buf[PATH_MAX];
+  while (nullptr != fgets(buf, PATH_MAX, fd)) {
+    found = std::string(buf).find(bundleName);
+    if (found != std::string::npos) {
+      if (-1 == pclose(fd)) {
+        std::cout << "WARNING:\n"
+                  << "pclose failed" << std::endl;
+      }
+      return true;
+    }
+  }
+
+  if (-1 == pclose(fd)) {
+    std::cout << "WARNING:\n"
+              << "pclose failed" << std::endl;
+  }
+  return false;
 #endif
 }
 

--- a/compendium/DeclarativeServices/test/TestUtils.hpp
+++ b/compendium/DeclarativeServices/test/TestUtils.hpp
@@ -23,9 +23,9 @@
 #ifndef TestUtils_hpp
 #define TestUtils_hpp
 
-#include <cppmicroservices/ServiceReference.h>
 #include <cppmicroservices/Bundle.h>
 #include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/ServiceReference.h>
 
 #include <random>
 #include <string>
@@ -50,12 +50,15 @@ bool RepeatTaskUntilOrTimeout(Task&& t, Predicate&& p)
 /**
  * Convenience Method to install but not start a bundle given the bundle's symbolic name.
  */
-void InstallLib(::cppmicroservices::BundleContext frameworkCtx, const std::string& libName);
+void InstallLib(::cppmicroservices::BundleContext frameworkCtx,
+                const std::string& libName);
 
 /**
  * Convenience Method to install and start a bundle given the bundle's symbolic name.
  */
-cppmicroservices::Bundle InstallAndStartBundle(::cppmicroservices::BundleContext frameworkCtx, const std::string& libName);
+cppmicroservices::Bundle InstallAndStartBundle(
+  ::cppmicroservices::BundleContext frameworkCtx,
+  const std::string& libName);
 
 /**
  * Convenience Method to install and start DS.

--- a/compendium/DeclarativeServices/test/main.cpp
+++ b/compendium/DeclarativeServices/test/main.cpp
@@ -21,7 +21,7 @@
   =============================================================================*/
 #include "gmock/gmock.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/compendium/LogService/include/cppmicroservices/logservice/LogService.hpp
+++ b/compendium/LogService/include/cppmicroservices/logservice/LogService.hpp
@@ -26,9 +26,9 @@
 
 #include "cppmicroservices/ServiceReferenceBase.h"
 
+#include <cstdint>
 #include <exception>
 #include <string>
-#include <cstdint>
 
 namespace cppmicroservices {
 namespace logservice {
@@ -45,10 +45,14 @@ namespace logservice {
  */
 enum class SeverityLevel : uint8_t
 {
-  LOG_ERROR = 1,    ///< Indicates the bundle or service may not be functional. Action should be taken to correct this situation.
-  LOG_WARNING = 2,  ///< Indicates a bundle or service is still functioning but may experience problems in the future because of the warning condition.
-  LOG_INFO = 3,     ///< May be the result of any change in the bundle or service and does not indicate a problem.
-  LOG_DEBUG = 4     ///< Used for problem determination and may be irrelevant to anyone but the bundle developer.
+  LOG_ERROR =
+    1, ///< Indicates the bundle or service may not be functional. Action should be taken to correct this situation.
+  LOG_WARNING =
+    2, ///< Indicates a bundle or service is still functioning but may experience problems in the future because of the warning condition.
+  LOG_INFO =
+    3, ///< May be the result of any change in the bundle or service and does not indicate a problem.
+  LOG_DEBUG =
+    4 ///< Used for problem determination and may be irrelevant to anyone but the bundle developer.
 };
 /** @}*/
 
@@ -69,7 +73,7 @@ enum class SeverityLevel : uint8_t
  */
 class US_usLogService_EXPORT LogService
 {
-  public:
+public:
   virtual ~LogService();
 
   /**
@@ -85,7 +89,9 @@ class US_usLogService_EXPORT LogService
    * @param message Human readable string describing the condition or empty string.
    * @param ex The exception that reflects the condition or nullptr.
    */
-  virtual void Log(SeverityLevel level, const std::string& message, const std::exception_ptr ex) = 0;
+  virtual void Log(SeverityLevel level,
+                   const std::string& message,
+                   const std::exception_ptr ex) = 0;
 
   /**
    * Logs a message.
@@ -93,7 +99,9 @@ class US_usLogService_EXPORT LogService
    * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
    * @param message Human readable string describing the condition or empty string.
    */
-  virtual void Log(const ServiceReferenceBase& sr, SeverityLevel level, const std::string& message) = 0;
+  virtual void Log(const ServiceReferenceBase& sr,
+                   SeverityLevel level,
+                   const std::string& message) = 0;
 
   /**
    * Logs a message with an exception associated and a ServiceReference object.
@@ -102,7 +110,10 @@ class US_usLogService_EXPORT LogService
    * @param message Human readable string describing the condition or empty string.
    * @param ex The exception that reflects the condition or nullptr.
    */
-  virtual void Log(const ServiceReferenceBase& sr, SeverityLevel level, const std::string& message, const std::exception_ptr ex) = 0;
+  virtual void Log(const ServiceReferenceBase& sr,
+                   SeverityLevel level,
+                   const std::string& message,
+                   const std::exception_ptr ex) = 0;
 };
 
 } // namespace logservice

--- a/compendium/LogServiceImpl/src/Activator.cpp
+++ b/compendium/LogServiceImpl/src/Activator.cpp
@@ -6,7 +6,8 @@ namespace logservice {
 namespace impl {
 void Activator::Start(cppmicroservices::BundleContext bc)
 {
-  auto svc = std::make_shared<cppmicroservices::logservice::LogServiceImpl>("cppmicroservices::logservice");
+  auto svc = std::make_shared<cppmicroservices::logservice::LogServiceImpl>(
+    "cppmicroservices::logservice");
   bc.RegisterService<cppmicroservices::logservice::LogService>(std::move(svc));
 }
 
@@ -15,4 +16,5 @@ void Activator::Stop(cppmicroservices::BundleContext) {}
 }
 }
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::logservice::impl::Activator)
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::logservice::impl::Activator)

--- a/compendium/LogServiceImpl/src/LogServiceImpl.cpp
+++ b/compendium/LogServiceImpl/src/LogServiceImpl.cpp
@@ -87,7 +87,8 @@ void LogServiceImpl::Log(const ServiceReferenceBase& sr,
                          const std::exception_ptr ex)
 {
   std::string full_message = message;
-  full_message = message + GetServiceReferenceInfo(sr) + GetExceptionMessage(ex);
+  full_message =
+    message + GetServiceReferenceInfo(sr) + GetExceptionMessage(ex);
   LogServiceImpl::Log(level, full_message);
 }
 

--- a/compendium/LogServiceImpl/src/LogServiceImpl.hpp
+++ b/compendium/LogServiceImpl/src/LogServiceImpl.hpp
@@ -27,57 +27,65 @@ class sink;
 }
 
 namespace spdlog {
-  class logger;
-  using sink_ptr = std::shared_ptr<sinks::sink>;
+class logger;
+using sink_ptr = std::shared_ptr<sinks::sink>;
 }
 
 namespace cppmicroservices {
-  namespace logservice {
-    class LogServiceImpl final : public LogService {
-    public:
-      LogServiceImpl(const std::string& loggerName);
-      ~LogServiceImpl() = default;
+namespace logservice {
+class LogServiceImpl final : public LogService
+{
+public:
+  LogServiceImpl(const std::string& loggerName);
+  ~LogServiceImpl() = default;
 
-      /**
-       * Logs a message.
-       * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
-       * @param message Human readable string describing the condition or empty string.
-       */
-      void Log(SeverityLevel level, const std::string& message) override;
+  /**
+   * Logs a message.
+   * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
+   * @param message Human readable string describing the condition or empty string.
+   */
+  void Log(SeverityLevel level, const std::string& message) override;
 
-      /**
-       * Logs a message.
-       * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
-       * @param message Human readable string describing the condition or empty string.
-       * @param ex The exception that reflects the condition or nullptr.
-       */
-      void Log(SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
+  /**
+   * Logs a message.
+   * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
+   * @param message Human readable string describing the condition or empty string.
+   * @param ex The exception that reflects the condition or nullptr.
+   */
+  void Log(SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
 
-      /**
-       * Logs a message.
-       * @param sr The ServiceReferenceBase object of the service that this message is associated with or an invalid object.
-       * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
-       * @param message Human readable string describing the condition or empty string.
-       */
-      void Log(const ServiceReferenceBase& sr, SeverityLevel level, const std::string& message) override;
+  /**
+   * Logs a message.
+   * @param sr The ServiceReferenceBase object of the service that this message is associated with or an invalid object.
+   * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
+   * @param message Human readable string describing the condition or empty string.
+   */
+  void Log(const ServiceReferenceBase& sr,
+           SeverityLevel level,
+           const std::string& message) override;
 
-      /**
-       * Logs a message with an exception associated and a ServiceReference object.
-       * @param sr The ServiceReferenceBase object of the service that this message is associated with or an invalid object.
-       * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
-       * @param message Human readable string describing the condition or empty string.
-       * @param ex The exception that reflects the condition or nullptr.
-       */
-      void Log(const ServiceReferenceBase& sr, SeverityLevel level, const std::string& message, const std::exception_ptr ex) override;
-      
-      /**
-       * Registers a sink to the logger for introspection of contents. This is not a publicly available
-       * function and should only be used for testing. This is NOT thread-safe.
-       */
-      void AddSink(spdlog::sink_ptr& sink);
+  /**
+   * Logs a message with an exception associated and a ServiceReference object.
+   * @param sr The ServiceReferenceBase object of the service that this message is associated with or an invalid object.
+   * @param level The severity of the message. This should be one of the defined log levels but may be any integer that is interpreted in a user defined way.
+   * @param message Human readable string describing the condition or empty string.
+   * @param ex The exception that reflects the condition or nullptr.
+   */
+  void Log(const ServiceReferenceBase& sr,
+           SeverityLevel level,
+           const std::string& message,
+           const std::exception_ptr ex) override;
 
-    private:
-      std::shared_ptr<::spdlog::logger> m_Logger;
-    };
-  }
+  /**
+   * Registers a sink to the logger for introspection of contents. This is not a publicly available
+   * function and should only be used for testing. This is NOT thread-safe.
+   */
+  void AddSink(spdlog::sink_ptr& sink);
+
+private:
+  std::shared_ptr<::spdlog::logger> m_Logger;
+};
+}
 }

--- a/compendium/LogServiceImpl/test/TestLogService.cpp
+++ b/compendium/LogServiceImpl/test/TestLogService.cpp
@@ -10,47 +10,53 @@
 
 #include <chrono>
 #include <functional>
-#include <memory>
 #include <limits>
+#include <memory>
 #include <ostream>
 #include <regex>
 #include <string>
 #include <thread>
 #include <utility>
 
-#include <spdlog/spdlog.h>
 #include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/spdlog.h>
 
 #include "LogServiceImpl.hpp"
 
 namespace ls = cppmicroservices::logservice;
 
 static const std::string sinkFormat = "[%T] [%P:%t] %n (%^%l%$): %v";
-static const std::string log_preamble("\\[([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})\\] \\[([0-9]{1,9}):([0-9]{1,9})\\] cppmicroservices::testing::logservice \\((debug|trace|info|warning|error)\\): ");
-static const std::string svcRef_preamble(
-  "ServiceReference: ");
-static const std::string exception_preamble(
-  "Exception logged: ");
+static const std::string log_preamble(
+  "\\[([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})\\] "
+  "\\[([0-9]{1,9}):([0-9]{1,9})\\] cppmicroservices::testing::logservice "
+  "\\((debug|trace|info|warning|error)\\): ");
+static const std::string svcRef_preamble("ServiceReference: ");
+static const std::string exception_preamble("Exception logged: ");
 
 class LogServiceImplTests : public ::testing::Test
 {
 public:
-  LogServiceImplTests() {
-    _impl = std::make_shared<ls::LogServiceImpl>("cppmicroservices::testing::logservice");
+  LogServiceImplTests()
+  {
+    _impl = std::make_shared<ls::LogServiceImpl>(
+      "cppmicroservices::testing::logservice");
   }
 
-  void SetUp() override {
+  void SetUp() override
+  {
     _sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
     _sink->set_pattern(sinkFormat);
     _impl->AddSink(_sink);
   }
 
-  void TearDown() override {
+  void TearDown() override
+  {
     _sink.reset();
     _impl.reset();
   }
 
-  bool ContainsRegex(const std::string& regex) {
+  bool ContainsRegex(const std::string& regex)
+  {
     std::string text = oss.str();
     std::smatch m;
     bool found = std::regex_search(text, m, std::regex(regex));
@@ -67,7 +73,8 @@ private:
   std::shared_ptr<ls::LogServiceImpl> _impl;
 };
 
-TEST_F(LogServiceImplTests, ProperLoggerUsage) {
+TEST_F(LogServiceImplTests, ProperLoggerUsage)
+{
   auto logger = GetLogger();
 
   logger->Log(ls::SeverityLevel::LOG_DEBUG, "Bonjour!");
@@ -82,61 +89,123 @@ TEST_F(LogServiceImplTests, ProperLoggerUsage) {
   logger->Log(ls::SeverityLevel::LOG_ERROR, "Salve!");
   EXPECT_TRUE(ContainsRegex(log_preamble + "Salve!"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_DEBUG, "Test debug message");
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" + svcRef_preamble + "Invalid service reference"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_DEBUG,
+              "Test debug message");
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" +
+                            svcRef_preamble + "Invalid service reference"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_INFO, "Test info message");
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" + svcRef_preamble + "Invalid service reference"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_INFO,
+              "Test info message");
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" +
+                            svcRef_preamble + "Invalid service reference"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_WARNING, "Test warning message");
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" + svcRef_preamble + "Invalid service reference"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_WARNING,
+              "Test warning message");
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" +
+                            svcRef_preamble + "Invalid service reference"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_ERROR, "Test error message");
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" + svcRef_preamble + "Invalid service reference"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_ERROR,
+              "Test error message");
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" +
+                            svcRef_preamble + "Invalid service reference"));
 
-  logger->Log(ls::SeverityLevel::LOG_DEBUG, "Test debug message", std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" + exception_preamble + "(.)+ uh oh"));
+  logger->Log(
+    ls::SeverityLevel::LOG_DEBUG,
+    "Test debug message",
+    std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" +
+                            exception_preamble + "(.)+ uh oh"));
 
-  logger->Log(ls::SeverityLevel::LOG_INFO, "Test info message", std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" + exception_preamble + "(.)+ uh oh"));
+  logger->Log(
+    ls::SeverityLevel::LOG_INFO,
+    "Test info message",
+    std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" +
+                            exception_preamble + "(.)+ uh oh"));
 
-  logger->Log(ls::SeverityLevel::LOG_WARNING, "Test warning message", std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" + exception_preamble + "(.)+ uh oh"));
+  logger->Log(
+    ls::SeverityLevel::LOG_WARNING,
+    "Test warning message",
+    std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" +
+                            exception_preamble + "(.)+ uh oh"));
 
-  logger->Log(ls::SeverityLevel::LOG_ERROR, "Test error message", std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" + exception_preamble + "(.)+ uh oh"));
+  logger->Log(
+    ls::SeverityLevel::LOG_ERROR,
+    "Test error message",
+    std::make_exception_ptr<std::runtime_error>(std::runtime_error("uh oh")));
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" +
+                            exception_preamble + "(.)+ uh oh"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_DEBUG, "Test debug message", std::exception_ptr{});
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_DEBUG,
+              "Test debug message",
+              std::exception_ptr{});
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test debug message(\\n)" +
+                            svcRef_preamble + "Invalid service reference(\\n)" +
+                            exception_preamble + "none"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_INFO, "Test info message", std::exception_ptr{});
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_INFO,
+              "Test info message",
+              std::exception_ptr{});
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test info message(\\n)" +
+                            svcRef_preamble + "Invalid service reference(\\n)" +
+                            exception_preamble + "none"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_WARNING, "Test warning message", std::exception_ptr{});
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_WARNING,
+              "Test warning message",
+              std::exception_ptr{});
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test warning message(\\n)" +
+                            svcRef_preamble + "Invalid service reference(\\n)" +
+                            exception_preamble + "none"));
 
-  logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_ERROR, "Test error message", std::exception_ptr{});
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none"));
+  logger->Log(cppmicroservices::ServiceReferenceU{},
+              ls::SeverityLevel::LOG_ERROR,
+              "Test error message",
+              std::exception_ptr{});
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test error message(\\n)" +
+                            svcRef_preamble + "Invalid service reference(\\n)" +
+                            exception_preamble + "none"));
 }
 
 TEST_F(LogServiceImplTests, InvalidLoggerUsage)
 {
   auto logger = GetLogger();
 
-  ASSERT_NO_THROW(logger->Log(static_cast<ls::SeverityLevel>(-1), "Test invalid negative severity level"));
-  EXPECT_FALSE(ContainsRegex(log_preamble + "Test invalid negative severity level"));
-  
-  ASSERT_NO_THROW(logger->Log(static_cast<ls::SeverityLevel>(std::numeric_limits<unsigned int>::max()), "Test invalid maximum severity level"));
-  EXPECT_FALSE(ContainsRegex(log_preamble + "Test invalid maximum severity level"));
+  ASSERT_NO_THROW(logger->Log(static_cast<ls::SeverityLevel>(-1),
+                              "Test invalid negative severity level"));
+  EXPECT_FALSE(
+    ContainsRegex(log_preamble + "Test invalid negative severity level"));
 
-  ASSERT_NO_THROW(logger->Log(ls::SeverityLevel::LOG_INFO, "Test invalid exception_ptr", nullptr));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test invalid exception_ptr(\\n)" + exception_preamble + "none"));
+  ASSERT_NO_THROW(logger->Log(
+    static_cast<ls::SeverityLevel>(std::numeric_limits<unsigned int>::max()),
+    "Test invalid maximum severity level"));
+  EXPECT_FALSE(
+    ContainsRegex(log_preamble + "Test invalid maximum severity level"));
 
-  ASSERT_NO_THROW(logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_INFO, "Test invalid ServiceReferenceBase object", nullptr));
-  EXPECT_TRUE(ContainsRegex(log_preamble + "Test invalid ServiceReferenceBase object(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none"));
+  ASSERT_NO_THROW(logger->Log(
+    ls::SeverityLevel::LOG_INFO, "Test invalid exception_ptr", nullptr));
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Test invalid exception_ptr(\\n)" +
+                            exception_preamble + "none"));
+
+  ASSERT_NO_THROW(logger->Log(cppmicroservices::ServiceReferenceU{},
+                              ls::SeverityLevel::LOG_INFO,
+                              "Test invalid ServiceReferenceBase object",
+                              nullptr));
+  EXPECT_TRUE(ContainsRegex(log_preamble +
+                            "Test invalid ServiceReferenceBase object(\\n)" +
+                            svcRef_preamble + "Invalid service reference(\\n)" +
+                            exception_preamble + "none"));
 }
 
-TEST_F(LogServiceImplTests, ThreadSafety) {
+TEST_F(LogServiceImplTests, ThreadSafety)
+{
   auto logger = GetLogger();
   auto& oss = GetStream();
 
@@ -144,19 +213,25 @@ TEST_F(LogServiceImplTests, ThreadSafety) {
   std::vector<std::thread> threads;
   for (int i = 0; i < iterations; i++) {
     threads.push_back(std::thread([&logger]() {
-        logger->Log(cppmicroservices::ServiceReferenceU{}, ls::SeverityLevel::LOG_INFO, "Test concurrent log calls", nullptr);
-      }));
+      logger->Log(cppmicroservices::ServiceReferenceU{},
+                  ls::SeverityLevel::LOG_INFO,
+                  "Test concurrent log calls",
+                  nullptr);
+    }));
   }
 
   for (auto& thread : threads) {
     thread.join();
   }
 
-  std::regex regexp(log_preamble + "Test concurrent log calls(\\n)" + svcRef_preamble + "Invalid service reference(\\n)" + exception_preamble + "none");
+  std::regex regexp(log_preamble + "Test concurrent log calls(\\n)" +
+                    svcRef_preamble + "Invalid service reference(\\n)" +
+                    exception_preamble + "none");
   std::string stream(oss.str());
   auto regex_iter_end = std::sregex_iterator();
 
-  auto regex_iter_begin = std::sregex_iterator(stream.begin(), stream.end(), regexp);
+  auto regex_iter_begin =
+    std::sregex_iterator(stream.begin(), stream.end(), regexp);
   std::ptrdiff_t num_found = std::distance(regex_iter_begin, regex_iter_end);
   ASSERT_TRUE(num_found == iterations);
 }

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentConstants.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentConstants.hpp
@@ -27,12 +27,14 @@
 
 #include <cppmicroservices/servicecomponent/ServiceComponentExport.h>
 
-namespace cppmicroservices { namespace service { namespace component {
+namespace cppmicroservices {
+namespace service {
+namespace component {
 
-	/**
-	\defgroup gr_componentconstants ComponentConstants
-	\brief Groups ComponentConstants related symbols.
-	*/
+/**
+ \defgroup gr_componentconstants ComponentConstants
+ \brief Groups ComponentConstants related symbols.
+ */
 
 /**
  * \ingroup gr_componentconstants 
@@ -85,9 +87,12 @@ US_ServiceComponent_EXPORT extern const std::string REFERENCE_TARGET_SUFFIX;
  * only if the service is registered with \c PROTOTYPE scope. Each component
  * instance receives a distinct service object.
  */
-US_ServiceComponent_EXPORT extern const std::string REFERENCE_SCOPE_PROTOTYPE_REQUIRED;
+US_ServiceComponent_EXPORT extern const std::string
+  REFERENCE_SCOPE_PROTOTYPE_REQUIRED;
 }
 
-}}} // namespaces
+}
+}
+} // namespaces
 
 #endif // ComponentConstants_hpp

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentContext.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentContext.hpp
@@ -23,21 +23,23 @@
 #ifndef ComponentContext_hpp
 #define ComponentContext_hpp
 
-#include <unordered_map>
-#include <vector>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/BundleContext.h"
-#include "cppmicroservices/ServiceReference.h"
 #include "cppmicroservices/ServiceInterface.h"
+#include "cppmicroservices/ServiceReference.h"
 #include "cppmicroservices/servicecomponent/ServiceComponentExport.h"
 
-namespace cppmicroservices { namespace service { namespace component {
+namespace cppmicroservices {
+namespace service {
+namespace component {
 
-    /**
+/**
 	\defgroup gr_componentcontext ComponentContext
 	\brief Groups ComponentContext class related symbols.
 	*/
@@ -55,7 +57,7 @@ namespace cppmicroservices { namespace service { namespace component {
  */
 class US_ServiceComponent_EXPORT ComponentContext
 {
-  public:
+public:
   virtual ~ComponentContext() noexcept;
 
   /**
@@ -63,7 +65,8 @@ class US_ServiceComponent_EXPORT ComponentContext
    *
    * @return The properties for this Component Context.
    */
-  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties() const = 0;
+  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
+    const = 0;
 
   /**
    * Returns the {@link BundleContext} of the bundle which contains this
@@ -138,7 +141,8 @@ class US_ServiceComponent_EXPORT ComponentContext
    *         invalid object if the component instance is not registered as a
    *         service.
    */
-  virtual cppmicroservices::ServiceReferenceBase GetServiceReference() const = 0;
+  virtual cppmicroservices::ServiceReferenceBase GetServiceReference()
+    const = 0;
 
   /**
    * Returns the service object for the specified reference name and type.
@@ -160,9 +164,10 @@ class US_ServiceComponent_EXPORT ComponentContext
    *         exception while activating the bound service.
    */
   template<class T>
-  std::shared_ptr<T>  LocateService(const std::string& refName) const
+  std::shared_ptr<T> LocateService(const std::string& refName) const
   {
-    std::shared_ptr<void> sObj = LocateService(refName, us_service_interface_iid<T>());
+    std::shared_ptr<void> sObj =
+      LocateService(refName, us_service_interface_iid<T>());
     return std::static_pointer_cast<T>(sObj);
   }
 
@@ -180,18 +185,18 @@ class US_ServiceComponent_EXPORT ComponentContext
    *         exception while activating a bound service.
    */
   template<class T>
-  std::vector<std::shared_ptr<T>>  LocateServices(const std::string& refName) const
+  std::vector<std::shared_ptr<T>> LocateServices(
+    const std::string& refName) const
   {
     auto sObjs = LocateServices(refName, us_service_interface_iid<T>());
     std::vector<std::shared_ptr<T>> objs;
-    for(auto obj : sObjs)
-    {
+    for (auto obj : sObjs) {
       objs.push_back(std::static_pointer_cast<T>(obj));
     }
     return objs;
   }
 
-  protected:
+protected:
   /**
    * Returns the service object for the specified reference name and type.
    *
@@ -212,7 +217,9 @@ class US_ServiceComponent_EXPORT ComponentContext
    * @throws ComponentException If Service Component Runtime catches an
    *         exception while activating the bound service.
    */
-  virtual std::shared_ptr<void> LocateService(const std::string& name, const std::string& type) const = 0;
+  virtual std::shared_ptr<void> LocateService(
+    const std::string& name,
+    const std::string& type) const = 0;
 
   /**
    * Returns the service objects for the specified reference name and type.
@@ -228,9 +235,13 @@ class US_ServiceComponent_EXPORT ComponentContext
    * @throws ComponentException If Service Component Runtime catches an
    *         exception while activating a bound service.
    */
-  virtual  std::vector<std::shared_ptr<void>> LocateServices(const std::string& name, const std::string& type) const = 0;
+  virtual std::vector<std::shared_ptr<void>> LocateServices(
+    const std::string& name,
+    const std::string& type) const = 0;
 };
 
-}}} // namespaces
+}
+}
+} // namespaces
 
 #endif /* ComponentContext_hpp */

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentException.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentException.hpp
@@ -32,10 +32,10 @@ namespace cppmicroservices {
 namespace service {
 namespace component {
 
-	/**
-	\defgroup gr_componentexception ComponentException
-	\brief Groups ComponentException class related symbols.
-	*/
+/**
+ \defgroup gr_componentexception ComponentException
+ \brief Groups ComponentException class related symbols.
+ */
 
 #ifdef _MSC_VER
 // C4275 can be ignored in Visual C++ if you are deriving from a type in the C++ Standard Library
@@ -47,17 +47,16 @@ namespace component {
  *
  * Exception which may be thrown by Service Component Runtime.
  */
-class US_ServiceComponent_EXPORT ComponentException final
-  : std::runtime_error
+class US_ServiceComponent_EXPORT ComponentException final : std::runtime_error
 {
-  public:
+public:
   /**
    * Construct a new ComponentException with the specified message.
    *
    * @param message The message for the exception.
    */
-  explicit ComponentException( const std::string& message );
-  explicit ComponentException( const char* message );
+  explicit ComponentException(const std::string& message);
+  explicit ComponentException(const char* message);
 
   virtual ~ComponentException() noexcept;
 };

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/Binders.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/Binders.hpp
@@ -28,23 +28,25 @@
 
 #include <cppmicroservices/ServiceReference.h>
 
-namespace cppmicroservices { namespace service { namespace component { namespace detail {
+namespace cppmicroservices {
+namespace service {
+namespace component {
+namespace detail {
 
 /**
  * Binder objects are used by the runtime to call the Bind and Unbind methods on a service component object.
  */
-template <class T>
+template<class T>
 class Binder
 {
 public:
-  Binder(const std::string& refName,
-         const std::string& refType)
+  Binder(const std::string& refName, const std::string& refType)
     : mRefName(refName)
     , mRefType(refType)
   {}
-  
-  virtual ~Binder() {};
-  
+
+  virtual ~Binder(){};
+
   virtual void Bind(cppmicroservices::BundleContext bc,
                     const cppmicroservices::ServiceReferenceBase& sRef,
                     const std::shared_ptr<T>& comp) = 0;
@@ -61,6 +63,7 @@ public:
                       const std::shared_ptr<T>& comp) = 0;
   std::string GetReferenceName() { return mRefName; }
   std::string GetReferenceType() { return mRefType; }
+
 private:
   std::string mRefName;
   std::string mRefType;
@@ -69,9 +72,8 @@ private:
 /**
  * This class is used to represent a binder object for a reference with static policy
  */
-template <class T, class R>
-class StaticBinder final
-  : public Binder<T>
+template<class T, class R>
+class StaticBinder final : public Binder<T>
 {
 public:
   StaticBinder(const std::string& refName)
@@ -83,9 +85,9 @@ public:
    * References with static policy must not be modified throught out the lifetime
    * of the service component object.
    */
-  void Bind(cppmicroservices::BundleContext
-            , const cppmicroservices::ServiceReferenceBase&
-            , const std::shared_ptr<T>&) override
+  void Bind(cppmicroservices::BundleContext,
+            const cppmicroservices::ServiceReferenceBase&,
+            const std::shared_ptr<T>&) override
   {
     throw std::runtime_error("Static dependency must not change at runtime");
   }
@@ -95,33 +97,31 @@ public:
    * References with static policy must not be modified throught out the lifetime
    * of the service component object.
    */
-  void UnBind(cppmicroservices::BundleContext
-              , const cppmicroservices::ServiceReferenceBase&
-              , const std::shared_ptr<T>&) override
+  void UnBind(cppmicroservices::BundleContext,
+              const cppmicroservices::ServiceReferenceBase&,
+              const std::shared_ptr<T>&) override
   {
     throw std::runtime_error("Static dependency must not change at runtime");
   }
 
-  void Bind(const std::shared_ptr<ComponentContext>&
-            , const std::shared_ptr<T>&) override
-  {
-    throw std::runtime_error("Static dependency must not change at runtime");
-  }
-  
-  void Unbind(const std::shared_ptr<ComponentContext>&
-              , const std::shared_ptr<T>&) override
+  void Bind(const std::shared_ptr<ComponentContext>&,
+            const std::shared_ptr<T>&) override
   {
     throw std::runtime_error("Static dependency must not change at runtime");
   }
 
-  void Bind(const std::shared_ptr<void>&
-            , const std::shared_ptr<T>&) override
+  void Unbind(const std::shared_ptr<ComponentContext>&,
+              const std::shared_ptr<T>&) override
   {
     throw std::runtime_error("Static dependency must not change at runtime");
   }
 
-  void Unbind(const std::shared_ptr<void>&
-              , const std::shared_ptr<T>&) override
+  void Bind(const std::shared_ptr<void>&, const std::shared_ptr<T>&) override
+  {
+    throw std::runtime_error("Static dependency must not change at runtime");
+  }
+
+  void Unbind(const std::shared_ptr<void>&, const std::shared_ptr<T>&) override
   {
     throw std::runtime_error("Static dependency must not change at runtime");
   }
@@ -130,18 +130,16 @@ public:
 /**
  * This class is used to represent a binder object for a reference with dynamic policy
  */
-template <class T, class R>
-class DynamicBinder final
-  : public Binder<T>
+template<class T, class R>
+class DynamicBinder final : public Binder<T>
 {
 public:
+  using BindFuncT = std::function<void(T*, const std::shared_ptr<R>&)>;
+  using UnbindFuncT = std::function<void(T*, const std::shared_ptr<R>&)>;
 
-  using BindFuncT = std::function<void(T*,const std::shared_ptr<R>&)>;
-  using UnbindFuncT = std::function<void(T*,const std::shared_ptr<R>&)>;
-
-  DynamicBinder(const std::string& refName
-                , BindFuncT bindFPtr
-                , UnbindFuncT unbindFPtr)
+  DynamicBinder(const std::string& refName,
+                BindFuncT bindFPtr,
+                UnbindFuncT unbindFPtr)
     : Binder<T>(refName, us_service_interface_iid<R>())
     , bindFunction(bindFPtr)
     , unbindFunction(unbindFPtr)
@@ -149,79 +147,83 @@ public:
 
   virtual ~DynamicBinder() = default;
 
-  void Bind(cppmicroservices::BundleContext bc
-            , const cppmicroservices::ServiceReferenceBase& sRef
-            , const std::shared_ptr<T>& comp) override
+  void Bind(cppmicroservices::BundleContext bc,
+            const cppmicroservices::ServiceReferenceBase& sRef,
+            const std::shared_ptr<T>& comp) override
   {
     cppmicroservices::ServiceReference<R> typedRef(sRef);
-    if(!typedRef)
-    {
+    if (!typedRef) {
       throw std::runtime_error("Invalid service reference");
     }
     std::shared_ptr<R> service = bc.template GetService<R>(typedRef);
     DoBind(service, comp);
   }
 
-  void UnBind(cppmicroservices::BundleContext bc
-              , const cppmicroservices::ServiceReferenceBase& sRef
-              , const std::shared_ptr<T>& comp) override
+  void UnBind(cppmicroservices::BundleContext bc,
+              const cppmicroservices::ServiceReferenceBase& sRef,
+              const std::shared_ptr<T>& comp) override
   {
     cppmicroservices::ServiceReference<R> typedRef(sRef);
-    if(!typedRef)
-    {
+    if (!typedRef) {
       throw std::runtime_error("Invalid service reference");
     }
     std::shared_ptr<R> service = bc.template GetService<R>(typedRef);
     DoUnbind(service, comp);
   }
 
-  void Bind(const std::shared_ptr<ComponentContext>& ctxt
-            , const std::shared_ptr<T>& comp) override
+  void Bind(const std::shared_ptr<ComponentContext>& ctxt,
+            const std::shared_ptr<T>& comp) override
   {
-    std::shared_ptr<R> service = ctxt->LocateService<R>(this->GetReferenceName());
+    std::shared_ptr<R> service =
+      ctxt->LocateService<R>(this->GetReferenceName());
     DoBind(service, comp);
   }
-  
-  void Unbind(const std::shared_ptr<ComponentContext>& ctxt
-              , const std::shared_ptr<T>& comp) override
+
+  void Unbind(const std::shared_ptr<ComponentContext>& ctxt,
+              const std::shared_ptr<T>& comp) override
   {
-    std::shared_ptr<R> service = ctxt->LocateService<R>(this->GetReferenceName());
+    std::shared_ptr<R> service =
+      ctxt->LocateService<R>(this->GetReferenceName());
     DoUnbind(service, comp);
   }
 
-  void Bind(const std::shared_ptr<void>& serv
-            , const std::shared_ptr<T>& comp) override
+  void Bind(const std::shared_ptr<void>& serv,
+            const std::shared_ptr<T>& comp) override
   {
     std::shared_ptr<R> service = std::static_pointer_cast<R>(serv);
     DoBind(service, comp);
   }
 
-  void DoBind(const std::shared_ptr<R>& service
-              , const std::shared_ptr<T>& comp)
+  void DoBind(const std::shared_ptr<R>& service, const std::shared_ptr<T>& comp)
   {
     auto bind = std::bind(bindFunction, comp.get(), service);
     bind(); // call the method on the component instance with service as parameter.
   }
 
-  void Unbind(const std::shared_ptr<void>& serv
-              , const std::shared_ptr<T>& comp) override
+  void Unbind(const std::shared_ptr<void>& serv,
+              const std::shared_ptr<T>& comp) override
   {
     std::shared_ptr<R> service = std::static_pointer_cast<R>(serv);
     DoUnbind(service, comp);
   }
 
-  void DoUnbind(const std::shared_ptr<R>& service
-                , const std::shared_ptr<T>& comp)
+  void DoUnbind(const std::shared_ptr<R>& service,
+                const std::shared_ptr<T>& comp)
   {
     auto unbind = std::bind(unbindFunction, comp.get(), service);
     unbind(); // call the method on the component instance with service as parameter.
   }
 
 private:
-  BindFuncT bindFunction;      // the function object used for callback to bind the reference
-  UnbindFuncT unbindFunction;  // the function object used for callback to unbind the reference
+  BindFuncT
+    bindFunction; // the function object used for callback to bind the reference
+  UnbindFuncT
+    unbindFunction; // the function object used for callback to unbind the reference
 };
 
-}}}} // namespaces
+}
+}
+}
+} // namespaces
 
 #endif /* Binders_h */

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstance.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstance.hpp
@@ -22,22 +22,26 @@
 
 #ifndef ComponentInstance_hpp
 #define ComponentInstance_hpp
-#include <memory>
 #include <map>
+#include <memory>
 
-#include <cppmicroservices/ServiceReference.h>
 #include "../ComponentContext.hpp"
 #include "cppmicroservices/servicecomponent/ServiceComponentExport.h"
+#include <cppmicroservices/ServiceReference.h>
 
-namespace cppmicroservices { namespace service { namespace component { namespace detail {
+namespace cppmicroservices {
+namespace service {
+namespace component {
+namespace detail {
 
 /**
  * This interface is used by the declarative services runtime to manage the
  * creation, dependency injection and deletion of instances of the service
  * component class.
  */
-class US_ServiceComponent_EXPORT ComponentInstance {
-  public:
+class US_ServiceComponent_EXPORT ComponentInstance
+{
+public:
   virtual ~ComponentInstance() noexcept;
 
   /**
@@ -47,9 +51,10 @@ class US_ServiceComponent_EXPORT ComponentInstance {
    *
    * @param ctxt The {@code ComponentContext} object associated with the component instance.
    */
-  virtual void CreateInstanceAndBindReferences(const std::shared_ptr<ComponentContext>& ctxt) = 0;
+  virtual void CreateInstanceAndBindReferences(
+    const std::shared_ptr<ComponentContext>& ctxt) = 0;
   virtual void UnbindReferences() = 0;
-  
+
   /**
    * This method is called by the runtime while activating the component configuration.
    * It is called after the call to {@code #CreateInstanceAndBindReferences} method suceeded.
@@ -71,12 +76,16 @@ class US_ServiceComponent_EXPORT ComponentInstance {
   /**
    * This method is called by the runtime to bind a reference with dynamic policy
    */
-  virtual void InvokeUnbindMethod(const std::string& refName, const cppmicroservices::ServiceReferenceBase& sRef) = 0;
+  virtual void InvokeUnbindMethod(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef) = 0;
 
   /**
    * This method is called by the runtime to unbind a reference with dynamic policy
    */
-  virtual void InvokeBindMethod(const std::string& refName, const cppmicroservices::ServiceReferenceBase& sRef) = 0;
+  virtual void InvokeBindMethod(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef) = 0;
 
   /**
    * This method is called when a call to @{code ServiceFactory#GetService} is received by the runtime.
@@ -84,6 +93,9 @@ class US_ServiceComponent_EXPORT ComponentInstance {
   virtual cppmicroservices::InterfaceMapPtr GetInterfaceMap() = 0;
 };
 
-}}}} // namespaces
+}
+}
+}
+} // namespaces
 
 #endif /* ComponentInstance_hpp */

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
@@ -23,54 +23,64 @@
 #ifndef ComponentWrapperImpl_hpp
 #define ComponentWrapperImpl_hpp
 
+#include <array>
 #include <cassert>
 #include <memory>
-#include <vector>
-#include <array>
 #include <tuple>
+#include <vector>
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "ComponentInstance.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+
 #include "Binders.hpp"
 
-namespace cppmicroservices { namespace service { namespace component { namespace detail {
+namespace cppmicroservices {
+namespace service {
+namespace component {
+namespace detail {
 
 /**
  * Util class to detect if a class has a method named Activate
  * Member Detector Idiom - https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector
  */
-template <class T, class ReturnT, class... ArgsT>
+template<class T, class ReturnT, class... ArgsT>
 class HasActivate
 {
 public:
-  struct BadType {};
-  
-  template <class U>
-  static decltype(std::declval<U>().Activate(std::declval<ArgsT>()...)) Test(int);
-  
-  template <class U>
+  struct BadType
+  {};
+
+  template<class U>
+  static decltype(std::declval<U>().Activate(std::declval<ArgsT>()...)) Test(
+    int);
+
+  template<class U>
   static BadType Test(...);
-  
-  static constexpr bool value = std::is_same<decltype(Test<T>(0)), ReturnT>::value;
+
+  static constexpr bool value =
+    std::is_same<decltype(Test<T>(0)), ReturnT>::value;
 };
 
 /**
  * Util class to detect if a class has a method named Deactivate
  * Member Detector Idiom - https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector
  */
-template <class T, class ReturnT, class... ArgsT>
+template<class T, class ReturnT, class... ArgsT>
 class HasDeactivate
 {
 public:
-  struct BadType {};
-  
-  template <class U>
-  static decltype(std::declval<U>().Deactivate(std::declval<ArgsT>()...)) Test(int);
-  
-  template <class U>
+  struct BadType
+  {};
+
+  template<class U>
+  static decltype(std::declval<U>().Deactivate(std::declval<ArgsT>()...)) Test(
+    int);
+
+  template<class U>
   static BadType Test(...);
-  
-  static constexpr bool value = std::is_same<decltype(Test<T>(0)), ReturnT>::value;
+
+  static constexpr bool value =
+    std::is_same<decltype(Test<T>(0)), ReturnT>::value;
 };
 
 namespace util {
@@ -82,11 +92,11 @@ template<typename T, typename FUNC, std::size_t... Is>
 void for_each(T&& t, FUNC f, std::index_sequence<Is...>)
 {
   // we use the comma operator to execute the function after the parameters are unpacked.
-  int dummy[] = {0, (f(std::get<Is>(t), Is), 0)...};
+  int dummy[] = { 0, (f(std::get<Is>(t), Is), 0)... };
   static_cast<void>(dummy); // silence unused varible warning
 }
 
-template <std::size_t I, class T>
+template<std::size_t I, class T>
 using tuple_element_t = typename std::tuple_element<I, T>::type;
 
 } // namespace util
@@ -94,51 +104,51 @@ using tuple_element_t = typename std::tuple_element<I, T>::type;
 template<typename... Ts, typename FUNC>
 void for_each_in_tuple(std::tuple<Ts...> const& t, FUNC f)
 {
-  util::for_each(t, f, std::make_index_sequence<std::tuple_size<std::tuple<Ts...>>::value>{});
+  util::for_each(
+    t,
+    f,
+    std::make_index_sequence<std::tuple_size<std::tuple<Ts...>>::value>{});
 }
 
-template <class T, class InterfaceTuple = std::tuple<>>
-class ComponentInstanceImplBase
-  : public ComponentInstance
+template<class T, class InterfaceTuple = std::tuple<>>
+class ComponentInstanceImplBase : public ComponentInstance
 {
 public:
-
-  ComponentInstanceImplBase(const std::vector<std::shared_ptr<Binder<T>>>& binders = {})
+  ComponentInstanceImplBase(
+    const std::vector<std::shared_ptr<Binder<T>>>& binders = {})
     : mContext(nullptr)
     , refBinders(binders)
   {
     // move all binders into a map
-    for(size_t i = 0; i < refBinders.size(); i++) {
+    for (size_t i = 0; i < refBinders.size(); i++) {
       refBinderMap[refBinders.at(i)->GetReferenceName()] = i;
     }
   }
 
   virtual ~ComponentInstanceImplBase() = default;
 
-  void Activate() override
-  {
-    DoActivate(mContext);
-  };
+  void Activate() override { DoActivate(mContext); };
 
-  void Deactivate() override
-  {
-    DoDeactivate(mContext);
-  };
+  void Deactivate() override { DoDeactivate(mContext); };
 
-  void Modified() override { /* no-op for now */};
+  void Modified() override{ /* no-op for now */ };
 
-  void InvokeBindMethod(const std::string& refName
-                        , const cppmicroservices::ServiceReferenceBase& sRef) override
+  void InvokeBindMethod(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef) override
   {
     size_t index = refBinderMap.at(refName);
-    refBinders.at(index)->Bind(mContext->GetBundleContext(), sRef, mServiceImpl);
+    refBinders.at(index)->Bind(
+      mContext->GetBundleContext(), sRef, mServiceImpl);
   };
 
-  void InvokeUnbindMethod(const std::string& refName
-                          , const cppmicroservices::ServiceReferenceBase& sRef) override
+  void InvokeUnbindMethod(
+    const std::string& refName,
+    const cppmicroservices::ServiceReferenceBase& sRef) override
   {
     size_t index = refBinderMap.at(refName);
-    refBinders.at(index)->UnBind(mContext->GetBundleContext(), sRef, mServiceImpl);
+    refBinders.at(index)->UnBind(
+      mContext->GetBundleContext(), sRef, mServiceImpl);
   };
 
   virtual std::shared_ptr<T> GetInstance() const { return mServiceImpl; };
@@ -149,31 +159,37 @@ public:
   }
 
   template<class C = T, class I = InterfaceTuple, std::size_t... Is>
-  cppmicroservices::InterfaceMapPtr MakeInterfaceMapWithTuple(const std::shared_ptr<T>& sObj
-                                                              , std::index_sequence<Is...>)
+  cppmicroservices::InterfaceMapPtr MakeInterfaceMapWithTuple(
+    const std::shared_ptr<T>& sObj,
+    std::index_sequence<Is...>)
   {
     // The static_ptr_cast inside MakeInterfaceMap will fail if the sObj does not implement any of the interfaces in I.
-    InterfaceMapPtr iMap = MakeInterfaceMap<util::tuple_element_t<Is, I>...>(sObj);
+    InterfaceMapPtr iMap =
+      MakeInterfaceMap<util::tuple_element_t<Is, I>...>(sObj);
     assert(iMap->size() == std::tuple_size<I>::value);
     return iMap;
   }
 
-  template <class ...Args>
+  template<class... Args>
   cppmicroservices::InterfaceMapPtr GetInterfaceMapHelper(Args...)
   {
     return nullptr;
   }
 
-  template <class I = InterfaceTuple, typename std::enable_if<std::tuple_size<I>::value != 0, int>::type = 0>
-  cppmicroservices::InterfaceMapPtr GetInterfaceMapHelper(const std::shared_ptr<T>& sObj)
+  template<
+    class I = InterfaceTuple,
+    typename std::enable_if<std::tuple_size<I>::value != 0, int>::type = 0>
+  cppmicroservices::InterfaceMapPtr GetInterfaceMapHelper(
+    const std::shared_ptr<T>& sObj)
   {
-    return MakeInterfaceMapWithTuple(sObj, std::make_index_sequence<std::tuple_size<I>::value>{});
+    return MakeInterfaceMapWithTuple(
+      sObj, std::make_index_sequence<std::tuple_size<I>::value>{});
   }
 
   /**
    * This method is used if the component implementation class does not provide an Activate method.
    */
-  template <typename ...A>
+  template<typename... A>
   void DoActivate(A...)
   {
     // no-op
@@ -182,8 +198,10 @@ public:
   /**
    * This method is used if the component implementation class provides an Activate method.
    */
-  template <class Impl = T,
-            class Z = typename std::enable_if<HasActivate<Impl, void, const std::shared_ptr<ComponentContext>&>::value>::type>
+  template<class Impl = T,
+           class Z = typename std::enable_if<
+             HasActivate<Impl, void, const std::shared_ptr<ComponentContext>&>::
+               value>::type>
   void DoActivate(const std::shared_ptr<ComponentContext>& ctxt)
   {
     mServiceImpl->Activate(ctxt);
@@ -192,7 +210,7 @@ public:
   /**
    * This method is used if the component implementation class does not provide a Deactivate method.
    */
-  template <typename ...A>
+  template<typename... A>
   void DoDeactivate(A...)
   {
     // no-op
@@ -201,59 +219,69 @@ public:
   /**
    * This method is used if the component implementation class provides a Deactivate method.
    */
-  template <class Impl = T,
-            class Z = typename std::enable_if<HasDeactivate<Impl, void, const std::shared_ptr<ComponentContext>&>::value>::type>
+  template<
+    class Impl = T,
+    class Z = typename std::enable_if<
+      HasDeactivate<Impl, void, const std::shared_ptr<ComponentContext>&>::
+        value>::type>
   void DoDeactivate(const std::shared_ptr<ComponentContext>& ctxt)
   {
     mServiceImpl->Deactivate(ctxt);
   }
 
-  std::shared_ptr<ComponentContext> mContext;          // The context object associated with the component instance
-  std::shared_ptr<T> mServiceImpl;                     // Instance of the implementation class
-  std::vector<std::shared_ptr<Binder<T>>> refBinders;  // Helpers used for bind and unbind calls on the instance
-  std::map<std::string, size_t> refBinderMap;          // a map to retrieve binders based on reference name
+  std::shared_ptr<ComponentContext>
+    mContext; // The context object associated with the component instance
+  std::shared_ptr<T> mServiceImpl; // Instance of the implementation class
+  std::vector<std::shared_ptr<Binder<T>>>
+    refBinders; // Helpers used for bind and unbind calls on the instance
+  std::map<std::string, size_t>
+    refBinderMap; // a map to retrieve binders based on reference name
 };
 
-
-template <class T, class InterfaceTuple = std::tuple<>, class... CtorInjectedRefs>
+template<class T,
+         class InterfaceTuple = std::tuple<>,
+         class... CtorInjectedRefs>
 class ComponentInstanceImpl final
   : public ComponentInstanceImplBase<T, InterfaceTuple>
 {
 public:
-  ComponentInstanceImpl(const std::array<std::string, sizeof...(CtorInjectedRefs)> staticRefNames = {}
-                          , const std::vector<std::shared_ptr<Binder<T>>>& binders = {})
+  ComponentInstanceImpl(
+    const std::array<std::string, sizeof...(CtorInjectedRefs)>
+      staticRefNames = {},
+    const std::vector<std::shared_ptr<Binder<T>>>& binders = {})
     : ComponentInstanceImplBase<T, InterfaceTuple>(binders)
     , mStaticRefNames(staticRefNames)
-  {
-  }
+  {}
 
   virtual ~ComponentInstanceImpl() = default;
 
-  using Injection = std::integral_constant<bool, sizeof...(CtorInjectedRefs)!=0>;
+  using Injection =
+    std::integral_constant<bool, sizeof...(CtorInjectedRefs) != 0>;
 
-  void CreateInstanceAndBindReferences(const std::shared_ptr<ComponentContext>& ctxt) override
+  void CreateInstanceAndBindReferences(
+    const std::shared_ptr<ComponentContext>& ctxt) override
   {
     this->mContext = ctxt;
     bool isConstructorInjected = Injection::value;
     std::shared_ptr<T> implObj = DoCreate(isConstructorInjected); // appropriate
     this->mServiceImpl = implObj;
-    for(auto& binder : this->refBinders) {
+    for (auto& binder : this->refBinders) {
       binder->Bind(ctxt, this->mServiceImpl);
     }
   }
 
   void UnbindReferences() override
   {
-    for(auto& binder : this->refBinders) {
+    for (auto& binder : this->refBinders) {
       binder->Unbind(this->mContext, this->mServiceImpl);
     }
   }
-  
+
   /**
    * DoCreate is a helper function used to invoke the appropriate constructor on the Implementation class.
    * SFINAE is used to determine which overload of DoCreate is used by the runtime.
    */
-  template <typename ...A>
+  template<typename... A>
   std::shared_ptr<T> DoCreate(A...)
   {
     // no-op fallback to mute the compiler.
@@ -262,68 +290,98 @@ public:
   }
 
   // this method is used when injection is false and default constructor is provided by the implementation class
-  template <class C = T, class I = Injection,
-            class X = typename std::enable_if<I::value == false>::type,
-            class Y = typename std::enable_if<std::is_default_constructible<C>::value == true>::type>
+  template<class C = T,
+           class I = Injection,
+           class X = typename std::enable_if<I::value == false>::type,
+           class Y = typename std::enable_if<
+             std::is_default_constructible<C>::value == true>::type>
   std::shared_ptr<T> DoCreate(bool)
   {
     return std::make_shared<T>();
   }
 
   // this method is used when injection is false and default constructor is not provided by the implementation class
-  template <class C = T, class I = Injection,
-            class X = typename std::enable_if<I::value == false>::type,
-            class Y = typename std::enable_if<std::is_default_constructible<C>::value == false>::type>
+  template<class C = T,
+           class I = Injection,
+           class X = typename std::enable_if<I::value == false>::type,
+           class Y = typename std::enable_if<
+             std::is_default_constructible<C>::value == false>::type>
   std::shared_ptr<T> DoCreate(bool, bool = false)
   {
-    static_assert(std::is_default_constructible<C>::value, "Default Constructor expected when injection is false");
+    static_assert(std::is_default_constructible<C>::value,
+                  "Default Constructor expected when injection is false");
     return nullptr;
   }
 
   // this method is used when injection is true and constructor with suitable parameters is not provided by the implementation class
-  template <class C = T, class I = Injection,
-            class Y = typename std::enable_if<I::value == true>::type,
-            class X = typename std::enable_if<std::is_constructible<C, const std::shared_ptr<CtorInjectedRefs>&...>::value == false>::type>
+  template<
+    class C = T,
+    class I = Injection,
+    class Y = typename std::enable_if<I::value == true>::type,
+    class X = typename std::enable_if<
+      std::is_constructible<C, const std::shared_ptr<CtorInjectedRefs>&...>::
+        value == false>::type>
   std::shared_ptr<T> DoCreate(const bool&)
   {
-    static_assert(std::is_constructible<C, const std::shared_ptr<CtorInjectedRefs>&...>::value , "Suitable constructor not found for constructor injection");
+    static_assert(
+      std::is_constructible<C,
+                            const std::shared_ptr<CtorInjectedRefs>&...>::value,
+      "Suitable constructor not found for constructor injection");
     return nullptr;
   }
 
   // this method is used when injection is true and constructor with parameters is provided by the implementation class
-  template <class C = T, class I = Injection,
-            class Y = typename std::enable_if<I::value == true>::type,
-            class X = typename std::enable_if<std::is_constructible<C, const std::shared_ptr<CtorInjectedRefs>&...>::value>::type>
+  template<class C = T,
+           class I = Injection,
+           class Y = typename std::enable_if<I::value == true>::type,
+           class X = typename std::enable_if<std::is_constructible<
+             C,
+             const std::shared_ptr<CtorInjectedRefs>&...>::value>::type>
   std::shared_ptr<T> DoCreate(bool& injected)
   {
-    std::tuple<std::shared_ptr<CtorInjectedRefs> ...> depObjs = GetAllDependencies(std::make_index_sequence<std::tuple_size<std::tuple<CtorInjectedRefs...>>::value>{});
-    std::shared_ptr<T> implObj = call_make_shared_with_tuple(depObjs, std::make_index_sequence<std::tuple_size<std::tuple<std::shared_ptr<CtorInjectedRefs>...>>::value>{});
+    std::tuple<std::shared_ptr<CtorInjectedRefs>...> depObjs =
+      GetAllDependencies(
+        std::make_index_sequence<
+          std::tuple_size<std::tuple<CtorInjectedRefs...>>::value>{});
+    std::shared_ptr<T> implObj = call_make_shared_with_tuple(
+      depObjs,
+      std::make_index_sequence<std::tuple_size<
+        std::tuple<std::shared_ptr<CtorInjectedRefs>...>>::value>{});
     injected = (implObj != nullptr);
     return implObj;
   }
 
   template<std::size_t... Is>
-  std::shared_ptr<T> call_make_shared_with_tuple(const std::tuple<const std::shared_ptr<CtorInjectedRefs>&...>& tuple,
-                                                 std::index_sequence<Is...>)
+  std::shared_ptr<T> call_make_shared_with_tuple(
+    const std::tuple<const std::shared_ptr<CtorInjectedRefs>&...>& tuple,
+    std::index_sequence<Is...>)
   {
     return std::make_shared<T>(std::get<Is>(tuple)...);
   }
 
   template<std::size_t... Is>
-  std::tuple<std::shared_ptr<CtorInjectedRefs>...> GetAllDependencies(std::index_sequence<Is...>)
+  std::tuple<std::shared_ptr<CtorInjectedRefs>...> GetAllDependencies(
+    std::index_sequence<Is...>)
   {
-    return std::make_tuple(GetDependency<typename std::tuple_element<Is, std::tuple<CtorInjectedRefs...>>::type>(std::get<Is>(mStaticRefNames))...);
+    return std::make_tuple(
+      GetDependency<
+        typename std::tuple_element<Is, std::tuple<CtorInjectedRefs...>>::type>(
+        std::get<Is>(mStaticRefNames))...);
   }
 
-  template <class R>
+  template<class R>
   std::shared_ptr<R> GetDependency(const std::string& name)
   {
     return this->mContext->template LocateService<R>(name);
   }
+
 private:
   std::array<std::string, sizeof...(CtorInjectedRefs)> mStaticRefNames;
 };
 
-}}}} // namespaces
+}
+}
+}
+} // namespaces
 
 #endif /* ComponentInstance_hpp */

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp
@@ -23,21 +23,24 @@
 #ifndef ServiceComponentRuntime_hpp
 #define ServiceComponentRuntime_hpp
 
-#include <vector>
 #include <future>
+#include <vector>
 
 #include <cppmicroservices/Bundle.h>
 
-#include "dto/ComponentDescriptionDTO.hpp"
-#include "dto/ComponentConfigurationDTO.hpp"
 #include "cppmicroservices/servicecomponent/ServiceComponentExport.h"
+#include "dto/ComponentConfigurationDTO.hpp"
+#include "dto/ComponentDescriptionDTO.hpp"
 
-namespace cppmicroservices { namespace service { namespace component { namespace runtime {
+namespace cppmicroservices {
+namespace service {
+namespace component {
+namespace runtime {
 
-	/**
-	\defgroup gr_servicecomponentruntime ServiceComponentRuntime
-	\brief Groups ServiceComponentRuntime class related symbols.
-	*/
+/**
+ \defgroup gr_servicecomponentruntime ServiceComponentRuntime
+ \brief Groups ServiceComponentRuntime class related symbols.
+ */
 
 /**
  * \ingroup gr_servicecomponentruntime
@@ -55,8 +58,9 @@ namespace cppmicroservices { namespace service { namespace component { namespace
  * {@link dto::ComponentConfigurationDTO ComponentConfigurationDTO} is a representation of an actual instance
  * of a declared component description parameterized by component properties.
  */
-class US_ServiceComponent_EXPORT ServiceComponentRuntime {
-  public:
+class US_ServiceComponent_EXPORT ServiceComponentRuntime
+{
+public:
   virtual ~ServiceComponentRuntime() noexcept;
 
   /**
@@ -76,7 +80,8 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    *         bundles. An empty collection is returned if there are no
    *         component descriptions for the specified active bundles.
    */
-  virtual std::vector<dto::ComponentDescriptionDTO> GetComponentDescriptionDTOs(const std::vector<cppmicroservices::Bundle>& bundles = {}) const = 0;
+  virtual std::vector<dto::ComponentDescriptionDTO> GetComponentDescriptionDTOs(
+    const std::vector<cppmicroservices::Bundle>& bundles = {}) const = 0;
 
   /**
    * Returns the {@link dto::ComponentDescriptionDTO ComponentDescriptionDTO} declared with the specified name
@@ -93,7 +98,9 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    *         specified bundle is not active or does not declare a component
    *         description with the specified name.
    */
-  virtual dto::ComponentDescriptionDTO GetComponentDescriptionDTO(const cppmicroservices::Bundle& bundle, const std::string& name) const = 0;
+  virtual dto::ComponentDescriptionDTO GetComponentDescriptionDTO(
+    const cppmicroservices::Bundle& bundle,
+    const std::string& name) const = 0;
 
   /**
    * Returns the component configurations for the specified component
@@ -104,7 +111,9 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    *         configurations for the specified component description. An empty
    *         vector is returned if there are none.
    */
-  virtual std::vector<dto::ComponentConfigurationDTO> GetComponentConfigurationDTOs(const dto::ComponentDescriptionDTO& description) const = 0;
+  virtual std::vector<dto::ComponentConfigurationDTO>
+  GetComponentConfigurationDTOs(
+    const dto::ComponentDescriptionDTO& description) const = 0;
 
   /**
    * Returns whether the specified component description is currently enabled.
@@ -122,7 +131,8 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    * @see ComponentContext#DisableComponent(std::string)
    * @see ComponentContext#EnableComponent(std::string)
    */
-  virtual bool IsComponentEnabled(const dto::ComponentDescriptionDTO& description) const = 0;
+  virtual bool IsComponentEnabled(
+    const dto::ComponentDescriptionDTO& description) const = 0;
 
   /**
    * Enables the specified component description.
@@ -143,7 +153,8 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    *         completed.
    * @see #IsComponentEnabled
    */
-  virtual std::shared_future<void> EnableComponent(const dto::ComponentDescriptionDTO& description) = 0;
+  virtual std::shared_future<void> EnableComponent(
+    const dto::ComponentDescriptionDTO& description) = 0;
 
   /**
    * Disables the specified component description.
@@ -164,10 +175,13 @@ class US_ServiceComponent_EXPORT ServiceComponentRuntime {
    *         completed.
    * @see #IsComponentEnabled
    */
-  virtual std::shared_future<void> DisableComponent(const dto::ComponentDescriptionDTO& description) = 0;
+  virtual std::shared_future<void> DisableComponent(
+    const dto::ComponentDescriptionDTO& description) = 0;
 };
 
-}}}} // namespaces
-
+}
+}
+}
+} // namespaces
 
 #endif /* ServiceComponentRuntime_hpp */

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/BundleDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/BundleDTO.hpp
@@ -31,16 +31,16 @@ namespace cppmicroservices {
 namespace framework {
 namespace dto {
 
-	/**
-	\defgroup gr_bundledto BundleDTO
-	\brief Groups BundleDTO related symbols.
-	*/
+/**
+ \defgroup gr_bundledto BundleDTO
+ \brief Groups BundleDTO related symbols.
+ */
 
-	/**
-	 * \ingroup gr_bundledto 
-	 * 
-	 * A representation of a bundle.
-	 */
+/**
+ * \ingroup gr_bundledto 
+ * 
+ * A representation of a bundle.
+ */
 struct US_ServiceComponent_EXPORT BundleDTO
 {
   /**

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
@@ -45,7 +45,8 @@ namespace dto {
  * \addtogroup gr_componentconfigurationdto
  * @{
  */
-enum class ComponentState : uint8_t {
+enum class ComponentState : uint8_t
+{
   /**
    * The component configuration is unsatisfied due to an unsatisfied
    * reference.
@@ -74,7 +75,8 @@ enum class ComponentState : uint8_t {
  * A representation of an actual instance of a declared component description
  * parameterized by component properties.
  */
-struct US_ServiceComponent_EXPORT ComponentConfigurationDTO {
+struct US_ServiceComponent_EXPORT ComponentConfigurationDTO
+{
   /**
    * The representation of the component configuration's component
    * description.

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
@@ -23,9 +23,9 @@
 #ifndef ComponentDescriptionDTO_hpp
 #define ComponentDescriptionDTO_hpp
 
-#include <vector>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "BundleDTO.hpp"
 #include "ReferenceDTO.hpp"
@@ -38,10 +38,10 @@ namespace component {
 namespace runtime {
 namespace dto {
 
-	/**
-	\defgroup gr_componentdescriptiondto ComponentDescriptionDTO
-	\brief Groups ComponentDescriptionDTO related symbols.
-	*/
+/**
+ \defgroup gr_componentdescriptiondto ComponentDescriptionDTO
+ \brief Groups ComponentDescriptionDTO related symbols.
+ */
 
 /**
  * \ingroup gr_componentdescriptiondto

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ReferenceDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ReferenceDTO.hpp
@@ -33,17 +33,18 @@ namespace component {
 namespace runtime {
 namespace dto {
 
-	/**
-	\defgroup gr_referencedto ReferenceDTO
-	\brief Groups ReferenceDTO related symbols.
-	*/
+/**
+ \defgroup gr_referencedto ReferenceDTO
+ \brief Groups ReferenceDTO related symbols.
+ */
 
 /**
  * \ingroup gr_referencedto 
  *
  * A representation of a declared reference to a service.
  */
-struct US_ServiceComponent_EXPORT ReferenceDTO {
+struct US_ServiceComponent_EXPORT ReferenceDTO
+{
   /**
    * The name of the reference.
    *

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/SatisfiedReferenceDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/SatisfiedReferenceDTO.hpp
@@ -34,10 +34,10 @@ namespace component {
 namespace runtime {
 namespace dto {
 
-	/**
-	\defgroup gr_satisfiedreferencedto SatisfiedReferenceDTO
-	\brief Groups SatisfiedReferenceDTO related symbols.
-	*/
+/**
+ \defgroup gr_satisfiedreferencedto SatisfiedReferenceDTO
+ \brief Groups SatisfiedReferenceDTO related symbols.
+ */
 
 /**
  * \ingroup gr_satisfiedreferencedto
@@ -77,7 +77,8 @@ struct SatisfiedReferenceDTO
    * to the satisfied reference. The vector must be empty if there are no bound
    * services.
    */
-  std::vector<cppmicroservices::framework::dto::ServiceReferenceDTO> boundServices;
+  std::vector<cppmicroservices::framework::dto::ServiceReferenceDTO>
+    boundServices;
 };
 }
 }

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ServiceReferenceDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ServiceReferenceDTO.hpp
@@ -24,8 +24,8 @@
 #define ServiceReferenceDTO_hpp
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/servicecomponent/ServiceComponentExport.h"
@@ -34,10 +34,10 @@ namespace cppmicroservices {
 namespace framework {
 namespace dto {
 
-	/**
-	\defgroup gr_servicereferencedto ServiceReferenceDTO
-	\brief Groups ServiceReferenceDTO related symbols.
-	*/
+/**
+ \defgroup gr_servicereferencedto ServiceReferenceDTO
+ \brief Groups ServiceReferenceDTO related symbols.
+ */
 
 /**
  * \ingroup gr_servicereferencedto

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/UnsatisfiedReferenceDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/UnsatisfiedReferenceDTO.hpp
@@ -23,8 +23,8 @@
 #ifndef UnsatisfiedReferenceDTO_hpp
 #define UnsatisfiedReferenceDTO_hpp
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "ServiceReferenceDTO.hpp"
 
@@ -34,10 +34,10 @@ namespace component {
 namespace runtime {
 namespace dto {
 
-	/**
-	\defgroup gr_unsatisfiedreferencedto UnsatisfiedReferenceDTO
-	\brief Groups UnsatisfiedReferenceDTO related symbols.
-	*/
+/**
+ \defgroup gr_unsatisfiedreferencedto UnsatisfiedReferenceDTO
+ \brief Groups UnsatisfiedReferenceDTO related symbols.
+ */
 
 /**
  * \ingroup gr_unsatisfiedreferencedto
@@ -79,7 +79,8 @@ struct UnsatisfiedReferenceDTO
    * is the upper bound on the {@link ReferenceDTO#cardinality cardinality} of
    * the reference.
    */
-  std::vector<cppmicroservices::framework::dto::ServiceReferenceDTO> targetServices;
+  std::vector<cppmicroservices::framework::dto::ServiceReferenceDTO>
+    targetServices;
 };
 }
 }

--- a/compendium/ServiceComponent/src/ComponentContext.cpp
+++ b/compendium/ServiceComponent/src/ComponentContext.cpp
@@ -22,8 +22,12 @@
 
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
-namespace cppmicroservices { namespace service { namespace component {
+namespace cppmicroservices {
+namespace service {
+namespace component {
 
-ComponentContext::~ComponentContext() noexcept {} ;
+ComponentContext::~ComponentContext() noexcept {};
 
-}}} // namespaces
+}
+}
+} // namespaces

--- a/compendium/ServiceComponent/src/ComponentException.cpp
+++ b/compendium/ServiceComponent/src/ComponentException.cpp
@@ -25,11 +25,11 @@
 namespace cppmicroservices {
 namespace service {
 namespace component {
-ComponentException::ComponentException( const std::string& message )
+ComponentException::ComponentException(const std::string& message)
   : std::runtime_error(message)
 {}
 
-ComponentException::ComponentException( const char* message )
+ComponentException::ComponentException(const char* message)
   : std::runtime_error(message)
 {}
 

--- a/compendium/ServiceComponent/src/ServiceComponentRuntime.cpp
+++ b/compendium/ServiceComponent/src/ServiceComponentRuntime.cpp
@@ -27,9 +27,7 @@ namespace service {
 namespace component {
 namespace runtime {
 
-ServiceComponentRuntime::~ServiceComponentRuntime() noexcept
-{
-}
+ServiceComponentRuntime::~ServiceComponentRuntime() noexcept {}
 
 }
 }

--- a/compendium/ServiceComponent/test/TestCompInst_InvalidInheritance.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_InvalidInheritance.cpp
@@ -20,30 +20,30 @@
 
   =============================================================================*/
 #if NEVER
-#include <cstdio>
-#include <iostream>
-#include <algorithm>
-#include <chrono>
+#  include <algorithm>
+#  include <chrono>
+#  include <cstdio>
+#  include <iostream>
 
 //#include "version.h"
 
-#include "gtest/gtest.h"
+#  include "gtest/gtest.h"
 
-#include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
-#include <cppmicroservices/ServiceInterface.h>
+#  include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
+#  include <cppmicroservices/ServiceInterface.h>
 
 using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 
 namespace {
 
 // dummy types used for testing
-struct TestServiceInterface1 {};
-struct TestServiceInterface2 {};
+struct TestServiceInterface1
+{};
+struct TestServiceInterface2
+{};
 
-class TestServiceImpl3
-  : public TestServiceInterface1
-{
-};
+class TestServiceImpl3 : public TestServiceInterface1
+{};
 
 /**
  * This test point is used to verify a compile error is generated when a service component
@@ -53,11 +53,13 @@ class TestServiceImpl3
  */
 TEST(ComponentInstance, ValidateInheritance)
 {
-  ComponentInstanceImpl<TestServiceImpl3, std::tuple<TestServiceInterface2>> compInstance; // compile error
+  ComponentInstanceImpl<TestServiceImpl3, std::tuple<TestServiceInterface2>>
+    compInstance; // compile error
 }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/compendium/ServiceComponent/test/TestCompInst_NoDepsNoDefaultCtor.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_NoDepsNoDefaultCtor.cpp
@@ -20,15 +20,15 @@
 
   =============================================================================*/
 #if NEVER
-#include <cstdio>
-#include <iostream>
-#include <algorithm>
-#include <chrono>
+#  include <algorithm>
+#  include <chrono>
+#  include <cstdio>
+#  include <iostream>
 
-#include "gtest/gtest.h"
+#  include "gtest/gtest.h"
 
-#include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
-#include <cppmicroservices/ServiceInterface.h>
+#  include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
+#  include <cppmicroservices/ServiceInterface.h>
 
 using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 
@@ -55,7 +55,8 @@ TEST(ComponentInstance, CheckNoDefaultCtor)
 }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
@@ -20,15 +20,15 @@
 
   =============================================================================*/
 #if NEVER
-#include <cstdio>
-#include <iostream>
-#include <algorithm>
-#include <chrono>
+#  include <algorithm>
+#  include <chrono>
+#  include <cstdio>
+#  include <iostream>
 
-#include "gtest/gtest.h"
+#  include "gtest/gtest.h"
 
-#include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
-#include <cppmicroservices/ServiceInterface.h>
+#  include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
+#  include <cppmicroservices/ServiceInterface.h>
 
 using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 
@@ -40,8 +40,11 @@ class TestServiceImpl
 {
 public:
   TestServiceImpl() = delete;
-  TestServiceImpl(const std::shared_ptr<ServiceDependency>& d) : dep(d) {}
+  TestServiceImpl(const std::shared_ptr<ServiceDependency>& d)
+    : dep(d)
+  {}
   virtual ~TestServiceImpl() = default;
+
 private:
   std::shared_ptr<ServiceDependency> dep;
 };
@@ -54,11 +57,16 @@ private:
  */
 TEST(ComponentInstance, CheckNoDefaultCtorNoInjection)
 {
-  ComponentInstanceImpl<TestServiceImpl, std::tuple<>, std::false_type, ServiceDependency> compInstance; // compile error
+  ComponentInstanceImpl<TestServiceImpl,
+                        std::tuple<>,
+                        std::false_type,
+                        ServiceDependency>
+    compInstance; // compile error
 }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
@@ -20,78 +20,93 @@
 
  =============================================================================*/
 #if NEVER
-#include <cstdio>
-#include <iostream>
-#include <algorithm>
-#include <chrono>
+#  include <algorithm>
+#  include <chrono>
+#  include <cstdio>
+#  include <iostream>
 
-#include "gtest/gtest.h"
+#  include "gtest/gtest.h"
 
-#include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
-#include <cppmicroservices/ServiceInterface.h>
+#  include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
+#  include <cppmicroservices/ServiceInterface.h>
 
-using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::Binder;
-using cppmicroservices::service::component::detail::StaticBinder;
+using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::DynamicBinder;
+using cppmicroservices::service::component::detail::StaticBinder;
 
 namespace {
 
-  // dummy types used for testing
-  struct ServiceDependency1 {};
-  struct ServiceDependency2 {};
+// dummy types used for testing
+struct ServiceDependency1
+{};
+struct ServiceDependency2
+{};
 
-  // Test class to simulate a servcie component
-  class TestServiceImpl1 final {
-  public:
-    TestServiceImpl1() = default;
+// Test class to simulate a servcie component
+class TestServiceImpl1 final
+{
+public:
+  TestServiceImpl1() = default;
 
-    TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
-                const std::shared_ptr<ServiceDependency2>& b)
+  TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
+                   const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
-    { }
+  {}
 
-    virtual ~TestServiceImpl1() = default;
+  virtual ~TestServiceImpl1() = default;
 
-    void BindFoo(const std::shared_ptr<ServiceDependency1>& f)
-    {
-      foo = f;
+  void BindFoo(const std::shared_ptr<ServiceDependency1>& f) { foo = f; }
+
+  void UnbindFoo(const std::shared_ptr<ServiceDependency1>& f)
+  {
+    if (foo == f) {
+      foo = nullptr;
     }
+  }
 
-    void UnbindFoo(const std::shared_ptr<ServiceDependency1>& f)
-    {
-      if(foo == f)
-      {
-        foo = nullptr;
-      }
-    }
+  std::shared_ptr<ServiceDependency1> GetFoo() const { return foo; }
+  std::shared_ptr<ServiceDependency2> GetBar() const { return bar; }
 
-    std::shared_ptr<ServiceDependency1> GetFoo() const { return foo; }
-    std::shared_ptr<ServiceDependency2> GetBar() const { return bar; }
-  private:
-    std::shared_ptr<ServiceDependency1> foo;        // dynamic dependency - can change during the lifetime of this object
-    const std::shared_ptr<ServiceDependency2> bar;  // static dependency - does not change during the lifetime of this object
-  };
+private:
+  std::shared_ptr<ServiceDependency1>
+    foo; // dynamic dependency - can change during the lifetime of this object
+  const std::shared_ptr<ServiceDependency2>
+    bar; // static dependency - does not change during the lifetime of this object
+};
 
-  /**
+/**
    * This test point is used to verify a compile error is generated when the number of dependencies specified in
    * the service component description does not match the dependencies in the service component implementation
    * class constructor.
    *
    * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
    */
-  TEST(ComponentInstance, VerifyDependencyCount)
-  {
-    std::vector<std::shared_ptr<Binder<TestServiceImpl1>>> binders;
-    binders.push_back(std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>("foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
-    binders.push_back(std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>("bar"));
-    binders.push_back(std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>("bar2"));
-    ComponentInstanceImpl<TestServiceImpl1, std::tuple<>, std::true_type, ServiceDependency1, ServiceDependency2, ServiceDependency2> compInstance(binders); // compile error
-  }
+TEST(ComponentInstance, VerifyDependencyCount)
+{
+  std::vector<std::shared_ptr<Binder<TestServiceImpl1>>> binders;
+  binders.push_back(
+    std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>(
+      "foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
+  binders.push_back(
+    std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>(
+      "bar"));
+  binders.push_back(
+    std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>(
+      "bar2"));
+  ComponentInstanceImpl<TestServiceImpl1,
+                        std::tuple<>,
+                        std::true_type,
+                        ServiceDependency1,
+                        ServiceDependency2,
+                        ServiceDependency2>
+    compInstance(binders); // compile error
+}
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/compendium/ServiceComponent/test/TestCompInst_RefOrder.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_RefOrder.cpp
@@ -20,78 +20,90 @@
  
  =============================================================================*/
 
-#include <cstdio>
-#include <iostream>
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <iostream>
 
 #include "gtest/gtest.h"
 
 #include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
 #include <cppmicroservices/ServiceInterface.h>
 
-using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::Binder;
-using cppmicroservices::service::component::detail::StaticBinder;
+using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::DynamicBinder;
+using cppmicroservices::service::component::detail::StaticBinder;
 
 #if NEVER
 namespace {
 
-  // dummy types used for testing
-  struct ServiceDependency1 {};
-  struct ServiceDependency2 {};
+// dummy types used for testing
+struct ServiceDependency1
+{};
+struct ServiceDependency2
+{};
 
-  // Test class to simulate a servcie component
-  class TestServiceImpl1 final {
-  public:
-    TestServiceImpl1() = default;
+// Test class to simulate a servcie component
+class TestServiceImpl1 final
+{
+public:
+  TestServiceImpl1() = default;
 
-    TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
-                     const std::shared_ptr<ServiceDependency2>& b)
+  TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
+                   const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
-    { }
+  {}
 
-    virtual ~TestServiceImpl1() = default;
+  virtual ~TestServiceImpl1() = default;
 
-    void BindFoo(const std::shared_ptr<ServiceDependency1>& f)
-    {
-      foo = f;
+  void BindFoo(const std::shared_ptr<ServiceDependency1>& f) { foo = f; }
+
+  void UnbindFoo(const std::shared_ptr<ServiceDependency1>& f)
+  {
+    if (foo == f) {
+      foo = nullptr;
     }
+  }
 
-    void UnbindFoo(const std::shared_ptr<ServiceDependency1>& f)
-    {
-      if(foo == f)
-      {
-        foo = nullptr;
-      }
-    }
+  std::shared_ptr<ServiceDependency1> GetFoo() const { return foo; }
+  std::shared_ptr<ServiceDependency2> GetBar() const { return bar; }
 
-    std::shared_ptr<ServiceDependency1> GetFoo() const { return foo; }
-    std::shared_ptr<ServiceDependency2> GetBar() const { return bar; }
-  private:
-    std::shared_ptr<ServiceDependency1> foo;        // dynamic dependency - can change during the lifetime of this object
-    const std::shared_ptr<ServiceDependency2> bar;  // static dependency - does not change during the lifetime of this object
-  };
+private:
+  std::shared_ptr<ServiceDependency1>
+    foo; // dynamic dependency - can change during the lifetime of this object
+  const std::shared_ptr<ServiceDependency2>
+    bar; // static dependency - does not change during the lifetime of this object
+};
 
-  /**
+/**
    * This test point is used to verify a compile error is generated when the order of dependencies specified in
    * the service component description does not match the dependencies in the service component implementation
    * class constructor.
    *
    * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
    */
-  TEST(ComponentInstance, VerifyDependencyOrder)
-  {
-    std::vector<std::shared_ptr<Binder<TestServiceImpl1>>> binders;
-    binders.push_back(std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>("bar"));
-    binders.push_back(std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>("foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
-    ComponentInstanceImpl<TestServiceImpl1, std::tuple<>, std::true_type, ServiceDependency2, ServiceDependency1> compInstance(binders); // compile error
-  }
+TEST(ComponentInstance, VerifyDependencyOrder)
+{
+  std::vector<std::shared_ptr<Binder<TestServiceImpl1>>> binders;
+  binders.push_back(
+    std::make_shared<StaticBinder<TestServiceImpl1, ServiceDependency2>>(
+      "bar"));
+  binders.push_back(
+    std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>(
+      "foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
+  ComponentInstanceImpl<TestServiceImpl1,
+                        std::tuple<>,
+                        std::true_type,
+                        ServiceDependency2,
+                        ServiceDependency1>
+    compInstance(binders); // compile error
+}
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/compendium/ServiceComponent/test/TestComponentInstance.cpp
+++ b/compendium/ServiceComponent/test/TestComponentInstance.cpp
@@ -20,77 +20,76 @@
 
   =============================================================================*/
 
-#include <cstdio>
-#include <iostream>
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <iostream>
 
 #include "gmock/gmock.h"
 
-#include <cppmicroservices/Framework.h>
-#include <cppmicroservices/FrameworkFactory.h>
-#include <cppmicroservices/FrameworkEvent.h>
 #include <cppmicroservices/BundleContext.h>
 #include <cppmicroservices/BundleImport.h>
 #include <cppmicroservices/Constants.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
 
 #include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
 #include <cppmicroservices/ServiceInterface.h>
 
 using cppmicroservices::service::component::ComponentContext;
-using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::Binder;
-using cppmicroservices::service::component::detail::StaticBinder;
+using cppmicroservices::service::component::detail::ComponentInstanceImpl;
 using cppmicroservices::service::component::detail::DynamicBinder;
+using cppmicroservices::service::component::detail::StaticBinder;
 
 namespace {
 
 // dummy types used for testing
-struct ServiceDependency1 {};
-struct ServiceDependency2 {};
-struct TestServiceInterface1 {};
-struct TestServiceInterface2 {};
-struct TestServiceInterface3 {};
+struct ServiceDependency1
+{};
+struct ServiceDependency2
+{};
+struct TestServiceInterface1
+{};
+struct TestServiceInterface2
+{};
+struct TestServiceInterface3
+{};
 
 // Test class to simulate a servcie component
 // TODO: Use Mock to add more behavior verification
 class TestServiceImpl1 final
-  : public TestServiceInterface1, public TestServiceInterface2
+  : public TestServiceInterface1
+  , public TestServiceInterface2
 {
 public:
   TestServiceImpl1()
     : foo(nullptr)
     , bar(nullptr)
     , activated(false)
-  {
-  }
+  {}
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
                    const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
     , activated(false)
-  {
-  }
+  {}
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency2>& b)
     : foo(nullptr)
     , bar(b)
     , activated(false)
-  {
-  }
+  {}
 
   virtual ~TestServiceImpl1() {}
 
-  void BindFoo(const std::shared_ptr<ServiceDependency1>& f)
-  {
-    foo = f;
-  }
+  void BindFoo(const std::shared_ptr<ServiceDependency1>& f) { foo = f; }
 
   void UnbindFoo(const std::shared_ptr<ServiceDependency1>& f)
   {
-    if(foo == f)
-    {
+    if (foo == f) {
       foo = nullptr;
     }
   }
@@ -100,10 +99,7 @@ public:
     // this is the wrong signature method.
   }
 
-  void Activate(const std::shared_ptr<ComponentContext>&)
-  {
-    activated = true;
-  }
+  void Activate(const std::shared_ptr<ComponentContext>&) { activated = true; }
 
   void Deactivate(const std::shared_ptr<ComponentContext>&)
   {
@@ -119,9 +115,12 @@ public:
 
   std::shared_ptr<ServiceDependency1> GetFoo() const { return foo; }
   std::shared_ptr<ServiceDependency2> GetBar() const { return bar; }
+
 private:
-  std::shared_ptr<ServiceDependency1> foo;        // dynamic dependency - can change during the lifetime of this object
-  const std::shared_ptr<ServiceDependency2> bar;  // static dependency - does not change during the lifetime of this object
+  std::shared_ptr<ServiceDependency1>
+    foo; // dynamic dependency - can change during the lifetime of this object
+  const std::shared_ptr<ServiceDependency2>
+    bar; // static dependency - does not change during the lifetime of this object
   bool activated;
 };
 
@@ -132,14 +131,21 @@ private:
 class MockComponentContext : public ComponentContext
 {
 public:
-  MOCK_CONST_METHOD0(GetProperties, std::unordered_map<std::string, cppmicroservices::Any>(void));
+  MOCK_CONST_METHOD0(
+    GetProperties,
+    std::unordered_map<std::string, cppmicroservices::Any>(void));
   MOCK_CONST_METHOD0(GetBundleContext, cppmicroservices::BundleContext(void));
   MOCK_CONST_METHOD0(GetUsingBundle, cppmicroservices::Bundle(void));
-  MOCK_CONST_METHOD0(GetServiceReference, cppmicroservices::ServiceReferenceBase(void));
+  MOCK_CONST_METHOD0(GetServiceReference,
+                     cppmicroservices::ServiceReferenceBase(void));
   MOCK_METHOD1(EnableComponent, void(const std::string&));
   MOCK_METHOD1(DisableComponent, void(const std::string&));
-  MOCK_CONST_METHOD2(LocateServices, std::vector<std::shared_ptr<void>>(const std::string&, const std::string&));
-  MOCK_CONST_METHOD2(LocateService, std::shared_ptr<void>(const std::string&, const std::string&));
+  MOCK_CONST_METHOD2(LocateServices,
+                     std::vector<std::shared_ptr<void>>(const std::string&,
+                                                        const std::string&));
+  MOCK_CONST_METHOD2(LocateService,
+                     std::shared_ptr<void>(const std::string&,
+                                           const std::string&));
 };
 
 /**
@@ -155,7 +161,8 @@ TEST(ComponentInstance, VerifyZeroServicesZeroDependencies)
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -172,7 +179,8 @@ TEST(ComponentInstanceImpl, VerifyZeroServicesZeroDependencies)
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -188,13 +196,16 @@ TEST(ComponentInstanceImpl, VerifyZeroServicesZeroDependencies)
  */
 TEST(ComponentInstance, VerifyWithSingleServiceZeroDependencies)
 {
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1>> compInstance;
+  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1>>
+    compInstance;
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_TRUE(iMap);
   ASSERT_EQ(iMap->size(), size_t(1));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()), size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()),
+            size_t(1));
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -205,13 +216,16 @@ TEST(ComponentInstance, VerifyWithSingleServiceZeroDependencies)
 
 TEST(ComponentInstanceImpl, VerifyWithSingleServiceZeroDependencies)
 {
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1>> compInstance;
+  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1>>
+    compInstance;
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_TRUE(iMap);
   ASSERT_EQ(iMap->size(), size_t(1));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()), size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()),
+            size_t(1));
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -227,14 +241,20 @@ TEST(ComponentInstanceImpl, VerifyWithSingleServiceZeroDependencies)
  */
 TEST(ComponentInstance, VerifyWithMultipleServiceZeroDependencies)
 {
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1, TestServiceInterface2>> compInstance;
+  ComponentInstanceImpl<
+    TestServiceImpl1,
+    std::tuple<TestServiceInterface1, TestServiceInterface2>>
+    compInstance;
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_TRUE(iMap);
   ASSERT_EQ(iMap->size(), size_t(2));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()), size_t(1));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface2>()), size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()),
+            size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface2>()),
+            size_t(1));
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -245,14 +265,20 @@ TEST(ComponentInstance, VerifyWithMultipleServiceZeroDependencies)
 
 TEST(ComponentInstanceImpl, VerifyWithMultipleServiceZeroDependencies)
 {
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<TestServiceInterface1, TestServiceInterface2>> compInstance;
+  ComponentInstanceImpl<
+    TestServiceImpl1,
+    std::tuple<TestServiceInterface1, TestServiceInterface2>>
+    compInstance;
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_TRUE(iMap);
   ASSERT_EQ(iMap->size(), size_t(2));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()), size_t(1));
-  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface2>()), size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface1>()),
+            size_t(1));
+  ASSERT_EQ(iMap->count(us_service_interface_iid<TestServiceInterface2>()),
+            size_t(1));
   auto mockContext = std::make_shared<MockComponentContext>();
-  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_)).Times(0); // ensure the mock context never gets a call to LocateService
+  EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
+    .Times(0); // ensure the mock context never gets a call to LocateService
   compInstance.CreateInstanceAndBindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
@@ -266,36 +292,46 @@ TEST(ComponentInstanceImpl, VerifyWithStaticDependencies)
   auto f = cppmicroservices::FrameworkFactory().NewFramework();
   f.Start();
   auto fc = f.GetBundleContext();
-  auto reg = fc.RegisterService<ServiceDependency1>(std::make_shared<ServiceDependency1>());
-  auto reg1 = fc.RegisterService<ServiceDependency2>(std::make_shared<ServiceDependency2>());
+  auto reg = fc.RegisterService<ServiceDependency1>(
+    std::make_shared<ServiceDependency1>());
+  auto reg1 = fc.RegisterService<ServiceDependency2>(
+    std::make_shared<ServiceDependency2>());
 
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<>, ServiceDependency1, ServiceDependency2> compInstance({("foo"), ("bar")}, {});
+  ComponentInstanceImpl<TestServiceImpl1,
+                        std::tuple<>,
+                        ServiceDependency1,
+                        ServiceDependency2>
+    compInstance({ ("foo"), ("bar") }, {});
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_FALSE(iMap);
 
   auto mockContext = std::make_shared<MockComponentContext>();
   auto locateService = [&fc](const std::string& type) -> std::shared_ptr<void> {
     auto sRef = fc.GetServiceReference(type);
-    if(sRef)
-    {
+    if (sRef) {
       auto serv = fc.GetService(sRef);
       return serv->at(type);
-    }
-    else
-    {
+    } else {
       return nullptr;
     }
   };
 
-  EXPECT_CALL(*(mockContext.get()), GetBundleContext()).WillRepeatedly(testing::Invoke([&fc]() { return fc;}));
+  EXPECT_CALL(*(mockContext.get()), GetBundleContext())
+    .WillRepeatedly(testing::Invoke([&fc]() { return fc; }));
 
-  EXPECT_CALL(*(mockContext.get()), LocateService("foo", us_service_interface_iid<ServiceDependency1>()))
+  EXPECT_CALL(
+    *(mockContext.get()),
+    LocateService("foo", us_service_interface_iid<ServiceDependency1>()))
     .Times(1)
-    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(locateService))); // ensure the mock context received a call to LocateService for dependency foo
+    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(
+      locateService))); // ensure the mock context received a call to LocateService for dependency foo
 
-  EXPECT_CALL(*(mockContext.get()), LocateService("bar", us_service_interface_iid<ServiceDependency2>()))
+  EXPECT_CALL(
+    *(mockContext.get()),
+    LocateService("bar", us_service_interface_iid<ServiceDependency2>()))
     .Times(1)
-    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(locateService))); // ensure the mock context received a call to LocateService for dependency bar
+    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(
+      locateService))); // ensure the mock context received a call to LocateService for dependency bar
 
   compInstance.CreateInstanceAndBindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
@@ -304,57 +340,72 @@ TEST(ComponentInstanceImpl, VerifyWithStaticDependencies)
   ASSERT_TRUE(compObj->GetFoo());
   ASSERT_TRUE(compObj->GetBar());
 
-  EXPECT_THROW(compInstance.InvokeBindMethod("foo", fc.GetServiceReference<ServiceDependency1>()), std::out_of_range);
-  EXPECT_THROW(compInstance.InvokeBindMethod("bar", fc.GetServiceReference<ServiceDependency2>()), std::out_of_range);
-  EXPECT_THROW(compInstance.InvokeUnbindMethod("foo", fc.GetServiceReference<ServiceDependency1>()), std::out_of_range);
-  EXPECT_THROW(compInstance.InvokeUnbindMethod("bar", fc.GetServiceReference<ServiceDependency2>()), std::out_of_range);
+  EXPECT_THROW(compInstance.InvokeBindMethod(
+                 "foo", fc.GetServiceReference<ServiceDependency1>()),
+               std::out_of_range);
+  EXPECT_THROW(compInstance.InvokeBindMethod(
+                 "bar", fc.GetServiceReference<ServiceDependency2>()),
+               std::out_of_range);
+  EXPECT_THROW(compInstance.InvokeUnbindMethod(
+                 "foo", fc.GetServiceReference<ServiceDependency1>()),
+               std::out_of_range);
+  EXPECT_THROW(compInstance.InvokeUnbindMethod(
+                 "bar", fc.GetServiceReference<ServiceDependency2>()),
+               std::out_of_range);
 
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
-
 
 TEST(ComponentInstanceImpl, VerifyWithDynamicDependencies)
 {
   auto f = cppmicroservices::FrameworkFactory().NewFramework();
   f.Start();
   auto fc = f.GetBundleContext();
-  auto reg = fc.RegisterService<ServiceDependency1>(std::make_shared<ServiceDependency1>());
-  auto reg1 = fc.RegisterService<ServiceDependency2>(std::make_shared<ServiceDependency2>());
+  auto reg = fc.RegisterService<ServiceDependency1>(
+    std::make_shared<ServiceDependency1>());
+  auto reg1 = fc.RegisterService<ServiceDependency2>(
+    std::make_shared<ServiceDependency2>());
 
   std::vector<std::shared_ptr<Binder<TestServiceImpl1>>> binders;
-  binders.push_back(std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>("foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
+  binders.push_back(
+    std::make_shared<DynamicBinder<TestServiceImpl1, ServiceDependency1>>(
+      "foo", &TestServiceImpl1::BindFoo, &TestServiceImpl1::UnbindFoo));
 
-  ComponentInstanceImpl<TestServiceImpl1, std::tuple<>, ServiceDependency2> compInstance({("bar")}, binders);
+  ComponentInstanceImpl<TestServiceImpl1, std::tuple<>, ServiceDependency2>
+    compInstance({ ("bar") }, binders);
   auto iMap = compInstance.GetInterfaceMap();
   ASSERT_FALSE(iMap);
   ASSERT_EQ(compInstance.GetInstance(), nullptr);
 
   // create a mock context and setup expectations on the context
   auto mockContext = std::make_shared<MockComponentContext>();
-  auto locateService = [&fc](const std::string& type) -> std::shared_ptr<void>
-                       {
-                         auto sRef = fc.GetServiceReference(type);
-                         if(sRef)
-                         {
-                           auto serv = fc.GetService(sRef);
-                           return serv->at(type);
-                         }
-                         else
-                         {
-                           return nullptr;
-                         }
-                       };
+  auto locateService = [&fc](const std::string& type) -> std::shared_ptr<void> {
+    auto sRef = fc.GetServiceReference(type);
+    if (sRef) {
+      auto serv = fc.GetService(sRef);
+      return serv->at(type);
+    } else {
+      return nullptr;
+    }
+  };
 
-  EXPECT_CALL(*(mockContext.get()), GetBundleContext()).WillRepeatedly(testing::Invoke([&fc]() { return fc;}));
+  EXPECT_CALL(*(mockContext.get()), GetBundleContext())
+    .WillRepeatedly(testing::Invoke([&fc]() { return fc; }));
 
-  EXPECT_CALL(*(mockContext.get()), LocateService("foo", us_service_interface_iid<ServiceDependency1>()))
+  EXPECT_CALL(
+    *(mockContext.get()),
+    LocateService("foo", us_service_interface_iid<ServiceDependency1>()))
     .Times(1)
-    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(locateService))); // ensure the mock context received a call to LocateService for dependency foo
+    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(
+      locateService))); // ensure the mock context received a call to LocateService for dependency foo
 
-  EXPECT_CALL(*(mockContext.get()), LocateService("bar", us_service_interface_iid<ServiceDependency2>()))
+  EXPECT_CALL(
+    *(mockContext.get()),
+    LocateService("bar", us_service_interface_iid<ServiceDependency2>()))
     .Times(1)
-    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(locateService))); // ensure the mock context received a call to LocateService for dependency bar
+    .WillRepeatedly(testing::WithArg<1>(testing::Invoke(
+      locateService))); // ensure the mock context received a call to LocateService for dependency bar
 
   // use mock context to create an instance of the component implementation class.
   compInstance.CreateInstanceAndBindReferences(mockContext);
@@ -366,11 +417,17 @@ TEST(ComponentInstanceImpl, VerifyWithDynamicDependencies)
 
   // ensure only dynamic dependencies can be re-bound.
   // The runtime calls the wrapper object with the name of the reference and the ServiceReference object to use for binding.
-  EXPECT_THROW(compInstance.InvokeUnbindMethod("bar", fc.GetServiceReference<ServiceDependency2>()), std::out_of_range);
-  EXPECT_THROW(compInstance.InvokeBindMethod("bar", fc.GetServiceReference<ServiceDependency2>()), std::out_of_range);
-  EXPECT_NO_THROW(compInstance.InvokeUnbindMethod("foo", fc.GetServiceReference<ServiceDependency1>()));
+  EXPECT_THROW(compInstance.InvokeUnbindMethod(
+                 "bar", fc.GetServiceReference<ServiceDependency2>()),
+               std::out_of_range);
+  EXPECT_THROW(compInstance.InvokeBindMethod(
+                 "bar", fc.GetServiceReference<ServiceDependency2>()),
+               std::out_of_range);
+  EXPECT_NO_THROW(compInstance.InvokeUnbindMethod(
+    "foo", fc.GetServiceReference<ServiceDependency1>()));
   ASSERT_EQ(compObj->GetFoo(), nullptr);
-  EXPECT_NO_THROW(compInstance.InvokeBindMethod("foo", fc.GetServiceReference<ServiceDependency1>()));
+  EXPECT_NO_THROW(compInstance.InvokeBindMethod(
+    "foo", fc.GetServiceReference<ServiceDependency1>()));
   ASSERT_NE(compObj->GetFoo(), nullptr);
 
   f.Stop();
@@ -389,7 +446,8 @@ TEST(ComponentInstance, VerifyLifeCycleHooks)
   ASSERT_FALSE(iMap);
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
-  compInstance.CreateInstanceAndBindReferences(std::make_shared<MockComponentContext>());
+  compInstance.CreateInstanceAndBindReferences(
+    std::make_shared<MockComponentContext>());
   compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj->IsActivated());
   compInstance.Activate();
@@ -405,7 +463,8 @@ TEST(ComponentInstanceImpl, VerifyLifeCycleHooks)
   ASSERT_FALSE(iMap);
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
-  compInstance.CreateInstanceAndBindReferences(std::make_shared<MockComponentContext>());
+  compInstance.CreateInstanceAndBindReferences(
+    std::make_shared<MockComponentContext>());
   compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj->IsActivated());
   compInstance.Activate();

--- a/compendium/ServiceComponent/test/suite_registration.cpp
+++ b/compendium/ServiceComponent/test/suite_registration.cpp
@@ -21,7 +21,7 @@
  =============================================================================*/
 
 #include "gmock/gmock.h"
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/compendium/test_bundles/BenchmarkDS/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/BenchmarkDS/src/ServiceImpl.cpp
@@ -1,8 +1,8 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  std::string DSBenchmarkComponent::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string DSBenchmarkComponent::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/BenchmarkDS/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/BenchmarkDS/src/ServiceImpl.hpp
@@ -3,16 +3,14 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace sample
+namespace sample {
+class DSBenchmarkComponent : public test::Interface1
 {
-    class DSBenchmarkComponent
-      : public test::Interface1
-    {
-      public:
-        DSBenchmarkComponent() = default;
-        ~DSBenchmarkComponent() override = default;
-        std::string Description() override;
-    };
+public:
+  DSBenchmarkComponent() = default;
+  ~DSBenchmarkComponent() override = default;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSFrenchDictionary/src/FrenchDictionary.cpp
+++ b/compendium/test_bundles/DSFrenchDictionary/src/FrenchDictionary.cpp
@@ -23,27 +23,27 @@
 
 namespace DSFrenchDictionary {
 
-  DictionaryImpl::DictionaryImpl()
-  {
-    m_dictionary.insert("bienvenue");
-    m_dictionary.insert("au");
-    m_dictionary.insert("tutoriel");
-    m_dictionary.insert("micro");
-    m_dictionary.insert("services");
-  }
+DictionaryImpl::DictionaryImpl()
+{
+  m_dictionary.insert("bienvenue");
+  m_dictionary.insert("au");
+  m_dictionary.insert("tutoriel");
+  m_dictionary.insert("micro");
+  m_dictionary.insert("services");
+}
 
-  /**
-   * Implements IDictionaryService::CheckWord(). Determines
-   * if the passed in word is contained in the dictionary.
-   * @param word the word to be checked.
-   * @return true if the word is in the dictionary,
-   *         false otherwise.
-   **/
-  bool DictionaryImpl::CheckWord(const std::string& word)
-  {
-    std::string lword(word);
-    std::transform(lword.begin(), lword.end(), lword.begin(), ::tolower);
-    return (m_dictionary.find(lword) != m_dictionary.end());
-  }
+/**
+ * Implements IDictionaryService::CheckWord(). Determines
+ * if the passed in word is contained in the dictionary.
+ * @param word the word to be checked.
+ * @return true if the word is in the dictionary,
+ *         false otherwise.
+ **/
+bool DictionaryImpl::CheckWord(const std::string& word)
+{
+  std::string lword(word);
+  std::transform(lword.begin(), lword.end(), lword.begin(), ::tolower);
+  return (m_dictionary.find(lword) != m_dictionary.end());
+}
 
 }

--- a/compendium/test_bundles/DSFrenchDictionary/src/FrenchDictionary.hpp
+++ b/compendium/test_bundles/DSFrenchDictionary/src/FrenchDictionary.hpp
@@ -22,33 +22,33 @@
 #ifndef FRENCHDICTIONARY_HPP
 #define FRENCHDICTIONARY_HPP
 
-#include <string>
 #include <algorithm>
 #include <set>
+#include <string>
 
 #include <IDictionaryService/IDictionaryService.hpp>
 
 namespace DSFrenchDictionary {
 
 class DictionaryImpl : public test::IDictionaryService
-  {
-  public:
+{
+public:
+  DictionaryImpl();
+  ~DictionaryImpl() override = default;
 
-    DictionaryImpl();
-    ~DictionaryImpl() override = default;
+  /**
+   * Implements IDictionaryService::CheckWord(). Determines
+   * if the passed in word is contained in the dictionary.
+   * @param word the word to be checked.
+   * @return true if the word is in the dictionary,
+   *         false otherwise.
+   **/
+  bool CheckWord(const std::string& word) override;
 
-    /**
-     * Implements IDictionaryService::CheckWord(). Determines
-     * if the passed in word is contained in the dictionary.
-     * @param word the word to be checked.
-     * @return true if the word is in the dictionary,
-     *         false otherwise.
-     **/
-    bool CheckWord(const std::string& word) override;
-  private:
-    // The set of words contained in the dictionary.
-    std::set<std::string> m_dictionary;
-  };
+private:
+  // The set of words contained in the dictionary.
+  std::set<std::string> m_dictionary;
+};
 }
 
 #endif // FRENCHDICTIONARY_HPP

--- a/compendium/test_bundles/DSGraph01/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph01/src/ServiceImpl.cpp
@@ -1,19 +1,17 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph01Impl::DSGraph01Impl(const std::shared_ptr<test::DSGraph02>& g02,
+                             const std::shared_ptr<test::DSGraph03>& g03)
+  : test::DSGraph01()
+  , graph02(g02)
+  , graph03(g03)
+{}
+
+DSGraph01Impl::~DSGraph01Impl() = default;
+
+std::string DSGraph01Impl::Description()
 {
-    DSGraph01Impl::DSGraph01Impl(const std::shared_ptr<test::DSGraph02>& g02
-                                 , const std::shared_ptr<test::DSGraph03>& g03)
-      : test::DSGraph01()
-      , graph02(g02)
-      , graph03(g03)
-    {
-    }
-    
-    DSGraph01Impl::~DSGraph01Impl() = default;
-    
-    std::string DSGraph01Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph01/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph01/src/ServiceImpl.hpp
@@ -3,19 +3,19 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph01Impl : public test::DSGraph01
 {
-    class DSGraph01Impl
-      : public test::DSGraph01
-    {
-      public:
-        DSGraph01Impl(const std::shared_ptr<test::DSGraph02>&, const std::shared_ptr<test::DSGraph03>&);
-        ~DSGraph01Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph02> graph02;
-        std::shared_ptr<test::DSGraph03> graph03;
-    };
+public:
+  DSGraph01Impl(const std::shared_ptr<test::DSGraph02>&,
+                const std::shared_ptr<test::DSGraph03>&);
+  ~DSGraph01Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph02> graph02;
+  std::shared_ptr<test::DSGraph03> graph03;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph02/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph02/src/ServiceImpl.cpp
@@ -1,18 +1,16 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph02Impl::DSGraph02Impl(const std::shared_ptr<test::DSGraph04>& g04,
+                             const std::shared_ptr<test::DSGraph05>& g05)
+  : graph04(g04)
+  , graph05(g05)
+{}
+
+DSGraph02Impl::~DSGraph02Impl() = default;
+
+std::string DSGraph02Impl::Description()
 {
-    DSGraph02Impl::DSGraph02Impl(const std::shared_ptr<test::DSGraph04>& g04,
-                                 const std::shared_ptr<test::DSGraph05>& g05)
-      : graph04(g04)
-      , graph05(g05)
-    {
-    }
-    
-    DSGraph02Impl::~DSGraph02Impl() = default;
-    
-    std::string DSGraph02Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph02/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph02/src/ServiceImpl.hpp
@@ -3,19 +3,19 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph02Impl : public test::DSGraph02
 {
-    class DSGraph02Impl
-      : public test::DSGraph02
-    {
-      public:
-        DSGraph02Impl(const std::shared_ptr<test::DSGraph04>&, const std::shared_ptr<test::DSGraph05>&);
-        ~DSGraph02Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph04> graph04;
-        std::shared_ptr<test::DSGraph05> graph05;
-    };
+public:
+  DSGraph02Impl(const std::shared_ptr<test::DSGraph04>&,
+                const std::shared_ptr<test::DSGraph05>&);
+  ~DSGraph02Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph04> graph04;
+  std::shared_ptr<test::DSGraph05> graph05;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph03/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph03/src/ServiceImpl.cpp
@@ -1,18 +1,16 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph03Impl::DSGraph03Impl(const std::shared_ptr<test::DSGraph06>& g06,
+                             const std::shared_ptr<test::DSGraph07>& g07)
+  : graph06(g06)
+  , graph07(g07)
+{}
+
+DSGraph03Impl::~DSGraph03Impl() = default;
+
+std::string DSGraph03Impl::Description()
 {
-    DSGraph03Impl::DSGraph03Impl(const std::shared_ptr<test::DSGraph06>& g06,
-                                 const std::shared_ptr<test::DSGraph07>& g07)
-      : graph06(g06)
-      , graph07(g07)
-    {
-    }
-    
-    DSGraph03Impl::~DSGraph03Impl() = default;
-    
-    std::string DSGraph03Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph03/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph03/src/ServiceImpl.hpp
@@ -3,19 +3,19 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph03Impl : public test::DSGraph03
 {
-    class DSGraph03Impl
-      : public test::DSGraph03
-    {
-      public:
-        DSGraph03Impl(const std::shared_ptr<test::DSGraph06>&, const std::shared_ptr<test::DSGraph07>&);
-        ~DSGraph03Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph06> graph06;
-        std::shared_ptr<test::DSGraph07> graph07;
-    };
+public:
+  DSGraph03Impl(const std::shared_ptr<test::DSGraph06>&,
+                const std::shared_ptr<test::DSGraph07>&);
+  ~DSGraph03Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph06> graph06;
+  std::shared_ptr<test::DSGraph07> graph07;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph04/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph04/src/ServiceImpl.cpp
@@ -1,15 +1,13 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph04Impl::~DSGraph04Impl() = default;
+
+DSGraph04Impl::DSGraph04Impl(const std::shared_ptr<test::DSGraph05>& g05)
+  : graph05(g05)
+{}
+std::string DSGraph04Impl::Description()
 {
-    DSGraph04Impl::~DSGraph04Impl() = default;
-    
-    DSGraph04Impl::DSGraph04Impl(const std::shared_ptr<test::DSGraph05>& g05)
-      : graph05(g05)
-    {
-    }
-    std::string DSGraph04Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph04/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph04/src/ServiceImpl.hpp
@@ -3,18 +3,17 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph04Impl : public test::DSGraph04
 {
-    class DSGraph04Impl
-      : public test::DSGraph04
-    {
-      public:
-        DSGraph04Impl(const std::shared_ptr<test::DSGraph05>&);
-        ~DSGraph04Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph05> graph05;
-    };
+public:
+  DSGraph04Impl(const std::shared_ptr<test::DSGraph05>&);
+  ~DSGraph04Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph05> graph05;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph05/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph05/src/ServiceImpl.cpp
@@ -1,15 +1,13 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph05Impl::~DSGraph05Impl() = default;
+
+DSGraph05Impl::DSGraph05Impl(const std::shared_ptr<test::DSGraph06>& g06)
+  : graph06(g06)
+{}
+std::string DSGraph05Impl::Description()
 {
-    DSGraph05Impl::~DSGraph05Impl() = default;
-    
-    DSGraph05Impl::DSGraph05Impl(const std::shared_ptr<test::DSGraph06>& g06)
-      : graph06(g06)
-    {
-    }
-    std::string DSGraph05Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph05/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph05/src/ServiceImpl.hpp
@@ -3,18 +3,17 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph05Impl : public test::DSGraph05
 {
-    class DSGraph05Impl
-      : public test::DSGraph05
-    {
-      public:
-        DSGraph05Impl(const std::shared_ptr<test::DSGraph06>&);
-        ~DSGraph05Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph06> graph06;
-    };
+public:
+  DSGraph05Impl(const std::shared_ptr<test::DSGraph06>&);
+  ~DSGraph05Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph06> graph06;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph06/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph06/src/ServiceImpl.cpp
@@ -1,15 +1,13 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph06Impl::~DSGraph06Impl() = default;
+
+DSGraph06Impl::DSGraph06Impl(const std::shared_ptr<test::DSGraph07>& g07)
+  : graph07(g07)
+{}
+std::string DSGraph06Impl::Description()
 {
-    DSGraph06Impl::~DSGraph06Impl() = default;
-    
-    DSGraph06Impl::DSGraph06Impl(const std::shared_ptr<test::DSGraph07>& g07)
-      : graph07(g07)
-    {
-    }
-    std::string DSGraph06Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph06/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph06/src/ServiceImpl.hpp
@@ -3,18 +3,17 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph06Impl : public test::DSGraph06
 {
-    class DSGraph06Impl
-      : public test::DSGraph06
-    {
-      public:
-        DSGraph06Impl(const std::shared_ptr<test::DSGraph07>&);
-        ~DSGraph06Impl() override;
-        std::string Description() override;
-      private:
-        std::shared_ptr<test::DSGraph07> graph07;
-    };
+public:
+  DSGraph06Impl(const std::shared_ptr<test::DSGraph07>&);
+  ~DSGraph06Impl() override;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::DSGraph07> graph07;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSGraph07/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph07/src/ServiceImpl.cpp
@@ -1,11 +1,10 @@
 #include "ServiceImpl.hpp"
 
-namespace graph
+namespace graph {
+DSGraph07Impl::~DSGraph07Impl() = default;
+
+std::string DSGraph07Impl::Description()
 {
-    DSGraph07Impl::~DSGraph07Impl() = default;
-    
-    std::string DSGraph07Impl::Description()
-    {
-        return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/DSGraph07/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/DSGraph07/src/ServiceImpl.hpp
@@ -3,16 +3,14 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace graph
+namespace graph {
+class DSGraph07Impl : public test::DSGraph07
 {
-    class DSGraph07Impl
-      : public test::DSGraph07
-    {
-      public:
-        DSGraph07Impl() = default;
-        ~DSGraph07Impl() override;
-        std::string Description() override;
-    };
+public:
+  DSGraph07Impl() = default;
+  ~DSGraph07Impl() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.cpp
+++ b/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.cpp
@@ -19,61 +19,57 @@
   limitations under the License.
 
 =============================================================================*/
-#include <map>
 #include "SpellCheckImpl.hpp"
 #include "cppmicroservices/BundleContext.h"
+#include <map>
 
 using namespace cppmicroservices;
 namespace DSSpellCheck {
-  /**
-   * Implements ISpellCheckService::Check(). Checks the given passage for
-   * misspelled words.
-   *
-   * @param passage the passage to spell check.
-   * @return A list of misspelled words.
-   */
-  std::vector<std::string> SpellCheckImpl::Check(const std::string& passage)
-  {
-    std::vector<std::string> errorList;
+/**
+ * Implements ISpellCheckService::Check(). Checks the given passage for
+ * misspelled words.
+ *
+ * @param passage the passage to spell check.
+ * @return A list of misspelled words.
+ */
+std::vector<std::string> SpellCheckImpl::Check(const std::string& passage)
+{
+  std::vector<std::string> errorList;
 
-    // No misspelled words for an empty string.
-    if (passage.empty())
-    {
-      return errorList;
-    }
-
-    // Tokenize the passage using spaces and punctuation.
-    const char* delimiters = " ,.!?;:";
-    char* passageCopy = new char[passage.size()+1];
-    std::memcpy(passageCopy, passage.c_str(), passage.size()+1);
-    char* pch = std::strtok(passageCopy, delimiters);
-
-    {
-      // Loop through each word in the passage.
-      while (pch)
-      {
-        std::string word(pch);
-
-        bool correct = false;
-
-        if (mDictionary->CheckWord(word))
-        {
-          correct = true;
-        }
-
-        // If the word is not correct, then add it
-        // to the incorrect word list.
-        if (!correct)
-        {
-          errorList.push_back(word);
-        }
-
-        pch = std::strtok(nullptr, delimiters);
-      }
-    }
-
-    delete[] passageCopy;
-
+  // No misspelled words for an empty string.
+  if (passage.empty()) {
     return errorList;
   }
+
+  // Tokenize the passage using spaces and punctuation.
+  const char* delimiters = " ,.!?;:";
+  char* passageCopy = new char[passage.size() + 1];
+  std::memcpy(passageCopy, passage.c_str(), passage.size() + 1);
+  char* pch = std::strtok(passageCopy, delimiters);
+
+  {
+    // Loop through each word in the passage.
+    while (pch) {
+      std::string word(pch);
+
+      bool correct = false;
+
+      if (mDictionary->CheckWord(word)) {
+        correct = true;
+      }
+
+      // If the word is not correct, then add it
+      // to the incorrect word list.
+      if (!correct) {
+        errorList.push_back(word);
+      }
+
+      pch = std::strtok(nullptr, delimiters);
+    }
+  }
+
+  delete[] passageCopy;
+
+  return errorList;
+}
 }

--- a/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.hpp
+++ b/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.hpp
@@ -23,8 +23,8 @@
 #ifndef SPELLCHECKIMPL_HPP
 #define SPELLCHECKIMPL_HPP
 
-#include "ISpellCheckService/ISpellCheckService.hpp"
 #include "IDictionaryService/IDictionaryService.hpp"
+#include "ISpellCheckService/ISpellCheckService.hpp"
 #include "cppmicroservices/ServiceReference.h"
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
@@ -42,7 +42,9 @@ private:
   std::shared_ptr<test::IDictionaryService> mDictionary;
 
 public:
-  SpellCheckImpl(const std::shared_ptr<test::IDictionaryService>& dict) : mDictionary(dict) {}
+  SpellCheckImpl(const std::shared_ptr<test::IDictionaryService>& dict)
+    : mDictionary(dict)
+  {}
   ~SpellCheckImpl() override = default;
   std::vector<std::string> Check(const std::string& passage) override;
 };

--- a/compendium/test_bundles/EnglishDictionary/src/Activator.cpp
+++ b/compendium/test_bundles/EnglishDictionary/src/Activator.cpp
@@ -25,33 +25,29 @@
 
 #include "EnglishDictionary.hpp"
 
-namespace EnglishDictionary
+namespace EnglishDictionary {
+
+class Activator : public cppmicroservices::BundleActivator
 {
-  
-  class Activator : public cppmicroservices::BundleActivator
+public:
+  Activator() = default;
+  ~Activator() = default;
+
+  void Start(cppmicroservices::BundleContext context)
   {
-  public:
-    
-    Activator() = default;
-    ~Activator() = default;
-    
-    void Start(cppmicroservices::BundleContext context)
-    {
-      std::shared_ptr<EnglishDictionary::DictionaryImpl> s = std::make_shared<EnglishDictionary::DictionaryImpl>();
-      cppmicroservices::ServiceProperties props;
-      props["Language"] = std::string("English");
-      sr = context.RegisterService<test::IDictionaryService>(s, props);
-    }
-    
-    void Stop(cppmicroservices::BundleContext /*context*/)
-    {
-      sr.Unregister();
-    }
-    
-  private:
-    cppmicroservices::ServiceRegistration<test::IDictionaryService> sr;
-  };
-  
+    std::shared_ptr<EnglishDictionary::DictionaryImpl> s =
+      std::make_shared<EnglishDictionary::DictionaryImpl>();
+    cppmicroservices::ServiceProperties props;
+    props["Language"] = std::string("English");
+    sr = context.RegisterService<test::IDictionaryService>(s, props);
+  }
+
+  void Stop(cppmicroservices::BundleContext /*context*/) { sr.Unregister(); }
+
+private:
+  cppmicroservices::ServiceRegistration<test::IDictionaryService> sr;
+};
+
 }
 
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(EnglishDictionary::Activator)

--- a/compendium/test_bundles/EnglishDictionary/src/EnglishDictionary.cpp
+++ b/compendium/test_bundles/EnglishDictionary/src/EnglishDictionary.cpp
@@ -23,29 +23,29 @@
 
 namespace EnglishDictionary {
 
-  DictionaryImpl::DictionaryImpl()
-  {
-    m_dictionary.insert("welcome");
-    m_dictionary.insert("to");
-    m_dictionary.insert("the");
-    m_dictionary.insert("micro");
-    m_dictionary.insert("services");
-    m_dictionary.insert("tutorial");
-  }
+DictionaryImpl::DictionaryImpl()
+{
+  m_dictionary.insert("welcome");
+  m_dictionary.insert("to");
+  m_dictionary.insert("the");
+  m_dictionary.insert("micro");
+  m_dictionary.insert("services");
+  m_dictionary.insert("tutorial");
+}
 
-  /**
-   * Implements IDictionaryService::CheckWord(). Determines
-   * if the passed in word is contained in the dictionary.
-   * @param word the word to be checked.
-   * @return true if the word is in the dictionary,
-   *         false otherwise.
-   **/
-  bool DictionaryImpl::CheckWord(const std::string& word)
-  {
-    std::string lword(word);
-    std::transform(lword.begin(), lword.end(), lword.begin(), ::tolower);
+/**
+ * Implements IDictionaryService::CheckWord(). Determines
+ * if the passed in word is contained in the dictionary.
+ * @param word the word to be checked.
+ * @return true if the word is in the dictionary,
+ *         false otherwise.
+ **/
+bool DictionaryImpl::CheckWord(const std::string& word)
+{
+  std::string lword(word);
+  std::transform(lword.begin(), lword.end(), lword.begin(), ::tolower);
 
-    return m_dictionary.find(lword) != m_dictionary.end();
-  }
+  return m_dictionary.find(lword) != m_dictionary.end();
+}
 
 }

--- a/compendium/test_bundles/EnglishDictionary/src/EnglishDictionary.hpp
+++ b/compendium/test_bundles/EnglishDictionary/src/EnglishDictionary.hpp
@@ -22,33 +22,33 @@
 #ifndef ENGLISHDICTIONARY_HPP
 #define ENGLISHDICTIONARY_HPP
 
-#include <string>
 #include <algorithm>
 #include <set>
+#include <string>
 
 #include <IDictionaryService/IDictionaryService.hpp>
 
 namespace EnglishDictionary {
 
 class DictionaryImpl : public test::IDictionaryService
-  {
-  public:
+{
+public:
+  DictionaryImpl();
+  ~DictionaryImpl() override = default;
 
-    DictionaryImpl();
-    ~DictionaryImpl() override = default;
+  /**
+   * Implements IDictionaryService::CheckWord(). Determines
+   * if the passed in word is contained in the dictionary.
+   * @param word the word to be checked.
+   * @return true if the word is in the dictionary,
+   *         false otherwise.
+   **/
+  bool CheckWord(const std::string& word) override;
 
-    /**
-     * Implements IDictionaryService::CheckWord(). Determines
-     * if the passed in word is contained in the dictionary.
-     * @param word the word to be checked.
-     * @return true if the word is in the dictionary,
-     *         false otherwise.
-     **/
-    bool CheckWord(const std::string& word) override;
-  private:
-    // The set of words contained in the dictionary.
-    std::set<std::string> m_dictionary;
-  };
+private:
+  // The set of words contained in the dictionary.
+  std::set<std::string> m_dictionary;
+};
 }
 
 #endif // ENGLISHDICTIONARY_HPP

--- a/compendium/test_bundles/IDictionaryService/include/IDictionaryService/IDictionaryService.hpp
+++ b/compendium/test_bundles/IDictionaryService/include/IDictionaryService/IDictionaryService.hpp
@@ -27,9 +27,9 @@
 
 namespace test {
 
-class US_IDictionaryService_EXPORT  IDictionaryService
+class US_IDictionaryService_EXPORT IDictionaryService
 {
-  public:
+public:
   virtual ~IDictionaryService();
   /**
    * Check for the existence of a word.

--- a/compendium/test_bundles/IDictionaryService/src/IDictionaryService.cpp
+++ b/compendium/test_bundles/IDictionaryService/src/IDictionaryService.cpp
@@ -21,8 +21,6 @@
 =============================================================================*/
 #include "IDictionaryService/IDictionaryService.hpp"
 
-namespace test
-{
-  IDictionaryService::~IDictionaryService()
-  {}
+namespace test {
+IDictionaryService::~IDictionaryService() {}
 }

--- a/compendium/test_bundles/ISpellCheckService/include/ISpellCheckService/ISpellCheckService.hpp
+++ b/compendium/test_bundles/ISpellCheckService/include/ISpellCheckService/ISpellCheckService.hpp
@@ -30,9 +30,9 @@ namespace test {
 
 class US_ISpellCheckService_EXPORT ISpellCheckService
 {
-  public:
+public:
   virtual ~ISpellCheckService();
-    
+
   /**
    * Checks a given passage for spelling errors. A passage is any number of
    * words separated by a space and any of the following punctuation marks:

--- a/compendium/test_bundles/ISpellCheckService/src/ISpellCheckService.cpp
+++ b/compendium/test_bundles/ISpellCheckService/src/ISpellCheckService.cpp
@@ -21,7 +21,6 @@
 =============================================================================*/
 #include "ISpellCheckService/ISpellCheckService.hpp"
 
-namespace test
-{
-  ISpellCheckService::~ISpellCheckService() {}
+namespace test {
+ISpellCheckService::~ISpellCheckService() {}
 }

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.cpp
@@ -9,40 +9,48 @@ namespace test {
 
 TestManagedServiceFactoryImpl::~TestManagedServiceFactoryImpl() = default;
 
-void TestManagedServiceFactoryImpl::Updated(std::string const& pid, AnyMap const& properties) {
-    std::lock_guard<std::mutex> lk(m_updatedMtx);
-    if (properties.empty()) {
-        m_updatedCallCount[pid] -= 1;
-    } else {
-        auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
-        m_updatedCallCount[pid] += incrementBy;
-    }
+void TestManagedServiceFactoryImpl::Updated(std::string const& pid,
+                                            AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  if (properties.empty()) {
+    m_updatedCallCount[pid] -= 1;
+  } else {
+    auto const incrementBy =
+      cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
+    m_updatedCallCount[pid] += incrementBy;
+  }
 }
 
-void TestManagedServiceFactoryImpl::Removed(std::string const& pid) {
-    std::lock_guard<std::mutex> lk(m_removedMtx);
-    ++m_removedCallCount[pid];
+void TestManagedServiceFactoryImpl::Removed(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  ++m_removedCallCount[pid];
 }
 
-int TestManagedServiceFactoryImpl::getUpdatedCounter(std::string const& pid) {
-    std::lock_guard<std::mutex> lk(m_updatedMtx);
-    return m_updatedCallCount[pid];
+int TestManagedServiceFactoryImpl::getUpdatedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  return m_updatedCallCount[pid];
 }
 
-int TestManagedServiceFactoryImpl::getRemovedCounter(std::string const& pid) {
-    std::lock_guard<std::mutex> lk(m_removedMtx);
-    return m_removedCallCount[pid];
+int TestManagedServiceFactoryImpl::getRemovedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  return m_removedCallCount[pid];
 }
 
-std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> TestManagedServiceFactoryImpl::create(
-    std::string const& config) {
+std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface>
+TestManagedServiceFactoryImpl::create(std::string const& config)
+{
 
-    std::lock_guard<std::mutex> lk(m_updatedMtx);
-    try {
-        return std::make_shared<TestManagedServiceFactoryServiceImpl>(m_updatedCallCount.at(config));
-    } catch (...) {
-        return nullptr;
-    }
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  try {
+    return std::make_shared<TestManagedServiceFactoryServiceImpl>(
+      m_updatedCallCount.at(config));
+  } catch (...) {
+    return nullptr;
+  }
 }
 
 } // namespace test

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryImpl.hpp
@@ -13,28 +13,30 @@ namespace cm {
 namespace test {
 
 class TestManagedServiceFactoryImpl
-    : public ::test::TestManagedServiceFactory,
-      public ::cppmicroservices::service::cm::ManagedServiceFactory {
+  : public ::test::TestManagedServiceFactory
+  , public ::cppmicroservices::service::cm::ManagedServiceFactory
+{
 
-  public:
-    virtual ~TestManagedServiceFactoryImpl();
+public:
+  virtual ~TestManagedServiceFactoryImpl();
 
-    void Updated(std::string const& pid, AnyMap const& properties) override;
+  void Updated(std::string const& pid, AnyMap const& properties) override;
 
-    void Removed(std::string const& pid) override;
+  void Removed(std::string const& pid) override;
 
-    int getUpdatedCounter(std::string const& pid) override;
+  int getUpdatedCounter(std::string const& pid) override;
 
-    int getRemovedCounter(std::string const& pid) override;
+  int getRemovedCounter(std::string const& pid) override;
 
-    std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> create(std::string const& config) override;
+  std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> create(
+    std::string const& config) override;
 
-  private:
-    std::map<std::string, int> m_updatedCallCount;
-    std::map<std::string, int> m_removedCallCount;
+private:
+  std::map<std::string, int> m_updatedCallCount;
+  std::map<std::string, int> m_removedCallCount;
 
-    std::mutex m_updatedMtx;
-    std::mutex m_removedMtx;
+  std::mutex m_updatedMtx;
+  std::mutex m_removedMtx;
 };
 
 } // namespace test

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
@@ -5,13 +5,17 @@ namespace service {
 namespace cm {
 namespace test {
 
-TestManagedServiceFactoryServiceImpl::TestManagedServiceFactoryServiceImpl(int initialValue)
-    : value{initialValue} {}
+TestManagedServiceFactoryServiceImpl::TestManagedServiceFactoryServiceImpl(
+  int initialValue)
+  : value{ initialValue }
+{}
 
-TestManagedServiceFactoryServiceImpl::~TestManagedServiceFactoryServiceImpl() = default;
+TestManagedServiceFactoryServiceImpl::~TestManagedServiceFactoryServiceImpl() =
+  default;
 
-int TestManagedServiceFactoryServiceImpl::getValue() {
-    return value;
+int TestManagedServiceFactoryServiceImpl::getValue()
+{
+  return value;
 }
 
 } // namespace test

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.hpp
@@ -5,15 +5,17 @@ namespace service {
 namespace cm {
 namespace test {
 
-class TestManagedServiceFactoryServiceImpl : public ::test::TestManagedServiceFactoryServiceInterface {
-  public:
-    TestManagedServiceFactoryServiceImpl(int initialValue);
-    ~TestManagedServiceFactoryServiceImpl();
+class TestManagedServiceFactoryServiceImpl
+  : public ::test::TestManagedServiceFactoryServiceInterface
+{
+public:
+  TestManagedServiceFactoryServiceImpl(int initialValue);
+  ~TestManagedServiceFactoryServiceImpl();
 
-    int getValue() override;
+  int getValue() override;
 
-  private:
-    int value;
+private:
+  int value;
 };
 
 } // namespace test

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
@@ -9,26 +9,28 @@ namespace cm {
 namespace test {
 
 TestManagedServiceImpl::TestManagedServiceImpl()
-    : m_counter{0} {
-}
+  : m_counter{ 0 }
+{}
 
 TestManagedServiceImpl::~TestManagedServiceImpl() = default;
 
-void TestManagedServiceImpl::Updated(AnyMap const& properties) {
-    std::lock_guard<std::mutex> lk(m_counterMtx);
-    if (properties.empty()) {
-        // Usually corresponds to the configuration being removed
-        m_counter -= 1;
-    }
-    else {
-        auto const incrementBy = cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
-        m_counter += incrementBy;
-    }
+void TestManagedServiceImpl::Updated(AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  if (properties.empty()) {
+    // Usually corresponds to the configuration being removed
+    m_counter -= 1;
+  } else {
+    auto const incrementBy =
+      cppmicroservices::any_cast<int>(properties.AtCompoundKey("anInt"));
+    m_counter += incrementBy;
+  }
 }
 
-int TestManagedServiceImpl::getCounter() {
-    std::lock_guard<std::mutex> lk(m_counterMtx);
-    return m_counter;
+int TestManagedServiceImpl::getCounter()
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  return m_counter;
 }
 
 } // namespace test

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.hpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.hpp
@@ -1,5 +1,5 @@
-#include <cppmicroservices/cm/ManagedService.hpp>
 #include <cppmicroservices/AnyMap.h>
+#include <cppmicroservices/cm/ManagedService.hpp>
 
 #include "TestInterfaces/Interfaces.hpp"
 
@@ -10,19 +10,22 @@ namespace service {
 namespace cm {
 namespace test {
 
-class TestManagedServiceImpl : public ::test::TestManagedServiceInterface, public cppmicroservices::service::cm::ManagedService {
-  public:
-    TestManagedServiceImpl();
+class TestManagedServiceImpl
+  : public ::test::TestManagedServiceInterface
+  , public cppmicroservices::service::cm::ManagedService
+{
+public:
+  TestManagedServiceImpl();
 
-    virtual ~TestManagedServiceImpl();
+  virtual ~TestManagedServiceImpl();
 
-    void Updated(AnyMap const& properties) override;
+  void Updated(AnyMap const& properties) override;
 
-    int getCounter() override;
+  int getCounter() override;
 
-  private:
-    int m_counter;
-    std::mutex m_counterMtx;
+private:
+  int m_counter;
+  std::mutex m_counterMtx;
 };
 
 } // namespace test

--- a/compendium/test_bundles/TestBindUnbindThrows/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBindUnbindThrows/src/ServiceImpl.cpp
@@ -5,8 +5,7 @@ namespace sample {
 
 std::string ServiceComponentDGMU::ExtendedDescription()
 {
-  if(!foo)
-  {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result(STRINGIZE(US_BUNDLE_NAME));
@@ -15,14 +14,12 @@ std::string ServiceComponentDGMU::ExtendedDescription()
   return result;
 }
 
-void ServiceComponentDGMU::Bindfoo(
-  const std::shared_ptr<test::Interface1>& )
+void ServiceComponentDGMU::Bindfoo(const std::shared_ptr<test::Interface1>&)
 {
   throw std::runtime_error("throw from bind method");
 }
 
-void ServiceComponentDGMU::Unbindfoo(
-  const std::shared_ptr<test::Interface1>& )
+void ServiceComponentDGMU::Unbindfoo(const std::shared_ptr<test::Interface1>&)
 {
   throw std::runtime_error("throw from unbind method");
 }
@@ -38,14 +35,12 @@ std::string ServiceComponentDGOU::ExtendedDescription()
   return result;
 }
 
-void ServiceComponentDGOU::Bindbar(
-  const std::shared_ptr<test::Interface1>& )
+void ServiceComponentDGOU::Bindbar(const std::shared_ptr<test::Interface1>&)
 {
   throw std::runtime_error("throw from bind method");
 }
 
-void ServiceComponentDGOU::Unbindbar(
-  const std::shared_ptr<test::Interface1>& )
+void ServiceComponentDGOU::Unbindbar(const std::shared_ptr<test::Interface1>&)
 {
 
   throw std::runtime_error("throw from unbind method");
@@ -63,13 +58,13 @@ std::string ServiceComponentFactory::ExtendedDescription()
 }
 
 void ServiceComponentFactory::Bindfactory(
-  const std::shared_ptr<test::Interface1>& )
+  const std::shared_ptr<test::Interface1>&)
 {
   throw std::runtime_error("throw from bind method");
 }
 
 void ServiceComponentFactory::Unbindfactory(
-  const std::shared_ptr<test::Interface1>& )
+  const std::shared_ptr<test::Interface1>&)
 {
 
   throw std::runtime_error("throw from unbind method");

--- a/compendium/test_bundles/TestBindUnbindThrows/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBindUnbindThrows/src/ServiceImpl.hpp
@@ -1,15 +1,14 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponentDGMU
-  : public test::Interface2
+class ServiceComponentDGMU : public test::Interface2
 {
 public:
   ServiceComponentDGMU() = default;
@@ -18,6 +17,7 @@ public:
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
 };

--- a/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
@@ -3,18 +3,18 @@
 
 namespace sample {
 
-void ServiceComponentDynamicGreedyMandatoryUnary::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponentDynamicGreedyMandatoryUnary::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponentDynamicGreedyMandatoryUnary::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
+
+void ServiceComponentDynamicGreedyMandatoryUnary::Deactivate(
+  const std::shared_ptr<ComponentContext>&)
+{}
 
 std::string ServiceComponentDynamicGreedyMandatoryUnary::ExtendedDescription()
 {
   std::lock_guard<std::mutex> lock(fooMutex);
-  if(!foo) {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result("ServiceComponentDynamicGreedyMandatoryUnary ");
@@ -23,7 +23,8 @@ std::string ServiceComponentDynamicGreedyMandatoryUnary::ExtendedDescription()
   return result;
 }
 
-void ServiceComponentDynamicGreedyMandatoryUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicGreedyMandatoryUnary::Bindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo != theFoo) {
@@ -31,7 +32,8 @@ void ServiceComponentDynamicGreedyMandatoryUnary::Bindfoo(const std::shared_ptr<
   }
 }
 
-void ServiceComponentDynamicGreedyMandatoryUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicGreedyMandatoryUnary::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo == theFoo) {

--- a/compendium/test_bundles/TestBundleDSDGMU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDGMU/src/ServiceImpl.hpp
@@ -3,25 +3,27 @@
 
 #include <mutex>
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponentDynamicGreedyMandatoryUnary final : public test::Interface2
+class ServiceComponentDynamicGreedyMandatoryUnary final
+  : public test::Interface2
 {
 public:
   ServiceComponentDynamicGreedyMandatoryUnary() = default;
   ~ServiceComponentDynamicGreedyMandatoryUnary() = default;
   virtual std::string ExtendedDescription() override;
-  
+
   void Activate(const std::shared_ptr<ComponentContext>&);
   void Deactivate(const std::shared_ptr<ComponentContext>&);
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
   std::mutex fooMutex;

--- a/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
@@ -3,13 +3,13 @@
 
 namespace sample {
 
-void ServiceComponentDynamicGreedyOptionalUnary::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponentDynamicGreedyOptionalUnary::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponentDynamicGreedyOptionalUnary::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
+
+void ServiceComponentDynamicGreedyOptionalUnary::Deactivate(
+  const std::shared_ptr<ComponentContext>&)
+{}
 
 std::string ServiceComponentDynamicGreedyOptionalUnary::ExtendedDescription()
 {
@@ -22,7 +22,8 @@ std::string ServiceComponentDynamicGreedyOptionalUnary::ExtendedDescription()
   return result;
 }
 
-void ServiceComponentDynamicGreedyOptionalUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicGreedyOptionalUnary::Bindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo != theFoo) {
@@ -30,7 +31,8 @@ void ServiceComponentDynamicGreedyOptionalUnary::Bindfoo(const std::shared_ptr<t
   }
 }
 
-void ServiceComponentDynamicGreedyOptionalUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicGreedyOptionalUnary::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo == theFoo) {

--- a/compendium/test_bundles/TestBundleDSDGOU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDGOU/src/ServiceImpl.hpp
@@ -3,8 +3,8 @@
 
 #include <mutex>
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
@@ -16,12 +16,13 @@ public:
   ServiceComponentDynamicGreedyOptionalUnary() = default;
   ~ServiceComponentDynamicGreedyOptionalUnary() = default;
   virtual std::string ExtendedDescription() override;
-  
+
   void Activate(const std::shared_ptr<ComponentContext>&);
   void Deactivate(const std::shared_ptr<ComponentContext>&);
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
   std::mutex fooMutex;

--- a/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
@@ -3,18 +3,19 @@
 
 namespace sample {
 
-void ServiceComponentDynamicReluctantMandatoryUnary::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponentDynamicReluctantMandatoryUnary::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponentDynamicReluctantMandatoryUnary::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
 
-std::string ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription()
+void ServiceComponentDynamicReluctantMandatoryUnary::Deactivate(
+  const std::shared_ptr<ComponentContext>&)
+{}
+
+std::string
+ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription()
 {
   std::lock_guard<std::mutex> lock(fooMutex);
-  if(!foo) {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result("ServiceComponentDynamicReluctantMandatoryUnary ");
@@ -23,7 +24,8 @@ std::string ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription(
   return result;
 }
 
-void ServiceComponentDynamicReluctantMandatoryUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicReluctantMandatoryUnary::Bindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo != theFoo) {
@@ -31,7 +33,8 @@ void ServiceComponentDynamicReluctantMandatoryUnary::Bindfoo(const std::shared_p
   }
 }
 
-void ServiceComponentDynamicReluctantMandatoryUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicReluctantMandatoryUnary::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo == theFoo) {

--- a/compendium/test_bundles/TestBundleDSDRMU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDRMU/src/ServiceImpl.hpp
@@ -3,25 +3,27 @@
 
 #include <mutex>
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponentDynamicReluctantMandatoryUnary final : public test::Interface2
+class ServiceComponentDynamicReluctantMandatoryUnary final
+  : public test::Interface2
 {
 public:
   ServiceComponentDynamicReluctantMandatoryUnary() = default;
   ~ServiceComponentDynamicReluctantMandatoryUnary() = default;
   std::string ExtendedDescription() override;
-  
+
   void Activate(const std::shared_ptr<ComponentContext>&);
   void Deactivate(const std::shared_ptr<ComponentContext>&);
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
   std::mutex fooMutex;

--- a/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
@@ -3,13 +3,13 @@
 
 namespace sample {
 
-void ServiceComponentDynamicReluctantOptionalUnary::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponentDynamicReluctantOptionalUnary::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponentDynamicReluctantOptionalUnary::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
+
+void ServiceComponentDynamicReluctantOptionalUnary::Deactivate(
+  const std::shared_ptr<ComponentContext>&)
+{}
 
 std::string ServiceComponentDynamicReluctantOptionalUnary::ExtendedDescription()
 {
@@ -22,7 +22,8 @@ std::string ServiceComponentDynamicReluctantOptionalUnary::ExtendedDescription()
   return result;
 }
 
-void ServiceComponentDynamicReluctantOptionalUnary::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicReluctantOptionalUnary::Bindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo != theFoo) {
@@ -30,7 +31,8 @@ void ServiceComponentDynamicReluctantOptionalUnary::Bindfoo(const std::shared_pt
   }
 }
 
-void ServiceComponentDynamicReluctantOptionalUnary::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponentDynamicReluctantOptionalUnary::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
   std::lock_guard<std::mutex> lock(fooMutex);
   if (foo == theFoo) {

--- a/compendium/test_bundles/TestBundleDSDROU/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSDROU/src/ServiceImpl.hpp
@@ -3,25 +3,27 @@
 
 #include <mutex>
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponentDynamicReluctantOptionalUnary final : public test::Interface2
+class ServiceComponentDynamicReluctantOptionalUnary final
+  : public test::Interface2
 {
 public:
   ServiceComponentDynamicReluctantOptionalUnary() = default;
   ~ServiceComponentDynamicReluctantOptionalUnary() = default;
   virtual std::string ExtendedDescription() override;
-  
+
   void Activate(const std::shared_ptr<ComponentContext>&);
   void Deactivate(const std::shared_ptr<ComponentContext>&);
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
   std::mutex fooMutex;

--- a/compendium/test_bundles/TestBundleDSTOI1/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI1/src/ServiceImpl.cpp
@@ -22,12 +22,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent::~ServiceComponent()
-  {
-  }
+ServiceComponent::~ServiceComponent() {}
 
-  std::string ServiceComponent::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI1/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI1/src/ServiceImpl.hpp
@@ -4,12 +4,13 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent : public test::Interface1 {
-  public:
-    ServiceComponent() = default;
-    ~ServiceComponent() override;
-    std::string Description() override;
-  };
+class ServiceComponent : public test::Interface1
+{
+public:
+  ServiceComponent() = default;
+  ~ServiceComponent() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI10/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI10/src/ServiceImpl.cpp
@@ -22,13 +22,13 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  void ServiceComponent10::Activate(const std::shared_ptr<ComponentContext>&)
-  {
-    activated = true;
-  };
-  void ServiceComponent10::Deactivate(const std::shared_ptr<ComponentContext>&)
-  {
-    deactivated = true;
-  };
-  ServiceComponent10::~ServiceComponent10() {};
+void ServiceComponent10::Activate(const std::shared_ptr<ComponentContext>&)
+{
+  activated = true;
+};
+void ServiceComponent10::Deactivate(const std::shared_ptr<ComponentContext>&)
+{
+  deactivated = true;
+};
+ServiceComponent10::~ServiceComponent10(){};
 }

--- a/compendium/test_bundles/TestBundleDSTOI10/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI10/src/ServiceImpl.hpp
@@ -1,24 +1,26 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
-  class ServiceComponent10 : public test::LifeCycleValidation {
-  public:
-    ServiceComponent10() = default;
-    ~ServiceComponent10() override;
-    void Activate(const std::shared_ptr<ComponentContext>& context);
-    void Deactivate(const std::shared_ptr<ComponentContext>& context);
-    bool IsActivated() override { return activated; };
-    bool IsDeactivated() override { return deactivated; };
-  private:
-    bool activated;
-    bool deactivated;
-  };
+class ServiceComponent10 : public test::LifeCycleValidation
+{
+public:
+  ServiceComponent10() = default;
+  ~ServiceComponent10() override;
+  void Activate(const std::shared_ptr<ComponentContext>& context);
+  void Deactivate(const std::shared_ptr<ComponentContext>& context);
+  bool IsActivated() override { return activated; };
+  bool IsDeactivated() override { return deactivated; };
+
+private:
+  bool activated;
+  bool deactivated;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI12/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI12/src/ServiceImpl.cpp
@@ -1,12 +1,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent12::~ServiceComponent12()
-  {
-  }
+ServiceComponent12::~ServiceComponent12() {}
 
-  std::string ServiceComponent12::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent12::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI12/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI12/src/ServiceImpl.hpp
@@ -4,12 +4,13 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent12 : public test::Interface1 {
-  public:
-    ServiceComponent12() = default;
-    ~ServiceComponent12() override;
-    std::string Description() override;
-  };
+class ServiceComponent12 : public test::Interface1
+{
+public:
+  ServiceComponent12() = default;
+  ~ServiceComponent12() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI14/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI14/src/ServiceImpl.cpp
@@ -22,12 +22,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent14::~ServiceComponent14()
-  {
-  }
+ServiceComponent14::~ServiceComponent14() {}
 
-  std::string ServiceComponent14::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent14::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI14/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI14/src/ServiceImpl.hpp
@@ -4,12 +4,13 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent14 : public test::Interface1 {
-  public:
-    ServiceComponent14() = default;
-    ~ServiceComponent14() override;
-    std::string Description() override;
-  };
+class ServiceComponent14 : public test::Interface1
+{
+public:
+  ServiceComponent14() = default;
+  ~ServiceComponent14() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI15/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI15/src/ServiceImpl.cpp
@@ -22,12 +22,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent15::~ServiceComponent15()
-  {
-  }
+ServiceComponent15::~ServiceComponent15() {}
 
-  std::string ServiceComponent15::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent15::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI15/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI15/src/ServiceImpl.hpp
@@ -4,12 +4,13 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent15 : public test::Interface1 {
-  public:
-    ServiceComponent15() = default;
-    ~ServiceComponent15() override;
-    std::string Description() override;
-  };
+class ServiceComponent15 : public test::Interface1
+{
+public:
+  ServiceComponent15() = default;
+  ~ServiceComponent15() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI16/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI16/src/ServiceImpl.cpp
@@ -21,17 +21,17 @@
 =============================================================================*/
 #include "ServiceImpl.hpp"
 
-namespace sample
+namespace sample {
+std::string ServiceComponent16::Description()
 {
-    std::string ServiceComponent16::Description()
-    {
-      return STRINGIZE(US_BUNDLE_NAME);
-    }
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 
-  std::string ServiceComponent16::ExtendedDescription()
-  {
-    return "This is a test bundle used to verify service components that implement multiple interfaces";
-  }
+std::string ServiceComponent16::ExtendedDescription()
+{
+  return "This is a test bundle used to verify service components that "
+         "implement multiple interfaces";
+}
 
-  ServiceComponent16::~ServiceComponent16() {}
+ServiceComponent16::~ServiceComponent16() {}
 }

--- a/compendium/test_bundles/TestBundleDSTOI16/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI16/src/ServiceImpl.hpp
@@ -3,15 +3,16 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace sample
+namespace sample {
+class ServiceComponent16
+  : public test::Interface1
+  , public test::Interface2
 {
-    class ServiceComponent16 : public test::Interface1, public test::Interface2
-    {
-    public:
-        std::string Description() override;
-        std::string ExtendedDescription() override;
-        ~ServiceComponent16() override;
-    };
+public:
+  std::string Description() override;
+  std::string ExtendedDescription() override;
+  ~ServiceComponent16() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI18/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI18/src/ServiceImpl.cpp
@@ -4,7 +4,7 @@ namespace sample {
 
 bool ServiceComponent18::isDependencyInjected()
 {
-    return constructorHit;
+  return constructorHit;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSTOI18/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI18/src/ServiceImpl.hpp
@@ -1,32 +1,33 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponent18 final : public test::Interface3
 {
-  class ServiceComponent18 final : public test::Interface3
-    {
-    public:
-      ServiceComponent18():constructorHit{false}{}
+public:
+  ServiceComponent18()
+    : constructorHit{ false }
+  {}
 
-      ServiceComponent18(std::shared_ptr<test::Interface1> interface1) : constructorHit{false}
-      {
-          if (nullptr != interface1)
-          {
-              constructorHit = true;
-          }
-      } 
+  ServiceComponent18(std::shared_ptr<test::Interface1> interface1)
+    : constructorHit{ false }
+  {
+    if (nullptr != interface1) {
+      constructorHit = true;
+    }
+  }
 
-      bool isDependencyInjected() override;
-      ~ServiceComponent18() = default;
+  bool isDependencyInjected() override;
+  ~ServiceComponent18() = default;
 
-    private:
-        bool constructorHit;
-    };
+private:
+  bool constructorHit;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI19/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI19/src/ServiceImpl.cpp
@@ -5,8 +5,7 @@ namespace sample {
 
 std::string ServiceComponent19::ExtendedDescription()
 {
-  if(!foo)
-  {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result(STRINGIZE(US_BUNDLE_NAME));
@@ -15,18 +14,18 @@ std::string ServiceComponent19::ExtendedDescription()
   return result;
 }
 
-void ServiceComponent19::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponent19::Bindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
-void ServiceComponent19::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponent19::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSTOI19/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI19/src/ServiceImpl.hpp
@@ -1,25 +1,25 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponent19 : public test::Interface2
 {
-  class ServiceComponent19 : public test::Interface2
-    {
-    public:
-      ServiceComponent19() = default;
-      std::string ExtendedDescription() override;
-      ~ServiceComponent19() = default;
+public:
+  ServiceComponent19() = default;
+  std::string ExtendedDescription() override;
+  ~ServiceComponent19() = default;
 
-      void Bindfoo(const std::shared_ptr<test::Interface1>&);
-      void Unbindfoo(const std::shared_ptr<test::Interface1>&);
-    private:
-      std::shared_ptr<test::Interface1> foo;
-    };
+  void Bindfoo(const std::shared_ptr<test::Interface1>&);
+  void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
+private:
+  std::shared_ptr<test::Interface1> foo;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI2/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI2/src/ServiceImpl.cpp
@@ -22,12 +22,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent2::~ServiceComponent2()
-  {
-  }
+ServiceComponent2::~ServiceComponent2() {}
 
-  std::string ServiceComponent2::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent2::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI2/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI2/src/ServiceImpl.hpp
@@ -23,11 +23,12 @@
 #define _SERVICE_IMPL_HPP_
 #include "TestInterfaces/Interfaces.hpp"
 namespace sample {
-  class ServiceComponent2 : public test::Interface1 {
-  public:
-    ~ServiceComponent2();
-    std::string Description() override;
-  };
+class ServiceComponent2 : public test::Interface1
+{
+public:
+  ~ServiceComponent2();
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI3/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI3/src/ServiceImpl.cpp
@@ -22,10 +22,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent3::~ServiceComponent3() = default;
+ServiceComponent3::~ServiceComponent3() = default;
 
-  std::string ServiceComponent3::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent3::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSTOI3/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI3/src/ServiceImpl.hpp
@@ -23,11 +23,12 @@
 #define _SERVICE_IMPL_HPP_
 #include "TestInterfaces/Interfaces.hpp"
 namespace sample {
-  class ServiceComponent3 : public test::Interface1 {
-  public:
-    ~ServiceComponent3() override;
-    std::string Description() override;
-  };
+class ServiceComponent3 : public test::Interface1
+{
+public:
+  ~ServiceComponent3() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.cpp
@@ -3,18 +3,15 @@
 
 namespace sample {
 
-void ServiceComponent5::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponent5::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponent5::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
+
+void ServiceComponent5::Deactivate(const std::shared_ptr<ComponentContext>&) {}
 
 std::string ServiceComponent5::ExtendedDescription()
 {
-  if(!foo)
-  {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result(STRINGIZE(US_BUNDLE_NAME));
@@ -25,16 +22,15 @@ std::string ServiceComponent5::ExtendedDescription()
 
 void ServiceComponent5::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
-void ServiceComponent5::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponent5::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.hpp
@@ -1,27 +1,27 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponent5 : public test::Interface2
 {
-  class ServiceComponent5 : public test::Interface2
-    {
-    public:
-      ServiceComponent5() = default;
-      std::string ExtendedDescription() override;
-      void Activate(const std::shared_ptr<ComponentContext>&);
-      void Deactivate(const std::shared_ptr<ComponentContext>&);
-      ~ServiceComponent5() = default;
+public:
+  ServiceComponent5() = default;
+  std::string ExtendedDescription() override;
+  void Activate(const std::shared_ptr<ComponentContext>&);
+  void Deactivate(const std::shared_ptr<ComponentContext>&);
+  ~ServiceComponent5() = default;
 
-      void Bindfoo(const std::shared_ptr<test::Interface1>&);
-      void Unbindfoo(const std::shared_ptr<test::Interface1>&);
-    private:
-      std::shared_ptr<test::Interface1> foo;
-    };
+  void Bindfoo(const std::shared_ptr<test::Interface1>&);
+  void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
+private:
+  std::shared_ptr<test::Interface1> foo;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI6/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI6/src/ServiceImpl.cpp
@@ -1,12 +1,11 @@
 #include "ServiceImpl.hpp"
 
-namespace sample
-{
+namespace sample {
 void ServiceComponent6::Activate(const std::shared_ptr<ComponentContext>& ctxt)
 {
   foo = ctxt->LocateService<test::Interface1>("foo");
 }
-  
+
 void ServiceComponent6::Deactivate(const std::shared_ptr<ComponentContext>&)
 {
   foo = nullptr;
@@ -14,8 +13,7 @@ void ServiceComponent6::Deactivate(const std::shared_ptr<ComponentContext>&)
 
 std::string ServiceComponent6::ExtendedDescription()
 {
-  if(!foo)
-  {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result(STRINGIZE(US_BUNDLE_NAME));
@@ -26,16 +24,15 @@ std::string ServiceComponent6::ExtendedDescription()
 
 void ServiceComponent6::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
-void ServiceComponent6::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponent6::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSTOI6/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI6/src/ServiceImpl.hpp
@@ -1,27 +1,27 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponent6 : public test::Interface2
 {
-  class ServiceComponent6 : public test::Interface2
-    {
-    public:
-      ServiceComponent6() = default;
-      std::string ExtendedDescription() override;
-      void Activate(const std::shared_ptr<ComponentContext>&);
-      void Deactivate(const std::shared_ptr<ComponentContext>&);
-      ~ServiceComponent6() = default;
+public:
+  ServiceComponent6() = default;
+  std::string ExtendedDescription() override;
+  void Activate(const std::shared_ptr<ComponentContext>&);
+  void Deactivate(const std::shared_ptr<ComponentContext>&);
+  ~ServiceComponent6() = default;
 
-      void Bindfoo(const std::shared_ptr<test::Interface1>&);
-      void Unbindfoo(const std::shared_ptr<test::Interface1>&);
-    private:
-      std::shared_ptr<test::Interface1> foo;
-    };
+  void Bindfoo(const std::shared_ptr<test::Interface1>&);
+  void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
+private:
+  std::shared_ptr<test::Interface1> foo;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.cpp
@@ -3,18 +3,15 @@
 
 namespace sample {
 
-void ServiceComponent7::Activate(const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{
-}
-  
-void ServiceComponent7::Deactivate(const std::shared_ptr<ComponentContext>&)
-{
-}
+void ServiceComponent7::Activate(
+  const std::shared_ptr<ComponentContext>& /*ctxt*/)
+{}
+
+void ServiceComponent7::Deactivate(const std::shared_ptr<ComponentContext>&) {}
 
 std::string ServiceComponent7::ExtendedDescription()
 {
-  if(!foo)
-  {
+  if (!foo) {
     throw std::runtime_error("Dependency not available");
   }
   std::string result(STRINGIZE(US_BUNDLE_NAME));
@@ -25,16 +22,15 @@ std::string ServiceComponent7::ExtendedDescription()
 
 void ServiceComponent7::Bindfoo(const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo != theFoo)
-  {
+  if (foo != theFoo) {
     foo = theFoo;
   }
 }
 
-void ServiceComponent7::Unbindfoo(const std::shared_ptr<test::Interface1>& theFoo)
+void ServiceComponent7::Unbindfoo(
+  const std::shared_ptr<test::Interface1>& theFoo)
 {
-  if (foo == theFoo)
-  {
+  if (foo == theFoo) {
     foo = nullptr;
   }
 }

--- a/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.hpp
@@ -1,15 +1,14 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponent7
-  : public test::Interface2
+class ServiceComponent7 : public test::Interface2
 {
 public:
   ServiceComponent7() = default;
@@ -20,6 +19,7 @@ public:
 
   void Bindfoo(const std::shared_ptr<test::Interface1>&);
   void Unbindfoo(const std::shared_ptr<test::Interface1>&);
+
 private:
   std::shared_ptr<test::Interface1> foo;
 };

--- a/compendium/test_bundles/TestBundleDSTOI8/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI8/src/ServiceImpl.hpp
@@ -1,15 +1,14 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
 
-class ServiceComponent8
-  : public test::Interface1
+class ServiceComponent8 : public test::Interface1
 {
 public:
   ServiceComponent8() = default;

--- a/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSTOI9/src/ServiceImpl.hpp
@@ -1,24 +1,26 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace sample {
-  class ServiceComponent9 : public test::LifeCycleValidation {
-  public:
-    ServiceComponent9() = default;
-    ~ServiceComponent9() override = default;
-    void Activate(const std::shared_ptr<ComponentContext>& context);
-    void Deactivate(const std::shared_ptr<ComponentContext>& context);
-    bool IsActivated() override { return activated; };
-    bool IsDeactivated() override { return deactivated; };
-  private:
-    bool activated;
-    bool deactivated;
-  };
+class ServiceComponent9 : public test::LifeCycleValidation
+{
+public:
+  ServiceComponent9() = default;
+  ~ServiceComponent9() override = default;
+  void Activate(const std::shared_ptr<ComponentContext>& context);
+  void Deactivate(const std::shared_ptr<ComponentContext>& context);
+  bool IsActivated() override { return activated; };
+  bool IsDeactivated() override { return deactivated; };
+
+private:
+  bool activated;
+  bool deactivated;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.cpp
@@ -1,11 +1,12 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent::ServiceComponent(std::shared_ptr<test::Interface1> interface1)
-      : m_interface1(std::move(interface1)) { }
+ServiceComponent::ServiceComponent(std::shared_ptr<test::Interface1> interface1)
+  : m_interface1(std::move(interface1))
+{}
 
-  std::string ServiceComponent::Description()
-  {
-    return m_interface1->Description();
-  }
+std::string ServiceComponent::Description()
+{
+  return m_interface1->Description();
+}
 }

--- a/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.hpp
@@ -4,15 +4,16 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent final : public test::Interface1 {
-  public:
-    ServiceComponent(std::shared_ptr<test::Interface1>);
-    ~ServiceComponent() override = default;
-    std::string Description() override;
-    
-  private:
-    std::shared_ptr<test::Interface1> m_interface1;  
-  };
+class ServiceComponent final : public test::Interface1
+{
+public:
+  ServiceComponent(std::shared_ptr<test::Interface1>);
+  ~ServiceComponent() override = default;
+  std::string Description() override;
+
+private:
+  std::shared_ptr<test::Interface1> m_interface1;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSb/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSb/src/ServiceImpl.cpp
@@ -1,12 +1,10 @@
 #include "ServiceImpl.hpp"
 
 namespace sample {
-  ServiceComponent::~ServiceComponent()
-  {
-  }
+ServiceComponent::~ServiceComponent() {}
 
-  std::string ServiceComponent::Description()
-  {
-    return STRINGIZE(US_BUNDLE_NAME);
-  }
+std::string ServiceComponent::Description()
+{
+  return STRINGIZE(US_BUNDLE_NAME);
+}
 }

--- a/compendium/test_bundles/TestBundleDSb/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSb/src/ServiceImpl.hpp
@@ -4,12 +4,13 @@
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace sample {
-  class ServiceComponent : public test::Interface1 {
-  public:
-    ServiceComponent() = default;
-    ~ServiceComponent() override;
-    std::string Description() override;
-  };
+class ServiceComponent : public test::Interface1
+{
+public:
+  ServiceComponent() = default;
+  ~ServiceComponent() override;
+  std::string Description() override;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
+++ b/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
@@ -24,8 +24,8 @@
 
 #include "TestInterfaces/TestInterfacesExport.h"
 
-#include <string>
 #include <memory>
+#include <string>
 
 /* This file contains interface declarations for the test bundles
    used in Declarative Services Tests */
@@ -33,118 +33,121 @@
 #define STRINGIZE(s) STR_HELPER(s)
 #define STR_HELPER(s) #s
 
-namespace test
+namespace test {
+class US_TestInterfaces_EXPORT Interface1
 {
-    class US_TestInterfaces_EXPORT Interface1
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~Interface1();
-    };
+public:
+  virtual std::string Description() = 0;
+  virtual ~Interface1();
+};
 
-    class US_TestInterfaces_EXPORT Interface2
-    {
-      public:
-      virtual std::string ExtendedDescription() = 0;
-      virtual ~Interface2();
-    };
+class US_TestInterfaces_EXPORT Interface2
+{
+public:
+  virtual std::string ExtendedDescription() = 0;
+  virtual ~Interface2();
+};
 
-    class US_TestInterfaces_EXPORT Interface3
-    {
-      public:
-      virtual bool isDependencyInjected() = 0;
-      virtual ~Interface3();
-    };
+class US_TestInterfaces_EXPORT Interface3
+{
+public:
+  virtual bool isDependencyInjected() = 0;
+  virtual ~Interface3();
+};
 
-    class US_TestInterfaces_EXPORT TestManagedServiceInterface {
-      public:
-        virtual ~TestManagedServiceInterface() = default;
+class US_TestInterfaces_EXPORT TestManagedServiceInterface
+{
+public:
+  virtual ~TestManagedServiceInterface() = default;
 
-        virtual int getCounter() = 0;
-    };
+  virtual int getCounter() = 0;
+};
 
-    class US_TestInterfaces_EXPORT TestManagedServiceFactoryServiceInterface {
-      public:
-        virtual ~TestManagedServiceFactoryServiceInterface() = default;
+class US_TestInterfaces_EXPORT TestManagedServiceFactoryServiceInterface
+{
+public:
+  virtual ~TestManagedServiceFactoryServiceInterface() = default;
 
-        virtual int getValue() = 0;
-    };
+  virtual int getValue() = 0;
+};
 
-    class US_TestInterfaces_EXPORT TestManagedServiceFactory {
-      public:
-        TestManagedServiceFactory() = default;
-        virtual ~TestManagedServiceFactory() = default;
+class US_TestInterfaces_EXPORT TestManagedServiceFactory
+{
+public:
+  TestManagedServiceFactory() = default;
+  virtual ~TestManagedServiceFactory() = default;
 
-        virtual int getUpdatedCounter(std::string const& pid) = 0;
+  virtual int getUpdatedCounter(std::string const& pid) = 0;
 
-        virtual int getRemovedCounter(std::string const& pid) = 0;
+  virtual int getRemovedCounter(std::string const& pid) = 0;
 
-        virtual std::shared_ptr<TestManagedServiceFactoryServiceInterface> create(std::string const& config) = 0;
-    };
-    
-    // Interfaces for declarative services dependency graph resolution benchmarks. The
-    // implentations of these interfaces have dependencies that form a complete 3 level tree:
-    // DSGraph01 : DSGraph02, DSGraph03
-    // DSGraph02 : DSGraph04, DSGraph05
-    // DSGraph03 : DSGraph06, DSGraph07
-    class US_TestInterfaces_EXPORT DSGraph01
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph01();
-    };
+  virtual std::shared_ptr<TestManagedServiceFactoryServiceInterface> create(
+    std::string const& config) = 0;
+};
 
-    class US_TestInterfaces_EXPORT DSGraph02
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph02();
-    };
+// Interfaces for declarative services dependency graph resolution benchmarks. The
+// implentations of these interfaces have dependencies that form a complete 3 level tree:
+// DSGraph01 : DSGraph02, DSGraph03
+// DSGraph02 : DSGraph04, DSGraph05
+// DSGraph03 : DSGraph06, DSGraph07
+class US_TestInterfaces_EXPORT DSGraph01
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph01();
+};
 
-    class US_TestInterfaces_EXPORT DSGraph03
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph03();
-    };
+class US_TestInterfaces_EXPORT DSGraph02
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph02();
+};
 
-    class US_TestInterfaces_EXPORT DSGraph04
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph04();
-    };
+class US_TestInterfaces_EXPORT DSGraph03
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph03();
+};
 
-    class US_TestInterfaces_EXPORT DSGraph05
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph05();
-    };
+class US_TestInterfaces_EXPORT DSGraph04
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph04();
+};
 
-    class US_TestInterfaces_EXPORT DSGraph06
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph06();
-    };
+class US_TestInterfaces_EXPORT DSGraph05
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph05();
+};
 
-    class US_TestInterfaces_EXPORT DSGraph07
-    {
-      public:
-      virtual std::string Description() = 0;
-      virtual ~DSGraph07();
-    };
+class US_TestInterfaces_EXPORT DSGraph06
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph06();
+};
 
-    // Use this interface in test bundles & test points to validate if the
-    // service component receives the life cycle callbacks from the DS runtime
-    class US_TestInterfaces_EXPORT LifeCycleValidation
-    {
-      public:
-      virtual bool IsActivated() = 0;
-      virtual bool IsDeactivated() = 0;
-      virtual ~LifeCycleValidation();
-    };
+class US_TestInterfaces_EXPORT DSGraph07
+{
+public:
+  virtual std::string Description() = 0;
+  virtual ~DSGraph07();
+};
+
+// Use this interface in test bundles & test points to validate if the
+// service component receives the life cycle callbacks from the DS runtime
+class US_TestInterfaces_EXPORT LifeCycleValidation
+{
+public:
+  virtual bool IsActivated() = 0;
+  virtual bool IsDeactivated() = 0;
+  virtual ~LifeCycleValidation();
+};
 }
 
 #endif

--- a/compendium/test_bundles/TestInterfaces/src/Interfaces.cpp
+++ b/compendium/test_bundles/TestInterfaces/src/Interfaces.cpp
@@ -1,18 +1,17 @@
 #include "TestInterfaces/Interfaces.hpp"
 
-namespace test
-{
-    Interface1::~Interface1() = default;
-    Interface2::~Interface2() = default;
-    Interface3::~Interface3() = default;
+namespace test {
+Interface1::~Interface1() = default;
+Interface2::~Interface2() = default;
+Interface3::~Interface3() = default;
 
-    DSGraph01::~DSGraph01() = default;
-    DSGraph02::~DSGraph02() = default;
-    DSGraph03::~DSGraph03() = default;
-    DSGraph04::~DSGraph04() = default;
-    DSGraph05::~DSGraph05() = default;
-    DSGraph06::~DSGraph06() = default;
-    DSGraph07::~DSGraph07() = default;
-    
-    LifeCycleValidation::~LifeCycleValidation() = default;
+DSGraph01::~DSGraph01() = default;
+DSGraph02::~DSGraph02() = default;
+DSGraph03::~DSGraph03() = default;
+DSGraph04::~DSGraph04() = default;
+DSGraph05::~DSGraph05() = default;
+DSGraph06::~DSGraph06() = default;
+DSGraph07::~DSGraph07() = default;
+
+LifeCycleValidation::~LifeCycleValidation() = default;
 }

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -25,23 +25,25 @@
 
 #include "ComponentInfo.hpp"
 
-namespace codegen { namespace datamodel {
+namespace codegen {
+namespace datamodel {
 
 std::string GetComponentNameStr(const ComponentInfo& compInfo)
 {
-  const auto name = compInfo.name.empty() ? compInfo.implClassName : compInfo.name;
+  const auto name =
+    compInfo.name.empty() ? compInfo.implClassName : compInfo.name;
   return std::regex_replace(name, std::regex("(::)"), "_");
 }
 
 std::string GetServiceInterfacesStr(const ServiceInfo& serviceInfo)
 {
   auto& interfaces = serviceInfo.interfaces;
-  if (interfaces.empty())
-  {
+  if (interfaces.empty()) {
     return "";
   }
   std::ostringstream strstream;
-  std::copy(std::begin(interfaces), std::end(interfaces) - 1,
+  std::copy(std::begin(interfaces),
+            std::end(interfaces) - 1,
             std::ostream_iterator<std::string>(strstream, ", "));
   strstream << interfaces.back();
   return strstream.str();
@@ -51,11 +53,8 @@ std::string GetCtorInjectedRefTypes(const ComponentInfo& compInfo)
 {
   std::string result;
   auto sep = ", ";
-  for (const auto& reference :  compInfo.references)
-  {
-    if ((true == compInfo.injectReferences)
-        && (reference.policy == "static"))
-    {
+  for (const auto& reference : compInfo.references) {
+    if ((true == compInfo.injectReferences) && (reference.policy == "static")) {
       result += (sep + reference.interface);
     }
   }
@@ -68,11 +67,8 @@ std::string GetCtorInjectedRefNames(const ComponentInfo& compInfo)
   auto sep = "";
 
   resultStr << "{{";
-  for (const auto& reference :  compInfo.references)
-  {
-    if ((true == compInfo.injectReferences)
-        && (reference.policy == "static"))
-    {
+  for (const auto& reference : compInfo.references) {
+    if ((true == compInfo.injectReferences) && (reference.policy == "static")) {
       resultStr << sep << "\"" << reference.name << "\"";
       sep = ", ";
     }
@@ -81,23 +77,19 @@ std::string GetCtorInjectedRefNames(const ComponentInfo& compInfo)
   return resultStr.str();
 }
 
-std::string GetReferenceBinderStr(const ReferenceInfo& ref, bool injectReferences)
+std::string GetReferenceBinderStr(const ReferenceInfo& ref,
+                                  bool injectReferences)
 {
   auto isStatic = (ref.policy == "static");
   std::stringstream binderObjStr;
-  if (!isStatic || !injectReferences)
-  {
+  if (!isStatic || !injectReferences) {
     binderObjStr << "std::make_shared<DynamicBinder<{0}, "
-                 << ref.interface
-                 << ">>(\"" + ref.name + "\""
-                 << ", &{0}::Bind"
-                 << ref.name
-                 << ", &{0}::Unbind"
-                 << ref.name
+                 << ref.interface << ">>(\"" + ref.name + "\""
+                 << ", &{0}::Bind" << ref.name << ", &{0}::Unbind" << ref.name
                  << ")";
   }
   return binderObjStr.str();
 }
 
-}} // namespaces
-
+}
+} // namespaces

--- a/compendium/tools/SCRCodeGen/ComponentInfo.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.hpp
@@ -60,7 +60,8 @@ std::string GetComponentNameStr(const ComponentInfo& compInfo);
 std::string GetServiceInterfacesStr(const ServiceInfo& compInfo);
 std::string GetCtorInjectedRefTypes(const ComponentInfo& compInfo);
 std::string GetCtorInjectedRefNames(const ComponentInfo& compInfo);
-std::string GetReferenceBinderStr(const ReferenceInfo& ref, bool injectReferences);
+std::string GetReferenceBinderStr(const ReferenceInfo& ref,
+                                  bool injectReferences);
 
 } // namespace datamodel
 } // namespace codegen

--- a/compendium/tools/SCRCodeGen/ManifestParser.hpp
+++ b/compendium/tools/SCRCodeGen/ManifestParser.hpp
@@ -22,11 +22,11 @@
 #ifndef MANIFESTPARSER_HPP
 #define MANIFESTPARSER_HPP
 
-#include <vector>
 #include <memory>
+#include <vector>
 
-#include "json/json.h"
 #include "ComponentInfo.hpp"
+#include "json/json.h"
 
 using codegen::datamodel::ComponentInfo;
 
@@ -44,7 +44,8 @@ class ManifestParser
 {
 public:
   virtual ~ManifestParser() = default;
-  virtual std::vector<ComponentInfo> ParseAndGetComponentInfos(const Json::Value& scr) const = 0;
+  virtual std::vector<ComponentInfo> ParseAndGetComponentInfos(
+    const Json::Value& scr) const = 0;
 };
 
 #endif // MANIFESTPARSER_HPP

--- a/compendium/tools/SCRCodeGen/ManifestParserFactory.hpp
+++ b/compendium/tools/SCRCodeGen/ManifestParserFactory.hpp
@@ -29,12 +29,12 @@ class ManifestParserFactory
 public:
   static std::unique_ptr<ManifestParser> Create(unsigned int version)
   {
-    switch (version)
-    {
+    switch (version) {
       case 1:
         return std::make_unique<ManifestParserImplV1>();
       default:
-        throw std::runtime_error("Unsupported manifest file version '" + std::to_string(version) + "'");
+        throw std::runtime_error("Unsupported manifest file version '" +
+                                 std::to_string(version) + "'");
         return nullptr; // to satisfy the compiler. Control should never reach here.
     }
   }

--- a/compendium/tools/SCRCodeGen/ManifestParserImpl.cpp
+++ b/compendium/tools/SCRCodeGen/ManifestParserImpl.cpp
@@ -86,7 +86,7 @@ std::vector<ComponentInfo> ManifestParserImplV1::ParseAndGetComponentInfos(
     if (jsonComponent.isMember("references")) {
       const auto jsonRefInfos = JsonValueValidator(
         jsonComponent, "references", Json::ValueType::arrayValue)();
-        
+
       std::unordered_map<std::string, std::size_t> duplicateRefs;
       duplicateRefs.reserve(jsonRefInfos.size());
       for (const auto& jsonRefInfo : jsonRefInfos) {
@@ -125,15 +125,16 @@ std::vector<ComponentInfo> ManifestParserImplV1::ParseAndGetComponentInfos(
         }
         componentInfo.references.push_back(refInfo);
       }
-        
+
       std::string listOfDuplicateRefNames;
-      for(auto const& dupRef : duplicateRefs) {
-        if(dupRef.second > 1) {
+      for (auto const& dupRef : duplicateRefs) {
+        if (dupRef.second > 1) {
           listOfDuplicateRefNames += dupRef.first + " ";
         }
       }
-      if(!listOfDuplicateRefNames.empty()) {
-        std::string exceptionMessage("Duplicate service reference names found. Reference names must be unique. ");
+      if (!listOfDuplicateRefNames.empty()) {
+        std::string exceptionMessage("Duplicate service reference names found. "
+                                     "Reference names must be unique. ");
         exceptionMessage += "Duplicate names: ";
         exceptionMessage += listOfDuplicateRefNames;
         throw std::invalid_argument(exceptionMessage);

--- a/compendium/tools/SCRCodeGen/ManifestParserImpl.hpp
+++ b/compendium/tools/SCRCodeGen/ManifestParserImpl.hpp
@@ -28,7 +28,8 @@ class ManifestParserImplV1 : public ManifestParser
 {
 public:
   ManifestParserImplV1() = default;
-  std::vector<ComponentInfo> ParseAndGetComponentInfos(const Json::Value& scr) const override;
+  std::vector<ComponentInfo> ParseAndGetComponentInfos(
+    const Json::Value& scr) const override;
 };
 
 #endif //  MANIFESTPARSERIMPL_HPP

--- a/compendium/tools/SCRCodeGen/Util.cpp
+++ b/compendium/tools/SCRCodeGen/Util.cpp
@@ -31,8 +31,7 @@ Json::Value ParseManifestOrThrow(std::istream& jsonStream)
   rbuilder["rejectDupKeys"] = true;
   std::string errs;
 
-  if (!Json::parseFromStream(rbuilder, jsonStream, &root, &errs))
-  {
+  if (!Json::parseFromStream(rbuilder, jsonStream, &root, &errs)) {
     throw std::runtime_error(errs);
   }
   return root;
@@ -40,9 +39,9 @@ Json::Value ParseManifestOrThrow(std::istream& jsonStream)
 
 void WriteToFile(const std::string& filePath, const std::string& content)
 {
-  auto fileStream = std::ofstream(filePath, std::ofstream::binary | std::ofstream::out);
-  if(!fileStream.is_open())
-  {
+  auto fileStream =
+    std::ofstream(filePath, std::ofstream::binary | std::ofstream::out);
+  if (!fileStream.is_open()) {
     throw std::runtime_error("Could not open out file at " + filePath);
   }
   fileStream << content;

--- a/compendium/tools/SCRCodeGen/Util.hpp
+++ b/compendium/tools/SCRCodeGen/Util.hpp
@@ -87,9 +87,10 @@ public:
 
     // The cast is to help the compiler resolve the correct overload.
     // Refer: https://stackoverflow.com/questions/7131858/stdtransform-and-toupper-no-matching-function/7131881
-    std::transform(
-      value.begin(), value.end(), value.begin(), [](unsigned char c) {
-      return std::tolower(c); });
+    std::transform(value.begin(),
+                   value.end(),
+                   value.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
 
     // Return true if string value == string b in a case-insensitive way.
     auto isCaseInsensitiveEqual = [&value](const std::string& b) {

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -667,8 +667,9 @@ INSTANTIATE_TEST_SUITE_P(
       manifest_illegal_ref_name,
       "Invalid value for the name 'name'. Expected non-empty string"),
     CodegenInvalidManifestState(
-        manifest_duplicate_ref_name,
-        "Duplicate service reference names found. Reference names must be unique. Duplicate names: foo "),
+      manifest_duplicate_ref_name,
+      "Duplicate service reference names found. Reference names must be "
+      "unique. Duplicate names: foo "),
     CodegenInvalidManifestState(
       manifest_no_ref_interface,
       "Mandatory name 'interface' missing from the manifest"),

--- a/compendium/tools/SCRCodeGen/test/main.cpp
+++ b/compendium/tools/SCRCodeGen/test/main.cpp
@@ -21,7 +21,7 @@
   =============================================================================*/
 #include "gmock/gmock.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();

--- a/doc/src/examples/makefile/main.cpp
+++ b/doc/src/examples/makefile/main.cpp
@@ -8,7 +8,7 @@
 
 using namespace cppmicroservices;
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   ServiceReference<IDictionaryService> dictionaryServiceRef =
     GetBundleContext().GetServiceReference<IDictionaryService>();

--- a/doc/src/tutorial/driver/main.cpp
+++ b/doc/src/tutorial/driver/main.cpp
@@ -109,12 +109,9 @@ int main(int /*argc*/, char** /*argv*/)
     /* install all available bundles for this example */
 #if defined(US_BUILD_SHARED_LIBS)
     for (auto name : GetExampleBundles()) {
-      framework.GetBundleContext().InstallBundles(BUNDLE_PATH
-                                                  + PATH_SEPARATOR
-                                                  + US_LIB_PREFIX
-                                                  + name
-                                                  + US_LIB_POSTFIX
-                                                  + US_LIB_EXT);
+      framework.GetBundleContext().InstallBundles(BUNDLE_PATH + PATH_SEPARATOR +
+                                                  US_LIB_PREFIX + name +
+                                                  US_LIB_POSTFIX + US_LIB_EXT);
     }
 #endif
 

--- a/framework/doc/snippets/uServices-activator/main.cpp
+++ b/framework/doc/snippets/uServices-activator/main.cpp
@@ -21,7 +21,7 @@ public:
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(MyActivator)
 //![0]
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-bundlecontext/main.cpp
+++ b/framework/doc/snippets/uServices-bundlecontext/main.cpp
@@ -23,7 +23,7 @@ void RetrieveBundleContext()
 CPPMICROSERVICES_INITIALIZE_BUNDLE
 //! [InitializeBundle]
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-registration/main.cpp
+++ b/framework/doc/snippets/uServices-registration/main.cpp
@@ -122,7 +122,7 @@ public:
 
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(MyActivator)
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-resources/main.cpp
+++ b/framework/doc/snippets/uServices-resources/main.cpp
@@ -42,7 +42,7 @@ void extenderPattern(const BundleContext& bundleCtx)
   // Check if a bundle defines a "service-component" property
   // and use its value to retrieve an embedded resource containing
   // a component description.
-  for (auto const & bundle : bundleCtx.GetBundles()) {
+  for (auto const& bundle : bundleCtx.GetBundles()) {
     if (bundle.GetState() == Bundle::STATE_UNINSTALLED)
       continue;
     auto headers = bundle.GetHeaders();
@@ -63,7 +63,7 @@ void extenderPattern(const BundleContext& bundleCtx)
   //! [2]
 }
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-servicelistenerhook/main.cpp
+++ b/framework/doc/snippets/uServices-servicelistenerhook/main.cpp
@@ -47,7 +47,7 @@ public:
 };
 //! [1]
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-servicetracker/main.cpp
+++ b/framework/doc/snippets/uServices-servicetracker/main.cpp
@@ -56,7 +56,7 @@ struct MyTrackingCustomizerVoid
   {}
 };
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/doc/snippets/uServices-staticbundles/main.cpp
+++ b/framework/doc/snippets/uServices-staticbundles/main.cpp
@@ -59,7 +59,7 @@ CPPMICROSERVICES_INITIALIZE_STATIC_BUNDLE(main)
 #endif
 //! [ImportStaticBundleIntoMain2]
 
-int main(int /*argc*/, char* /*argv*/ [])
+int main(int /*argc*/, char* /*argv*/[])
 {
   std::cout
     << "This snippet is not meant to be executed.\n"

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -36,6 +36,7 @@ DEALINGS IN THE SOFTWARE.
 #include "cppmicroservices/FrameworkConfig.h"
 
 #include <algorithm>
+#include <array>
 #include <list>
 #include <map>
 #include <memory>
@@ -44,7 +45,6 @@ DEALINGS IN THE SOFTWARE.
 #include <typeinfo>
 #include <utility>
 #include <vector>
-#include <array>
 
 namespace {
 
@@ -52,14 +52,19 @@ namespace {
  * Provide a compare function that will do the comparison if the operator is available, and always
  * return false otherwise. Use SFINAE to pick the right implementation based on type.
  */
-template <class T>
+template<class T>
 struct has_op_eq
 {
-  template <class U>
+  template<class U>
   static auto op_eq_test(const U* u) -> decltype(char(*u == *u))
-  { return char(0); }
+  {
+    return char(0);
+  }
 
-  static std::array<char, 2> op_eq_test(...) { return std::array<char,2>{{0,0}}; }
+  static std::array<char, 2> op_eq_test(...)
+  {
+    return std::array<char, 2>{ { 0, 0 } };
+  }
 
   static const bool value = (sizeof(op_eq_test(static_cast<T*>(0))) == 1);
 };
@@ -96,11 +101,23 @@ namespace cppmicroservices {
 
 class Any;
 
-US_Framework_EXPORT std::ostream& newline_and_indent(std::ostream& os, const uint8_t increment, const int32_t indent);
-US_Framework_EXPORT std::ostream& any_value_to_string(std::ostream& os, const Any& any);
-US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os, const Any& val, const uint8_t, const int32_t);
-US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os, const std::string& val, const uint8_t, const int32_t);
-US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os, bool val, const uint8_t, const int32_t);
+US_Framework_EXPORT std::ostream& newline_and_indent(std::ostream& os,
+                                                     const uint8_t increment,
+                                                     const int32_t indent);
+US_Framework_EXPORT std::ostream& any_value_to_string(std::ostream& os,
+                                                      const Any& any);
+US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
+                                                    const Any& val,
+                                                    const uint8_t,
+                                                    const int32_t);
+US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
+                                                    const std::string& val,
+                                                    const uint8_t,
+                                                    const int32_t);
+US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
+                                                    bool val,
+                                                    const uint8_t,
+                                                    const int32_t);
 
 template<typename ValueType>
 ValueType* any_cast(Any* operand);
@@ -113,7 +130,10 @@ std::ostream& any_value_to_string(std::ostream& os, const T& val)
 }
 
 template<class T>
-std::ostream& any_value_to_json(std::ostream& os, const T& val, const uint8_t = 0, const int32_t = 0)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const T& val,
+                                const uint8_t = 0,
+                                const int32_t = 0)
 {
   return os << val;
 }
@@ -142,10 +162,17 @@ std::ostream& container_to_string(std::ostream& os, Iterator i1, Iterator i2)
  * \internal
  */
 template<typename Iterator>
-std::ostream& container_to_json(std::ostream& os, Iterator i1, Iterator i2, const uint8_t increment = 0, const int32_t indent = 0)
+std::ostream& container_to_json(std::ostream& os,
+                                Iterator i1,
+                                Iterator i2,
+                                const uint8_t increment = 0,
+                                const int32_t indent = 0)
 {
-  if (i1 == i2) { os << "[]"; return os; }
-  
+  if (i1 == i2) {
+    os << "[]";
+    return os;
+  }
+
   os << "[";
   const Iterator begin = i1;
   for (; i1 != i2; ++i1) {
@@ -155,7 +182,7 @@ std::ostream& container_to_json(std::ostream& os, Iterator i1, Iterator i2, cons
     newline_and_indent(os, increment, indent);
     any_value_to_json(os, *i1, increment, indent + increment);
   }
-  newline_and_indent(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent - increment);
   os << "]";
   return os;
 }
@@ -167,7 +194,10 @@ std::ostream& any_value_to_string(std::ostream& os, const std::vector<E>& vec)
 }
 
 template<class E>
-std::ostream& any_value_to_json(std::ostream& os, const std::vector<E>& vec, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::vector<E>& vec,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
   return container_to_json(os, vec.begin(), vec.end(), increment, indent);
 }
@@ -179,7 +209,10 @@ std::ostream& any_value_to_string(std::ostream& os, const std::list<E>& l)
 }
 
 template<class E>
-std::ostream& any_value_to_json(std::ostream& os, const std::list<E>& l, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::list<E>& l,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
   return container_to_json(os, l.begin(), l.end(), increment, indent);
 }
@@ -191,7 +224,10 @@ std::ostream& any_value_to_string(std::ostream& os, const std::set<E>& s)
 }
 
 template<class E>
-std::ostream& any_value_to_json(std::ostream& os, const std::set<E>& s, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::set<E>& s,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
   return container_to_json(os, s.begin(), s.end(), increment, indent);
 }
@@ -203,10 +239,16 @@ template<class K, class V>
 std::ostream& any_value_to_string(std::ostream& os, const std::map<K, V>& m);
 
 template<class M>
-std::ostream& any_value_to_json(std::ostream& os, const std::map<M, Any>& m, const uint8_t increment, const int32_t indent);
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::map<M, Any>& m,
+                                const uint8_t increment,
+                                const int32_t indent);
 
 template<class K, class V>
-std::ostream& any_value_to_json(std::ostream& os, const std::map<K, V>& m, const uint8_t increment, const int32_t indent);
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::map<K, V>& m,
+                                const uint8_t increment,
+                                const int32_t indent);
 
 /**
  * \ingroup gr_any
@@ -222,7 +264,7 @@ public:
   /**
    * Creates an empty any type.
    */
-    Any();
+  Any();
 
   /**
    * Creates an Any which stores the init parameter inside.
@@ -282,7 +324,7 @@ public:
   {
     if (Type() != typeid(ValueType))
       return false;
-    return compare(*any_cast<const ValueType>(this),val);
+    return compare(*any_cast<const ValueType>(this), val);
   }
 
   /**
@@ -294,11 +336,8 @@ public:
    * @return bool return true if rhs compares equal to *this AND the underlying ValueType has an
    *              operator==, and return false otherwise.
    */
-  bool operator==(const Any& rhs) const
-  {
-    return rhs._content->compare(*this);
-  }
-  
+  bool operator==(const Any& rhs) const { return rhs._content->compare(*this); }
+
   /**
    * Compares this Any with another value for inequality.
    *
@@ -425,7 +464,8 @@ private:
     virtual ~Placeholder() = default;
 
     virtual std::string ToString() const = 0;
-    virtual std::string ToJSON(const uint8_t increment = 0, const int32_t indent = 0) const = 0;
+    virtual std::string ToJSON(const uint8_t increment = 0,
+                               const int32_t indent = 0) const = 0;
 
     virtual const std::type_info& Type() const = 0;
     virtual std::unique_ptr<Placeholder> Clone() const = 0;
@@ -440,7 +480,7 @@ private:
       : _held(value)
     {}
 
-    Holder(ValueType&&  value)
+    Holder(ValueType&& value)
       : _held(std::move(value))
     {}
 
@@ -451,7 +491,8 @@ private:
       return ss.str();
     }
 
-    std::string ToJSON(const uint8_t increment, const int32_t indent) const override
+    std::string ToJSON(const uint8_t increment,
+                       const int32_t indent) const override
     {
       std::stringstream ss;
       any_value_to_json(ss, _held, increment, indent);
@@ -471,12 +512,9 @@ private:
      * compare _held with lhs. This invokes the Any::operator==(ValueType) above. 
      * @param lhs an Any containing a value to compare against _held
      * @return bool return true if the value held in lhs is equal to _held.
-     */ 
-    bool compare(const Any& lhs) const override
-    {
-      return lhs == _held;
-    }
-    
+     */
+    bool compare(const Any& lhs) const override { return lhs == _held; }
+
   private: // intentionally left unimplemented
     Holder& operator=(const Holder&) = delete;
   };
@@ -500,7 +538,7 @@ private:
 class BadAnyCastException : public std::bad_cast
 {
 public:
-  BadAnyCastException(std::string  msg = "")
+  BadAnyCastException(std::string msg = "")
     : std::bad_cast()
     , _msg(std::move(msg))
   {}
@@ -741,9 +779,15 @@ std::ostream& any_value_to_string(std::ostream& os, const std::map<K, V>& m)
 }
 
 template<class K>
-std::ostream& any_value_to_json(std::ostream& os, const std::map<K, Any>& m, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::map<K, Any>& m,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
-  if (m.empty()) { os << "{}"; return os; }
+  if (m.empty()) {
+    os << "{}";
+    return os;
+  }
 
   os << "{";
   using Iterator = typename std::map<K, Any>::const_iterator;
@@ -755,17 +799,24 @@ std::ostream& any_value_to_json(std::ostream& os, const std::map<K, Any>& m, con
       os << ", ";
     }
     newline_and_indent(os, increment, indent);
-    os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
+    os << "\"" << i1->first
+       << "\" : " << i1->second.ToJSON(increment, indent + increment);
   }
-  newline_and_indent(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent - increment);
   os << "}";
   return os;
 }
 
 template<class K, class V>
-std::ostream& any_value_to_json(std::ostream& os, const std::map<K, V>& m, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const std::map<K, V>& m,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
-  if (m.empty()) { os << "{}"; return os; }
+  if (m.empty()) {
+    os << "{}";
+    return os;
+  }
 
   os << "{";
   using Iterator = typename std::map<K, V>::const_iterator;
@@ -779,7 +830,7 @@ std::ostream& any_value_to_json(std::ostream& os, const std::map<K, V>& m, const
     newline_and_indent(os, increment, indent);
     os << "\"" << i1->first << "\" : " << i1->second;
   }
-  newline_and_indent(os, increment, std::max(0, indent-increment));
+  newline_and_indent(os, increment, std::max(0, indent - increment));
   os << "}";
   return os;
 }

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -282,7 +282,7 @@ public:
    * Erase entry for value for 'key'
    * @param key the key for the entry to Erase
    * @return the number of elements erased.
-   */ 
+   */
   size_type erase(const key_type& key);
 
   /**
@@ -292,6 +292,7 @@ public:
    */
   bool operator==(const any_map& rhs) const;
   bool operator!=(const any_map& rhs) const { return !(operator==(rhs)); }
+
 protected:
   map_type type;
 
@@ -413,8 +414,8 @@ public:
    * @param defaultValue is the value to be returned if the key is not found
    * @return A copy of the key's value.
    */
-  mapped_type AtCompoundKey(const key_type& key, mapped_type defaultValue) const
-    noexcept;
+  mapped_type AtCompoundKey(const key_type& key,
+                            mapped_type defaultValue) const noexcept;
 };
 
 template<>

--- a/framework/include/cppmicroservices/Bundle.h
+++ b/framework/include/cppmicroservices/Bundle.h
@@ -394,7 +394,7 @@ public:
     * @post If the symbol does not exist, the API returns nullptr 
     */
 
-   void* GetSymbol(void * handle, const std::string& symname) const;
+  void* GetSymbol(void* handle, const std::string& symname) const;
 
   /**
    * Returns the symbolic name of this bundle as specified by the

--- a/framework/include/cppmicroservices/BundleResource.h
+++ b/framework/include/cppmicroservices/BundleResource.h
@@ -23,8 +23,8 @@
 #ifndef CPPMICROSERVICES_BUNDLERESOURCE_H
 #define CPPMICROSERVICES_BUNDLERESOURCE_H
 
-#include <functional>
 #include "cppmicroservices/FrameworkExport.h"
+#include <functional>
 
 #include <cstdint>
 #include <memory>

--- a/framework/include/cppmicroservices/BundleVersion.h
+++ b/framework/include/cppmicroservices/BundleVersion.h
@@ -65,9 +65,9 @@ class US_Framework_EXPORT BundleVersion
 private:
   friend class BundlePrivate;
 
-  unsigned int majorVersion{0};
-  unsigned int minorVersion{0};
-  unsigned int microVersion{0};
+  unsigned int majorVersion{ 0 };
+  unsigned int minorVersion{ 0 };
+  unsigned int microVersion{ 0 };
   std::string qualifier;
 
   static const char SEPARATOR; //  = "."
@@ -122,7 +122,7 @@ public:
   BundleVersion(unsigned int majorVersion,
                 unsigned int minorVersion,
                 unsigned int microVersion,
-                std::string  qualifier);
+                std::string qualifier);
 
   /**
    * Created a version identifier from the specified string.

--- a/framework/include/cppmicroservices/LDAPProp.h
+++ b/framework/include/cppmicroservices/LDAPProp.h
@@ -125,7 +125,7 @@ public:
    *
    * @param property The name of the LDAP property.
    */
-  LDAPProp(std::string  property);
+  LDAPProp(std::string property);
 
   /**
    * \addtogroup gr_ldap

--- a/framework/include/cppmicroservices/ListenerFunctors.h
+++ b/framework/include/cppmicroservices/ListenerFunctors.h
@@ -43,81 +43,81 @@ class ServiceListeners;
   */
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A \c ServiceEvent listener.
-   *
-   * A \c ServiceListener can be any callable object and is registered
-   * with the Framework using the
-   * {@link BundleContext#AddServiceListener(const ServiceListener&, const std::string&)} method.
-   * \c ServiceListener instances are called with a \c ServiceEvent object when a
-   * service has been registered, unregistered, or modified.
-   *
-   * @see ServiceEvent
-   */
-using ServiceListener = std::function<void (const ServiceEvent &)>;
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A \c ServiceEvent listener.
+ *
+ * A \c ServiceListener can be any callable object and is registered
+ * with the Framework using the
+ * {@link BundleContext#AddServiceListener(const ServiceListener&, const std::string&)} method.
+ * \c ServiceListener instances are called with a \c ServiceEvent object when a
+ * service has been registered, unregistered, or modified.
+ *
+ * @see ServiceEvent
+ */
+using ServiceListener = std::function<void(const ServiceEvent&)>;
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A \c BundleEvent listener. When a \c BundleEvent is fired, it is
-   * asynchronously (if threading support is enabled) delivered to a
-   * \c BundleListener. The Framework delivers \c BundleEvent objects to
-   * a \c BundleListener in order and does not concurrently call a
-   * \c BundleListener.
-   *
-   * A \c BundleListener can be any callable object and is registered
-   * with the Framework using the
-   * {@link BundleContext#AddBundleListener(const BundleListener&)} method.
-   * \c BundleListener instances are called with a \c BundleEvent object when a
-   * bundle has been installed, resolved, started, stopped, updated, unresolved,
-   * or uninstalled.
-   *
-   * @see BundleEvent
-   */
-using BundleListener = std::function<void (const BundleEvent &)>;
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A \c BundleEvent listener. When a \c BundleEvent is fired, it is
+ * asynchronously (if threading support is enabled) delivered to a
+ * \c BundleListener. The Framework delivers \c BundleEvent objects to
+ * a \c BundleListener in order and does not concurrently call a
+ * \c BundleListener.
+ *
+ * A \c BundleListener can be any callable object and is registered
+ * with the Framework using the
+ * {@link BundleContext#AddBundleListener(const BundleListener&)} method.
+ * \c BundleListener instances are called with a \c BundleEvent object when a
+ * bundle has been installed, resolved, started, stopped, updated, unresolved,
+ * or uninstalled.
+ *
+ * @see BundleEvent
+ */
+using BundleListener = std::function<void(const BundleEvent&)>;
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A \c FrameworkEvent listener. When a \c BundleEvent is fired, it is
-   * asynchronously (if threading support is enabled) delivered to a
-   * \c FrameworkListener. The Framework delivers \c FrameworkEvent objects to
-   * a \c FrameworkListener in order and does not concurrently call a
-   * \c FrameworkListener.
-   *
-   * A \c FrameworkListener can be any callable object and is registered
-   * with the Framework using the
-   * {@link BundleContext#AddFrameworkListener(const FrameworkListener&)} method.
-   * \c FrameworkListener instances are called with a \c FrameworkEvent object when a
-   * framework life-cycle event or notification message occured.
-   *
-   * @see FrameworkEvent
-   */
-using FrameworkListener = std::function<void (const FrameworkEvent &)>;
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A \c FrameworkEvent listener. When a \c BundleEvent is fired, it is
+ * asynchronously (if threading support is enabled) delivered to a
+ * \c FrameworkListener. The Framework delivers \c FrameworkEvent objects to
+ * a \c FrameworkListener in order and does not concurrently call a
+ * \c FrameworkListener.
+ *
+ * A \c FrameworkListener can be any callable object and is registered
+ * with the Framework using the
+ * {@link BundleContext#AddFrameworkListener(const FrameworkListener&)} method.
+ * \c FrameworkListener instances are called with a \c FrameworkEvent object when a
+ * framework life-cycle event or notification message occured.
+ *
+ * @see FrameworkEvent
+ */
+using FrameworkListener = std::function<void(const FrameworkEvent&)>;
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A convenience function that binds the member function <code>callback</code> of
-   * an object of type <code>R</code> and returns a <code>ServiceListener</code> object.
-   * This object can then be passed into <code>AddServiceListener()</code>.
-   *
-   * \rststar
-   * .. deprecated:: 3.1.0
-   *    This function exists only to maintain backwards compatibility
-   *     and will be removed in the next major release. Use std::bind instead.
-   * \endrststar
-   *
-   * @tparam R The type containing the member function.
-   * @param receiver The object of type R.
-   * @param callback The member function pointer.
-   * @returns a ServiceListener object.
-   */
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A convenience function that binds the member function <code>callback</code> of
+ * an object of type <code>R</code> and returns a <code>ServiceListener</code> object.
+ * This object can then be passed into <code>AddServiceListener()</code>.
+ *
+ * \rststar
+ * .. deprecated:: 3.1.0
+ *    This function exists only to maintain backwards compatibility
+ *     and will be removed in the next major release. Use std::bind instead.
+ * \endrststar
+ *
+ * @tparam R The type containing the member function.
+ * @param receiver The object of type R.
+ * @param callback The member function pointer.
+ * @returns a ServiceListener object.
+ */
 template<class R>
 US_DEPRECATED ServiceListener
 ServiceListenerMemberFunctor(R* receiver,
@@ -127,24 +127,24 @@ ServiceListenerMemberFunctor(R* receiver,
 }
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A convenience function that binds the member function <code>callback</code> of
-   * an object of type <code>R</code> and returns a <code>BundleListener</code> object.
-   * This object can then be passed into <code>AddBundleListener()</code>.
-   *
-   * \rststar
-   * .. deprecated:: 3.1.0
-   *    This function exists only to maintain backwards compatibility
-   *     and will be removed in the next major release. Use std::bind instead.
-   * \endrststar
-   *
-   * @tparam R The type containing the member function.
-   * @param receiver The object of type R.
-   * @param callback The member function pointer.
-   * @returns a BundleListener object.
-   */
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A convenience function that binds the member function <code>callback</code> of
+ * an object of type <code>R</code> and returns a <code>BundleListener</code> object.
+ * This object can then be passed into <code>AddBundleListener()</code>.
+ *
+ * \rststar
+ * .. deprecated:: 3.1.0
+ *    This function exists only to maintain backwards compatibility
+ *     and will be removed in the next major release. Use std::bind instead.
+ * \endrststar
+ *
+ * @tparam R The type containing the member function.
+ * @param receiver The object of type R.
+ * @param callback The member function pointer.
+ * @returns a BundleListener object.
+ */
 template<class R>
 US_DEPRECATED BundleListener
 BundleListenerMemberFunctor(R* receiver,
@@ -154,24 +154,24 @@ BundleListenerMemberFunctor(R* receiver,
 }
 
 /**
-   * \ingroup MicroServices
-   * \ingroup gr_listeners
-   *
-   * A convenience function that binds the member function <code>callback</code> of
-   * an object of type <code>R</code> and returns a <code>FrameworkListener</code> object.
-   * This object can then be passed into <code>AddFrameworkListener()</code>.
-   *
-   * \rststar
-   * .. deprecated:: 3.1.0
-   *    This function exists only to maintain backwards compatibility
-   *     and will be removed in the next major release. Use std::bind instead.
-   * \endrststar
-   *
-   * @tparam R The type containing the member function.
-   * @param receiver The object of type R.
-   * @param callback The member function pointer.
-   * @returns a FrameworkListener object.
-   */
+ * \ingroup MicroServices
+ * \ingroup gr_listeners
+ *
+ * A convenience function that binds the member function <code>callback</code> of
+ * an object of type <code>R</code> and returns a <code>FrameworkListener</code> object.
+ * This object can then be passed into <code>AddFrameworkListener()</code>.
+ *
+ * \rststar
+ * .. deprecated:: 3.1.0
+ *    This function exists only to maintain backwards compatibility
+ *     and will be removed in the next major release. Use std::bind instead.
+ * \endrststar
+ *
+ * @tparam R The type containing the member function.
+ * @param receiver The object of type R.
+ * @param callback The member function pointer.
+ * @returns a FrameworkListener object.
+ */
 template<class R>
 US_DEPRECATED FrameworkListener
 BindFrameworkListenerToFunctor(R* receiver,
@@ -182,7 +182,7 @@ BindFrameworkListenerToFunctor(R* receiver,
 }
 
 US_HASH_FUNCTION_BEGIN(cppmicroservices::ServiceListener)
-using TargetType = void (*)(const cppmicroservices::ServiceEvent &);
+using TargetType = void (*)(const cppmicroservices::ServiceEvent&);
 const auto* targetFunc = arg.target<TargetType>();
 void* targetPtr = nullptr;
 std::memcpy(&targetPtr, &targetFunc, sizeof(void*));

--- a/framework/include/cppmicroservices/PrototypeServiceFactory.h
+++ b/framework/include/cppmicroservices/PrototypeServiceFactory.h
@@ -96,8 +96,8 @@ struct PrototypeServiceFactory : public ServiceFactory
    * @see ServiceObjects::UngetService()
    */
   void UngetService(const Bundle& bundle,
-                            const ServiceRegistrationBase& registration,
-                            const InterfaceMapConstPtr& service) override = 0;
+                    const ServiceRegistrationBase& registration,
+                    const InterfaceMapConstPtr& service) override = 0;
 };
 }
 

--- a/framework/include/cppmicroservices/ServiceEventListenerHook.h
+++ b/framework/include/cppmicroservices/ServiceEventListenerHook.h
@@ -49,8 +49,9 @@ struct US_Framework_EXPORT ServiceEventListenerHook
   /**
    * ShrinkableMap type for filtering event listeners.
    */
-  using ShrinkableMapType = ShrinkableMap<BundleContext,
-                                          ShrinkableVector<ServiceListenerHook::ListenerInfo>>;
+  using ShrinkableMapType =
+    ShrinkableMap<BundleContext,
+                  ShrinkableVector<ServiceListenerHook::ListenerInfo>>;
 
   virtual ~ServiceEventListenerHook();
 

--- a/framework/include/cppmicroservices/ServiceListenerHook.h
+++ b/framework/include/cppmicroservices/ServiceListenerHook.h
@@ -23,9 +23,9 @@
 #ifndef CPPMICROSERVICES_SERVICELISTENERHOOK_H
 #define CPPMICROSERVICES_SERVICELISTENERHOOK_H
 
-#include <functional>
 #include "cppmicroservices/ServiceInterface.h"
 #include "cppmicroservices/ShrinkableVector.h"
+#include <functional>
 
 #include <string>
 

--- a/framework/include/cppmicroservices/ServiceReferenceBase.h
+++ b/framework/include/cppmicroservices/ServiceReferenceBase.h
@@ -23,8 +23,8 @@
 #ifndef CPPMICROSERVICES_SERVICEREFERENCEBASE_H
 #define CPPMICROSERVICES_SERVICEREFERENCEBASE_H
 
-#include <functional>
 #include "cppmicroservices/Any.h"
+#include <functional>
 
 #include <atomic>
 #include <memory>

--- a/framework/include/cppmicroservices/ServiceRegistrationBase.h
+++ b/framework/include/cppmicroservices/ServiceRegistrationBase.h
@@ -23,9 +23,9 @@
 #ifndef CPPMICROSERVICES_SERVICEREGISTRATIONBASE_H
 #define CPPMICROSERVICES_SERVICEREGISTRATIONBASE_H
 
-#include <functional>
 #include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/ServiceReference.h"
+#include <functional>
 
 namespace cppmicroservices {
 
@@ -202,7 +202,7 @@ private:
                           const InterfaceMapConstPtr& service,
                           Properties&& props);
 
-  ServiceRegistrationBasePrivate* d{nullptr};
+  ServiceRegistrationBasePrivate* d{ nullptr };
 };
 
 /**

--- a/framework/include/cppmicroservices/ServiceTracker.h
+++ b/framework/include/cppmicroservices/ServiceTracker.h
@@ -97,7 +97,8 @@ public:
   using TrackedParamType =
     typename ServiceTrackerCustomizer<S, T>::TrackedParamType;
 
-  using TrackingMap = std::unordered_map<ServiceReference<S>, std::shared_ptr<TrackedParamType>>;
+  using TrackingMap =
+    std::unordered_map<ServiceReference<S>, std::shared_ptr<TrackedParamType>>;
 
   /**
    * Automatically closes the <code>ServiceTracker</code>
@@ -451,8 +452,9 @@ protected:
    * @param service The service object for the modified service.
    * @see ServiceTrackerCustomizer::ModifiedService(const ServiceReference&, TrackedArgType)
    */
-  void ModifiedService(const ServiceReference<S>& reference,
-                       const std::shared_ptr<TrackedParamType>& service) override;
+  void ModifiedService(
+    const ServiceReference<S>& reference,
+    const std::shared_ptr<TrackedParamType>& service) override;
 
   /**
    * Default implementation of the
@@ -470,8 +472,9 @@ protected:
    * @param service The service object for the removed service.
    * @see ServiceTrackerCustomizer::RemovedService(const ServiceReferenceType&, TrackedArgType)
    */
-  void RemovedService(const ServiceReference<S>& reference,
-                      const std::shared_ptr<TrackedParamType>& service) override;
+  void RemovedService(
+    const ServiceReference<S>& reference,
+    const std::shared_ptr<TrackedParamType>& service) override;
 
 private:
   using TypeTraits = typename ServiceTrackerCustomizer<S, T>::TypeTraits;

--- a/framework/include/cppmicroservices/ShrinkableMap.h
+++ b/framework/include/cppmicroservices/ShrinkableMap.h
@@ -42,7 +42,7 @@ private:
   static std::map<Key, T> emptyContainer;
 
 public:
-  using  container_type = std::map<Key, T>;
+  using container_type = std::map<Key, T>;
   using iterator = typename container_type::iterator;
   using const_iterator = typename container_type::const_iterator;
   using size_type = typename container_type::size_type;

--- a/framework/include/cppmicroservices/detail/CounterLatch.h
+++ b/framework/include/cppmicroservices/detail/CounterLatch.h
@@ -21,7 +21,7 @@
   =============================================================================*/
 
 #ifndef CPPMICROSERVICES_DETAIL_COUNTERLATCH_H
-#  define CPPMICROSERVICES_DETAIL_COUNTERLATCH_H
+#define CPPMICROSERVICES_DETAIL_COUNTERLATCH_H
 
 #include <mutex>
 

--- a/framework/include/cppmicroservices/detail/ScopeGuard.h
+++ b/framework/include/cppmicroservices/detail/ScopeGuard.h
@@ -21,7 +21,7 @@
   =============================================================================*/
 
 #ifndef CPPMICROSERVICES_DETAIL_SCOPEGUARD_H
-#  define CPPMICROSERVICES_DETAIL_SCOPEGUARD_H
+#define CPPMICROSERVICES_DETAIL_SCOPEGUARD_H
 
 #include <functional>
 
@@ -34,24 +34,26 @@ namespace detail {
  * to guarantee operations are executed when 
  * the ScopeGuard object goes out of scope.
  */
-class ScopeGuard {
+class ScopeGuard
+{
 public:
-    template <typename Callable>
-    ScopeGuard(Callable&& func)
-        : f(func) {
-    }
+  template<typename Callable>
+  ScopeGuard(Callable&& func)
+    : f(func)
+  {}
 
-    ScopeGuard(const ScopeGuard&) = delete;
-    ScopeGuard& operator=(const ScopeGuard&) = delete;
-    ScopeGuard(ScopeGuard&&) = delete;
-    ScopeGuard& operator=(ScopeGuard&&) = delete;
+  ScopeGuard(const ScopeGuard&) = delete;
+  ScopeGuard& operator=(const ScopeGuard&) = delete;
+  ScopeGuard(ScopeGuard&&) = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
 
-    ~ScopeGuard() noexcept {
-        f(); // must not throw
-    }
+  ~ScopeGuard() noexcept
+  {
+    f(); // must not throw
+  }
 
 private:
-    std::function<void()> f;
+  std::function<void()> f;
 };
 
 }

--- a/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.h
+++ b/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.h
@@ -44,12 +44,12 @@ public:
   using TrackedParamType = typename TTT::TrackedParamType;
 
   ServiceTrackerPrivate(ServiceTracker<S, T>* st,
-                        BundleContext  context,
+                        BundleContext context,
                         const ServiceReference<S>& reference,
                         ServiceTrackerCustomizer<S, T>* customizer);
 
   ServiceTrackerPrivate(ServiceTracker<S, T>* st,
-                        BundleContext  context,
+                        BundleContext context,
                         const std::string& clazz,
                         ServiceTrackerCustomizer<S, T>* customizer);
 

--- a/framework/include/cppmicroservices/detail/TrackedService.h
+++ b/framework/include/cppmicroservices/detail/TrackedService.h
@@ -63,7 +63,8 @@ public:
   void WaitOnCustomizersToFinish();
 
 private:
-  using Superclass = BundleAbstractTracked<ServiceReference<S>, TTT, ServiceEvent>;
+  using Superclass =
+    BundleAbstractTracked<ServiceReference<S>, TTT, ServiceEvent>;
 
   ServiceTracker<S, T>* serviceTracker;
   ServiceTrackerCustomizer<S, T>* customizer;
@@ -99,9 +100,10 @@ private:
    * @param related Action related object.
    * @param object Customized object for the tracked item.
    */
-  void CustomizerModified(ServiceReference<S> item,
-                          const ServiceEvent& related,
-                          const std::shared_ptr<TrackedParamType>& object) override;
+  void CustomizerModified(
+    ServiceReference<S> item,
+    const ServiceEvent& related,
+    const std::shared_ptr<TrackedParamType>& object) override;
 
   /**
    * Call the specific customizer removed method. This method must not be
@@ -111,9 +113,10 @@ private:
    * @param related Action related object.
    * @param object Customized object for the tracked item.
    */
-  void CustomizerRemoved(ServiceReference<S> item,
-                         const ServiceEvent& related,
-                         const std::shared_ptr<TrackedParamType>& object) override;
+  void CustomizerRemoved(
+    ServiceReference<S> item,
+    const ServiceEvent& related,
+    const std::shared_ptr<TrackedParamType>& object) override;
 };
 
 } // namespace detail

--- a/framework/src/bundle/BundleHooks.cpp
+++ b/framework/src/bundle/BundleHooks.cpp
@@ -153,9 +153,7 @@ void BundleHooks::FilterBundleEventReceivers(
     }
 
     if (unfilteredSize != bundleContexts.size()) {
-      for (auto le =
-             bundleListeners.begin();
-           le != bundleListeners.end();) {
+      for (auto le = bundleListeners.begin(); le != bundleListeners.end();) {
         if (std::find_if(bundleContexts.begin(),
                          bundleContexts.end(),
                          [&le](const BundleContext& bc) {

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -52,9 +52,7 @@ public:
   InitialBundleMapCleanup(std::function<void()> cleanupFcn)
     : _cleanupFcn(std::move(cleanupFcn))
   {}
-  ~InitialBundleMapCleanup() {
-    _cleanupFcn();
-  }
+  ~InitialBundleMapCleanup() { _cleanupFcn(); }
 
 private:
   std::function<void()> _cleanupFcn;
@@ -125,7 +123,7 @@ BundleRegistry::GetAlreadyInstalledBundlesAtLocation(
        ? std::make_shared<BundleResourceContainer>(location, bundleManifest)
        : foundBundles.first->second->GetBundleArchive()
            ->GetResourceContainer());
-  
+
   while (foundBundles.first != foundBundles.second) {
     auto installedBundlePrivate = foundBundles.first->second;
     alreadyInstalled.emplace_back(installedBundlePrivate->symbolicName);
@@ -225,18 +223,18 @@ std::vector<Bundle> BundleRegistry::Install(
       std::vector<Bundle> installedBundles;
       {
         // create instance of clean-up object to ensure RAII
-        InitialBundleMapCleanup cleanup ([this, &l, &location]() {
-                                            {
-                                              l.Lock();
-                                              auto& p = initialBundleInstallMap[location];
-                                              // Notify all waiting threads that it is safe to install the bundle
-                                              std::lock_guard<std::mutex> lock(*(p.second.m));
-                                              p.second.waitFlag = false;
-                                              p.second.cv->notify_all();
-                                              l.UnLock();
-                                            }
-                                            DecrementInitialBundleMapRef(l, location);
-                                         });
+        InitialBundleMapCleanup cleanup([this, &l, &location]() {
+          {
+            l.Lock();
+            auto& p = initialBundleInstallMap[location];
+            // Notify all waiting threads that it is safe to install the bundle
+            std::lock_guard<std::mutex> lock(*(p.second.m));
+            p.second.waitFlag = false;
+            p.second.cv->notify_all();
+            l.UnLock();
+          }
+          DecrementInitialBundleMapRef(l, location);
+        });
 
         // Perform the install
         auto resCont =
@@ -282,9 +280,9 @@ std::vector<Bundle> BundleRegistry::Install(
       std::vector<Bundle> newBundles;
       {
         // create instance of clean-up object to ensure RAII
-        InitialBundleMapCleanup cleanup ([this, &l, &location]() {
-                                           DecrementInitialBundleMapRef(l, location);
-                                         });
+        InitialBundleMapCleanup cleanup([this, &l, &location]() {
+          DecrementInitialBundleMapRef(l, location);
+        });
 
         // Perform the install
         newBundles =

--- a/framework/src/bundle/BundleResourceBuffer.cpp
+++ b/framework/src/bundle/BundleResourceBuffer.cpp
@@ -24,9 +24,9 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <memory>
-#include <cstdlib>
 
 #ifdef US_PLATFORM_WINDOWS
 #  define DATA_NEEDS_NEWLINE_CONVERSION 1
@@ -98,7 +98,8 @@ BundleResourceBuffer::BundleResourceBuffer(
   }
 #endif
 
-  d = std::make_unique<BundleResourceBufferPrivate>(std::move(data), size, begin, mode);
+  d = std::make_unique<BundleResourceBufferPrivate>(
+    std::move(data), size, begin, mode);
 }
 
 BundleResourceBuffer::~BundleResourceBuffer() = default;

--- a/framework/src/bundle/BundleUtils.h
+++ b/framework/src/bundle/BundleUtils.h
@@ -23,9 +23,9 @@
 #ifndef CPPMICROSERVICES_BUNDLEUTILS_H
 #define CPPMICROSERVICES_BUNDLEUTILS_H
 
+#include <functional>
 #include <string>
 #include <utility>
-#include <functional>
 
 namespace cppmicroservices {
 
@@ -36,12 +36,13 @@ void* GetExecutableHandle();
 // returns the address of the symbol in library libHandle
 void* GetSymbol(void* libHandle, const char* symbol);
 
-template<typename T> void GetSymbol(std::function<T>& fptr,
-                                    void* libHandle,
-                                    const std::string& symbol)
+template<typename T>
+void GetSymbol(std::function<T>& fptr,
+               void* libHandle,
+               const std::string& symbol)
 {
-    void* f = GetSymbol(libHandle, symbol.c_str());
-    fptr = reinterpret_cast<T*>(f);
+  void* f = GetSymbol(libHandle, symbol.c_str());
+  fptr = reinterpret_cast<T*>(f);
 }
 
 }

--- a/framework/src/bundle/BundleVersion.cpp
+++ b/framework/src/bundle/BundleVersion.cpp
@@ -53,8 +53,7 @@ BundleVersion BundleVersion::UndefinedVersion()
 BundleVersion& BundleVersion::operator=(const BundleVersion&) = default;
 
 BundleVersion::BundleVersion(bool undefined)
-  : 
-   qualifier("")
+  : qualifier("")
   , undefined(undefined)
 {}
 
@@ -80,7 +79,7 @@ BundleVersion::BundleVersion(unsigned int majorVersion,
 BundleVersion::BundleVersion(unsigned int majorVersion,
                              unsigned int minorVersion,
                              unsigned int microVersion,
-                             std::string  qualifier)
+                             std::string qualifier)
   : majorVersion(majorVersion)
   , minorVersion(minorVersion)
   , microVersion(microVersion)

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -144,15 +144,13 @@ void ServiceListenerEntry::CallDelegate(const ServiceEvent& event) const
 
 bool ServiceListenerEntry::operator==(const ServiceListenerEntry& other) const
 {
-  return (d->data == other.d->data)
-         && (d->tokenId == other.d->tokenId)
-         && ServiceListenerCompare()(d->listener, other.d->listener)
-         && ((d->context == nullptr
-              || other.d->context == nullptr)
-            || d->context == other.d->context);
+  return (d->data == other.d->data) && (d->tokenId == other.d->tokenId) &&
+         ServiceListenerCompare()(d->listener, other.d->listener) &&
+         ((d->context == nullptr || other.d->context == nullptr) ||
+          d->context == other.d->context);
 }
 
-bool ServiceListenerEntry::operator<(const ServiceListenerEntry& other) const 
+bool ServiceListenerEntry::operator<(const ServiceListenerEntry& other) const
 {
   return d->tokenId < other.d->tokenId;
 }

--- a/framework/src/service/ServiceListenerHook.cpp
+++ b/framework/src/service/ServiceListenerHook.cpp
@@ -34,11 +34,11 @@ namespace cppmicroservices {
 ServiceListenerHook::~ServiceListenerHook() = default;
 
 ServiceListenerHook::ListenerInfoData::ListenerInfoData(
-  std::shared_ptr<BundleContextPrivate>  context,
-  ServiceListener  l,
+  std::shared_ptr<BundleContextPrivate> context,
+  ServiceListener l,
   void* data,
   ListenerTokenId tokenId,
-  std::string  filter)
+  std::string filter)
   : context(std::move(context))
   , listener(std::move(l))
   , data(data)
@@ -61,7 +61,8 @@ ServiceListenerHook::ListenerInfo::ListenerInfo(const ListenerInfo&) = default;
 
 ServiceListenerHook::ListenerInfo::~ListenerInfo() = default;
 
-ServiceListenerHook::ListenerInfo& ServiceListenerHook::ListenerInfo::operator=(const ListenerInfo&) = default;
+ServiceListenerHook::ListenerInfo& ServiceListenerHook::ListenerInfo::operator=(
+  const ListenerInfo&) = default;
 
 bool ServiceListenerHook::ListenerInfo::IsNull() const
 {

--- a/framework/src/service/ServiceListenerHookPrivate.h
+++ b/framework/src/service/ServiceListenerHookPrivate.h
@@ -32,11 +32,11 @@ namespace cppmicroservices {
 class ServiceListenerHook::ListenerInfoData
 {
 public:
-  ListenerInfoData(std::shared_ptr<BundleContextPrivate>  context,
-                   ServiceListener  l,
+  ListenerInfoData(std::shared_ptr<BundleContextPrivate> context,
+                   ServiceListener l,
                    void* data,
                    ListenerTokenId tokenId,
-                   std::string  filter);
+                   std::string filter);
 
   virtual ~ListenerInfoData();
 

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -318,8 +318,7 @@ void ServiceListeners::RemoveAllListeners(
   {
     auto l = this->Lock();
     US_UNUSED(l);
-    for (auto it = serviceSet.begin();
-         it != serviceSet.end();) {
+    for (auto it = serviceSet.begin(); it != serviceSet.end();) {
 
       if (GetPrivate(it->GetBundleContext()) == context) {
         RemoveFromCache_unlocked(*it);

--- a/framework/src/service/ServiceListeners.h
+++ b/framework/src/service/ServiceListeners.h
@@ -50,20 +50,23 @@ class ServiceListeners : private detail::MultiThreaded<>
 
 public:
   using BundleListenerEntry = std::tuple<BundleListener, void*>;
-  using BundleListenerMap = std::unordered_map<std::shared_ptr<BundleContextPrivate>,
-                                               std::unordered_map<ListenerTokenId, BundleListenerEntry>>;
-  
+  using BundleListenerMap = std::unordered_map<
+    std::shared_ptr<BundleContextPrivate>,
+    std::unordered_map<ListenerTokenId, BundleListenerEntry>>;
+
   struct : public MultiThreaded<>
   {
     BundleListenerMap value;
   } bundleListenerMap;
 
-  using CacheType = std::unordered_map<std::string, std::set<ServiceListenerEntry>>;
+  using CacheType =
+    std::unordered_map<std::string, std::set<ServiceListenerEntry>>;
   using ServiceListenerEntries = std::unordered_set<ServiceListenerEntry>;
 
   using FrameworkListenerEntry = std::tuple<FrameworkListener, void*>;
-  using FrameworkListenerMap = std::unordered_map<std::shared_ptr<BundleContextPrivate>,
-                                                  std::unordered_map<ListenerTokenId, FrameworkListenerEntry>>;
+  using FrameworkListenerMap = std::unordered_map<
+    std::shared_ptr<BundleContextPrivate>,
+    std::unordered_map<ListenerTokenId, FrameworkListenerEntry>>;
 
 private:
   std::atomic<uint64_t> listenerId;

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -43,9 +43,8 @@ public:
   std::shared_ptr<BundleContextPrivate> m_context;
   ServiceReferenceBase m_reference;
 
-  ServiceObjectsBasePrivate(
-    std::shared_ptr<BundleContextPrivate>  context,
-    const ServiceReferenceBase& reference)
+  ServiceObjectsBasePrivate(std::shared_ptr<BundleContextPrivate> context,
+                            const ServiceReferenceBase& reference)
     : m_context(std::move(context))
     , m_reference(reference)
   {}
@@ -95,7 +94,7 @@ struct UngetHelper
   const ServiceReferenceBase sref;
   const std::weak_ptr<BundlePrivate> b;
 
-  UngetHelper(InterfaceMapConstPtr  im,
+  UngetHelper(InterfaceMapConstPtr im,
               const ServiceReferenceBase& sr,
               const std::shared_ptr<BundlePrivate>& b)
     : interfaceMap(std::move(im))
@@ -144,11 +143,11 @@ std::shared_ptr<void> ServiceObjectsBase::GetService() const
   if (!interfaceMap) {
     return nullptr;
   }
-  
-  auto h = std::make_shared<UngetHelper>(interfaceMap
-                                         , d->m_reference
-                                         , d->m_context->bundle->shared_from_this());
-  auto deleter = h->interfaceMap->find(d->m_reference.GetInterfaceId())->second.get();
+
+  auto h = std::make_shared<UngetHelper>(
+    interfaceMap, d->m_reference, d->m_context->bundle->shared_from_this());
+  auto deleter =
+    h->interfaceMap->find(d->m_reference.GetInterfaceId())->second.get();
   return std::shared_ptr<void>(h, deleter);
 }
 

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -214,7 +214,8 @@ std::string ServiceReferenceBase::GetInterfaceId() const
 
 std::size_t ServiceReferenceBase::Hash() const
 {
-  return std::hash<ServiceRegistrationBasePrivate*>()(this->d.load()->registration);
+  return std::hash<ServiceRegistrationBasePrivate*>()(
+    this->d.load()->registration);
 }
 
 std::ostream& operator<<(std::ostream& os,

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -40,8 +40,9 @@ US_MSVC_DISABLE_WARNING(
 
 namespace cppmicroservices {
 
-using ThreadMarksMapType = std::unordered_map<BundlePrivate*,
-                           std::unordered_set<ServiceRegistrationBasePrivate*>>;
+using ThreadMarksMapType =
+  std::unordered_map<BundlePrivate*,
+                     std::unordered_set<ServiceRegistrationBasePrivate*>>;
 
 ServiceReferenceBasePrivate::ServiceReferenceBasePrivate(
   ServiceRegistrationBasePrivate* reg)
@@ -73,13 +74,11 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
       std::string message =
         "ServiceFactory returned an empty or nullptr interface map.";
       registration->bundle->coreCtx->listeners.SendFrameworkEvent(
-        FrameworkEvent(
-          FrameworkEvent::Type::FRAMEWORK_ERROR,
-          MakeBundle(bundle->shared_from_this()),
-          message,
-          std::make_exception_ptr(ServiceException(message, 
-            ServiceException::Type::FACTORY_ERROR)
-          )));
+        FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
+                       MakeBundle(bundle->shared_from_this()),
+                       message,
+                       std::make_exception_ptr(ServiceException(
+                         message, ServiceException::Type::FACTORY_ERROR))));
       return smap;
     }
     std::vector<std::string> classes =
@@ -115,8 +114,8 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
       FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
                      MakeBundle(bundle->shared_from_this()),
                      message,
-                     std::make_exception_ptr(ServiceException(ex.what(),
-                       ServiceException::Type::FACTORY_EXCEPTION))));
+                     std::make_exception_ptr(ServiceException(
+                       ex.what(), ServiceException::Type::FACTORY_EXCEPTION))));
   }
   return s;
 }
@@ -281,7 +280,7 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(
   if (!sf)
     return false;
 
-  for (auto & prototypeServiceMap : prototypeServiceMaps) {
+  for (auto& prototypeServiceMap : prototypeServiceMaps) {
     // compare the contents of the map
     if (*service.get() == *prototypeServiceMap.get()) {
       try {
@@ -290,11 +289,12 @@ bool ServiceReferenceBasePrivate::UngetPrototypeService(
       } catch (const std::exception& ex) {
         std::string message("ServiceFactory threw an exception");
         registration->bundle->coreCtx->listeners.SendFrameworkEvent(
-          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
-                         MakeBundle(bundle->shared_from_this()),
-                         message,
-                         std::make_exception_ptr(ServiceException(ex.what(),
-                           ServiceException::Type::FACTORY_EXCEPTION))));
+          FrameworkEvent(
+            FrameworkEvent::Type::FRAMEWORK_ERROR,
+            MakeBundle(bundle->shared_from_this()),
+            message,
+            std::make_exception_ptr(ServiceException(
+              ex.what(), ServiceException::Type::FACTORY_EXCEPTION))));
       }
 
       auto l = registration->Lock();
@@ -371,11 +371,12 @@ bool ServiceReferenceBasePrivate::UngetService(
     } catch (const std::exception& ex) {
       std::string message("ServiceFactory threw an exception");
       registration->bundle->coreCtx->listeners.SendFrameworkEvent(
-        FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
-                       MakeBundle(bundle->shared_from_this()),
-                       message,
-                       std::make_exception_ptr(ServiceException(ex.what(), 
-                         ServiceException::Type::FACTORY_EXCEPTION))));
+        FrameworkEvent(
+          FrameworkEvent::Type::FRAMEWORK_ERROR,
+          MakeBundle(bundle->shared_from_this()),
+          message,
+          std::make_exception_ptr(ServiceException(
+            ex.what(), ServiceException::Type::FACTORY_EXCEPTION))));
     }
   }
 

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -90,7 +90,8 @@ ServiceRegistrationBase::~ServiceRegistrationBase()
     delete d;
 }
 
-ServiceReferenceBase ServiceRegistrationBase::GetReference(const std::string& interfaceId) const
+ServiceReferenceBase ServiceRegistrationBase::GetReference(
+  const std::string& interfaceId) const
 {
   if (!d)
     throw std::logic_error("ServiceRegistrationBase object invalid");
@@ -254,12 +255,12 @@ void ServiceRegistrationBase::Unregister()
         } catch (const std::exception& ex) {
           std::string message(
             "ServiceFactory UngetService implementation threw an exception");
-          d->bundle->coreCtx->listeners.SendFrameworkEvent(
-            FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
-                           MakeBundle(d->bundle->shared_from_this()),
-                           message,
-                           std::make_exception_ptr(ServiceException(ex.what(), 
-                             ServiceException::Type::FACTORY_EXCEPTION))));
+          d->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
+            FrameworkEvent::Type::FRAMEWORK_ERROR,
+            MakeBundle(d->bundle->shared_from_this()),
+            message,
+            std::make_exception_ptr(ServiceException(
+              ex.what(), ServiceException::Type::FACTORY_EXCEPTION))));
         }
       }
     }
@@ -272,12 +273,12 @@ void ServiceRegistrationBase::Unregister()
       } catch (const std::exception& ex) {
         std::string message(
           "ServiceFactory UngetService implementation threw an exception");
-        d->bundle->coreCtx->listeners.SendFrameworkEvent(
-          FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
-                         MakeBundle(d->bundle->shared_from_this()),
-                         message,
-                         std::make_exception_ptr(ServiceException(ex.what(), 
-                           ServiceException::Type::FACTORY_EXCEPTION))));
+        d->bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
+          FrameworkEvent::Type::FRAMEWORK_ERROR,
+          MakeBundle(d->bundle->shared_from_this()),
+          message,
+          std::make_exception_ptr(ServiceException(
+            ex.what(), ServiceException::Type::FACTORY_EXCEPTION))));
       }
     }
   }

--- a/framework/src/service/ServiceRegistrationBasePrivate.cpp
+++ b/framework/src/service/ServiceRegistrationBasePrivate.cpp
@@ -33,7 +33,7 @@ namespace cppmicroservices {
 
 ServiceRegistrationBasePrivate::ServiceRegistrationBasePrivate(
   BundlePrivate* bundle,
-  InterfaceMapConstPtr  service,
+  InterfaceMapConstPtr service,
   Properties&& props)
   : ref(0)
   , service(std::move(service))

--- a/framework/src/service/ServiceRegistrationBasePrivate.h
+++ b/framework/src/service/ServiceRegistrationBasePrivate.h
@@ -64,8 +64,10 @@ protected:
 
 public:
   using BundleToRefsMap = std::unordered_map<BundlePrivate*, int>;
-  using BundleToServiceMap = std::unordered_map<BundlePrivate*, InterfaceMapConstPtr>;
-  using BundleToServicesMap = std::unordered_map<BundlePrivate*, std::list<InterfaceMapConstPtr>>;
+  using BundleToServiceMap =
+    std::unordered_map<BundlePrivate*, InterfaceMapConstPtr>;
+  using BundleToServicesMap =
+    std::unordered_map<BundlePrivate*, std::list<InterfaceMapConstPtr>>;
 
   ServiceRegistrationBasePrivate(const ServiceRegistrationBasePrivate&) =
     delete;
@@ -117,7 +119,7 @@ public:
   std::atomic<bool> unregistering;
 
   ServiceRegistrationBasePrivate(BundlePrivate* bundle,
-                                 InterfaceMapConstPtr  service,
+                                 InterfaceMapConstPtr service,
                                  Properties&& props);
 
   ~ServiceRegistrationBasePrivate();

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -79,9 +79,10 @@ ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)
   : core(coreCtx)
 {}
 
-ServiceRegistrationBase ServiceRegistry::RegisterService(BundlePrivate* bundle
-                                                         , const InterfaceMapConstPtr& service
-                                                         , const ServiceProperties& properties)
+ServiceRegistrationBase ServiceRegistry::RegisterService(
+  BundlePrivate* bundle,
+  const InterfaceMapConstPtr& service,
+  const ServiceProperties& properties)
 {
   if (!service || service->empty()) {
     throw std::invalid_argument(
@@ -106,12 +107,11 @@ ServiceRegistrationBase ServiceRegistry::RegisterService(BundlePrivate* bundle
     classes.push_back(i.first);
   }
 
-  ServiceRegistrationBase res(bundle
-                              , service
-                              , CreateServiceProperties(properties
-                                                        , classes
-                                                        , isFactory
-                                                        , isPrototypeFactory));
+  ServiceRegistrationBase res(
+    bundle,
+    service,
+    CreateServiceProperties(
+      properties, classes, isFactory, isPrototypeFactory));
   {
     auto l = this->Lock();
     US_UNUSED(l);

--- a/framework/src/service/ServiceRegistry.h
+++ b/framework/src/service/ServiceRegistry.h
@@ -58,8 +58,10 @@ public:
     bool isPrototypeFactory = false,
     long sid = -1);
 
-  using MapServiceClasses = std::unordered_map<ServiceRegistrationBase, std::vector<std::string>>;
-  using MapClassServices  = std::unordered_map<std::string, std::vector<ServiceRegistrationBase>>;
+  using MapServiceClasses =
+    std::unordered_map<ServiceRegistrationBase, std::vector<std::string>>;
+  using MapClassServices =
+    std::unordered_map<std::string, std::vector<ServiceRegistrationBase>>;
 
   /**
    * All registered services in the current framework.

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -23,8 +23,8 @@
 #include "cppmicroservices/Any.h"
 #include "Utils.h"
 
-#include <stdexcept>
 #include <iomanip>
+#include <stdexcept>
 
 namespace cppmicroservices {
 
@@ -43,7 +43,9 @@ void ThrowBadAnyCastException(const std::string& funcName,
 }
 }
 
-std::ostream& newline_and_indent(std::ostream& os, const uint8_t increment, const int32_t indent)
+std::ostream& newline_and_indent(std::ostream& os,
+                                 const uint8_t increment,
+                                 const int32_t indent)
 {
   if (increment > 0) {
     // We only do formatting if increment > 0, because if increment was actually zero everything
@@ -65,28 +67,48 @@ std::ostream& any_value_to_string(std::ostream& os, const Any& any)
   return os;
 }
 
-std::ostream& any_value_to_json(std::ostream& os, const Any& val, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const Any& val,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
   os << val.ToJSON(increment, indent);
   return os;
 }
 
-std::ostream& any_value_to_json(std::ostream& o, const std::string& s, const uint8_t, const int32_t)
+std::ostream& any_value_to_json(std::ostream& o,
+                                const std::string& s,
+                                const uint8_t,
+                                const int32_t)
 {
   o << '"';
   for (auto c = s.cbegin(); c != s.cend(); c++) {
     switch (*c) {
-      case '"' : o << "\\\""; break;
-      case '\\': o << "\\\\"; break;
-      case '\b': o << "\\b";  break;
-      case '\f': o << "\\f";  break;
-      case '\n': o << "\\n";  break;
-      case '\r': o << "\\r";  break;
-      case '\t': o << "\\t";  break;
+      case '"':
+        o << "\\\"";
+        break;
+      case '\\':
+        o << "\\\\";
+        break;
+      case '\b':
+        o << "\\b";
+        break;
+      case '\f':
+        o << "\\f";
+        break;
+      case '\n':
+        o << "\\n";
+        break;
+      case '\r':
+        o << "\\r";
+        break;
+      case '\t':
+        o << "\\t";
+        break;
       default:
         if ('\x00' <= *c && *c <= '\x1f') {
-          o << "\\u"
-            << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(*c);
+          o << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+            << static_cast<int>(*c);
         } else {
           o << *c;
         }
@@ -95,7 +117,10 @@ std::ostream& any_value_to_json(std::ostream& o, const std::string& s, const uin
   return o << '"';
 }
 
-std::ostream& any_value_to_json(std::ostream& os, bool val, const uint8_t, const int32_t)
+std::ostream& any_value_to_json(std::ostream& os,
+                                bool val,
+                                const uint8_t,
+                                const int32_t)
 {
   return os << std::boolalpha << val;
 }
@@ -105,7 +130,7 @@ std::ostream& any_value_to_json(std::ostream& os, bool val, const uint8_t, const
 // "default initialization of an object of const type 'const cppmicroservices::Any' without
 // a user-provided default constructor"
 Any::Any() = default;
-    
+
 std::string Any::ToString() const
 {
   if (Empty()) {

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -842,9 +842,12 @@ any_map::const_iterator any_map::find(const key_type& key) const
 any_map::size_type any_map::erase(const key_type& key)
 {
   switch (type) {
-    case map_type::ORDERED_MAP                        : return o_m().erase(key);
-    case map_type::UNORDERED_MAP                      : return uo_m().erase(key);
-    case map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS : return uoci_m().erase(key);
+    case map_type::ORDERED_MAP:
+      return o_m().erase(key);
+    case map_type::UNORDERED_MAP:
+      return uo_m().erase(key);
+    case map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS:
+      return uoci_m().erase(key);
     default:
       throw std::logic_error("invalid map type");
   }
@@ -997,9 +1000,15 @@ std::ostream& any_value_to_string(std::ostream& os, const AnyMap& m)
 }
 
 template<>
-std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m, const uint8_t increment, const int32_t indent)
+std::ostream& any_value_to_json(std::ostream& os,
+                                const AnyMap& m,
+                                const uint8_t increment,
+                                const int32_t indent)
 {
-  if (m.empty()) { os << "{}"; return os; }
+  if (m.empty()) {
+    os << "{}";
+    return os;
+  }
 
   os << "{";
   using Iterator = any_map::const_iterator;
@@ -1011,9 +1020,10 @@ std::ostream& any_value_to_json(std::ostream& os, const AnyMap& m, const uint8_t
       os << ", ";
     }
     newline_and_indent(os, increment, indent);
-    os << "\"" << i1->first << "\" : " << i1->second.ToJSON(increment, indent + increment);
+    os << "\"" << i1->first
+       << "\" : " << i1->second.ToJSON(increment, indent + increment);
   }
-  newline_and_indent(os, increment, indent-increment);
+  newline_and_indent(os, increment, indent - increment);
   os << "}";
   return os;
 }

--- a/framework/src/util/FrameworkEvent.cpp
+++ b/framework/src/util/FrameworkEvent.cpp
@@ -34,8 +34,8 @@ class FrameworkEventData
 {
 public:
   FrameworkEventData(FrameworkEvent::Type type,
-                     Bundle  bundle,
-                     std::string  message,
+                     Bundle bundle,
+                     std::string message,
                      const std::exception_ptr exception)
     : type(type)
     , bundle(std::move(bundle))
@@ -44,8 +44,8 @@ public:
   {}
 
   FrameworkEventData(const FrameworkEventData& other)
-     
-  = default;
+
+    = default;
 
   const FrameworkEvent::Type type;
   const Bundle bundle;

--- a/framework/src/util/FrameworkPrivate.h
+++ b/framework/src/util/FrameworkPrivate.h
@@ -116,6 +116,7 @@ public:
    * The thread that performs shutdown of this framework instance.
    */
   std::thread shutdownThread;
+
 private:
   AnyMap headers;
 };

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -132,14 +132,14 @@ public:
 class LDAPExprData
 {
 public:
-  LDAPExprData(int op, std::vector<LDAPExpr>  args)
+  LDAPExprData(int op, std::vector<LDAPExpr> args)
     : m_operator(op)
     , m_args(std::move(args))
     , m_attrName()
     , m_attrValue()
   {}
 
-  LDAPExprData(int op, std::string attrName, std::string  attrValue)
+  LDAPExprData(int op, std::string attrName, std::string attrValue)
     : m_operator(op)
     , m_args()
     , m_attrName(std::move(attrName))
@@ -147,8 +147,8 @@ public:
   {}
 
   LDAPExprData(const LDAPExprData& other)
-     
-  = default;
+
+    = default;
 
   int m_operator;
   std::vector<LDAPExpr> m_args;
@@ -168,7 +168,8 @@ LDAPExpr::LDAPExpr(const std::string& filter)
     LDAPExpr expr = ParseExpr(ps);
 
     if (!Trim(ps.rest()).empty()) {
-      ps.error(absl::StrCat(LDAPExprConstants::GARBAGE(), " '", ps.rest(), "'"));
+      ps.error(
+        absl::StrCat(LDAPExprConstants::GARBAGE(), " '", ps.rest(), "'"));
     }
 
     d = expr.d;
@@ -216,7 +217,7 @@ bool LDAPExpr::GetMatchedObjectClasses(ObjectClassSet& objClasses) const
     return false;
   } else if (d->m_operator == AND) {
     bool result = false;
-    for (const auto & m_arg : d->m_args) {
+    for (const auto& m_arg : d->m_args) {
       LDAPExpr::ObjectClassSet r;
       if (m_arg.GetMatchedObjectClasses(r)) {
         result = true;
@@ -245,7 +246,7 @@ bool LDAPExpr::GetMatchedObjectClasses(ObjectClassSet& objClasses) const
     }
     return result;
   } else if (d->m_operator == OR) {
-    for (const auto & m_arg : d->m_args) {
+    for (const auto& m_arg : d->m_args) {
       LDAPExpr::ObjectClassSet r;
       if (m_arg.GetMatchedObjectClasses(r)) {
         std::copy(
@@ -288,7 +289,7 @@ bool LDAPExpr::IsSimple(const StringList& keywords,
       return true;
     }
   } else if (d->m_operator == OR) {
-    for (const auto & m_arg : d->m_args) {
+    for (const auto& m_arg : d->m_args) {
       if (!m_arg.IsSimple(keywords, cache, matchCase))
         return false;
     }
@@ -315,13 +316,13 @@ bool LDAPExpr::Evaluate(const PropertiesHandle& p, bool matchCase) const
   } else { // (d->m_operator & COMPLEX) != 0
     switch (d->m_operator) {
       case AND:
-        for (const auto & m_arg : d->m_args) {
+        for (const auto& m_arg : d->m_args) {
           if (!m_arg.Evaluate(p, matchCase))
             return false;
         }
         return true;
       case OR:
-        for (const auto & m_arg : d->m_args) {
+        for (const auto& m_arg : d->m_args) {
           if (m_arg.Evaluate(p, matchCase))
             return true;
         }
@@ -346,16 +347,14 @@ bool LDAPExpr::Compare(const Any& obj, int op, const std::string& s) const
     if (objType == typeid(std::string)) {
       return CompareString(ref_any_cast<std::string>(obj), op, s);
     } else if (objType == typeid(std::vector<std::string>)) {
-      const auto& list =
-        ref_any_cast<std::vector<std::string>>(obj);
+      const auto& list = ref_any_cast<std::vector<std::string>>(obj);
       for (std::size_t it = 0; it != list.size(); it++) {
         if (CompareString(list[it], op, s))
           return true;
       }
     } else if (objType == typeid(std::list<std::string>)) {
-      const auto& list =
-        ref_any_cast<std::list<std::string>>(obj);
-      for (const auto & it : list) {
+      const auto& list = ref_any_cast<std::list<std::string>>(obj);
+      for (const auto& it : list) {
         if (CompareString(it, op, s))
           return true;
       }
@@ -634,7 +633,7 @@ const std::string LDAPExpr::ToString() const
         res.append("!");
         break;
     }
-    for (const auto & m_arg : d->m_args) {
+    for (const auto& m_arg : d->m_args) {
       res.append(m_arg.ToString());
     }
   }
@@ -747,7 +746,8 @@ std::string LDAPExpr::ParseState::getAttributeValue()
 
 void LDAPExpr::ParseState::error(const std::string& m) const
 {
-  std::string errorStr = absl::StrCat(m, ": ", (m_str.empty() ? "" : m_str.substr(m_pos)));
+  std::string errorStr =
+    absl::StrCat(m, ": ", (m_str.empty() ? "" : m_str.substr(m_pos)));
   throw std::invalid_argument(errorStr);
 }
 }

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -110,8 +110,7 @@ bool LDAPFilter::operator==(const LDAPFilter& other) const
   return (this->ToString() == other.ToString());
 }
 
-LDAPFilter& LDAPFilter::operator=(const LDAPFilter& filter)
-= default;
+LDAPFilter& LDAPFilter::operator=(const LDAPFilter& filter) = default;
 
 std::ostream& operator<<(std::ostream& os, const LDAPFilter& filter)
 {

--- a/framework/src/util/LDAPProp.cpp
+++ b/framework/src/util/LDAPProp.cpp
@@ -66,7 +66,7 @@ LDAPPropExpr& LDAPPropExpr::operator&=(const LDAPPropExpr& right)
   return *this;
 }
 
-LDAPProp::LDAPProp(std::string  property)
+LDAPProp::LDAPProp(std::string property)
   : m_property(std::move(property))
 {
   if (m_property.empty())

--- a/framework/src/util/SharedLibrary.cpp
+++ b/framework/src/util/SharedLibrary.cpp
@@ -56,7 +56,7 @@ public:
     , m_Prefix(US_LIB_PREFIX)
   {}
 
-  void * m_Handle{ nullptr };
+  void* m_Handle{ nullptr };
 
   std::string m_Name;
   std::string m_Path;
@@ -105,7 +105,6 @@ void SharedLibrary::Load(int flags)
     if (err) {
       err_msg += " " + std::string(err);
     }
-
 
     d->m_Handle = nullptr;
 

--- a/framework/src/util/Utils.h
+++ b/framework/src/util/Utils.h
@@ -46,7 +46,8 @@ bool IsBundleFile(const std::string& location);
  *         manifest file, false otherwise.
  * @throw std::runtime_error if the bundle manifest cannot be read.
  */
-bool OnlyContainsManifest(const std::shared_ptr<BundleResourceContainer>& resContainer);
+bool OnlyContainsManifest(
+  const std::shared_ptr<BundleResourceContainer>& resContainer);
 
 //-------------------------------------------------------------------
 // Framework storage
@@ -59,18 +60,18 @@ extern const std::string FWDIR_DEFAULT;
 std::string GetFrameworkDir(CoreBundleContext* ctx);
 
 /**
-* Optionally create and get the persistent storage path.
-*
-* @param ctx Pointer to the CoreBundleContext object.
-* @param leafDir The name of the leaf directory in the persistent storage path.
-* @param create Specify if the directory needs to be created if it doesn't already exist.
-*
-* @return A directory path or an empty string if no storage is available.
-*
-* @throw std::runtime_error if the storage directory is inaccessible
-*        or if there exists a file named @c leafDir in that directory
-*        or if the directory cannot be created when @c create is @c true.
-*/
+ * Optionally create and get the persistent storage path.
+ *
+ * @param ctx Pointer to the CoreBundleContext object.
+ * @param leafDir The name of the leaf directory in the persistent storage path.
+ * @param create Specify if the directory needs to be created if it doesn't already exist.
+ *
+ * @return A directory path or an empty string if no storage is available.
+ *
+ * @throw std::runtime_error if the storage directory is inaccessible
+ *        or if there exists a file named @c leafDir in that directory
+ *        or if the directory cannot be created when @c create is @c true.
+ */
 std::string GetPersistentStoragePath(CoreBundleContext* ctx,
                                      const std::string& leafDir,
                                      bool create = true);

--- a/framework/test/bench/ServiceTrackerTest.cpp
+++ b/framework/test/bench/ServiceTrackerTest.cpp
@@ -11,17 +11,16 @@
 #include "benchmark/benchmark.h"
 #include "fooservice.h"
 
-
 class ServiceTrackerFixture : public ::benchmark::Fixture
 {
 public:
   using benchmark::Fixture::SetUp;
   using benchmark::Fixture::TearDown;
-    
+
   void SetUp(const ::benchmark::State&)
   {
     using namespace cppmicroservices;
-    
+
     framework = std::make_shared<Framework>(FrameworkFactory().NewFramework());
     framework->Start();
   }
@@ -29,7 +28,7 @@ public:
   void TearDown(const ::benchmark::State&)
   {
     using namespace std::chrono;
-    
+
     framework->Stop();
     framework->WaitForStop(milliseconds::zero());
   }
@@ -40,12 +39,13 @@ public:
 };
 
 /// Benchmark how long it takes to open a service tracker using a service reference
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithSvcRef)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithSvcRef)
+(benchmark::State& state)
 {
   using namespace std::chrono;
   using namespace benchmark::test;
   using namespace cppmicroservices;
-  
+
   auto fc = framework->GetBundleContext();
   auto serviceReg = fc.RegisterService<Foo>(std::make_shared<FooImpl>());
   ServiceTracker<Foo> fooTracker(fc, serviceReg.GetReference<Foo>());
@@ -61,12 +61,13 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithSvcRef)(benchmar
 }
 
 /// Benchmark how long it takes to open a service tracker using a bundle context
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)
+(benchmark::State& state)
 {
   using namespace std::chrono;
   using namespace benchmark::test;
   using namespace cppmicroservices;
-  
+
   auto fc = framework->GetBundleContext();
   auto serviceReg = fc.RegisterService<Foo>(std::make_shared<FooImpl>());
   ServiceTracker<Foo> fooTracker(fc);
@@ -81,12 +82,13 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)(b
 }
 
 /// Benchmark how long it takes to open a service tracker using an interface name string
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)
+(benchmark::State& state)
 {
   using namespace std::chrono;
   using namespace benchmark::test;
   using namespace cppmicroservices;
-  
+
   auto fc = framework->GetBundleContext();
   auto serviceReg = fc.RegisterService<Foo>(std::make_shared<FooImpl>());
   ServiceTracker<Foo> fooTracker(fc, std::string("benchmark::test::Foo"));
@@ -103,11 +105,12 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)(b
 
 /// Benchmark service tracker scalability
 /// How do service trackers perform as the number of service tracker objects grow?
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalability)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalability)
+(benchmark::State& state)
 {
   using namespace benchmark::test;
   using namespace cppmicroservices;
-  
+
   auto fc = framework->GetBundleContext();
 
   int64_t maxServiceTrackers{ state.range(0) };
@@ -129,7 +132,9 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalability)(benchmark::
 }
 
 /// Benchmark service tracker scalability (use case: one ServiceTracker, multiple service impls)
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTrackerScalability)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture,
+                   MultipleImplOneInterfaceServiceTrackerScalability)
+(benchmark::State& state)
 {
   using namespace benchmark::test;
   using namespace cppmicroservices;
@@ -142,7 +147,8 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTracker
   for (int64_t i = 0; i < maxServices; ++i) {
     impls.emplace_back(std::make_shared<FooImpl>());
   }
-  std::unique_ptr<ServiceTracker<Foo>> tracker = std::make_unique<ServiceTracker<Foo>>(fc);
+  std::unique_ptr<ServiceTracker<Foo>> tracker =
+    std::make_unique<ServiceTracker<Foo>>(fc);
   tracker->Open();
 
   for (auto _ : state) {
@@ -154,7 +160,9 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, MultipleImplOneInterfaceServiceTracker
   tracker->Close();
 }
 
-BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalabilityWithLDAPFilter)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceTrackerFixture,
+                   ServiceTrackerScalabilityWithLDAPFilter)
+(benchmark::State& state)
 {
   using namespace benchmark::test;
   using namespace cppmicroservices;
@@ -164,7 +172,9 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalabilityWithLDAPFilte
   int64_t maxServiceTrackers{ state.range(0) };
   std::vector<std::unique_ptr<ServiceTracker<Foo>>> trackers;
   for (int64_t i = 0; i < maxServiceTrackers; ++i) {
-    auto fooTracker = std::make_unique<ServiceTracker<Foo>>(fc, cppmicroservices::LDAPFilter(std::string("(bundle.symbolic_name=main)")));
+    auto fooTracker = std::make_unique<ServiceTracker<Foo>>(
+      fc,
+      cppmicroservices::LDAPFilter(std::string("(bundle.symbolic_name=main)")));
     fooTracker->Open();
     trackers.emplace_back(std::move(fooTracker));
   }
@@ -180,19 +190,25 @@ BENCHMARK_DEFINE_F(ServiceTrackerFixture, ServiceTrackerScalabilityWithLDAPFilte
 }
 
 // Register benchmark functions
-BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithSvcRef)->UseManualTime();
-BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)->UseManualTime();
-BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)->UseManualTime();
+BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithSvcRef)
+  ->UseManualTime();
+BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)
+  ->UseManualTime();
+BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)
+  ->UseManualTime();
 
 // Run this benchmark for each Arg(...) call, passing in the parameter value to the benchmark.
-BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalability)->Arg(1)
-                                                                      ->Arg(4000)
-                                                                      ->Arg(10000);
+BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalability)
+  ->Arg(1)
+  ->Arg(4000)
+  ->Arg(10000);
 BENCHMARK_REGISTER_F(ServiceTrackerFixture,
-                     MultipleImplOneInterfaceServiceTrackerScalability)->Arg(1)
-                                                                       ->Arg(4000)
-                                                                       ->Arg(10000);
-BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalabilityWithLDAPFilter)->Arg(1)
-                                                                                    ->Arg(4000)
-                                                                                    ->Arg(10000);
-                               
+                     MultipleImplOneInterfaceServiceTrackerScalability)
+  ->Arg(1)
+  ->Arg(4000)
+  ->Arg(10000);
+BENCHMARK_REGISTER_F(ServiceTrackerFixture,
+                     ServiceTrackerScalabilityWithLDAPFilter)
+  ->Arg(1)
+  ->Arg(4000)
+  ->Arg(10000);

--- a/framework/test/bench/ldappropexpr.cpp
+++ b/framework/test/bench/ldappropexpr.cpp
@@ -1,10 +1,10 @@
-#include <cppmicroservices/LDAPProp.h>
 #include "benchmark/benchmark.h"
+#include <cppmicroservices/LDAPProp.h>
 
 static void ConstructFilterIncremental(benchmark::State& state)
 {
   using namespace cppmicroservices;
-  
+
   LDAPPropExpr expr;
   LDAPPropExpr secondaryExpr;
   for (auto _ : state) {
@@ -18,11 +18,11 @@ static void ConstructFilterIncremental(benchmark::State& state)
 static void ConstructFilterNotOperator(benchmark::State& state)
 {
   using namespace cppmicroservices;
-  
+
   LDAPPropExpr expr;
   for (auto _ : state) {
-    expr  = !LDAPProp("IsDynamic");
-    expr |=  LDAPProp("IsDynamic") != "false";
+    expr = !LDAPProp("IsDynamic");
+    expr |= LDAPProp("IsDynamic") != "false";
   };
 }
 

--- a/framework/test/bench/servicequery.cpp
+++ b/framework/test/bench/servicequery.cpp
@@ -20,16 +20,17 @@ public:
   {
     using namespace cppmicroservices;
     using namespace benchmark::test;
-    
+
     framework = std::make_shared<Framework>(FrameworkFactory().NewFramework());
     framework->Start();
-    (void)framework->GetBundleContext().RegisterService<Foo>(std::make_shared<FooImpl>());
+    (void)framework->GetBundleContext().RegisterService<Foo>(
+      std::make_shared<FooImpl>());
   }
-    
+
   void TearDown(const ::benchmark::State&)
   {
     using namespace std::chrono;
-    
+
     framework->Stop();
     framework->WaitForStop(milliseconds::zero());
   }
@@ -39,45 +40,59 @@ public:
   std::shared_ptr<cppmicroservices::Framework> framework;
 };
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetServiceReferenceByInterface)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture, GetServiceReferenceByInterface)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReference<benchmark::test::Foo>();
+    (void)framework->GetBundleContext()
+      .GetServiceReference<benchmark::test::Foo>();
   }
 }
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetServiceReferenceByClassName)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture, GetServiceReferenceByClassName)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReference("benchmark::test::Foo");
+    (void)framework->GetBundleContext().GetServiceReference(
+      "benchmark::test::Foo");
   }
 }
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByInterface)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByInterface)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReferences<benchmark::test::Foo>();
+    (void)framework->GetBundleContext()
+      .GetServiceReferences<benchmark::test::Foo>();
   }
 }
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByClassName)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByClassName)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReferences("benchmark::test::Foo");
+    (void)framework->GetBundleContext().GetServiceReferences(
+      "benchmark::test::Foo");
   }
 }
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByClassNameAndLDAPFilter)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture,
+                   GetAllServiceReferencesByClassNameAndLDAPFilter)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReferences("benchmark::test::Foo", "(objectclass=Foo)");
+    (void)framework->GetBundleContext().GetServiceReferences(
+      "benchmark::test::Foo", "(objectclass=Foo)");
   }
 }
 
-BENCHMARK_DEFINE_F(ServiceFixture, GetAllServiceReferencesByInterfaceAndLDAPFilter)(benchmark::State& state)
+BENCHMARK_DEFINE_F(ServiceFixture,
+                   GetAllServiceReferencesByInterfaceAndLDAPFilter)
+(benchmark::State& state)
 {
   for (auto _ : state) {
-    (void)framework->GetBundleContext().GetServiceReferences<benchmark::test::Foo>("(objectclass=Foo)");
+    (void)framework->GetBundleContext()
+      .GetServiceReferences<benchmark::test::Foo>("(objectclass=Foo)");
   }
 }
 
@@ -86,5 +101,7 @@ BENCHMARK_REGISTER_F(ServiceFixture, GetServiceReferenceByInterface);
 BENCHMARK_REGISTER_F(ServiceFixture, GetServiceReferenceByClassName);
 BENCHMARK_REGISTER_F(ServiceFixture, GetAllServiceReferencesByInterface);
 BENCHMARK_REGISTER_F(ServiceFixture, GetAllServiceReferencesByClassName);
-BENCHMARK_REGISTER_F(ServiceFixture, GetAllServiceReferencesByClassNameAndLDAPFilter);
-BENCHMARK_REGISTER_F(ServiceFixture, GetAllServiceReferencesByInterfaceAndLDAPFilter);
+BENCHMARK_REGISTER_F(ServiceFixture,
+                     GetAllServiceReferencesByClassNameAndLDAPFilter);
+BENCHMARK_REGISTER_F(ServiceFixture,
+                     GetAllServiceReferencesByInterfaceAndLDAPFilter);

--- a/framework/test/bundles/libStartBundleA/TestStartBundleA.cpp
+++ b/framework/test/bundles/libStartBundleA/TestStartBundleA.cpp
@@ -38,20 +38,21 @@ public:
 
   void Start(BundleContext context)
   {
-      auto bundles = context.GetBundles();
-      auto bundleA = std::find_if(bundles.begin(),
-                                    bundles.end(),
-                                    [](const cppmicroservices::Bundle& b) { return "TestBundleA" == b.GetSymbolicName(); });
+    auto bundles = context.GetBundles();
+    auto bundleA = std::find_if(
+      bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& b) {
+        return "TestBundleA" == b.GetSymbolicName();
+      });
 
-      if (std::end(bundles) != bundleA)
-      {
-        (*bundleA).Start();
-      }
+    if (std::end(bundles) != bundleA) {
+      (*bundleA).Start();
+    }
   }
 
-  void Stop(BundleContext) { }
+  void Stop(BundleContext) {}
 };
 
 }
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::TestStartBundleAActivator)
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::TestStartBundleAActivator)

--- a/framework/test/bundles/libStopBundleA/TestStopBundleA.cpp
+++ b/framework/test/bundles/libStopBundleA/TestStopBundleA.cpp
@@ -36,22 +36,23 @@ public:
   TestStopBundleAActivator() {}
   ~TestStopBundleAActivator() {}
 
-  void Start(BundleContext) { }
+  void Start(BundleContext) {}
 
-  void Stop(BundleContext context) 
+  void Stop(BundleContext context)
   {
     auto bundles = context.GetBundles();
-    auto bundleA = std::find_if(bundles.begin(),
-                                bundles.end(),
-                                [](const cppmicroservices::Bundle& b) { return "TestBundleA" == b.GetSymbolicName(); });
+    auto bundleA = std::find_if(
+      bundles.begin(), bundles.end(), [](const cppmicroservices::Bundle& b) {
+        return "TestBundleA" == b.GetSymbolicName();
+      });
 
-    if (std::end(bundles) != bundleA)
-    {
+    if (std::end(bundles) != bundleA) {
       (*bundleA).Stop();
-    }      
+    }
   }
 };
 
 }
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::TestStopBundleAActivator)
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::TestStopBundleAActivator)

--- a/framework/test/bundles/libWithDeepManifest/TestBundleDeep.cpp
+++ b/framework/test/bundles/libWithDeepManifest/TestBundleDeep.cpp
@@ -28,14 +28,14 @@ namespace cppmicroservices {
 class TestBundleDeepActivator : public BundleActivator
 {
 public:
-
   TestBundleDeepActivator() {}
   ~TestBundleDeepActivator() {}
 
-  void Start(BundleContext) { }
-  void Stop(BundleContext) { }
+  void Start(BundleContext) {}
+  void Stop(BundleContext) {}
 };
 
 }
 
-CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::TestBundleDeepActivator)
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(
+  cppmicroservices::TestBundleDeepActivator)

--- a/framework/test/driver/BundleHooksTest.cpp
+++ b/framework/test/driver/BundleHooksTest.cpp
@@ -104,8 +104,7 @@ public:
 class TestBundleEventHookFailure : public BundleEventHook
 {
 public:
-  void Event(const BundleEvent&,
-             ShrinkableVector<BundleContext>& )
+  void Event(const BundleEvent&, ShrinkableVector<BundleContext>&)
   {
     throw std::runtime_error("TestBundleEventHookFailure Event exception");
   }
@@ -214,19 +213,19 @@ void TestEventHookFailure(const Framework& framework)
                              "Test for expected number of framework events");
 
   std::for_each(
-      listener.events.begin(),
-      listener.events.end(),
-      [](const FrameworkEvent& evt) {
-        US_TEST_CONDITION_REQUIRED(evt.GetThrowable() != nullptr,
-                                    "Test for the existence of an exception");
-        US_TEST_CONDITION_REQUIRED(evt.GetType() ==
-                                    FrameworkEvent::Type::FRAMEWORK_WARNING,
-                                    "Test for the correct framework event type");
-        std::string msg(evt.GetMessage());
-        US_TEST_CONDITION_REQUIRED(
+    listener.events.begin(),
+    listener.events.end(),
+    [](const FrameworkEvent& evt) {
+      US_TEST_CONDITION_REQUIRED(evt.GetThrowable() != nullptr,
+                                 "Test for the existence of an exception");
+      US_TEST_CONDITION_REQUIRED(evt.GetType() ==
+                                   FrameworkEvent::Type::FRAMEWORK_WARNING,
+                                 "Test for the correct framework event type");
+      std::string msg(evt.GetMessage());
+      US_TEST_CONDITION_REQUIRED(
         std::string::npos != msg.find("Failed to call Bundle EventHook #"),
         "Test for the correct event message");
-      });
+    });
 
   bundleA.Stop();
   eventHookReg.Unregister();
@@ -274,7 +273,7 @@ void TestFindHookFailure(const Framework& framework)
 
 } // end unnamed namespace
 
-int BundleHooksTest(int /*argc*/, char* /*argv*/ [])
+int BundleHooksTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("BundleHooksTest");
 

--- a/framework/test/driver/BundleRegistryConcurrencyTest.cpp
+++ b/framework/test/driver/BundleRegistryConcurrencyTest.cpp
@@ -49,12 +49,9 @@ std::unique_lock<std::mutex> io_lock()
 inline void InstallTestBundleNoErrorHandling(BundleContext frameworkCtx,
                                              const std::string& bundleName)
 {
-  auto bundles = frameworkCtx.InstallBundles(testing::LIB_PATH
-                              + util::DIR_SEP
-                              + US_LIB_PREFIX
-                              + bundleName
-                              + US_LIB_POSTFIX
-                              + US_LIB_EXT);
+  auto bundles = frameworkCtx.InstallBundles(testing::LIB_PATH + util::DIR_SEP +
+                                             US_LIB_PREFIX + bundleName +
+                                             US_LIB_POSTFIX + US_LIB_EXT);
 
   for (auto& b : bundles) {
     std::unique_lock<std::mutex> lock = io_lock();
@@ -136,15 +133,16 @@ void TestConcurrent(const Framework& f)
     th.join();
   }
 
-  io_lock(), US_TEST_CONDITION(numTestBundles == f.GetBundleContext().GetBundles().size(),
-                    "Test for correct number of installed bundles")
+  io_lock(), US_TEST_CONDITION(numTestBundles ==
+                                 f.GetBundleContext().GetBundles().size(),
+                               "Test for correct number of installed bundles")
 }
 #  endif
 
 } // end anonymous namespace
 #endif
 
-int BundleRegistryConcurrencyTest(int /*argc*/, char* /*argv*/ [])
+int BundleRegistryConcurrencyTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("BundleRegistryConcurrencyTest")
 

--- a/framework/test/driver/FrameworkListenerTest.cpp
+++ b/framework/test/driver/FrameworkListenerTest.cpp
@@ -45,7 +45,8 @@ void testStartStopFrameworkEvents()
 
   TestFrameworkListener l;
   f.Init();
-  f.GetBundleContext().AddFrameworkListener(&l, &TestFrameworkListener::frameworkEvent);
+  f.GetBundleContext().AddFrameworkListener(
+    &l, &TestFrameworkListener::frameworkEvent);
   f.Start();
   f.Stop();
 
@@ -55,7 +56,7 @@ void testStartStopFrameworkEvents()
   US_TEST_CONDITION_REQUIRED(
     l.CheckEvents(events),
     "Test for the correct number and order of Framework start/stop events.");
-  
+
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 
@@ -148,7 +149,7 @@ void testAddRemoveFrameworkListener()
   US_TEST_CONDITION(
     count2 == 1,
     "Test that multiple framework listeners were NOT called after removal");
-  
+
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
@@ -176,7 +177,7 @@ void testFrameworkListenersAfterFrameworkStop()
   f.Start(); // generate framework event (started) with no listener to see it
   US_TEST_CONDITION(events == 1,
                     "Test that listeners were released on Framework Stop");
-  
+
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
@@ -277,7 +278,7 @@ void testFrameworkListenerThrowingInvariant()
     std::string::npos !=
       logstream.str().find("A Framework Listener threw an exception:"),
     "Test for internal log message from Framework event handler");
-  
+
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
@@ -319,7 +320,7 @@ void testDeadLock()
 
 } // end anonymous namespace
 
-int FrameworkListenerTest(int /*argc*/, char* /*argv*/ [])
+int FrameworkListenerTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("FrameworkListenerTest");
 

--- a/framework/test/driver/HelgrindTest.cpp
+++ b/framework/test/driver/HelgrindTest.cpp
@@ -44,7 +44,7 @@ void WrongLockOrder()
   std::unique_lock<std::mutex> l2(m1);
 }
 
-int HelgrindTest(int /*argc*/, char* /*argv*/ [])
+int HelgrindTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("HelgrindTest");
 

--- a/framework/test/driver/MemcheckTest.cpp
+++ b/framework/test/driver/MemcheckTest.cpp
@@ -27,7 +27,7 @@ limitations under the License.
  * sanitizer (using Clang or GCC) or memcheck.
  */
 
-int MemcheckTest(int /*argc*/, char* /*argv*/ [])
+int MemcheckTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("MemcheckTest");
 

--- a/framework/test/driver/MultipleListenersTest.cpp
+++ b/framework/test/driver/MultipleListenersTest.cpp
@@ -504,7 +504,7 @@ void testConcurrentAddRemove(std::string listenerStr)
 #endif // US_ENABLE_THREADING_SUPPORT
 }
 
-int MultipleListenersTest(int /*argc*/, char* /*argv*/ [])
+int MultipleListenersTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("MultipleListenersTest");
   testMultipleListeners();

--- a/framework/test/driver/ResourceCompilerTest.cpp
+++ b/framework/test/driver/ResourceCompilerTest.cpp
@@ -1321,7 +1321,7 @@ void testManifestWithNullTerminator(const std::string& rcbinpath,
 }
 }
 
-int ResourceCompilerTest(int /*argc*/, char* /*argv*/ [])
+int ResourceCompilerTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ResourceCompilerTest");
 
@@ -1329,9 +1329,9 @@ int ResourceCompilerTest(int /*argc*/, char* /*argv*/ [])
 
   auto rcbinpath = testing::RCC_PATH;
   /*
-  * If ResourceCompiler executable is not found, we can't run the tests, we
-  * mark it as a failure and exit
-  */
+   * If ResourceCompiler executable is not found, we can't run the tests, we
+   * mark it as a failure and exit
+   */
   std::ifstream binf(rcbinpath.c_str());
   if (!binf.good()) {
     US_TEST_FAILED_MSG(<< "Cannot find usResourceCompiler executable:"

--- a/framework/test/driver/ServiceFactoryTest.cpp
+++ b/framework/test/driver/ServiceFactoryTest.cpp
@@ -293,14 +293,15 @@ void TestServiceFactoryBundleScopeErrorConditions()
                              "Test for correct framwork event type");
   US_TEST_CONDITION_REQUIRED(fwEvents[0].GetBundle() == context.GetBundle(),
                              "Test for correct framwork event bundle");
-  US_TEST_NO_EXCEPTION_REQUIRED(try {
-    std::rethrow_exception(fwEvents[0].GetThrowable());
-    US_TEST_FAILED_MSG(<< "Exception not thrown");
-  } catch (const ServiceException& exc) {
-    US_TEST_CONDITION_REQUIRED(
-      exc.GetType() == ServiceException::FACTORY_RECURSION,
-      "Test for correct service exception type (recursion)");
-  });
+  US_TEST_NO_EXCEPTION_REQUIRED(
+    try {
+      std::rethrow_exception(fwEvents[0].GetThrowable());
+      US_TEST_FAILED_MSG(<< "Exception not thrown");
+    } catch (const ServiceException& exc) {
+      US_TEST_CONDITION_REQUIRED(
+        exc.GetType() == ServiceException::FACTORY_RECURSION,
+        "Test for correct service exception type (recursion)");
+    });
 #endif
 
 #ifdef US_ENABLE_THREADING_SUPPORT
@@ -475,7 +476,7 @@ void TestConcurrentServiceFactory()
 }
 #endif
 
-int ServiceFactoryTest(int /*argc*/, char* /*argv*/ [])
+int ServiceFactoryTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ServiceFactoryTest");
 

--- a/framework/test/driver/ServiceHooksTest.cpp
+++ b/framework/test/driver/ServiceHooksTest.cpp
@@ -586,7 +586,8 @@ void TestListenerHookFailure(const Framework& framework)
   auto fwkListenerToken = framework.GetBundleContext().AddFrameworkListener(
     std::bind(&TestFrameworkListener::Event, &listener, std::placeholders::_1));
 
-  auto listenerToken = framework.GetBundleContext().AddServiceListener([](const ServiceEvent&) { });
+  auto listenerToken =
+    framework.GetBundleContext().AddServiceListener([](const ServiceEvent&) {});
 
   framework.GetBundleContext().RemoveListener(std::move(listenerToken));
 
@@ -614,7 +615,7 @@ void TestListenerHookFailure(const Framework& framework)
 
 } // end unnamed namespace
 
-int ServiceHooksTest(int /*argc*/, char* /*argv*/ [])
+int ServiceHooksTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ServiceHooksTest");
 

--- a/framework/test/driver/ServiceListenerTest.cpp
+++ b/framework/test/driver/ServiceListenerTest.cpp
@@ -515,7 +515,7 @@ void frameSL25a(const Framework& framework)
   }
 }
 
-int ServiceListenerTest(int /*argc*/, char* /*argv*/ [])
+int ServiceListenerTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ServiceListenerTest");
 

--- a/framework/test/driver/ServiceRegistryPerformanceTest.cpp
+++ b/framework/test/driver/ServiceRegistryPerformanceTest.cpp
@@ -261,7 +261,7 @@ void ServiceRegistryPerformanceTest::UnregisterServices()
   regs.clear();
 }
 
-int ServiceRegistryPerformanceTest(int /*argc*/, char* /*argv*/ [])
+int ServiceRegistryPerformanceTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ServiceRegistryPerformanceTest")
 

--- a/framework/test/driver/ServiceTemplateTest.cpp
+++ b/framework/test/driver/ServiceTemplateTest.cpp
@@ -140,7 +140,7 @@ struct MyFactory3 : public cppmicroservices::ServiceFactory
 
 using namespace cppmicroservices;
 
-int ServiceTemplateTest(int /*argc*/, char* /*argv*/ [])
+int ServiceTemplateTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ServiceTemplateTest");
 

--- a/framework/test/driver/ShrinkableMapTest.cpp
+++ b/framework/test/driver/ShrinkableMapTest.cpp
@@ -44,7 +44,7 @@ public:
 
 using namespace cppmicroservices;
 
-int ShrinkableMapTest(int /*argc*/, char* /*argv*/ [])
+int ShrinkableMapTest(int /*argc*/, char* /*argv*/[])
 {
   US_TEST_BEGIN("ShrinkableMapTest");
 

--- a/framework/test/gtest/AnyMapTest.cpp
+++ b/framework/test/gtest/AnyMapTest.cpp
@@ -351,18 +351,20 @@ TEST(AnyMapTest, GeneralUsage)
   });
 }
 
-
-cppmicroservices::AnyMap manifest_from_cache(const cppmicroservices::any_map::key_type& key, cppmicroservices::any_map& cache)
+cppmicroservices::AnyMap manifest_from_cache(
+  const cppmicroservices::any_map::key_type& key,
+  cppmicroservices::any_map& cache)
 {
   using namespace cppmicroservices;
-  
+
   AnyMap& bundles = ref_any_cast<AnyMap>(cache["bundles"]);
   if (bundles.find(key) != std::end(bundles)) {
     try {
       AnyMap result = std::move(ref_any_cast<AnyMap>(bundles[key]));
       bundles.erase(key);
       return result;
-    } catch (...) {}
+    } catch (...) {
+    }
   }
   return AnyMap(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
 }
@@ -383,17 +385,17 @@ TEST(AnyMapTest, ManifestFromCache)
   cache_bundle2["e"] = std::string("E");
   cache_bundle2["f"] = std::string("F");
   auto cache_bundle2_copy = cache_bundle2;
-  
+
   cache_bundles.emplace(std::string("bundle1"), std::move(cache_bundle1));
   cache_bundles.emplace(std::string("bundle2"), std::move(cache_bundle2));
   cache["created"] = 1234567890;
   cache["version"] = 1;
-  cache.emplace(std::string("bundles"),std::move(cache_bundles));
+  cache.emplace(std::string("bundles"), std::move(cache_bundles));
   EXPECT_EQ(3, cache.size()); // created, version, bundles
 
   auto const& bundles = ref_any_cast<AnyMap>(cache.at("bundles"));
   EXPECT_EQ(2, bundles.size()); // bundle1, bundle2
-  
+
   auto bundle1 = manifest_from_cache(std::string("bundle1"), cache);
   EXPECT_EQ(cache_bundle1_copy, bundle1);
   EXPECT_EQ(1, bundles.size());

--- a/framework/test/gtest/AnyTest.cpp
+++ b/framework/test/gtest/AnyTest.cpp
@@ -178,7 +178,6 @@ TEST(AnyTest, AnyMapAny)
   EXPECT_EQ(anyMap.ToJSON(), "{\"1\" : 0.3, \"3\" : \"bonjour\"}");
 }
 
-
 TEST(AnyTest, AnyStringEscapeCharacters)
 {
   Any anyString = std::string("\"\\\b\f\n\r\t\x1f");
@@ -190,19 +189,15 @@ TEST(AnyTest, AnyToJSONWithFormatting)
   std::map<int, Any> emptyMap;
   std::vector<int> emptyVector;
 
-  std::map<int32_t, Any> mapToInsert = {
-    { 1, 0.3 }
-    , { 3, std::string("bonjour") }
-    , { 4, emptyMap }
-    , { 5, emptyVector }
-  };
-  std::vector<int32_t> numbers { 9, 8, 7 };
-  std::map<std::string, Any> map {
-    { "number", 5 }
-    , { "vector", numbers }
-    , { "map", mapToInsert }
-  };
- 
+  std::map<int32_t, Any> mapToInsert = { { 1, 0.3 },
+                                         { 3, std::string("bonjour") },
+                                         { 4, emptyMap },
+                                         { 5, emptyVector } };
+  std::vector<int32_t> numbers{ 9, 8, 7 };
+  std::map<std::string, Any> map{ { "number", 5 },
+                                  { "vector", numbers },
+                                  { "map", mapToInsert } };
+
   Any anyMap = map;
   std::string expected = R"({
     "map" : {
@@ -241,11 +236,13 @@ TEST(AnyTest, AnyMapComplex)
   EXPECT_EQ(anyMap.ToJSON(), toJSONRes);
 }
 
-TEST(AnyTest, AnyBadAnyCastException) {
+TEST(AnyTest, AnyBadAnyCastException)
+{
   const Any uncastableConstAny(0.0);
   Any uncastableAny(0.0);
 
-  EXPECT_THROW(any_cast<std::string>(uncastableConstAny), cppmicroservices::BadAnyCastException);
+  EXPECT_THROW(any_cast<std::string>(uncastableConstAny),
+               cppmicroservices::BadAnyCastException);
   EXPECT_THROW(any_cast<std::string>(uncastableAny),
                cppmicroservices::BadAnyCastException);
   EXPECT_THROW(ref_any_cast<std::string>(uncastableConstAny),
@@ -254,11 +251,17 @@ TEST(AnyTest, AnyBadAnyCastException) {
                cppmicroservices::BadAnyCastException);
 }
 
-struct no_eq {
+struct no_eq
+{
   bool operator==(const no_eq&) const = delete;
-  friend std::ostream& operator<<(std::ostream& os, no_eq const&) { os << "OOPS"; return os; }
+  friend std::ostream& operator<<(std::ostream& os, no_eq const&)
+  {
+    os << "OOPS";
+    return os;
+  }
 };
-TEST(AnyTest, AnyEquality) {
+TEST(AnyTest, AnyEquality)
+{
   EXPECT_EQ(Any(std::string("A")), Any(std::string("A")));
   EXPECT_NE(Any(std::string("A")), Any(std::string("B")));
   EXPECT_NE(Any(1), Any(std::string("A")));
@@ -271,10 +274,12 @@ TEST(AnyTest, AnyEquality) {
   EXPECT_EQ(Any(1.5), Any(1.5));
   EXPECT_NE(Any(1.5), Any(1.6));
 
-  Any no_eq_operator { no_eq() };
-  EXPECT_NE(no_eq_operator, no_eq_operator); // Since no_eq has the equality operator deleted, Any,
-                                             // by design, always returns FALSE when equality is
-                                             // checked.
+  Any no_eq_operator{ no_eq() };
+  EXPECT_NE(
+    no_eq_operator,
+    no_eq_operator); // Since no_eq has the equality operator deleted, Any,
+                     // by design, always returns FALSE when equality is
+                     // checked.
 
   AnyMap lhs(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
   lhs["int"] = 1;
@@ -286,7 +291,7 @@ TEST(AnyTest, AnyEquality) {
   submap["b"] = std::string("b");
   lhs["submap"] = submap;
 
-  AnyMap rhs = lhs; // make a copy of lhs
+  AnyMap rhs = lhs;    // make a copy of lhs
   EXPECT_EQ(lhs, rhs); // they should be equal
 
   rhs["int"] = 2;
@@ -294,6 +299,8 @@ TEST(AnyTest, AnyEquality) {
   rhs["int"] = 1;
   EXPECT_EQ(lhs, rhs); // now they should be equal again
   rhs.erase("int");
-  EXPECT_NE(lhs, rhs); // and finally, with the "int" element erased, they should not be equal
-                       // anymore. 
+  EXPECT_NE(
+    lhs,
+    rhs); // and finally, with the "int" element erased, they should not be equal
+          // anymore.
 }

--- a/framework/test/gtest/BundleActivatorTest.cpp
+++ b/framework/test/gtest/BundleActivatorTest.cpp
@@ -44,7 +44,8 @@ protected:
     ctx = f.GetBundleContext();
   }
 
-  ~BundleActivatorTest() { 
+  ~BundleActivatorTest()
+  {
     f.Stop();
     f.WaitForStop(std::chrono::milliseconds::zero());
   }

--- a/framework/test/gtest/BundleDeadLockTest.cpp
+++ b/framework/test/gtest/BundleDeadLockTest.cpp
@@ -39,8 +39,10 @@ TEST(BundleDeadLock, BundleActivatorCallsStart)
   ASSERT_TRUE(f);
   f.Start();
 
-  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA"));
-  auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestStartBundleA");
+  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(
+    f.GetBundleContext(), "TestBundleA"));
+  auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(),
+                                                      "TestStartBundleA");
   ASSERT_NO_THROW(bundle.Start());
 
   f.Stop();
@@ -53,8 +55,10 @@ TEST(BundleDeadLock, BundleActivatorCallsStop)
   ASSERT_TRUE(f);
   f.Start();
 
-  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA"));
-  auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestStopBundleA");
+  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(
+    f.GetBundleContext(), "TestBundleA"));
+  auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(),
+                                                      "TestStopBundleA");
   ASSERT_NO_THROW(bundle.Start());
   ASSERT_NO_THROW(bundle.Stop());
 
@@ -67,27 +71,26 @@ TEST(BundleDeadLock, BundleInstall0Throws)
   auto f = cppmicroservices::FrameworkFactory().NewFramework();
   ASSERT_TRUE(f);
   f.Start();
-  
+
   // Test that multiple calls to installing a bundle with the same symbolic name and
   // different paths produce the same result (i.e. an exception).
-  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA"));
-    
-  const std::string nonCanonicalBundleInstallPath(cppmicroservices::testing::LIB_PATH
-                                                  + cppmicroservices::util::DIR_SEP
-                                                  + "."
-                                                  + cppmicroservices::util::DIR_SEP
-                                                  + US_LIB_PREFIX
-                                                  + "TestBundleA"
-                                                  + US_LIB_POSTFIX
-                                                  + US_LIB_EXT);
+  ASSERT_NO_THROW((void)cppmicroservices::testing::InstallLib(
+    f.GetBundleContext(), "TestBundleA"));
+
+  const std::string nonCanonicalBundleInstallPath(
+    cppmicroservices::testing::LIB_PATH + cppmicroservices::util::DIR_SEP +
+    "." + cppmicroservices::util::DIR_SEP + US_LIB_PREFIX + "TestBundleA" +
+    US_LIB_POSTFIX + US_LIB_EXT);
   auto frameworkCtx = f.GetBundleContext();
-  ASSERT_THROW(frameworkCtx.InstallBundles(nonCanonicalBundleInstallPath), std::runtime_error);
-  
+  ASSERT_THROW(frameworkCtx.InstallBundles(nonCanonicalBundleInstallPath),
+               std::runtime_error);
+
   // This install call could hang if BundleRegistry::Install doesn't
   // implement proper RAII for resources that need to be cleaned up
   // in cases where BundleRegistry::Install0 throws.
-  ASSERT_THROW(frameworkCtx.InstallBundles(nonCanonicalBundleInstallPath), std::runtime_error);
-    
+  ASSERT_THROW(frameworkCtx.InstallBundles(nonCanonicalBundleInstallPath),
+               std::runtime_error);
+
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }

--- a/framework/test/gtest/BundleGetSymbolTest.cpp
+++ b/framework/test/gtest/BundleGetSymbolTest.cpp
@@ -41,74 +41,81 @@ using namespace cppmicroservices;
 
 class BundleGetSymbolTest : public ::testing::Test
 {
-protected:    
-    Framework f;
-    Bundle bd;
+protected:
+  Framework f;
+  Bundle bd;
 
 public:
-    BundleGetSymbolTest() : f(FrameworkFactory().NewFramework()){}
-    ~BundleGetSymbolTest() override = default;
+  BundleGetSymbolTest()
+    : f(FrameworkFactory().NewFramework())
+  {}
+  ~BundleGetSymbolTest() override = default;
 
-    void SetUp() override
-    {
-        f.Start();
-        auto bctx = f.GetBundleContext();
-        bd = cppmicroservices::testing::InstallLib(bctx, "TestBundleA");
-        bd.Start();
-    }
+  void SetUp() override
+  {
+    f.Start();
+    auto bctx = f.GetBundleContext();
+    bd = cppmicroservices::testing::InstallLib(bctx, "TestBundleA");
+    bd.Start();
+  }
 
-    void TearDown() override
-    {
-        bd.Stop();
-        f.Stop();
-    }
+  void TearDown() override
+  {
+    bd.Stop();
+    f.Stop();
+  }
 };
 
 // Test for invalid bundle
 TEST_F(BundleGetSymbolTest, TestGetSymbolInvalidBundleInput)
 {
-    Bundle b;
-    EXPECT_THROW(b.GetSymbol(nullptr,""),std::invalid_argument);
+  Bundle b;
+  EXPECT_THROW(b.GetSymbol(nullptr, ""), std::invalid_argument);
 }
 
 // Test for invalid symbol handle on valid bundle
 TEST_F(BundleGetSymbolTest, TestGetSymbolValidBundleWithInvalidSymbolName)
 {
-    EXPECT_THROW(bd.GetSymbol(nullptr,"_us_create_activator_TestBundleA"),std::invalid_argument);
+  EXPECT_THROW(bd.GetSymbol(nullptr, "_us_create_activator_TestBundleA"),
+               std::invalid_argument);
 }
 
 // Test for invalid symbol name on valid bundle
 TEST_F(BundleGetSymbolTest, TestGetSymbolValidBundleWithInvalidSymbolHandle)
 {
-    SharedLibrary sh(bd.GetLocation());
-    sh.Load();
- 
-    EXPECT_THROW(bd.GetSymbol(sh.GetHandle(),""),std::invalid_argument);
+  SharedLibrary sh(bd.GetLocation());
+  sh.Load();
+
+  EXPECT_THROW(bd.GetSymbol(sh.GetHandle(), ""), std::invalid_argument);
 }
 
 // Test for bundle which is not started but with valid inputs
 TEST_F(BundleGetSymbolTest, TestGetSymbolNotInstalledBundle)
 {
-    auto bctx =  f.GetBundleContext();
-    auto bdx = cppmicroservices::testing::InstallLib(bctx, "TestBundleA2");
-    
-    SharedLibrary sh(bdx.GetLocation());
-    sh.Load();
+  auto bctx = f.GetBundleContext();
+  auto bdx = cppmicroservices::testing::InstallLib(bctx, "TestBundleA2");
 
-    EXPECT_THROW(bdx.GetSymbol(sh.GetHandle(),"_us_create_activator_TestBundleA2"), std::runtime_error);
+  SharedLibrary sh(bdx.GetLocation());
+  sh.Load();
 
-    sh.Unload();
+  EXPECT_THROW(
+    bdx.GetSymbol(sh.GetHandle(), "_us_create_activator_TestBundleA2"),
+    std::runtime_error);
+
+  sh.Unload();
 }
 
 // Test for valid bundle and valid input
 TEST_F(BundleGetSymbolTest, TestGetSymbolValidInput)
 {
-    SharedLibrary sh(bd.GetLocation());
-    sh.Load();
+  SharedLibrary sh(bd.GetLocation());
+  sh.Load();
 
-    EXPECT_TRUE(bd.GetSymbol(sh.GetHandle(),"_us_create_activator_TestBundleA") != nullptr) << "Error : Empty symbol returned from Bundle::GetSymbol !\n";
+  EXPECT_TRUE(
+    bd.GetSymbol(sh.GetHandle(), "_us_create_activator_TestBundleA") != nullptr)
+    << "Error : Empty symbol returned from Bundle::GetSymbol !\n";
 
-    sh.Unload();
+  sh.Unload();
 }
 
 #endif

--- a/framework/test/gtest/BundleManifestTest.cpp
+++ b/framework/test/gtest/BundleManifestTest.cpp
@@ -265,14 +265,14 @@ TEST_F(BundleManifestTest, DirectManifestInstallNoSymbolicName)
     // We need to have at least one entry in the manifest to check and make sure it has what's
     // required. This is because if the manifest is empty, it is assumed that we are NOT injecting a
     // manifest and we go through the standard install by reading the manifest from the bundle
-    // itself. 
-    { "foo" , std::string("bar") }
+    // itself.
+    { "foo", std::string("bar") }
   };
   manifests["TestBundleA"] = cppmicroservices::AnyMap(testBundleAManifest);
 
   auto const libPath = fullLibPath("TestBundleA");
 
-  EXPECT_THROW( { ctx.InstallBundles(libPath, manifests); }, std::runtime_error);
+  EXPECT_THROW({ ctx.InstallBundles(libPath, manifests); }, std::runtime_error);
 }
 
 TEST_F(BundleManifestTest, DirectManifestInstallBadLocation)

--- a/framework/test/gtest/BundleObjFileTest.cpp
+++ b/framework/test/gtest/BundleObjFileTest.cpp
@@ -20,8 +20,8 @@
 
 =============================================================================*/
 
-#include "cppmicroservices/util/BundleObjFactory.h"
 #include "cppmicroservices/util/BundleObjFile.h"
+#include "cppmicroservices/util/BundleObjFactory.h"
 
 #include "cppmicroservices/util/FileSystem.h"
 
@@ -33,56 +33,58 @@
 #include "gtest/gtest.h"
 
 namespace {
-#if defined (US_BUILD_SHARED_LIBS)
-const std::string testBundlePath = cppmicroservices::testing::LIB_PATH
-                                   + cppmicroservices::util::DIR_SEP
-                                   + US_LIB_PREFIX
-                                   + "TestBundleRL"
-                                   + US_LIB_POSTFIX
-                                   + US_LIB_EXT;
+#if defined(US_BUILD_SHARED_LIBS)
+const std::string testBundlePath =
+  cppmicroservices::testing::LIB_PATH + cppmicroservices::util::DIR_SEP +
+  US_LIB_PREFIX + "TestBundleRL" + US_LIB_POSTFIX + US_LIB_EXT;
 #else
-const std::string testBundlePath = cppmicroservices::testing::BIN_PATH
-                                   + cppmicroservices::util::DIR_SEP
-                                   + "usFrameworkTests"
-                                   + US_EXE_EXT;
+const std::string testBundlePath = cppmicroservices::testing::BIN_PATH +
+                                   cppmicroservices::util::DIR_SEP +
+                                   "usFrameworkTests" + US_EXE_EXT;
 #endif
 }
 
 TEST(BundleObjFile, InvalidLocation)
 {
-  ASSERT_THROW(cppmicroservices::BundleObjFactory().CreateBundleFileObj("/does/not/exist/bogus.bundle"),
-    cppmicroservices::InvalidObjFileException);
+  ASSERT_THROW(cppmicroservices::BundleObjFactory().CreateBundleFileObj(
+                 "/does/not/exist/bogus.bundle"),
+               cppmicroservices::InvalidObjFileException);
 }
 
 TEST(BundleObjFile, InvalidBinaryFileFormat)
 {
-  cppmicroservices::testing::File tempFile = cppmicroservices::testing::MakeUniqueTempFile(cppmicroservices::testing::GetTempDirectory());
+  cppmicroservices::testing::File tempFile =
+    cppmicroservices::testing::MakeUniqueTempFile(
+      cppmicroservices::testing::GetTempDirectory());
   std::string invalidFileFormat(tempFile.Path);
-  ASSERT_TRUE(cppmicroservices::util::Exists(invalidFileFormat)) << invalidFileFormat + " should exist on disk.";
-  ASSERT_THROW(cppmicroservices::BundleObjFactory().CreateBundleFileObj(invalidFileFormat),
+  ASSERT_TRUE(cppmicroservices::util::Exists(invalidFileFormat))
+    << invalidFileFormat + " should exist on disk.";
+  ASSERT_THROW(
+    cppmicroservices::BundleObjFactory().CreateBundleFileObj(invalidFileFormat),
     cppmicroservices::InvalidObjFileException);
 }
 
 TEST(BundleObjFile, NonStandardBundleExt)
 {
-#if defined (US_BUILD_SHARED_LIBS)
-  std::string nonStandardExtBundlePath(cppmicroservices::testing::LIB_PATH
-                                       + cppmicroservices::util::DIR_SEP
-                                       + US_LIB_PREFIX
-                                       + "TestBundleExt"
-                                       + US_LIB_POSTFIX
-                                       + ".cppms");
-  ASSERT_TRUE(cppmicroservices::util::Exists(nonStandardExtBundlePath)) << nonStandardExtBundlePath + " should exist on disk.";
-  ASSERT_NO_THROW(cppmicroservices::BundleObjFactory().CreateBundleFileObj(nonStandardExtBundlePath));
+#if defined(US_BUILD_SHARED_LIBS)
+  std::string nonStandardExtBundlePath(
+    cppmicroservices::testing::LIB_PATH + cppmicroservices::util::DIR_SEP +
+    US_LIB_PREFIX + "TestBundleExt" + US_LIB_POSTFIX + ".cppms");
+  ASSERT_TRUE(cppmicroservices::util::Exists(nonStandardExtBundlePath))
+    << nonStandardExtBundlePath + " should exist on disk.";
+  ASSERT_NO_THROW(cppmicroservices::BundleObjFactory().CreateBundleFileObj(
+    nonStandardExtBundlePath));
 #endif
 }
 
 TEST(BundleObjFile, GetRawBundleResourceContainer)
 {
-#if defined (US_BUILD_SHARED_LIBS)
-  ASSERT_TRUE(cppmicroservices::util::Exists(testBundlePath)) << testBundlePath + " should exist on disk.";
+#if defined(US_BUILD_SHARED_LIBS)
+  ASSERT_TRUE(cppmicroservices::util::Exists(testBundlePath))
+    << testBundlePath + " should exist on disk.";
   ASSERT_NO_THROW({
-    auto bundleObj = cppmicroservices::BundleObjFactory().CreateBundleFileObj(testBundlePath);
+    auto bundleObj =
+      cppmicroservices::BundleObjFactory().CreateBundleFileObj(testBundlePath);
     auto data = bundleObj->GetRawBundleResourceContainer();
 
     ASSERT_TRUE(data);
@@ -91,28 +93,30 @@ TEST(BundleObjFile, GetRawBundleResourceContainer)
 #endif
 }
 
-#if defined (US_BUILD_SHARED_LIBS)
-#if defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
+#if defined(US_BUILD_SHARED_LIBS)
+#  if defined(US_PLATFORM_APPLE) || defined(US_PLATFORM_POSIX)
 TEST(BundleObjFile, MappedFile)
 {
   int fileDesc = open(testBundlePath.c_str(), O_RDONLY);
   struct stat sb;
   fstat(fileDesc, &sb);
-  off_t offset{0};
+  off_t offset{ 0 };
   off_t pa_offset = offset & ~(sysconf(_SC_PAGE_SIZE) - 1);
   /* offset for mmap() must be page aligned */
   size_t length = sb.st_size - offset;
   close(fileDesc);
 
-  cppmicroservices::MappedFile mappedBundleFile(testBundlePath, length, pa_offset);
+  cppmicroservices::MappedFile mappedBundleFile(
+    testBundlePath, length, pa_offset);
   ASSERT_TRUE(mappedBundleFile.GetData());
   ASSERT_GT(mappedBundleFile.GetSize(), 0u);
 
   ASSERT_NO_THROW({
-      cppmicroservices::MappedFile mappedBundleFile("/does/not/exist/bogus.bundle", 0, 0);
-      ASSERT_EQ(mappedBundleFile.GetData(), nullptr);
-      ASSERT_EQ(mappedBundleFile.GetSize(), 0u);
+    cppmicroservices::MappedFile mappedBundleFile(
+      "/does/not/exist/bogus.bundle", 0, 0);
+    ASSERT_EQ(mappedBundleFile.GetData(), nullptr);
+    ASSERT_EQ(mappedBundleFile.GetSize(), 0u);
   });
 }
-#endif // defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
-#endif // defined (US_BUILD_SHARED_LIBS)
+#  endif // defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
+#endif   // defined (US_BUILD_SHARED_LIBS)

--- a/framework/test/gtest/BundleResourceTest.cpp
+++ b/framework/test/gtest/BundleResourceTest.cpp
@@ -471,7 +471,7 @@ TEST_F(BundleResourceTest, testResourceFromExecutable)
   ASSERT_EQ(line, "meant to be compiled into the test driver");
 }
 
-// Note: Following test has broken encoding 
+// Note: Following test has broken encoding
 TEST_F(BundleResourceTest, testSpecialCharacters)
 {
   BundleResource res = testBundle.GetResource("special_chars.dummy.ptxt");

--- a/framework/test/gtest/BundleVersionTest.cpp
+++ b/framework/test/gtest/BundleVersionTest.cpp
@@ -139,9 +139,11 @@ TEST(BundleVersion, Comparison)
   ASSERT_TRUE(zeroVersion == BundleVersion::EmptyVersion());
   ASSERT_FALSE(zeroVersion == alphaVersion);
   ASSERT_FALSE(alphaVersion == betaVersion);
-  ASSERT_TRUE(BundleVersion::UndefinedVersion() == BundleVersion::UndefinedVersion());
-  ASSERT_THROW((void)(BundleVersion::UndefinedVersion() == zeroVersion.EmptyVersion()), 
-	           std::logic_error);
+  ASSERT_TRUE(BundleVersion::UndefinedVersion() ==
+              BundleVersion::UndefinedVersion());
+  ASSERT_THROW(
+    (void)(BundleVersion::UndefinedVersion() == zeroVersion.EmptyVersion()),
+    std::logic_error);
 }
 
 TEST(BundleVersion, ParseVersion)

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -371,7 +371,9 @@ TEST(FrameworkTest, Properties)
     f.GetSymbolicName(),
     Constants::SYSTEM_BUNDLE_SYMBOLICNAME); // "Test Framework Bundle Name"
   ASSERT_EQ(f.GetBundleId(), 0);            // "Test Framework Bundle Id"
-  ASSERT_EQ(f.GetVersion().ToString(), US_FRAMEWORK_VERSION_STR); // Test that the build correctly generated the version
+  ASSERT_EQ(
+    f.GetVersion().ToString(),
+    US_FRAMEWORK_VERSION_STR); // Test that the build correctly generated the version
 }
 
 TEST(Framework, LifeCycle)

--- a/framework/test/gtest/LogTest.cpp
+++ b/framework/test/gtest/LogTest.cpp
@@ -222,4 +222,3 @@ TEST(LogTest, testLogMultiThreaded)
 #  endif
 }
 #endif
-

--- a/framework/test/gtest/OpenFileHandleTest.cpp
+++ b/framework/test/gtest/OpenFileHandleTest.cpp
@@ -35,11 +35,11 @@ limitations under the License.
 #include "gtest/gtest.h"
 
 #if defined(US_PLATFORM_WINDOWS)
-#include "windows.h"
+#  include "windows.h"
 #elif defined(US_PLATFORM_POSIX)
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
+#  include <stdio.h>
+#  include <sys/types.h>
+#  include <unistd.h>
 #endif
 
 using namespace cppmicroservices;
@@ -50,7 +50,8 @@ static unsigned long GetHandleCountForCurrentProcess()
   auto processHandle = GetCurrentProcess();
   unsigned long handleCount{ 0 };
   if (!GetProcessHandleCount(processHandle, &handleCount)) {
-      throw std::runtime_error("GetProcessHandleCount failed to retrieve the number of open handles.");
+    throw std::runtime_error(
+      "GetProcessHandleCount failed to retrieve the number of open handles.");
   }
   return handleCount;
 #elif defined(US_PLATFORM_POSIX)
@@ -58,19 +59,20 @@ static unsigned long GetHandleCountForCurrentProcess()
   std::string command("lsof -p " + std::to_string(pid_t) + " | wc -l");
   FILE* fd = popen(command.c_str(), "r");
   if (nullptr == fd) {
-      throw std::runtime_error("popen failed.");
+    throw std::runtime_error("popen failed.");
   }
   std::string result;
   char buf[PATH_MAX];
   while (nullptr != fgets(buf, PATH_MAX, fd)) {
-      result += buf;
+    result += buf;
   }
   if (-1 == pclose(fd)) {
-      throw std::runtime_error("pclose failed.");
+    throw std::runtime_error("pclose failed.");
   }
   return stoul(result);
 #else
-  throw std::runtime_error("unsupported platform - can't get handle count for current process.")
+  throw std::runtime_error(
+    "unsupported platform - can't get handle count for current process.")
 #endif
 }
 
@@ -83,7 +85,7 @@ TEST(OpenFileHandleTest, InstallBundle)
   f.Start();
 
   auto handleCountBefore = GetHandleCountForCurrentProcess();
-  
+
 #if defined(US_BUILD_SHARED_LIBS)
   auto bundle =
     cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA");
@@ -93,7 +95,9 @@ TEST(OpenFileHandleTest, InstallBundle)
 #endif
 
   auto handleCountAfter = GetHandleCountForCurrentProcess();
-  ASSERT_EQ(handleCountBefore, handleCountAfter) << "The handle counts before and after installing a bundle should not differ.";
+  ASSERT_EQ(handleCountBefore, handleCountAfter)
+    << "The handle counts before and after installing a bundle should not "
+       "differ.";
 
   f.Stop();
   f.WaitForStop(std::chrono::seconds::zero());

--- a/framework/test/gtest/ServiceEventStreamOperatorTest.cpp
+++ b/framework/test/gtest/ServiceEventStreamOperatorTest.cpp
@@ -44,7 +44,8 @@ TEST(ServiceEventStreamOperatorTest, serviceEventTypeModified)
 
 TEST(ServiceEventStreamOperatorTest, serviceEventTypeModifiedEndMatch)
 {
-  serviceEventOperatorTest(ServiceEvent::SERVICE_MODIFIED_ENDMATCH, "MODIFIED_ENDMATCH");
+  serviceEventOperatorTest(ServiceEvent::SERVICE_MODIFIED_ENDMATCH,
+                           "MODIFIED_ENDMATCH");
 }
 
 TEST(ServiceEventStreamOperatorTest, serviceEventTypeDefault)

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -44,18 +44,16 @@ struct ITestServiceB
 };
 
 // Service implementations
-struct TestServiceAImpl
-  : public ITestServiceA
+struct TestServiceAImpl : public ITestServiceA
 {};
 
 // Mocks
-class MockFactory
-  : public ServiceFactory
+class MockFactory : public ServiceFactory
 {
 public:
   MOCK_METHOD2(GetService,
-               InterfaceMapConstPtr(const Bundle&
-                                    , const ServiceRegistrationBase&));
+               InterfaceMapConstPtr(const Bundle&,
+                                    const ServiceRegistrationBase&));
   MOCK_METHOD3(UngetService,
                void(const Bundle&,
                     const ServiceRegistrationBase&,
@@ -142,7 +140,8 @@ TEST_F(ServiceFactoryTest, TestGetServiceThrows)
     [&exceptionMsg](const cppmicroservices::FrameworkEvent& evt) {
       ASSERT_EQ(evt.GetType(), FrameworkEvent::FRAMEWORK_ERROR);
       ASSERT_NE(evt.GetThrowable(), nullptr);
-      EXPECT_NO_THROW(try {
+      EXPECT_NO_THROW(
+        try {
           std::rethrow_exception(evt.GetThrowable());
         } catch (const std::runtime_error& err) {
           ASSERT_STREQ(err.what(), exceptionMsg.c_str());
@@ -165,11 +164,9 @@ TEST_F(ServiceFactoryTest, TestGetServiceObjectThrows)
     .WillRepeatedly(testing::Throw(std::runtime_error(exceptionMsg)));
   EXPECT_CALL(*sf, UngetService(testing::_, testing::_, testing::_)).Times(0);
 
-  (void)context.RegisterService<ITestServiceA>(ToFactory(sf)
-                                               , {{
-                                                   Constants::SERVICE_SCOPE
-                                                   , Any(Constants::SCOPE_PROTOTYPE)
-                                                 }});
+  (void)context.RegisterService<ITestServiceA>(
+    ToFactory(sf),
+    { { Constants::SERVICE_SCOPE, Any(Constants::SCOPE_PROTOTYPE) } });
 
   auto sref = context.GetServiceReference<ITestServiceA>();
   auto serviceObjects = context.GetServiceObjects<ITestServiceA>(sref);

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -20,6 +20,7 @@
 
 =============================================================================*/
 
+#include "cppmicroservices/ServiceTracker.h"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/Framework.h"
@@ -28,7 +29,6 @@
 #include "cppmicroservices/GetBundleContext.h"
 #include "cppmicroservices/ServiceInterface.h"
 #include "cppmicroservices/ServiceReference.h"
-#include "cppmicroservices/ServiceTracker.h"
 
 #include "ServiceControlInterface.h"
 #include "TestUtils.h"
@@ -110,12 +110,24 @@ private:
 };
 
 template<typename Interface>
-class MockCustomizedServiceTracker : public cppmicroservices::ServiceTrackerCustomizer<Interface>
+class MockCustomizedServiceTracker
+  : public cppmicroservices::ServiceTrackerCustomizer<Interface>
 {
 public:
-    MOCK_METHOD(std::shared_ptr<Interface>, AddingService,(const ServiceReference<Interface>& reference), (override));
-    MOCK_METHOD(void, ModifiedService, (const ServiceReference<Interface>& reference, const std::shared_ptr<Interface>& service), (override));
-    MOCK_METHOD(void, RemovedService, (const ServiceReference<Interface>& reference, const std::shared_ptr<Interface>& service), (override));
+  MOCK_METHOD(std::shared_ptr<Interface>,
+              AddingService,
+              (const ServiceReference<Interface>& reference),
+              (override));
+  MOCK_METHOD(void,
+              ModifiedService,
+              (const ServiceReference<Interface>& reference,
+               const std::shared_ptr<Interface>& service),
+              (override));
+  MOCK_METHOD(void,
+              RemovedService,
+              (const ServiceReference<Interface>& reference,
+               const std::shared_ptr<Interface>& service),
+              (override));
 };
 
 class ServiceTrackerTestFixture : public ::testing::Test
@@ -124,7 +136,7 @@ public:
   ServiceTrackerTestFixture()
     : framework(FrameworkFactory().NewFramework()){};
   ~ServiceTrackerTestFixture() override = default;
-  
+
   void SetUp() override { framework.Start(); }
   void TearDown() override
   {
@@ -157,8 +169,7 @@ TEST_F(ServiceTrackerTestFixture, TestFilterString)
   context.RegisterService<MyInterfaceOne>(serviceOne);
   context.RegisterService<MyInterfaceTwo>(serviceTwo);
 
-  EXPECT_EQ(tracker.GetServiceReferences().size(), 1) <<
-                    "tracking count";
+  EXPECT_EQ(tracker.GetServiceReferences().size(), 1) << "tracking count";
 }
 
 TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
@@ -173,9 +184,8 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   std::string s1("cppmicroservices::TestBundleSService");
   ServiceReferenceU servref = context.GetServiceReference(s1 + "0");
 
-  ASSERT_TRUE(
-    servref) <<
-    "Test if registered service of id cppmicroservices::TestBundleSService0";
+  ASSERT_TRUE(servref)
+    << "Test if registered service of id cppmicroservices::TestBundleSService0";
 
   ServiceReference<ServiceControlInterface> servCtrlRef =
     context.GetServiceReference<ServiceControlInterface>();
@@ -199,7 +209,8 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   std::vector<ServiceReferenceU> sa2 = st1->GetServiceReferences();
 
   ASSERT_EQ(sa2.size(), 1) << "Checking ServiceTracker size";
-  ASSERT_EQ(s1 + "0", sa2[0].GetInterfaceId()) << "Checking service implementation name";
+  ASSERT_EQ(s1 + "0", sa2[0].GetInterfaceId())
+    << "Checking service implementation name";
 
 #ifdef US_ENABLE_THREADING_SUPPORT
   // 4. Test notifications via closing the tracker
@@ -216,22 +227,20 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
     });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    ASSERT_EQ(fut1.wait_for(std::chrono::milliseconds(1)),
-                                 US_FUTURE_TIMEOUT) <<
-                               "Waiter not notified yet";
-    ASSERT_EQ(fut2.wait_for(std::chrono::milliseconds(1)),
-                                 US_FUTURE_TIMEOUT) <<
-                               "Waiter not notified yet";
+    ASSERT_EQ(fut1.wait_for(std::chrono::milliseconds(1)), US_FUTURE_TIMEOUT)
+      << "Waiter not notified yet";
+    ASSERT_EQ(fut2.wait_for(std::chrono::milliseconds(1)), US_FUTURE_TIMEOUT)
+      << "Waiter not notified yet";
 
     st2.Close();
 
     // Closing the tracker should notify the waiters
     auto wait_until =
       std::chrono::steady_clock::now() + std::chrono::seconds(3);
-    ASSERT_EQ(fut1.wait_until(wait_until), US_FUTURE_READY) <<
-                               "Closed service tracker notifies waiters";
-    ASSERT_EQ(fut2.wait_until(wait_until), US_FUTURE_READY) <<
-                               "Closed service tracker notifies waiters";
+    ASSERT_EQ(fut1.wait_until(wait_until), US_FUTURE_READY)
+      << "Closed service tracker notifies waiters";
+    ASSERT_EQ(fut2.wait_until(wait_until), US_FUTURE_READY)
+      << "Closed service tracker notifies waiters";
   }
 #endif
 
@@ -267,9 +276,8 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   st1->Open();
   sa2 = st1->GetServiceReferences();
   ASSERT_EQ(sa2.size(), 2) << "Checking service reference count";
-  ASSERT_TRUE(
-    CheckConvertibility(sa2, ids.cbegin(), ids.cbegin() + 2)) <<
-    "Check for 2 expected interface ids";
+  ASSERT_TRUE(CheckConvertibility(sa2, ids.cbegin(), ids.cbegin() + 2))
+    << "Check for 2 expected interface ids";
 
   // 10. Get libTestBundleS to register one more service and see if it appears
   serviceController->ServiceControl(2, "register", 1);
@@ -277,16 +285,15 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
 
   ASSERT_EQ(sa2.size(), 3) << "Checking service reference count";
 
-  ASSERT_TRUE(
-    CheckConvertibility(sa2, ids.cbegin(), ids.cbegin() + 3)) <<
-    "Check for 3 expected interface ids";
+  ASSERT_TRUE(CheckConvertibility(sa2, ids.cbegin(), ids.cbegin() + 3))
+    << "Check for 3 expected interface ids";
 
   // 11. Get libTestBundleS to register one more service and see if it appears
   serviceController->ServiceControl(3, "register", 2);
   sa2 = st1->GetServiceReferences();
   ASSERT_EQ(sa2.size(), 4) << "Checking service reference count";
-  ASSERT_TRUE(CheckConvertibility(sa2, ids.cbegin(), ids.cend())) <<
-                             "Check for 4 expected interface ids";
+  ASSERT_TRUE(CheckConvertibility(sa2, ids.cbegin(), ids.cend()))
+    << "Check for 4 expected interface ids";
 
   // 12. Get libTestBundleS to unregister one service and see if it disappears
   serviceController->ServiceControl(3, "unregister", 0);
@@ -301,12 +308,13 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   // 14. Get the service of the highest ranked service reference
 
   auto o1 = st1->GetService(h1);
-  ASSERT_TRUE(o1.get() != nullptr && !o1->empty()) << "Check for non-null service";
+  ASSERT_TRUE(o1.get() != nullptr && !o1->empty())
+    << "Check for non-null service";
 
   // 14a Get the highest ranked service, directly this time
   auto o3 = st1->GetService();
-  ASSERT_TRUE(o3.get() != nullptr && !o3->empty()) <<
-                             "Check for non-null service";
+  ASSERT_TRUE(o3.get() != nullptr && !o3->empty())
+    << "Check for non-null service";
   ASSERT_EQ(o1, o3) << "Check for equal service instances";
 
   // 15. Now release the tracking of that service and then try to get it
@@ -325,9 +333,8 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   h1 = st1->GetServiceReference();
   auto sa3 = st1->GetServiceReferences();
   ASSERT_EQ(sa3.size(), 3) << "Check service reference count";
-  ASSERT_TRUE(
-    CheckConvertibility(sa3, ids.cbegin(), ids.cbegin() + 3)) <<
-    "Check for 3 expected interface ids";
+  ASSERT_TRUE(CheckConvertibility(sa3, ids.cbegin(), ids.cbegin() + 3))
+    << "Check for 3 expected interface ids";
 
   st1->Remove(h1); // remove tracking on one servref
   sa2 = st1->GetServiceReferences();
@@ -345,16 +352,23 @@ TEST_F(ServiceTrackerTestFixture, TestServiceTracker)
   MockCustomizedServiceTracker<MyInterfaceOne> customizer;
 
   // expect that closing the tracker results in RemovedService being called.
-  ON_CALL(customizer, AddingService(::testing::_)).WillByDefault(::testing::Return(std::make_shared<MyInterfaceOne>()));
-  EXPECT_CALL(customizer, AddingService(::testing::_)).Times(::testing::Exactly(1));
-  EXPECT_CALL(customizer, ModifiedService(::testing::_, ::testing::_)).Times(::testing::Exactly(0));
-  EXPECT_CALL(customizer, RemovedService(::testing::_, ::testing::_)).Times(::testing::Exactly(1));
+  ON_CALL(customizer, AddingService(::testing::_))
+    .WillByDefault(::testing::Return(std::make_shared<MyInterfaceOne>()));
+  EXPECT_CALL(customizer, AddingService(::testing::_))
+    .Times(::testing::Exactly(1));
+  EXPECT_CALL(customizer, ModifiedService(::testing::_, ::testing::_))
+    .Times(::testing::Exactly(0));
+  EXPECT_CALL(customizer, RemovedService(::testing::_, ::testing::_))
+    .Times(::testing::Exactly(1));
 
-  auto tracker = std::make_unique<cppmicroservices::ServiceTracker<MyInterfaceOne>>(context, &customizer);
+  auto tracker =
+    std::make_unique<cppmicroservices::ServiceTracker<MyInterfaceOne>>(
+      context, &customizer);
   tracker->Open();
   struct MyServiceOne : public MyInterfaceOne
   {};
-  auto svcReg = context.RegisterService<MyInterfaceOne>(std::make_shared<MyServiceOne>());
+  auto svcReg =
+    context.RegisterService<MyInterfaceOne>(std::make_shared<MyServiceOne>());
   tracker->Close();
 }
 
@@ -391,7 +405,9 @@ TEST_F(ServiceTrackerTestFixture, GetTracked)
 {
   BundleContext context = framework.GetBundleContext();
   cppmicroservices::ServiceTracker<MyInterfaceOne> tracker(context);
-  std::unordered_map<ServiceReference<MyInterfaceOne>, std::shared_ptr<MyInterfaceOne>> tracked;
+  std::unordered_map<ServiceReference<MyInterfaceOne>,
+                     std::shared_ptr<MyInterfaceOne>>
+    tracked;
   tracker.GetTracked(tracked);
   ASSERT_TRUE(tracked.empty());
   tracker.Open();
@@ -427,7 +443,6 @@ TEST_F(ServiceTrackerTestFixture, IsEmpty)
   tracker.Close();
   ASSERT_TRUE(tracker.IsEmpty());
 }
-
 
 #ifdef US_ENABLE_THREADING_SUPPORT
 namespace {
@@ -466,9 +481,8 @@ class CustomFooTracker final
   /**
      * Called when a service is removed.
      */
-  void RemovedService(
-    ::cppmicroservices::ServiceReference<FooService> const& ,
-    std::shared_ptr<FooService> const& ) override
+  void RemovedService(::cppmicroservices::ServiceReference<FooService> const&,
+                      std::shared_ptr<FooService> const&) override
   {}
 };
 }

--- a/framework/test/gtest/ShrinkableVectorTest.cpp
+++ b/framework/test/gtest/ShrinkableVectorTest.cpp
@@ -28,8 +28,7 @@ using namespace cppmicroservices;
 
 // Fake a BundleHooks class so we can create
 // ShrinkableVector instances
-namespace cppmicroservices 
-{
+namespace cppmicroservices {
 class BundleHooks
 {
 
@@ -44,7 +43,7 @@ public:
 
 TEST(ShrinkableVectorTest, ShrinkableVector)
 {
-  ShrinkableVector<int32_t>::container_type vec({1, 2, 3});
+  ShrinkableVector<int32_t>::container_type vec({ 1, 2, 3 });
   auto shrinkable = BundleHooks::MakeVector(vec);
 
   EXPECT_EQ(vec.size(), 3);

--- a/framework/test/gtest/StaticBundleResourceTest.cpp
+++ b/framework/test/gtest/StaticBundleResourceTest.cpp
@@ -152,4 +152,3 @@ TEST_F(StaticBundleResourceTest, testResources)
   //Check still valid static.txt resource
   ASSERT_TRUE(resource.IsValid());
 }
-

--- a/framework/test/gtest/TestCounterLatch.cpp
+++ b/framework/test/gtest/TestCounterLatch.cpp
@@ -20,11 +20,11 @@
 
   =============================================================================*/
 
-#include "gtest/gtest.h"
 #include "../util/ConcurrencyTestUtil.hpp"
 #include "cppmicroservices/detail/CounterLatch.h"
+#include "gtest/gtest.h"
 
-namespace cppmicroservices{
+namespace cppmicroservices {
 namespace detail {
 
 using namespace test;
@@ -38,10 +38,10 @@ TEST(CounterLatchTest, TestInitialState)
 TEST(CounterLatchTest, TestCountUp)
 {
   CounterLatch latch;
-  for(int i =0; i<50; i++)
-  {
+  for (int i = 0; i < 50; i++) {
     latch.CountUp();
-    EXPECT_EQ(latch.GetCount(), i+1) << "Latch count must be equal to the number of times CountUp is called";
+    EXPECT_EQ(latch.GetCount(), i + 1)
+      << "Latch count must be equal to the number of times CountUp is called";
   }
 }
 
@@ -50,17 +50,18 @@ TEST(CounterLatchTest, TestCountUpConcurrent)
   CounterLatch latch;
   std::function<bool()> func = [&latch]() { return latch.CountUp(); };
   auto results = ConcurrentInvoke(func);
-  EXPECT_TRUE(latch.GetCount() > 0) << "Latch count must be greater than zero after concurrent calls to CountUp";
+  EXPECT_TRUE(latch.GetCount() > 0) << "Latch count must be greater than zero "
+                                       "after concurrent calls to CountUp";
 }
 
 TEST(CounterLatchTest, TestCountDown_Initial)
 {
   CounterLatch latch;
   EXPECT_EQ(latch.GetCount(), 0) << "Initial count of the latch must be zero";
-  for(int i =0; i<50; i++)
-  {
+  for (int i = 0; i < 50; i++) {
     latch.CountDown();
-    EXPECT_EQ(latch.GetCount(), 0) << "Latch count must stay at zero if CountDown is called when count is zero";
+    EXPECT_EQ(latch.GetCount(), 0) << "Latch count must stay at zero if "
+                                      "CountDown is called when count is zero";
   }
 }
 
@@ -69,17 +70,16 @@ TEST(CounterLatchTest, TestCountDown_AfterCountUp)
   CounterLatch latch;
   EXPECT_EQ(latch.GetCount(), 0) << "Initial count of the latch must be zero";
   int iterCount = 50;
-  for(int i =0; i<iterCount; i++)
-  {
+  for (int i = 0; i < iterCount; i++) {
     latch.CountUp();
-
   }
-  EXPECT_EQ(latch.GetCount(), iterCount) << "Latch count must be equal to number of calls to CountUp";
-  for(int i =0; i<iterCount; i++)
-  {
+  EXPECT_EQ(latch.GetCount(), iterCount)
+    << "Latch count must be equal to number of calls to CountUp";
+  for (int i = 0; i < iterCount; i++) {
     latch.CountDown();
   }
-  EXPECT_EQ(latch.GetCount(), 0) << "Latch count must be zero after calls to CountDown";
+  EXPECT_EQ(latch.GetCount(), 0)
+    << "Latch count must be zero after calls to CountDown";
 }
 
 TEST(CounterLatchTest, TestWait)
@@ -87,9 +87,11 @@ TEST(CounterLatchTest, TestWait)
   CounterLatch latch;
   EXPECT_EQ(latch.GetCount(), 0) << "Initial count of the latch must be zero";
   EXPECT_NO_THROW(latch.Wait()) << "First call to Wait must not throw";
-  EXPECT_TRUE(latch.GetCount() < 0) << "latch count must negative after call to Wait";
+  EXPECT_TRUE(latch.GetCount() < 0)
+    << "latch count must negative after call to Wait";
   // subsequent calls to wait will result in an exception
-  EXPECT_THROW(latch.Wait(), std::runtime_error) << "Second call to Wait must throw";
+  EXPECT_THROW(latch.Wait(), std::runtime_error)
+    << "Second call to Wait must throw";
 }
 
 TEST(CounterLatchTest, TestWaitAfterCountUp)
@@ -98,14 +100,16 @@ TEST(CounterLatchTest, TestWaitAfterCountUp)
   EXPECT_EQ(latch.GetCount(), 0);
   std::function<bool()> func = [&latch]() { return latch.CountUp(); };
   auto results = ConcurrentInvoke(func);
-  EXPECT_TRUE(latch.GetCount() > 0) << "latch count must be positive after calls to count up";
+  EXPECT_TRUE(latch.GetCount() > 0)
+    << "latch count must be positive after calls to count up";
   auto fut = std::async(std::launch::async, [&latch]() { latch.Wait(); });
   EXPECT_FALSE(is_ready(fut)) << "The call to Wait must not return yet";
-  while(latch.GetCount() > 0)
-  {
+  while (latch.GetCount() > 0) {
     latch.CountDown();
   }
-  EXPECT_TRUE(latch.GetCount() < 1) << "latch count could be 0 if the waiting thread has not woke up, negative if the waiting thread woke up";
+  EXPECT_TRUE(latch.GetCount() < 1)
+    << "latch count could be 0 if the waiting thread has not woke up, negative "
+       "if the waiting thread woke up";
   EXPECT_NO_THROW(fut.get()) << "The call to Wait must have returned";
   EXPECT_TRUE(latch.GetCount() < 0);
 }

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -152,12 +152,9 @@ Bundle InstallLib(BundleContext frameworkCtx, const std::string& libName)
   std::vector<Bundle> bundles;
 
 #if defined(US_BUILD_SHARED_LIBS)
-  bundles = frameworkCtx.InstallBundles(LIB_PATH
-                                        + util::DIR_SEP
-                                        + US_LIB_PREFIX
-                                        + libName
-                                        + US_LIB_POSTFIX
-                                        + US_LIB_EXT);
+  bundles =
+    frameworkCtx.InstallBundles(LIB_PATH + util::DIR_SEP + US_LIB_PREFIX +
+                                libName + US_LIB_POSTFIX + US_LIB_EXT);
 #else
   bundles = frameworkCtx.GetBundles();
 #endif

--- a/httpservice/src/HttpServlet.cpp
+++ b/httpservice/src/HttpServlet.cpp
@@ -282,9 +282,8 @@ void HttpServlet::DoTrace(HttpServletRequest& request,
 
   std::vector<std::string> reqHeaders = request.GetHeaderNames();
 
-  for (const auto & reqHeader : reqHeaders) {
-    responseString +=
-      CRLF + reqHeader + ": " + request.GetHeader(reqHeader);
+  for (const auto& reqHeader : reqHeaders) {
+    responseString += CRLF + reqHeader + ": " + request.GetHeader(reqHeader);
   }
 
   responseString += CRLF;

--- a/httpservice/src/HttpServletRequest.cpp
+++ b/httpservice/src/HttpServletRequest.cpp
@@ -39,7 +39,7 @@
 namespace cppmicroservices {
 
 HttpServletRequestPrivate::HttpServletRequestPrivate(
-  std::shared_ptr<ServletContext>  servletContext,
+  std::shared_ptr<ServletContext> servletContext,
   CivetServer* server,
   mg_connection* conn)
   : m_ServletContext(std::move(servletContext))
@@ -94,7 +94,8 @@ HttpServletRequestPrivate::HttpServletRequestPrivate(
 
 HttpServletRequest::~HttpServletRequest() = default;
 HttpServletRequest::HttpServletRequest(const HttpServletRequest&) = default;
-HttpServletRequest& HttpServletRequest::operator=(const HttpServletRequest&) = default;
+HttpServletRequest& HttpServletRequest::operator=(const HttpServletRequest&) =
+  default;
 
 std::shared_ptr<ServletContext> HttpServletRequest::GetServletContext() const
 {
@@ -282,7 +283,8 @@ std::vector<std::string> HttpServletRequest::GetHeaderNames() const
 {
   std::vector<std::string> names;
   for (int i = 0; i < mg_get_request_info(d->m_Connection)->num_headers; ++i) {
-    names.emplace_back(mg_get_request_info(d->m_Connection)->http_headers[i].name);
+    names.emplace_back(
+      mg_get_request_info(d->m_Connection)->http_headers[i].name);
   }
   return names;
 }

--- a/httpservice/src/HttpServletRequestPrivate.h
+++ b/httpservice/src/HttpServletRequestPrivate.h
@@ -37,10 +37,9 @@ class ServletContext;
 
 struct HttpServletRequestPrivate
 {
-  HttpServletRequestPrivate(
-    std::shared_ptr<ServletContext>  servletContext,
-    CivetServer* server,
-    mg_connection* conn);
+  HttpServletRequestPrivate(std::shared_ptr<ServletContext> servletContext,
+                            CivetServer* server,
+                            mg_connection* conn);
 
   const std::shared_ptr<ServletContext> m_ServletContext;
   CivetServer* const m_Server;

--- a/httpservice/src/HttpServletResponse.cpp
+++ b/httpservice/src/HttpServletResponse.cpp
@@ -28,10 +28,10 @@
 
 #include "civetweb/civetweb.h"
 
+#include <ctime>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
-#include <ctime>
 #include <vector>
 
 namespace cppmicroservices {
@@ -67,7 +67,7 @@ bool HttpServletResponsePrivate::Commit()
 
   std::stringstream ss;
   ss << "HTTP/1.1 " << m_StatusCode << "\r\n";
-  for (auto & m_Header : m_Headers) {
+  for (auto& m_Header : m_Headers) {
     ss << m_Header.first << ": " << m_Header.second << "\r\n";
   }
   ss << "\r\n";
@@ -138,7 +138,8 @@ std::string HttpServletResponsePrivate::LexicalCastHex(long value)
 
 HttpServletResponse::~HttpServletResponse() = default;
 HttpServletResponse::HttpServletResponse(const HttpServletResponse&) = default;
-HttpServletResponse& HttpServletResponse::operator=(const HttpServletResponse&) = default;
+HttpServletResponse& HttpServletResponse::operator=(
+  const HttpServletResponse&) = default;
 
 void HttpServletResponse::FlushBuffer()
 {
@@ -161,8 +162,7 @@ std::size_t HttpServletResponse::GetBufferSize() const
 
 std::string HttpServletResponse::GetContentType() const
 {
-  auto iter =
-    d->m_Headers.find("Content-Type");
+  auto iter = d->m_Headers.find("Content-Type");
   if (iter != d->m_Headers.end()) {
     return iter->second;
   }

--- a/httpservice/src/ServletConfig.cpp
+++ b/httpservice/src/ServletConfig.cpp
@@ -54,5 +54,5 @@ ServletConfig::ServletConfig()
 
 ServletConfig::ServletConfig(const ServletConfig&) = default;
 ServletConfig& ServletConfig::operator=(const ServletConfig&) = default;
-    
+
 }

--- a/shellservice/include/cppmicroservices/shellservice/ShellService.h
+++ b/shellservice/include/cppmicroservices/shellservice/ShellService.h
@@ -28,8 +28,8 @@
 #include "cppmicroservices/shellservice/ShellServiceExport.h"
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace cppmicroservices {
 

--- a/shellservice/src/ShellService.cpp
+++ b/shellservice/src/ShellService.cpp
@@ -334,7 +334,7 @@ ShellService::ShellService()
 
   std::vector<BundleResource> schemeResources =
     GetBundleContext().GetBundle().FindResources("/", "*.scm", false);
-  for (auto & schemeResource : schemeResources) {
+  for (auto& schemeResource : schemeResources) {
     if (schemeResource) {
       this->LoadSchemeResource(schemeResource);
     }
@@ -409,7 +409,7 @@ std::vector<std::string> ShellService::GetCompletions(const std::string& in)
     return result;
   }
 
-  for (const auto & symIter : iter->second) {
+  for (const auto& symIter : iter->second) {
     if (symIter.size() < cmd.size())
       continue;
     if (symIter.compare(0, cmd.size(), cmd) == 0) {

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -191,8 +191,8 @@ void validateManifestInArchive(mz_zip_archive* zipArchive,
 
   try {
     Json::Value root;
-    std::istringstream json(
-      std::string(reinterpret_cast<const char *>(manifestFileContents.get()), length));
+    std::istringstream json(std::string(
+      reinterpret_cast<const char*>(manifestFileContents.get()), length));
     parseAndValidateJson(json, root);
   } catch (const InvalidManifest& e) {
     std::string exceptionMsg(archiveFile);

--- a/util/include/cppmicroservices/util/BundleMachOFile.h
+++ b/util/include/cppmicroservices/util/BundleMachOFile.h
@@ -20,21 +20,21 @@
 
 =============================================================================*/
 
-#if defined (US_PLATFORM_APPLE)
+#if defined(US_PLATFORM_APPLE)
 
-#include "BundleObjFile.h"
-#include "DataContainer.h"
-#include "MappedFile.h"
+#  include "BundleObjFile.h"
+#  include "DataContainer.h"
+#  include "MappedFile.h"
 
-#include <cerrno>
-#include <cstring>
-#include <mach-o/fat.h>
-#include <mach-o/loader.h>
-#include <mach-o/nlist.h>
-#include <fstream>
-#include <memory>
+#  include <cerrno>
+#  include <cstring>
+#  include <fstream>
+#  include <mach-o/fat.h>
+#  include <mach-o/loader.h>
+#  include <mach-o/nlist.h>
+#  include <memory>
 
-#include <sys/stat.h>
+#  include <sys/stat.h>
 
 namespace cppmicroservices {
 
@@ -65,16 +65,16 @@ struct MachO<MH_MAGIC_64>
 template<typename I>
 I readBE(I i)
 {
-#ifdef US_LITTLE_ENDIAN
+#  ifdef US_LITTLE_ENDIAN
   I r = 0;
   for (unsigned int n = 0; n < sizeof(I); ++n) {
     r |= static_cast<I>(*(reinterpret_cast<unsigned char*>(&i) + n))
          << ((sizeof(I) - 1 - n) * 8);
   }
   return r;
-#else
+#  else
   return i;
-#endif
+#  endif
 }
 
 template<class MachOType>
@@ -86,7 +86,9 @@ public:
   typedef typename MachOType::Mhdr Mhdr;
   typedef typename MachOType::symtab_entry symtab_entry;
 
-  BundleMachOFile(std::ifstream& fs, std::size_t fileOffset, const std::string& location)
+  BundleMachOFile(std::ifstream& fs,
+                  std::size_t fileOffset,
+                  const std::string& location)
     : m_rawData()
   {
     fs.seekg(fileOffset);
@@ -96,20 +98,22 @@ public:
       throw InvalidMachOException(
         "Not a Mach-O dynamic shared library or bundle file.");
     }
-      
+
     fs.seekg(fileOffset + sizeof(mach_header_64));
 
     // iterate over all load commands
     uint32_t ncmds = mhdr.ncmds;
     uint32_t lcmd_offset = static_cast<uint32_t>(fs.tellg());
-    
+
     for (uint32_t i = 0; i < ncmds; ++i) {
       load_command lcmd;
       fs.read(reinterpret_cast<char*>(&lcmd), sizeof lcmd);
       if (!m_rawData && LC_SEGMENT_64 == lcmd.cmd) {
-        m_rawData = GetRawBundleResources<segment_command_64, section_64>(fs, location, fileOffset, lcmd_offset);
+        m_rawData = GetRawBundleResources<segment_command_64, section_64>(
+          fs, location, fileOffset, lcmd_offset);
       } else if (!m_rawData && LC_SEGMENT == lcmd.cmd) {
-        m_rawData = GetRawBundleResources<segment_command, section>(fs, location, fileOffset, lcmd_offset);
+        m_rawData = GetRawBundleResources<segment_command, section>(
+          fs, location, fileOffset, lcmd_offset);
       }
 
       lcmd_offset += lcmd.cmdsize;
@@ -118,43 +122,56 @@ public:
   }
 
   template<typename SegmentCommand, typename Section>
-  std::shared_ptr<RawBundleResources> GetRawBundleResources(std::ifstream& fs, const std::string& filePath, std::size_t fileOffset, uint32_t lcmd_offset)
+  std::shared_ptr<RawBundleResources> GetRawBundleResources(
+    std::ifstream& fs,
+    const std::string& filePath,
+    std::size_t fileOffset,
+    uint32_t lcmd_offset)
   {
     fs.seekg(fileOffset + lcmd_offset);
     SegmentCommand segment;
     fs.read(reinterpret_cast<char*>(&segment), sizeof(SegmentCommand));
-    if(0 == strcmp("__TEXT", segment.segname)) {
-       // find "us_resources" section
-       for (uint32_t i = 0; i < segment.nsects; ++i) {
-         Section section;
-         fs.read(reinterpret_cast<char*>(&section), sizeof(Section));
-         if (0 == strcmp("us_resources", section.sectname) &&
-             0 < section.size) {
-           // try to be smart about when to use mmap. Benchmark tests show
-           // that mmap is slower than std::ifstream::read until the file size is around 10mb.
-           constexpr std::size_t zipFileSizeThreshold{10485760};
-           if(section.size >= zipFileSizeThreshold) {
-             off_t pa_offset = (fileOffset + section.offset) & ~(sysconf(_SC_PAGESIZE) - 1);
-             size_t mappedLength = section.size + (fileOffset + section.offset) - pa_offset;
-             return std::make_shared<RawBundleResources>(std::make_unique<MappedFile>(filePath, mappedLength, pa_offset));
-           } else {
-             void* zipData = malloc(section.size * sizeof(char));
-             if (zipData) {
-               std::unique_ptr<void, void(*)(void*)> scopedData(zipData, ::free);
-               fs.seekg(fileOffset + section.offset);
-               fs.read(reinterpret_cast<char*>(zipData), section.size);
-               return std::make_shared<RawBundleResources>( std::make_unique<RawDataContainer>(std::move(scopedData), section.size) );
-             }
-           }
-           
-         }
-         fs.seekg(lcmd_offset + sizeof(SegmentCommand) + ((i+1)*sizeof(Section)));
-       }
+    if (0 == strcmp("__TEXT", segment.segname)) {
+      // find "us_resources" section
+      for (uint32_t i = 0; i < segment.nsects; ++i) {
+        Section section;
+        fs.read(reinterpret_cast<char*>(&section), sizeof(Section));
+        if (0 == strcmp("us_resources", section.sectname) && 0 < section.size) {
+          // try to be smart about when to use mmap. Benchmark tests show
+          // that mmap is slower than std::ifstream::read until the file size is around 10mb.
+          constexpr std::size_t zipFileSizeThreshold{ 10485760 };
+          if (section.size >= zipFileSizeThreshold) {
+            off_t pa_offset =
+              (fileOffset + section.offset) & ~(sysconf(_SC_PAGESIZE) - 1);
+            size_t mappedLength =
+              section.size + (fileOffset + section.offset) - pa_offset;
+            return std::make_shared<RawBundleResources>(
+              std::make_unique<MappedFile>(filePath, mappedLength, pa_offset));
+          } else {
+            void* zipData = malloc(section.size * sizeof(char));
+            if (zipData) {
+              std::unique_ptr<void, void (*)(void*)> scopedData(zipData,
+                                                                ::free);
+              fs.seekg(fileOffset + section.offset);
+              fs.read(reinterpret_cast<char*>(zipData), section.size);
+              return std::make_shared<RawBundleResources>(
+                std::make_unique<RawDataContainer>(std::move(scopedData),
+                                                   section.size));
+            }
+          }
+        }
+        fs.seekg(lcmd_offset + sizeof(SegmentCommand) +
+                 ((i + 1) * sizeof(Section)));
+      }
     }
     return {};
   }
 
-  std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer() const override { return m_rawData; }
+  std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer()
+    const override
+  {
+    return m_rawData;
+  }
 
 private:
   std::shared_ptr<RawBundleResources> m_rawData;
@@ -173,7 +190,8 @@ static std::vector<std::vector<uint32_t>> GetMachOIdents(std::ifstream& is)
     is.seekg(0);
     fat_header fatHdr;
     is.read(reinterpret_cast<char*>(&fatHdr), sizeof fatHdr);
-    std::unique_ptr<fat_arch[]> fatArchs(new fat_arch[readBE(fatHdr.nfat_arch)]);
+    std::unique_ptr<fat_arch[]> fatArchs(
+      new fat_arch[readBE(fatHdr.nfat_arch)]);
     is.read(reinterpret_cast<char*>(fatArchs.get()),
             sizeof(fatArchs) * readBE(fatHdr.nfat_arch));
     const fat_arch* currArch = fatArchs.get();
@@ -205,30 +223,31 @@ static std::vector<uint32_t> GetMachOIdent()
   // magic (32 or 64 bit) | cputype | offset
   std::vector<uint32_t> ident(3, 0);
 
-#ifdef __LP64__
+#  ifdef __LP64__
   ident[0] = MH_MAGIC_64;
-#else
+#  else
   ident[0] = MH_MAGIC;
-#endif
+#  endif
 
-#if defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
+#  if defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
   ident[1] = CPU_TYPE_POWERPC64;
-#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+#  elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
   ident[1] = CPU_TYPE_POWERPC;
-#elif defined(__sparc)
+#  elif defined(__sparc)
   ident[1] = CPU_TYPE_SPARC;
-#elif defined(__x86_64__) || defined(_M_X64)
+#  elif defined(__x86_64__) || defined(_M_X64)
   ident[1] = CPU_TYPE_X86_64;
-#elif defined(__i386) || defined(_M_IX86)
+#  elif defined(__i386) || defined(_M_IX86)
   ident[1] = CPU_TYPE_X86;
-#elif defined(__arm__) || defined(_M_ARM)
+#  elif defined(__arm__) || defined(_M_ARM)
   ident[1] = CPU_TYPE_ARM;
-#endif
+#  endif
 
   return ident;
 }
 
-std::unique_ptr<BundleObjFile> CreateBundleMachOFile(const std::string& fileName)
+std::unique_ptr<BundleObjFile> CreateBundleMachOFile(
+  const std::string& fileName)
 {
   struct stat machStat;
   errno = 0;
@@ -264,12 +283,14 @@ std::unique_ptr<BundleObjFile> CreateBundleMachOFile(const std::string& fileName
   }
 
   if (matchingIdent[0] == MH_MAGIC) {
-    return std::make_unique<BundleMachOFile<MachO<MH_MAGIC>>>(machFile, matchingIdent[2], fileName);
+    return std::make_unique<BundleMachOFile<MachO<MH_MAGIC>>>(
+      machFile, matchingIdent[2], fileName);
   } else if (matchingIdent[0] == MH_MAGIC_64) {
-    return std::make_unique<BundleMachOFile<MachO<MH_MAGIC_64>>>(machFile, matchingIdent[2], fileName);
+    return std::make_unique<BundleMachOFile<MachO<MH_MAGIC_64>>>(
+      machFile, matchingIdent[2], fileName);
   } else {
-    throw InvalidMachOException(
-      "Internal error: Mach-O magic field value is neither MH_MAGIC nor MH_MAGIC_64");
+    throw InvalidMachOException("Internal error: Mach-O magic field value is "
+                                "neither MH_MAGIC nor MH_MAGIC_64");
   }
 }
 }

--- a/util/include/cppmicroservices/util/BundleObjFactory.h
+++ b/util/include/cppmicroservices/util/BundleObjFactory.h
@@ -30,19 +30,19 @@ namespace cppmicroservices {
 class BundleObjFactory
 {
 public:
-    BundleObjFactory() = default;
-    
-    /// Return a BundleObjFile which represents data read from the binary at
-    /// the given location.
-    ///
-    /// @param location absolute path to a PE, ELF or Mach-O binary file.
-    /// @return A BundleObjFile object
-    /// @throws If location is not a valid PE, ELF or Mach-O binary file.
-    ///
-    /// @note The location must be a valid binary format for the host machine.
-    ///       i.e. PE file on Windows, Mach-O on macOS, ELF on Linux
-    std::unique_ptr<BundleObjFile> CreateBundleFileObj(const std::string& location);
-    
+  BundleObjFactory() = default;
+
+  /// Return a BundleObjFile which represents data read from the binary at
+  /// the given location.
+  ///
+  /// @param location absolute path to a PE, ELF or Mach-O binary file.
+  /// @return A BundleObjFile object
+  /// @throws If location is not a valid PE, ELF or Mach-O binary file.
+  ///
+  /// @note The location must be a valid binary format for the host machine.
+  ///       i.e. PE file on Windows, Mach-O on macOS, ELF on Linux
+  std::unique_ptr<BundleObjFile> CreateBundleFileObj(
+    const std::string& location);
 };
 
 }

--- a/util/include/cppmicroservices/util/BundleObjFile.h
+++ b/util/include/cppmicroservices/util/BundleObjFile.h
@@ -37,9 +37,10 @@ namespace cppmicroservices {
 struct InvalidObjFileException : public std::exception
 {
   ~InvalidObjFileException() throw() {}
-  InvalidObjFileException(std::string  what, int errorNumber = 0);
+  InvalidObjFileException(std::string what, int errorNumber = 0);
 
   virtual const char* what() const throw();
+
 private:
   std::string m_What;
 };
@@ -52,7 +53,7 @@ class RawBundleResources
 public:
   RawBundleResources(std::unique_ptr<DataContainer> data)
     : m_Data(std::move(data))
-  { }
+  {}
 
   operator bool() const
   {
@@ -61,7 +62,7 @@ public:
 
   void* GetData() const { return m_Data->GetData(); }
   std::size_t GetSize() const { return m_Data->GetSize(); }
-    
+
 private:
   std::unique_ptr<DataContainer> m_Data;
 };
@@ -69,11 +70,11 @@ private:
 class BundleObjFile
 {
 public:
-
   virtual ~BundleObjFile() {}
 
   /// Return the raw bundle resource container bits.
-  virtual std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer() const = 0;
+  virtual std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer()
+    const = 0;
 };
 
 }

--- a/util/include/cppmicroservices/util/BundlePEFile.h
+++ b/util/include/cppmicroservices/util/BundlePEFile.h
@@ -20,21 +20,21 @@
 
 =============================================================================*/
 
-#if defined (US_PLATFORM_WINDOWS)
+#if defined(US_PLATFORM_WINDOWS)
 
-#include "BundleObjFile.h"
-#include "DataContainer.h"
-#include "Error.h"
-#include "String.h"
-#include "cppmicroservices_pe.h"
+#  include "BundleObjFile.h"
+#  include "DataContainer.h"
+#  include "Error.h"
+#  include "String.h"
+#  include "cppmicroservices_pe.h"
 
-#include <cerrno>
-#include <fstream>
-#include <memory>
+#  include <cerrno>
+#  include <fstream>
+#  include <memory>
 
-#include <sys/stat.h>
+#  include <sys/stat.h>
 
-#include <Windows.h>
+#  include <Windows.h>
 
 namespace cppmicroservices {
 
@@ -45,7 +45,8 @@ struct hModuleDeleter
   // pointer instead of T*.
   typedef HMODULE pointer;
 
-  void operator()(HMODULE handle) const {
+  void operator()(HMODULE handle) const
+  {
     if (handle) {
       FreeLibrary(handle);
     }
@@ -89,25 +90,34 @@ public:
     : m_rawData(nullptr)
   {
     std::wstring wpath(cppmicroservices::util::ToWString(location));
-    HMODULE hBundleResources = LoadLibraryExW(wpath.c_str(), nullptr, LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+    HMODULE hBundleResources =
+      LoadLibraryExW(wpath.c_str(),
+                     nullptr,
+                     LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
     if (hBundleResources) {
       // RAII - automatically free the library handle on object destruction
-      auto loadLibraryHandle = std::unique_ptr<HMODULE, hModuleDeleter>(hBundleResources, hModuleDeleter{});
-      HRSRC hResource = FindResourceA(hBundleResources, "US_RESOURCES", MAKEINTRESOURCEA(300));
+      auto loadLibraryHandle = std::unique_ptr<HMODULE, hModuleDeleter>(
+        hBundleResources, hModuleDeleter{});
+      HRSRC hResource =
+        FindResourceA(hBundleResources, "US_RESOURCES", MAKEINTRESOURCEA(300));
       HGLOBAL hRes = LoadResource(hBundleResources, hResource);
       const LPVOID res = LockResource(hRes);
       const DWORD zipSizeInBytes = SizeofResource(hBundleResources, hResource);
       if (0 < zipSizeInBytes) {
-        m_rawData = std::make_shared<RawBundleResources>(std::make_unique<ResDataContainer>(std::move(loadLibraryHandle), res, zipSizeInBytes));
+        m_rawData = std::make_shared<RawBundleResources>(
+          std::make_unique<ResDataContainer>(
+            std::move(loadLibraryHandle), res, zipSizeInBytes));
       }
-    }
-    else {
-      throw InvalidPEException("LoadLibrary failed for path " + location + " with error " + cppmicroservices::util::GetLastWin32ErrorStr());
+    } else {
+      throw InvalidPEException("LoadLibrary failed for path " + location +
+                               " with error " +
+                               cppmicroservices::util::GetLastWin32ErrorStr());
     }
   };
   ~BundlePEFile() = default;
 
-  std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer() const override
+  std::shared_ptr<RawBundleResources> GetRawBundleResourceContainer()
+    const override
   {
     return m_rawData;
   }

--- a/util/include/cppmicroservices/util/DataContainer.h
+++ b/util/include/cppmicroservices/util/DataContainer.h
@@ -42,6 +42,7 @@ public:
   DataContainer& operator=(DataContainer&&) = default;
   virtual void* GetData() const = 0;
   virtual std::size_t GetSize() const = 0;
+
 protected:
   DataContainer() = default;
 };
@@ -49,20 +50,20 @@ protected:
 class RawDataContainer final : public DataContainer
 {
 public:
-  RawDataContainer(std::unique_ptr<void, void(*)(void*)> data, std::size_t dataSize)
+  RawDataContainer(std::unique_ptr<void, void (*)(void*)> data,
+                   std::size_t dataSize)
     : m_Data(std::move(data))
     , m_DataSize(dataSize)
-    { }
+  {}
   ~RawDataContainer() = default;
-    
+
   void* GetData() const override { return m_Data.get(); }
   std::size_t GetSize() const override { return m_DataSize; }
-  
+
 private:
-  std::unique_ptr<void, void(*)(void*)> m_Data;
+  std::unique_ptr<void, void (*)(void*)> m_Data;
   std::size_t m_DataSize;
 };
-
 
 }
 

--- a/util/include/cppmicroservices/util/MappedFile.h
+++ b/util/include/cppmicroservices/util/MappedFile.h
@@ -20,17 +20,17 @@
  
  =============================================================================*/
 
-#if defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)
+#if defined(US_PLATFORM_APPLE) || defined(US_PLATFORM_POSIX)
 
-#ifndef CPPMICROSERVICES_MAPPEDFILE_H
-#define CPPMICROSERVICES_MAPPEDFILE_H
+#  ifndef CPPMICROSERVICES_MAPPEDFILE_H
+#    define CPPMICROSERVICES_MAPPEDFILE_H
 
-#include "DataContainer.h"
+#    include "DataContainer.h"
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#    include <fcntl.h>
+#    include <sys/mman.h>
+#    include <sys/stat.h>
+#    include <unistd.h>
 
 namespace cppmicroservices {
 
@@ -40,32 +40,34 @@ public:
   MappedFile()
     : fileDesc(-1)
     , mappedAddress(nullptr)
-    , mapSize(0) {}
+    , mapSize(0)
+  {}
   MappedFile(const std::string& fileLocation, size_t mapLength, off_t offset)
     : fileDesc(-1)
     , mappedAddress(nullptr)
     , mapSize(mapLength)
   {
     fileDesc = open(fileLocation.c_str(), O_RDONLY);
-    if(fileDesc >= 0) {
-      mappedAddress = mmap(0, mapLength, PROT_READ, MAP_PRIVATE, fileDesc, offset);
+    if (fileDesc >= 0) {
+      mappedAddress =
+        mmap(0, mapLength, PROT_READ, MAP_PRIVATE, fileDesc, offset);
       if (MAP_FAILED == mappedAddress) {
         mappedAddress = nullptr;
         mapSize = 0;
       }
     }
   }
-    
+
   ~MappedFile()
   {
-    if(mappedAddress && mapSize) {
+    if (mappedAddress && mapSize) {
       munmap(mappedAddress, mapSize);
     }
-    if(0 <= fileDesc) {
+    if (0 <= fileDesc) {
       close(fileDesc);
     }
   }
-  
+
   void* GetData() const override { return mappedAddress; }
   std::size_t GetSize() const override { return mapSize; }
 
@@ -76,6 +78,6 @@ private:
 };
 
 }
-#endif // CPPMICROSERVICES_MAPPEDFILE_H
+#  endif // CPPMICROSERVICES_MAPPEDFILE_H
 
 #endif // defined (US_PLATFORM_APPLE) || defined (US_PLATFORM_POSIX)

--- a/util/src/BundleObjFactory.cpp
+++ b/util/src/BundleObjFactory.cpp
@@ -21,10 +21,10 @@ Library: CppMicroServices
 =============================================================================*/
 
 #include "cppmicroservices/util/BundleObjFactory.h"
-#include "cppmicroservices/util/BundleObjFile.h"
-#include "cppmicroservices/util/BundlePEFile.h"
 #include "cppmicroservices/util/BundleElfFile.h"
 #include "cppmicroservices/util/BundleMachOFile.h"
+#include "cppmicroservices/util/BundleObjFile.h"
+#include "cppmicroservices/util/BundlePEFile.h"
 
 namespace cppmicroservices {
 
@@ -37,7 +37,8 @@ namespace cppmicroservices {
 ///
 /// @note The location must be a valid binary format for the host machine.
 ///       i.e. PE file on Windows, Mach-O on macOS, ELF on Linux
-std::unique_ptr<BundleObjFile> BundleObjFactory::CreateBundleFileObj(const std::string& location)
+std::unique_ptr<BundleObjFile> BundleObjFactory::CreateBundleFileObj(
+  const std::string& location)
 {
 #if defined(US_PLATFORM_WINDOWS)
   return CreateBundlePEFile(location);
@@ -46,8 +47,8 @@ std::unique_ptr<BundleObjFile> BundleObjFactory::CreateBundleFileObj(const std::
 #elif defined(US_PLATFORM_LINUX)
   return CreateBundleElfFile(location);
 #else
-  #error "Unknown OS platform";
+#  error "Unknown OS platform";
 #endif
   return {};
-}   
+}
 };

--- a/util/src/BundleObjFile.cpp
+++ b/util/src/BundleObjFile.cpp
@@ -27,7 +27,7 @@
 
 namespace cppmicroservices {
 
-InvalidObjFileException::InvalidObjFileException(std::string  what,
+InvalidObjFileException::InvalidObjFileException(std::string what,
                                                  int errorNumber)
   : m_What(std::move(what))
 {

--- a/util/src/FileSystem.cpp
+++ b/util/src/FileSystem.cpp
@@ -30,10 +30,10 @@
 #include <vector>
 
 #ifdef US_PLATFORM_POSIX
-#  include <dirent.h>
-#  include <dlfcn.h>
 #  include <cerrno>
 #  include <cstring>
+#  include <dirent.h>
+#  include <dlfcn.h>
 #  include <unistd.h> // getcwd
 
 #  define US_STAT struct stat
@@ -77,11 +77,11 @@ namespace util {
 #ifdef US_PLATFORM_WINDOWS
 bool not_found_win32_error(int errval)
 {
-  return (errval == ERROR_FILE_NOT_FOUND
-          || errval == ERROR_PATH_NOT_FOUND
-          || errval == ERROR_INVALID_NAME      // "//foo"
-          || errval == ERROR_INVALID_DRIVE     // USB card reader with no card inserted
-          || errval == ERROR_NOT_READY         // CD/DVD drive with no disc inserted
+  return (errval == ERROR_FILE_NOT_FOUND || errval == ERROR_PATH_NOT_FOUND ||
+          errval == ERROR_INVALID_NAME // "//foo"
+          ||
+          errval == ERROR_INVALID_DRIVE // USB card reader with no card inserted
+          || errval == ERROR_NOT_READY  // CD/DVD drive with no disc inserted
           || errval == ERROR_INVALID_PARAMETER // ":sys:stat.h"
           || errval == ERROR_BAD_PATHNAME      // "//nosuch" on Win64
           || errval == ERROR_BAD_NETPATH);     // "//nosuch" on Win32
@@ -154,11 +154,10 @@ std::string GetExecutablePath()
 #endif
 }
 
-
 namespace {
 
 // no reason to export this function... only used to initialize static local variable in
-// GetCurrentWorkingDirectory. 
+// GetCurrentWorkingDirectory.
 std::string InitCurrentWorkingDirectory()
 {
 #ifdef US_PLATFORM_WINDOWS
@@ -170,14 +169,14 @@ std::string InitCurrentWorkingDirectory()
     return util::ToUTF8String(buf.data());
   }
 #else
-  errno = 0;                    // reset errno to zero in case it was set to some other
-                                // value before this call.
+  errno = 0; // reset errno to zero in case it was set to some other
+             // value before this call.
   for (std::size_t bufSize = PATH_MAX;
-       (0 == errno) || (ERANGE == errno); // break out of the loop if any error other than
-                                          // ERANGE occurs. In the case of ERANGE, we
-                                          // double the bufSize and try again.
-       bufSize *= 2)
-  {
+       (0 == errno) ||
+       (ERANGE == errno); // break out of the loop if any error other than
+                          // ERANGE occurs. In the case of ERANGE, we
+                          // double the bufSize and try again.
+       bufSize *= 2) {
     std::vector<char> buf(bufSize, '\0');
     const char* rval = getcwd(buf.data(), bufSize);
     if (rval != nullptr) {

--- a/util/src/String.cpp
+++ b/util/src/String.cpp
@@ -23,8 +23,8 @@
 #include "cppmicroservices/util/String.h"
 #include "cppmicroservices/util/Error.h"
 #include <cppmicroservices/GlobalConfig.h>
-#include <stdexcept>
 #include <memory>
+#include <stdexcept>
 
 #ifdef US_PLATFORM_WINDOWS
 #  include <windows.h>


### PR DESCRIPTION
This PR has no functional or code changes. This PR merely formats all existing C, CPP, CXX, H, and HPP files in the repo (excluding any thirdparty libraries).

There are two exceptions to the formatting done by clang-format:

1) ComponentInstanceImpl.hpp: The '#include "Binders.hpp"' statement must be included after the includes above it since it relies on a using statement which they declare. Because clang-format will sort includes based on alphabetical order, this broke the code and so it was moved lower with a white space in between to keep it from sorting.

This seems like something we can create an issue out of since I don't think include order for "Binders.hpp" should matter.

2) ReferenceAutogenFiles.hpp: The order of the strings in the file matters. Clang-format was incorrectly changing the order of text within double quotes because an R string was used. This means that there were no quotes in front of the text on each line and thus clang-format treated it as actual c++ code.

The tests rely on a specific string which is defined in this file and so I manually reverted the formatting changes made.
