### PR TITLE
Fix: add missing include

### DIFF
--- a/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.cpp
+++ b/compendium/DeclarativeServices/src/metadata/ReferenceMetadata.cpp
@@ -20,6 +20,8 @@
 
   =============================================================================*/
 
+#include <limits>
+
 #include "ReferenceMetadata.hpp"
 #include "Util.hpp"
 


### PR DESCRIPTION
Compile exits with error for missing numeric_limits<size_t>::max() on g++-11.
Added missing include for <limits> for a successful compile.