### PR TITLE
Update valgrind suppressions [skip appveyor]

### DIFF
--- a/valgrind_suppressions.txt
+++ b/valgrind_suppressions.txt
@@ -240,7 +240,6 @@
    fun:mz_zip_writer_add_mem_ex
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 
@@ -252,7 +251,6 @@
    fun:mz_zip_writer_add_mem_ex
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 
@@ -263,7 +261,6 @@
    ...
    fun:mz_zip_writer_add_mem
    ...
-   fun:main
 }
 
 {


### PR DESCRIPTION
suppressions were broken after porting usResourceCompiler tests to gtest

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>