### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,44 +21,6 @@ matrix:
 environment:
   matrix:
   # ---------- Visual Studio 2015 ------------
-  #---- Win32
-  #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #  platform: Win32
-  #  configuration: Release
-  #  gen: "Visual Studio 14 2015"
-  #  US_SHARED: 0
-  #  US_THREADED: 0
-  #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #  platform: Win32
-  #  configuration: Release
-  #  gen: "Visual Studio 14 2015"
-  #  US_SHARED: 1
-  #  US_THREADED: 0
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 14 2015"
-    US_SHARED: 0
-    US_THREADED: 1
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 14 2015"
-    US_SHARED: 1
-    US_THREADED: 1
-  #---- Win64
-  #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #  platform: Win64
-  #  configuration: Release
-  #  gen: "Visual Studio 14 2015 Win64"
-  #  US_SHARED: 0
-  #  US_THREADED: 0
-  #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #  platform: x64
-  #  configuration: Release
-  #  gen: "Visual Studio 14 2015 Win64"
-  #  US_SHARED: 1
-  #  US_THREADED: 0
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     platform: x64
     configuration: Release
@@ -72,31 +34,6 @@ environment:
     US_SHARED: 1
     US_THREADED: 1
   # ---------- Visual Studio 2017 ------------
-  #---- Win32
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 15 2017"
-    US_SHARED: 0
-    US_THREADED: 0
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 15 2017"
-    US_SHARED: 1
-    US_THREADED: 0
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 15 2017"
-    US_SHARED: 0
-    US_THREADED: 1
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 15 2017"
-    US_SHARED: 1
-    US_THREADED: 1
   #---- Win64
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     platform: x64
@@ -137,31 +74,6 @@ environment:
     US_SHARED: 1
     US_THREADED: 1
   # ---------- Visual Studio 2019 ------------
-  #---- Win32
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 16 2019"
-    US_SHARED: 0
-    US_THREADED: 0
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 16 2019"
-    US_SHARED: 1
-    US_THREADED: 0
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 16 2019"
-    US_SHARED: 0
-    US_THREADED: 1
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    platform: Win32
-    configuration: Release
-    gen: "Visual Studio 16 2019"
-    US_SHARED: 1
-    US_THREADED: 1
   #---- Win64
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     platform: x64


### PR DESCRIPTION
remove Win32 builds. 32-bit Windows has limited support and all new Windows OSes are 64-bit.
[ci skip]
Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>