### PR TITLE
Temporarily disable clang build

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -39,26 +39,26 @@ jobs:
          CC: gcc-5
          CXX: g++-5
   
-  linux_clang_build:
-    name: Build and test on supported clang compiler
-    runs-on: ubuntu-18.04
-    env:
-       BUILD_CONFIGURATION: 0
-       WITH_COVERAGE: 0
+  # linux_clang_build:
+  #   name: Build and test on supported clang compiler
+  #   runs-on: ubuntu-18.04
+  #   env:
+  #      BUILD_CONFIGURATION: 0
+  #      WITH_COVERAGE: 0
 
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       submodules: true
     
-    - name: Install dependencies
-      run: sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind
+  #   - name: Install dependencies
+  #     run: sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind
       
-    - name: Configure Build and Test
-      run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_travis.cmake
-      env:
-         CC: clang
-         CXX: clang++
+  #   - name: Configure Build and Test
+  #     run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_travis.cmake
+  #     env:
+  #        CC: clang
+  #        CXX: clang++
   
   build:
     name: Build and test on ${{matrix.os}} with build configuration ${{matrix.buildconfiguration}} 


### PR DESCRIPTION
This PR temporarily disables the clang build which runs in GitHub Actions.

There was an update to the GitHub Actions runners which has exposed an issue with the way our CMake checks for linking capabilities used within the project when using Clang on Linux.

There will be a follow-up PR which re-enables this configuration with a fix.