### PR TITLE
Fix deadlock in ConfigAdmin Update, UpdateIfDifferent and Remove

### DIFF
--- a/compendium/ConfigurationAdmin/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/CMakeLists.txt
@@ -31,7 +31,7 @@ if(MINGW)
 endif()
 
 usMacroCreateBundle(ConfigurationAdmin
-  VERSION "1.0.0"
+  VERSION "1.1.1"
   DEPENDS Framework
   TARGET ConfigurationAdmin
   SYMBOLIC_NAME configuration_admin

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -227,8 +227,8 @@ private:
   std::mutex futuresMutex;
   std::uint64_t futuresID;
   std::condition_variable futuresCV;
-  std::vector<std::future<void>> completeFutures;
-  std::unordered_map<std::uint64_t, std::future<void>> incompleteFutures;
+  std::vector<std::shared_future<void>> completeFutures;
+  std::unordered_map<std::uint64_t, std::shared_future<void>> incompleteFutures;
   cppmicroservices::ServiceTracker<
     cppmicroservices::service::cm::ManagedService,
     TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -481,7 +481,8 @@ TEST_F(ConfigAdminTests, testRemoveFactoryConfiguration)
   auto configuration_config1 =
     m_configAdmin->GetFactoryConfiguration("cm.testfactory", "config1");
 
-  configuration_config1->Remove();
+  auto fut = configuration_config1->Remove();
+  fut.get();
 
   EXPECT_NE(serviceFactory->getRemovedCounter("cm.testfactory~config1"), 0);
   EXPECT_EQ(serviceFactory->getRemovedCounter("cm.testfactory~config2"), 0);

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -66,6 +66,7 @@ struct BlockingConfigurationListener final
   void configurationEvent(
     const cppmicroservices::service::cm::ConfigurationEvent& event) noexcept
   {
+    auto type = event.type;  //just to avoid the unused parameter error on some platforms.
     {
       std::lock_guard<std::mutex> lg{ mutex_ };
     }

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -141,7 +141,7 @@ TEST_F(TestConfigurationAdminImpl, VerifyNoUpdateDeadlock)
       EXPECT_EQ(std::future_status::timeout,
                 fut.wait_for(std::chrono::milliseconds(10)));
     }
-    //fut goes out of scope here. If the destructor incorrectly blocks, the test would stall now.
+    //fut goes out of scope here. If the destructor blocks, the test would stall now.
   }
   // Lock is out of scope here, so configurationEvent should be unblocked, and the promise should be set.
   callCompletedFut.get();

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -64,9 +64,8 @@ struct BlockingConfigurationListener final
    *
    */
   void configurationEvent(
-    const cppmicroservices::service::cm::ConfigurationEvent& event) noexcept
+    const cppmicroservices::service::cm::ConfigurationEvent&) noexcept
   {
-    auto type = event.type;  //just to avoid the unused parameter error on some platforms.
     {
       std::lock_guard<std::mutex> lg{ mutex_ };
     }

--- a/compendium/DeclarativeServices/test/TestCCActiveState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCActiveState.cpp
@@ -209,5 +209,43 @@ TEST_F(CCActiveStateTest, TestConcurrentActivateDeactivate)
   EXPECT_NE(mockCompConfig->GetState(), state);
   EXPECT_EQ(activeInstanceCount, 0);
 }
+// Test that DS completes Modification before Deactivation
+// The Deactivate method is called immediately following the Modified method
+// This test verifies that the Modified method processing is allowed to complete
+// before the Deactivate method processing begins.
+// The Modified method does some processing and eventually calls ModifyComponentInstanceProperties
+// The Deactivate method calls DestroyComponentInstances.
+// If the Modified method is allowed to complete then the ModifyComponentInstanceProperties method
+// will be called before the DestroyComponentInstances.
+
+TEST_F(CCActiveStateTest, TestModifiedWithDeactivate)
+{
+  // testing::InSequence says that any EXPECT_CALLS that occur in this block must happen
+  // in the order in which they appear in the block.
+  testing::InSequence expectCallsInOrder;
+
+  // Create a mockComponentConfigurationImpl object and set the state to Active.
+  auto state = std::make_shared<CCActiveState>();
+  mockCompConfig->SetState(state);
+  EXPECT_EQ(mockCompConfig->GetConfigState(), ComponentState::ACTIVE);
+
+  // Expect ModifyComponentInstanceProperties to happen before DestroyComponentInstances.
+  // Also, ModifyComponentInstanceProperties has an action specified so that it will return
+  // true when called. If it returned the default (false) then DestroyComponentInstances would
+  // be called by the code that calls ModifyComponentInstanceProperties
+  // and would not be a valid test.
+  EXPECT_CALL(*mockCompConfig, ModifyComponentInstanceProperties)
+    .Times(1)
+    .WillOnce(testing::Return(true));
+  EXPECT_CALL(*mockCompConfig, DestroyComponentInstances()).Times(1);
+  EXPECT_NO_THROW({ state->Modified(*mockCompConfig); });
+  EXPECT_NO_THROW({ state->Deactivate(*mockCompConfig); });
+
+  // Verify that the Deactivate operation completed successfully and the state is changed to
+  // UNSATISFIED_REFERENCE.
+  EXPECT_EQ(mockCompConfig->GetConfigState(),
+            ComponentState::UNSATISFIED_REFERENCE);
+  EXPECT_NE(mockCompConfig->GetState(), state);
+}
 }
 }

--- a/compendium/DeclarativeServices/test/TestUpdateConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/TestUpdateConfiguration.cpp
@@ -83,7 +83,7 @@ TEST_F(tServiceComponent, testUpdateConfig_Modified) //DS_CAI_FTC_1
   EXPECT_EQ(uniqueProp->second, instanceId);
 
   // Component should still be active as modified method is present.
-  // The configuration is updated without deactivating and reactivating the service.
+  // The configuration is updated without deactivating and reactivating theÂ service.
   compConfigs = GetComponentConfigs(testBundle, componentName, compDescDTO);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";
   ASSERT_EQ(compConfigs.at(0).state, scr::dto::ComponentState::ACTIVE)

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -106,7 +106,7 @@ std::ostream& any_value_to_json(std::ostream& o,
         o << "\\t";
         break;
       default:
-// suppress type-limits error on linux arm 64 build
+// suppress type-limits warning on linux arm 64 build
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -106,12 +106,20 @@ std::ostream& any_value_to_json(std::ostream& o,
         o << "\\t";
         break;
       default:
+// suppress type-limits error on linux arm 64 build
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
         if ('\x00' <= *c && *c <= '\x1f') {
           o << "\\u" << std::hex << std::setw(4) << std::setfill('0')
             << static_cast<int>(*c);
         } else {
           o << *c;
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     }
   }
   return o << '"';


### PR DESCRIPTION
The Update, UpdateIfDifferent and Remove methods on Configuration objects send
an asynchronous notification to all services that have published a ConfigurationListener
interface. The asynchronous thread creates a std::future and saves it in a vector (incompleteFutures). 
A ConfigurationAdminImpl non-public method (WaitForAllAsync) can be used to wait for all futures in the vector to complete. The future created by the asynchronous notification thread is also shared (std::shared_future) and is returned to the caller of the Update, UpdateIfDifferent or Remove method so they can wait for the operation to complete. There was a bug in the initial version of ConfigurationAdmin that resulted in a deadlock under some circumstances because a std::future was being saved in the incompleteFutures vector instead of a std::shared_future. When the std::shared_future went out of scope, the destructor would stall because the std::future would still exist. This test confirms that
this deadlock no longer exists.

The actual situation in the field involved a complex problem where the notification of the updated configuration object in turn resulted in the code doing the updating being called. Instead of trying to duplicate this in user code, this tests creates a blocking ConfigurationListener and recreates the blocking circumstances that way. 

The code was tested by verifying that the test would stall (deadlock) when the value stored in the incompleteFutures and completeFutures vectors was of type std::future and does not stall in it’s present condition with the value stored in those two vectors of type std::shared_vector. 
