### PR TITLE
Add TSAN build to CI

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -47,6 +47,7 @@ jobs:
        WITH_COVERAGE: 0
        WITH_MEMCHECK: 0
        WITH_TSAN: 1
+       TSAN_OPTIONS: "suppressions=${{github.workspace}}/tsan_suppressions.txt"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -38,6 +38,23 @@ jobs:
       env:
          CC: gcc-5
          CXX: g++-5
+
+  gcc_tsan_build:
+    name: Build and test with gcc and tsan (no memcheck)
+    runs-on: ubuntu-18.04
+    env:
+       BUILD_CONFIGURATION: 0
+       WITH_COVERAGE: 0
+       WITH_MEMCHECK: 0
+       WITH_TSAN: 1
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Configure Build and Test
+      run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_travis.cmake
   
   # linux_clang_build:
   #   name: Build and test on supported clang compiler

--- a/cmake/usCTestScript.cmake
+++ b/cmake/usCTestScript.cmake
@@ -1,6 +1,5 @@
 
 macro(build_and_test)
-
   set(CTEST_SOURCE_DIRECTORY ${US_SOURCE_DIR})
   set(CTEST_BINARY_DIRECTORY "${CTEST_DASHBOARD_ROOT}/${CTEST_PROJECT_NAME}_${CTEST_DASHBOARD_NAME}")
 
@@ -14,6 +13,10 @@ macro(build_and_test)
 
   if(NOT EXISTS "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt")
     file(WRITE "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" "${CTEST_INITIAL_CACHE}")
+  endif()
+
+  if (WITH_TSAN)
+    set(US_ENABLE_TSAN ON)
   endif()
 
   ctest_configure(RETURN_VALUE res)

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,6 @@
+# ServiceTracker/ServiceListener races
+race:cppmicroservices::ServiceListeners::RemoveServiceListener
+race:cppmicroservices::ServiceTracker*
+
+# Potential Deadlock in CCACtiveState
+deadlock:cppmicroservices::scrimpl::CCActiveState::Activate


### PR DESCRIPTION
This PR adds a new build to GitHub Actions which builds and tests the project with TSAN turned on.

We do not run memcheck in this configuration since TSAN and Valgrind do not play well together.