### PR TITLE
Fixes TSAN loading on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,7 +492,7 @@ else()
 
   set(_orig_req_libs ${CMAKE_REQUIRED_LIBRARIES})
   set(CMAKE_REQUIRED_LIBRARIES "-fsanitize=thread")
-  usFunctionCheckCompilerFlags("-01 -fsanitize=thread" US_CXX_TSAN_FLAGS)
+  usFunctionCheckCompilerFlags("-O1 -fsanitize=thread" US_CXX_TSAN_FLAGS)
   set(CMAKE_REQUIRED_LIBRARIES "${_orig_req_libs}")
   if(NOT US_CXX_TSAN_FLAGS AND US_ENABLE_TSAN)
     message(WARNING "TSAN requested, but compiler does not recognize it")


### PR DESCRIPTION
In a previous PR, the check for compiler flags related to TSAN was modified so that it checked for "-01 -fsanitize=thread" instead of "-O1 -fsanitize=thread".

This PR fixes that typo.