### PR TITLE
Fix clang build

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -57,26 +57,26 @@ jobs:
     - name: Configure Build and Test
       run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake
   
-  # linux_clang_build:
-  #   name: Build and test on supported clang compiler
-  #   runs-on: ubuntu-18.04
-  #   env:
-  #      BUILD_CONFIGURATION: 0
-  #      WITH_COVERAGE: 0
+  linux_clang_build:
+    name: Build and test on supported clang compiler
+    runs-on: ubuntu-18.04
+    env:
+       BUILD_CONFIGURATION: 0
+       WITH_COVERAGE: 0
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       submodules: true
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
     
-  #   - name: Install dependencies
-  #     run: sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind
+    - name: Install dependencies
+      run: sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind lld
       
-  #   - name: Configure Build and Test
-  #     run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake
-  #     env:
-  #        CC: clang
-  #        CXX: clang++
+    - name: Configure Build and Test
+      run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake
+      env:
+         CC: clang
+         CXX: clang++
   
   build:
     name: Build and test on ${{matrix.os}} with build configuration ${{matrix.buildconfiguration}} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if(NOT APPLE AND US_COMPILER_CLANG)
   # the target emulator for ld.lld to use.
   string(REGEX MATCH ".*(ld\.lld)$" _matches_lld "${CMAKE_LINKER}")
   if (NOT _matches_lld STREQUAL "")
-    set(_ADDITIONAL_LINKER_FLAGS -m elf_amd64_fbsd)
+    set(_ADDITIONAL_LINKER_FLAGS -m elf_x86_64)
   endif()
 
   # use libc++ instead of libstdc++ when using the clang/llvm toolchain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,15 @@ set(IMPORT_EXECUTABLES "${CMAKE_BINARY_DIR}/ImportExecutables.cmake" CACHE FILEP
 
 # global options based on compiler
 if(NOT APPLE AND US_COMPILER_CLANG)
+  # If we are using ld.lld instead of ld, which we will do from now on
+  # when building with clang on Linux because of a bug in CMake 3.21.1 (and possibly
+  # other version), we need to specify additional linker flags which specify
+  # the target emulator for ld.lld to use.
+  string(REGEX MATCH ".*(ld\.lld)$" _matches_lld "${CMAKE_LINKER}")
+  if (NOT _matches_lld STREQUAL "")
+    set(_ADDITIONAL_LINKER_FLAGS -m elf_amd64_fbsd)
+  endif()
+
   # use libc++ instead of libstdc++ when using the clang/llvm toolchain
   # libstdc++ shipped with GCC 4.9 does not support std::atomic operations on std::shared_ptr
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")

--- a/cmake/usFunctionCheckResourceLinking.cmake
+++ b/cmake/usFunctionCheckResourceLinking.cmake
@@ -16,7 +16,7 @@ function(usFunctionCheckResourceLinking)
       set(_suffix .rc)
     elseif(UNIX)
       execute_process(
-        COMMAND ${CMAKE_LINKER} -r -b binary -o "${CMAKE_CURRENT_BINARY_DIR}/us_resource_link.o" "${CMAKE_COMMAND}"
+        COMMAND ${CMAKE_LINKER} -r -o "${CMAKE_CURRENT_BINARY_DIR}/us_resource_link.o" ${_ADDITIONAL_LINKER_FLAGS} --format=binary "${CMAKE_COMMAND}"
         RESULT_VARIABLE _result
       )
       if(_result EQUAL 0)

--- a/cmake/usFunctionEmbedResources.cmake
+++ b/cmake/usFunctionEmbedResources.cmake
@@ -198,7 +198,7 @@ function(usFunctionEmbedResources)
     elseif(UNIX)
       add_custom_command(
         OUTPUT ${_source_output}
-        COMMAND ${CMAKE_LINKER} -r -b binary -o ${_source_output} ${_zip_archive_name}
+        COMMAND ${CMAKE_LINKER} -r --format=binary ${_ADDITIONAL_LINKER_FLAGS} -o ${_source_output} ${_zip_archive_name}
         COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.us_resources,alloc,load,readonly,data,contents ${_source_output} ${_source_output}
         DEPENDS ${_zip_archive}
         WORKING_DIRECTORY ${_zip_archive_path}


### PR DESCRIPTION
This PR fixes the clang build which was broken after GitHub updated the runners for GitHub Actions.

This issue is that there is a bug in CMake 3.21.0+ where if you are using clang on linux without lld installed, CMake will not use ld as the linker even if it is installed. See filed CMake issue: https://gitlab.kitware.com/cmake/cmake/-/issues/22500

This PR introduces changes to our CMake files which check to see if we are using lld; if we are, extra link flags are added since using lld requires specifying an emulation target (elf_amd64_fbsd).

Additionally, the clang build configuration was re-enabled and updated to always install lld so that we shouldn't experience this issue again.