### PR TITLE
Stop AppVeyor from running builds on branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ pull_requests:
   do_not_increment_build_number: true
 
 branches:
-  except:
-  - coverity_scan
-  - gh_pages
+  only:
+  - master
+  - development
 
 skip_tags: true
 
@@ -171,4 +171,3 @@ after_test:
 test_script:
 - cd %APPVEYOR_BUILD_FOLDER%/build
 - ctest -j2 -C %CONFIGURATION% --output-on-failure
-


### PR DESCRIPTION
This PR prevents AppVeyor from queueing builds for branches (except development and master). When a PR is created, AppVeyor still runs.

Before this PR, AppVeyor would run for every commit. This means that if a PR was submitted and somebody added a commit to that branch, AppVeyor would queue a build for the commit in the PR and also on the branch. This PR aims to stop that duplicated work which clogs the queue.

Additionally, similar to our GitHub Actions setup, we no longer run builds on branches before they have a PR associated with them.
