### PR TITLE
include the missing <exception>

### DIFF
--- a/framework/src/util/Utils.h
+++ b/framework/src/util/Utils.h
@@ -26,6 +26,7 @@
 #include "BundleResourceContainer.h"
 #include "cppmicroservices/FrameworkExport.h"
 
+#include <exception>
 #include <string>
 
 namespace cppmicroservices {


### PR DESCRIPTION
cf. intel/linux-sgx#709

This PR attempts to fix a compilation failure with GNU G++ 11.0. In this header `Utils.h`, `std::exception_ptr` is not defined unless `<exception>` header is included.