### PR TITLE
Refactor AsyncWorkService

### DIFF
--- a/compendium/AsyncWorkService/include/cppmicroservices/asyncworkservice/AsyncWorkService.hpp
+++ b/compendium/AsyncWorkService/include/cppmicroservices/asyncworkservice/AsyncWorkService.hpp
@@ -30,7 +30,6 @@
 
 namespace cppmicroservices {
 namespace async {
-namespace detail {
 
 /**
  * 
@@ -53,7 +52,6 @@ public:
    */
   virtual void post(std::packaged_task<void()>&& task) = 0;
 };
-}
 }
 }
 

--- a/compendium/AsyncWorkService/src/AsyncWorkService.cpp
+++ b/compendium/AsyncWorkService/src/AsyncWorkService.cpp
@@ -24,10 +24,8 @@
 
 namespace cppmicroservices {
 namespace async {
-namespace detail {
 
 AsyncWorkService::~AsyncWorkService() = default;
 
-}
 }
 }

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
@@ -43,9 +43,9 @@ class SCRAsyncWorkServiceDetail;
  * testing purposes.
  */
 class SCRAsyncWorkService final
-  : public cppmicroservices::async::detail::AsyncWorkService
+  : public cppmicroservices::async::AsyncWorkService
   , public cppmicroservices::ServiceTrackerCustomizer<
-      cppmicroservices::async::detail::AsyncWorkService>
+      cppmicroservices::async::AsyncWorkService>
 {
 public:
   explicit SCRAsyncWorkService(cppmicroservices::BundleContext context,
@@ -56,23 +56,23 @@ public:
   SCRAsyncWorkService& operator=(SCRAsyncWorkService&&) noexcept = delete;
   ~SCRAsyncWorkService() noexcept override;
 
-  // methods from the cppmicroservices::async::detail::AsyncWorkService interface
+  // methods from the cppmicroservices::async::AsyncWorkService interface
   void post(std::packaged_task<void()>&& task) override;
 
   // methods from the cppmicroservices::ServiceTrackerCustomizer interface
   std::shared_ptr<TrackedParamType> AddingService(
-    const ServiceReference<cppmicroservices::async::detail::AsyncWorkService>&
+    const ServiceReference<cppmicroservices::async::AsyncWorkService>&
       reference) override;
   void ModifiedService(
-    const ServiceReference<cppmicroservices::async::detail::AsyncWorkService>&
+    const ServiceReference<cppmicroservices::async::AsyncWorkService>&
       reference,
-    const std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>&
-      service) override;
+    const std::shared_ptr<cppmicroservices::async::AsyncWorkService>& service)
+    override;
   void RemovedService(
-    const ServiceReference<cppmicroservices::async::detail::AsyncWorkService>&
+    const ServiceReference<cppmicroservices::async::AsyncWorkService>&
       reference,
-    const std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>&
-      service) override;
+    const std::shared_ptr<cppmicroservices::async::AsyncWorkService>& service)
+    override;
 
   // method to stop tracking the AsyncWorkService. This must be called from the SCR
   // BundleActivate's Stop method. Not thread-safe. Must not be called simultaneously from
@@ -81,11 +81,10 @@ public:
 
 private:
   cppmicroservices::BundleContext scrContext;
-  std::unique_ptr<cppmicroservices::ServiceTracker<
-    cppmicroservices::async::detail::AsyncWorkService>>
+  std::unique_ptr<
+    cppmicroservices::ServiceTracker<cppmicroservices::async::AsyncWorkService>>
     serviceTracker;
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-    asyncWorkService;
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService;
   std::shared_ptr<SCRLogger> logger;
 };
 }

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
@@ -45,7 +45,7 @@ SCRBundleExtension::SCRBundleExtension(
   const cppmicroservices::AnyMap& scrMetadata,
   const std::shared_ptr<ComponentRegistry>& registry,
   const std::shared_ptr<LogService>& logger,
-  const std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>&
+  const std::shared_ptr<cppmicroservices::async::AsyncWorkService>&
     asyncWorkService,
   const std::shared_ptr<ConfigurationNotifier>& configNotifier)
   : bundleContext(bundleContext)

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -55,7 +55,7 @@ public:
     const cppmicroservices::AnyMap& scrMetadata,
     const std::shared_ptr<ComponentRegistry>& registry,
     const std::shared_ptr<LogService>& logger,
-    const std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>&
+    const std::shared_ptr<cppmicroservices::async::AsyncWorkService>&
       asyncWorkService,
     const std::shared_ptr<ConfigurationNotifier>& configNotifier);
 

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
@@ -38,8 +38,7 @@ ComponentManagerImpl::ComponentManagerImpl(
   std::shared_ptr<ComponentRegistry> registry,
   BundleContext bundleContext,
   std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-    asyncWorkService,
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
   std::shared_ptr<ConfigurationNotifier> configNotifier,
   std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
   : registry(std::move(registry))

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -53,8 +53,7 @@ public:
     std::shared_ptr<ComponentRegistry> registry,
     cppmicroservices::BundleContext bundleContext,
     std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-    std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-      asyncWorkService,
+    std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
     std::shared_ptr<ConfigurationNotifier> configNotifier,
     std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
   ComponentManagerImpl(const ComponentManagerImpl&) = delete;
@@ -137,7 +136,7 @@ public:
   /**
    * Returns the threadpool object associated with this ComponentManager
    */
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService>
   GetAsyncWorkService() const
   {
     return asyncWorkService;
@@ -223,7 +222,7 @@ private:
   std::vector<std::shared_future<void>>
     disableFutures; ///< futures created when the component transitioned to \c DISABLED state
   std::mutex futuresMutex; ///< mutex to protect the #disableFutures member
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService>
     asyncWorkService; ///< work service to execute async work
   std::mutex
     transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
@@ -36,8 +36,7 @@ using cppmicroservices::scrimpl::metadata::ComponentMetadata;
 ConfigurationNotifier::ConfigurationNotifier(
   const cppmicroservices::BundleContext& context,
   std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-    asyncWorkService_)
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService_)
   : tokenCounter(0)
   , bundleContext(context)
   , logger(std::move(logger))

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
@@ -74,7 +74,7 @@ public:
   ConfigurationNotifier(
     const cppmicroservices::BundleContext& context,
     std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-    std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
+    std::shared_ptr<cppmicroservices::async::AsyncWorkService>
       asyncWorkService_);
 
   ConfigurationNotifier(const ConfigurationNotifier&) = delete;
@@ -120,8 +120,7 @@ private:
 
   cppmicroservices::BundleContext bundleContext;
   std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-  std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-    asyncWorkService;
+  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService;
 };
 
 } // namespace scrimpl

--- a/compendium/DeclarativeServices/test/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/Mocks.hpp
@@ -308,8 +308,7 @@ public:
     std::shared_ptr<ComponentRegistry> registry,
     BundleContext bundleContext,
     std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-    std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>
-      asyncWorkService,
+    std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
     std::shared_ptr<ConfigurationNotifier> notifier,
     std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
     : ComponentManagerImpl(metadata,
@@ -399,12 +398,11 @@ public:
 }
 
 namespace async {
-class MockAsyncWorkService
-  : public cppmicroservices::async::detail::AsyncWorkService
+class MockAsyncWorkService : public cppmicroservices::async::AsyncWorkService
 {
 public:
   MockAsyncWorkService()
-    : cppmicroservices::async::detail::AsyncWorkService()
+    : cppmicroservices::async::AsyncWorkService()
   {}
 
   MOCK_METHOD1(post, void(std::packaged_task<void()>&&));

--- a/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
@@ -45,12 +45,12 @@
 
 namespace test {
 
-namespace async = cppmicroservices::async::detail;
+namespace async = cppmicroservices::async;
 namespace scr = cppmicroservices::service::component::runtime;
 
 class TestAsyncWorkServiceEndToEnd
   : public ::testing::TestWithParam<
-      std::shared_ptr<cppmicroservices::async::detail::AsyncWorkService>>
+      std::shared_ptr<cppmicroservices::async::AsyncWorkService>>
 {
 public:
   TestAsyncWorkServiceEndToEnd()
@@ -80,23 +80,22 @@ public:
   cppmicroservices::Framework framework;
 };
 
-class AsyncWorkServiceInline
-  : public cppmicroservices::async::detail::AsyncWorkService
+class AsyncWorkServiceInline : public cppmicroservices::async::AsyncWorkService
 {
 public:
   AsyncWorkServiceInline()
-    : cppmicroservices::async::detail::AsyncWorkService()
+    : cppmicroservices::async::AsyncWorkService()
   {}
 
   void post(std::packaged_task<void()>&& task) override { task(); }
 };
 
 class AsyncWorkServiceStdAsync
-  : public cppmicroservices::async::detail::AsyncWorkService
+  : public cppmicroservices::async::AsyncWorkService
 {
 public:
   AsyncWorkServiceStdAsync()
-    : cppmicroservices::async::detail::AsyncWorkService()
+    : cppmicroservices::async::AsyncWorkService()
   {}
 
   void post(std::packaged_task<void()>&& task) override
@@ -107,11 +106,11 @@ public:
 };
 
 class AsyncWorkServiceThreadPool
-  : public cppmicroservices::async::detail::AsyncWorkService
+  : public cppmicroservices::async::AsyncWorkService
 {
 public:
   AsyncWorkServiceThreadPool(int nThreads)
-    : cppmicroservices::async::detail::AsyncWorkService()
+    : cppmicroservices::async::AsyncWorkService()
   {
     threadpool = std::make_shared<boost::asio::thread_pool>(nThreads);
   }
@@ -176,9 +175,8 @@ TEST_F(tGenericDSSuite, TestUserServiceUsedAfterInstall)
       std::make_shared<cppmicroservices::async::MockAsyncWorkService>();
     auto bundleContext = framework.GetBundleContext();
     auto reg =
-      bundleContext
-        .RegisterService<cppmicroservices::async::detail::AsyncWorkService>(
-          mockAsyncWorkService);
+      bundleContext.RegisterService<cppmicroservices::async::AsyncWorkService>(
+        mockAsyncWorkService);
     EXPECT_CALL(*mockAsyncWorkService, post(::testing::_)).Times(1);
 
     std::shared_ptr<cppmicroservices::scrimpl::SCRLogger> logger =
@@ -205,9 +203,8 @@ TEST_F(tGenericDSSuite, TestFallbackUsedAfterUnregister)
       std::make_shared<cppmicroservices::async::MockAsyncWorkService>();
     auto bundleContext = framework.GetBundleContext();
     auto reg =
-      bundleContext
-        .RegisterService<cppmicroservices::async::detail::AsyncWorkService>(
-          mockAsyncWorkService);
+      bundleContext.RegisterService<cppmicroservices::async::AsyncWorkService>(
+        mockAsyncWorkService);
     EXPECT_CALL(*mockAsyncWorkService, post(::testing::_)).Times(1);
 
     std::shared_ptr<cppmicroservices::scrimpl::SCRLogger> logger =
@@ -283,9 +280,10 @@ TEST_F(tGenericDSSuite, TestUseAsyncWorkServiceDuringConcurrentBundleOperations)
           EXPECT_CALL(*mockAsyncWorkService, post(::testing::_))
             .Times(::testing::AtLeast(1));
           do {
-            auto reg1 = bundleContext.RegisterService<
-              cppmicroservices::async::detail::AsyncWorkService>(
-              mockAsyncWorkService);
+            auto reg1 =
+              bundleContext
+                .RegisterService<cppmicroservices::async::AsyncWorkService>(
+                  mockAsyncWorkService);
             std::this_thread::sleep_for(std::chrono::seconds(1));
             reg1.Unregister();
           } while (stop.wait_for(std::chrono::milliseconds(1)) !=
@@ -327,8 +325,7 @@ TEST_P(TestAsyncWorkServiceEndToEnd, TestEndToEndBehaviorWithAsyncWorkService)
     auto ctx = framework.GetBundleContext();
 
     auto reg =
-      ctx.RegisterService<cppmicroservices::async::detail::AsyncWorkService>(
-        param);
+      ctx.RegisterService<cppmicroservices::async::AsyncWorkService>(param);
 
     for (const auto& bundleName : bundlesToInstall) {
       installedBundles.emplace_back(


### PR DESCRIPTION
This PR removes AsyncWorkService from the nested "detail" workspace.

The interface would now live in cppmicroservices::async::AsyncWorkService.