### PR TITLE
Fix -Wmissing-prototypes warning regarding macros

### DIFF
--- a/framework/include/cppmicroservices/BundleActivator.h
+++ b/framework/include/cppmicroservices/BundleActivator.h
@@ -128,10 +128,14 @@ struct BundleActivator
  */
 #define CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(_activator_type)              \
   extern "C" US_ABI_EXPORT cppmicroservices::BundleActivator*                  \
+    US_CREATE_ACTIVATOR_FUNC(US_BUNDLE_NAME)();                                \
+  extern "C" US_ABI_EXPORT cppmicroservices::BundleActivator*                  \
     US_CREATE_ACTIVATOR_FUNC(US_BUNDLE_NAME)()                                 \
   {                                                                            \
     return new _activator_type();                                              \
   }                                                                            \
+  extern "C" US_ABI_EXPORT void US_DESTROY_ACTIVATOR_FUNC(US_BUNDLE_NAME)(     \
+    cppmicroservices::BundleActivator * activator);                            \
   extern "C" US_ABI_EXPORT void US_DESTROY_ACTIVATOR_FUNC(US_BUNDLE_NAME)(     \
     cppmicroservices::BundleActivator * activator)                             \
   {                                                                            \

--- a/framework/include/cppmicroservices/BundleInitialization.h
+++ b/framework/include/cppmicroservices/BundleInitialization.h
@@ -61,11 +61,15 @@ class BundleContextPrivate;
       US_BUNDLE_NAME){};                                                       \
                                                                                \
     extern "C" cppmicroservices::BundleContextPrivate* US_GET_CTX_FUNC(        \
+      US_BUNDLE_NAME)();                                                       \
+    extern "C" cppmicroservices::BundleContextPrivate* US_GET_CTX_FUNC(        \
       US_BUNDLE_NAME)()                                                        \
     {                                                                          \
       return US_CTX_INS(US_BUNDLE_NAME).load();                                \
     }                                                                          \
                                                                                \
+    extern "C" US_ABI_EXPORT void US_SET_CTX_FUNC(US_BUNDLE_NAME)(             \
+      cppmicroservices::BundleContextPrivate * ctx);                           \
     extern "C" US_ABI_EXPORT void US_SET_CTX_FUNC(US_BUNDLE_NAME)(             \
       cppmicroservices::BundleContextPrivate * ctx)                            \
     {                                                                          \


### PR DESCRIPTION
This PR fixes the -Wmissing-prototypes warning which both the CPPMICROSERVICES_INITIALIZE_BUNDLE and CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR macros were producing.

To get rid of the error, prototypes for the functions being defined were included above the actual definitions.

Another way to approach this is to include pragma statements in the code to define how the compiler/linker should act but this would be tricky since you are not able to put preprocessor statements in a macro definition. Additionally, the fix for the warning is simple and the amount of code added is negligible.
