### PR TITLE
Adjust valgrind suppressions

### DIFF
--- a/compendium/DeclarativeServices/test/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/Mocks.hpp
@@ -256,7 +256,10 @@ class MockComponentInstance
 {
 public:
   MOCK_METHOD1(
-    CreateInstanceAndBindReferences,
+    CreateInstance,
+    void(const std::shared_ptr<service::component::ComponentContext>&));
+  MOCK_METHOD1(
+    BindReferences,
     void(const std::shared_ptr<service::component::ComponentContext>&));
   MOCK_METHOD0(UnbindReferences, void(void));
   MOCK_METHOD0(Activate, void(void));

--- a/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
@@ -118,7 +118,9 @@ TEST_F(SingletonComponentConfigurationTest,
   EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_))
     .Times(1)
     .WillOnce(testing::Invoke([](ComponentInstance* obj) { delete obj; }));
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+  EXPECT_CALL(*mockInstance, CreateInstance(testing::_))
+    .Times(1);
+  EXPECT_CALL(*mockInstance, BindReferences(testing::_))
     .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
 
@@ -170,7 +172,9 @@ TEST_F(SingletonComponentConfigurationTest,
   EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_))
     .Times(1)
     .WillOnce(testing::Invoke([](ComponentInstance* obj) { delete obj; }));
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+  EXPECT_CALL(*mockInstance, CreateInstance(testing::_))
+    .Times(1);
+  EXPECT_CALL(*mockInstance, BindReferences(testing::_))
     .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
 
@@ -210,7 +214,9 @@ TEST_F(SingletonComponentConfigurationTest, TestGetService)
     .WillOnce(testing::Return(mockInstance.get()));
   EXPECT_CALL(mockCompFactory, DeleteComponentInstance(testing::_)).Times(1);
   cppmicroservices::InterfaceMapPtr iMap;
-  EXPECT_CALL(*mockInstance, CreateInstanceAndBindReferences(testing::_))
+  EXPECT_CALL(*mockInstance, CreateInstance(testing::_))
+    .Times(1);
+  EXPECT_CALL(*mockInstance, BindReferences(testing::_))
     .Times(1);
   EXPECT_CALL(*mockInstance, Activate()).Times(1);
   EXPECT_CALL(*mockInstance, GetInterfaceMap())

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstance.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstance.hpp
@@ -51,7 +51,9 @@ public:
    *
    * @param ctxt The {@code ComponentContext} object associated with the component instance.
    */
-  virtual void CreateInstanceAndBindReferences(
+  virtual void CreateInstance(
+    const std::shared_ptr<ComponentContext>& ctxt) = 0;
+  virtual void BindReferences(
     const std::shared_ptr<ComponentContext>& ctxt) = 0;
   virtual void UnbindReferences() = 0;
 

--- a/compendium/ServiceComponent/test/TestComponentInstance.cpp
+++ b/compendium/ServiceComponent/test/TestComponentInstance.cpp
@@ -163,7 +163,8 @@ TEST(ComponentInstance, VerifyZeroServicesZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -181,7 +182,8 @@ TEST(ComponentInstanceImpl, VerifyZeroServicesZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -206,7 +208,8 @@ TEST(ComponentInstance, VerifyWithSingleServiceZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -226,7 +229,8 @@ TEST(ComponentInstanceImpl, VerifyWithSingleServiceZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -255,7 +259,8 @@ TEST(ComponentInstance, VerifyWithMultipleServiceZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -279,7 +284,8 @@ TEST(ComponentInstanceImpl, VerifyWithMultipleServiceZeroDependencies)
   auto mockContext = std::make_shared<MockComponentContext>();
   EXPECT_CALL(*(mockContext.get()), LocateService(testing::_, testing::_))
     .Times(0); // ensure the mock context never gets a call to LocateService
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure none of the dependencies are bound. Dependencies are only bound if they are declared.
@@ -333,7 +339,8 @@ TEST(ComponentInstanceImpl, VerifyWithStaticDependencies)
     .WillRepeatedly(testing::WithArg<1>(testing::Invoke(
       locateService))); // ensure the mock context received a call to LocateService for dependency bar
 
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure the dependencies are bound when the object is constructed
@@ -408,7 +415,8 @@ TEST(ComponentInstanceImpl, VerifyWithDynamicDependencies)
       locateService))); // ensure the mock context received a call to LocateService for dependency bar
 
   // use mock context to create an instance of the component implementation class.
-  compInstance.CreateInstanceAndBindReferences(mockContext);
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   auto compObj = compInstance.GetInstance();
   ASSERT_TRUE(compObj);
   // ensure the dependencies are bound when the object is constructed
@@ -446,8 +454,9 @@ TEST(ComponentInstance, VerifyLifeCycleHooks)
   ASSERT_FALSE(iMap);
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
-  compInstance.CreateInstanceAndBindReferences(
-    std::make_shared<MockComponentContext>());
+  auto mockContext = std::make_shared<MockComponentContext>();
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj->IsActivated());
   compInstance.Activate();
@@ -463,8 +472,9 @@ TEST(ComponentInstanceImpl, VerifyLifeCycleHooks)
   ASSERT_FALSE(iMap);
   auto compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj);
-  compInstance.CreateInstanceAndBindReferences(
-    std::make_shared<MockComponentContext>());
+  auto mockContext = std::make_shared<MockComponentContext>();
+  compInstance.CreateInstance(mockContext);
+  compInstance.BindReferences(mockContext);
   compObj = compInstance.GetInstance();
   ASSERT_FALSE(compObj->IsActivated());
   compInstance.Activate();

--- a/compendium/test_bundles/TestBundleDSUpstreamDependencyA/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSUpstreamDependencyA/src/ServiceImpl.hpp
@@ -1,6 +1,9 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+
 #include "TestInterfaces/Interfaces.hpp"
 
 namespace dependent {
@@ -10,6 +13,16 @@ class TestBundleDSUpstreamDependencyImpl
 public:
   TestBundleDSUpstreamDependencyImpl();
   ~TestBundleDSUpstreamDependencyImpl() override;
+
+  void Activate(const std::shared_ptr<cppmicroservices::service::component::ComponentContext>& context)
+  {
+    ctx = context->GetBundleContext();  
+  }
+
+  void Deactivate(const std::shared_ptr<cppmicroservices::service::component::ComponentContext>&) {}
+
+private:
+  cppmicroservices::BundleContext ctx;
 };
 }
 

--- a/valgrind_suppressions.txt
+++ b/valgrind_suppressions.txt
@@ -240,7 +240,6 @@
    fun:mz_zip_writer_add_mem_ex
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 
@@ -252,7 +251,6 @@
    fun:mz_zip_writer_add_mem_ex
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 
@@ -263,7 +261,6 @@
    ...
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 {


### PR DESCRIPTION
valgrind suppressions no longer work after porting usResourceCompiler tests to gtest