### PR TITLE
Change all DSCA bundles to use shared_ptr for holding properties

### DIFF
--- a/compendium/test_bundles/TestBundleDSCA01/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA01/src/ServiceImpl.cpp
@@ -8,13 +8,13 @@ void ServiceComponentCA01::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 
 cppmicroservices::AnyMap ServiceComponentCA01::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA01/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA01/src/ServiceImpl.hpp
@@ -12,7 +12,7 @@ class ServiceComponentCA01 : public test::CAInterface
 {
 public:
   ServiceComponentCA01(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
+    : properties(props)
   {}
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,7 +21,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA02/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA02/src/ServiceImpl.cpp
@@ -7,15 +7,15 @@ void ServiceComponentCA02::Modified(
   const std::shared_ptr<ComponentContext>& /*context*/,
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
-	throw std::runtime_error("Modified method exception");
-	std::lock_guard<std::mutex> lock(propertiesLock);
-	properties = *configuration;
+  throw std::runtime_error("Modified method exception");
+  std::lock_guard<std::mutex> lock(propertiesLock);
+  properties = configuration;
 }
 
 cppmicroservices::AnyMap ServiceComponentCA02::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA02/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA02/src/ServiceImpl.hpp
@@ -11,8 +11,8 @@ namespace sample {
 class ServiceComponentCA02 : public test::CAInterface
 {
 public:
-    ServiceComponentCA02(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
+  ServiceComponentCA02(const std::shared_ptr<cppmicroservices::AnyMap>& props)
+    : properties(props)
   {}
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,7 +21,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA03/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA03/src/ServiceImpl.cpp
@@ -6,7 +6,7 @@ namespace sample {
 cppmicroservices::AnyMap ServiceComponentCA03::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA03/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA03/src/ServiceImpl.hpp
@@ -1,30 +1,28 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA03 : public test::CAInterface
 {
-  class ServiceComponentCA03 : public test::CAInterface
-    {
-    public:
-      ServiceComponentCA03(const std::shared_ptr<cppmicroservices::AnyMap>& props) 
-          : properties(*props)
-      {
-      }
+public:
+  ServiceComponentCA03(const std::shared_ptr<cppmicroservices::AnyMap>& props)
+    : properties(props)
+  {}
 
-      cppmicroservices::AnyMap GetProperties();
+  cppmicroservices::AnyMap GetProperties();
 
-      ~ServiceComponentCA03() = default;
+  ~ServiceComponentCA03() = default;
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-    };
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA04/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA04/src/ServiceImpl.cpp
@@ -6,7 +6,7 @@ namespace sample {
 cppmicroservices::AnyMap ServiceComponentCA04::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA04/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA04/src/ServiceImpl.hpp
@@ -1,30 +1,28 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA04 : public test::CAInterface
 {
-  class ServiceComponentCA04 : public test::CAInterface
-    {
-    public:
-      ServiceComponentCA04(const std::shared_ptr<cppmicroservices::AnyMap>& props) 
-          : properties(*props)
-      {
-      }
+public:
+  ServiceComponentCA04(const std::shared_ptr<cppmicroservices::AnyMap>& props)
+    : properties(props)
+  {}
 
-      cppmicroservices::AnyMap GetProperties();
+  cppmicroservices::AnyMap GetProperties();
 
-      ~ServiceComponentCA04() = default;
+  ~ServiceComponentCA04() = default;
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-    };
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA05/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA05/src/ServiceImpl.cpp
@@ -8,12 +8,12 @@ void ServiceComponentCA05::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA05::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA05/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA05/src/ServiceImpl.hpp
@@ -11,7 +11,10 @@ namespace sample {
 class ServiceComponentCA05 : public test::CAInterface
 {
 public:
-  ServiceComponentCA05() = default;
+  ServiceComponentCA05()
+    : properties(std::make_shared<cppmicroservices::AnyMap>(
+        cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS))
+  {}
 
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,10 +24,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties{
-    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS
-  };
-  
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA05a/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA05a/src/ServiceImpl.cpp
@@ -6,7 +6,7 @@ namespace sample {
 cppmicroservices::AnyMap ServiceComponentCA05a::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA05a/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA05a/src/ServiceImpl.hpp
@@ -12,8 +12,8 @@ class ServiceComponentCA05a : public test::CAInterface
 {
 public:
   ServiceComponentCA05a(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
-    {}
+    : properties(props)
+  {}
 
   cppmicroservices::AnyMap GetProperties();
 
@@ -21,7 +21,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA07/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA07/src/ServiceImpl.cpp
@@ -8,12 +8,12 @@ void ServiceComponentCA07::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA07::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA07/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA07/src/ServiceImpl.hpp
@@ -11,7 +11,10 @@ namespace sample {
 class ServiceComponentCA07 : public test::CAInterface
 {
 public:
-  ServiceComponentCA07() = default;
+  ServiceComponentCA07()
+    : properties(std::make_shared<cppmicroservices::AnyMap>(
+        cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS))
+  {}
 
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,9 +24,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties{
-    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS
-  };
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.cpp
@@ -3,21 +3,21 @@
 
 namespace sample {
 
-ServiceComponentCA08::ServiceComponentCA08(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
-{
-}
+ServiceComponentCA08::ServiceComponentCA08(
+  const std::shared_ptr<cppmicroservices::AnyMap>& props)
+  : properties(props)
+{}
 void ServiceComponentCA08::Modified(
   const std::shared_ptr<ComponentContext>& /*context*/,
-    const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
+  const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA08::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.hpp
@@ -1,29 +1,27 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA08 : public test::CAInterface
 {
-  class ServiceComponentCA08 : public test::CAInterface
-    {
-    public:
-      ServiceComponentCA08(const std::shared_ptr<cppmicroservices::AnyMap>& props);
-      void Modified(
-        const std::shared_ptr<ComponentContext>& context,
-        const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
-      cppmicroservices::AnyMap GetProperties();
- 
-      ~ServiceComponentCA08() = default;
+public:
+  ServiceComponentCA08(const std::shared_ptr<cppmicroservices::AnyMap>& props);
+  void Modified(const std::shared_ptr<ComponentContext>& context,
+                const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
+  cppmicroservices::AnyMap GetProperties();
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-    };
+  ~ServiceComponentCA08() = default;
+
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA09/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA09/src/ServiceImpl.cpp
@@ -3,9 +3,11 @@
 
 namespace sample {
 
-ServiceComponentCA09::ServiceComponentCA09(const std::shared_ptr<cppmicroservices::AnyMap>& props,
-                                           const std::shared_ptr<test::Interface1> interface1)
-: properties(*props), constructorHit{false}
+ServiceComponentCA09::ServiceComponentCA09(
+  const std::shared_ptr<cppmicroservices::AnyMap>& props,
+  const std::shared_ptr<test::Interface1> interface1)
+  : properties(props)
+  , constructorHit{ false }
 {
   if (nullptr != interface1) {
     constructorHit = true;
@@ -16,12 +18,12 @@ void ServiceComponentCA09::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA09::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 bool ServiceComponentCA09::isDependencyInjected()
 {

--- a/compendium/test_bundles/TestBundleDSCA09/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA09/src/ServiceImpl.hpp
@@ -1,32 +1,30 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA09 : public test::CAInterface1
 {
-  class ServiceComponentCA09 : public test::CAInterface1
-    {
-    public:
-      ServiceComponentCA09(const std::shared_ptr<cppmicroservices::AnyMap>& props,
-                           const std::shared_ptr<test::Interface1> interface1);
-      void Modified(
-        const std::shared_ptr<ComponentContext>& context,
-        const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
-      cppmicroservices::AnyMap GetProperties() override;
-      bool isDependencyInjected() override;
- 
-      ~ServiceComponentCA09() = default;
+public:
+  ServiceComponentCA09(const std::shared_ptr<cppmicroservices::AnyMap>& props,
+                       const std::shared_ptr<test::Interface1> interface1);
+  void Modified(const std::shared_ptr<ComponentContext>& context,
+                const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
+  cppmicroservices::AnyMap GetProperties() override;
+  bool isDependencyInjected() override;
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-      bool constructorHit;
-    };
+  ~ServiceComponentCA09() = default;
+
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+  bool constructorHit;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA12/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA12/src/ServiceImpl.cpp
@@ -8,12 +8,12 @@ void ServiceComponentCA12::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA12::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA12/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA12/src/ServiceImpl.hpp
@@ -11,7 +11,10 @@ namespace sample {
 class ServiceComponentCA12 : public test::CAInterface
 {
 public:
-  ServiceComponentCA12() = default;
+  ServiceComponentCA12()
+    : properties(std::make_shared<cppmicroservices::AnyMap>(
+        cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS))
+  {}
 
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,9 +24,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties{
-    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS
-  };
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA16/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA16/src/ServiceImpl.cpp
@@ -6,7 +6,7 @@ namespace sample {
 cppmicroservices::AnyMap ServiceComponentCA16::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA16/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA16/src/ServiceImpl.hpp
@@ -1,30 +1,28 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA16 : public test::CAInterface
 {
-  class ServiceComponentCA16 : public test::CAInterface
-    {
-    public:
-      ServiceComponentCA16(const std::shared_ptr<cppmicroservices::AnyMap>& props) 
-          : properties(*props)
-      {
-      }
+public:
+  ServiceComponentCA16(const std::shared_ptr<cppmicroservices::AnyMap>& props)
+    : properties(props)
+  {}
 
-      cppmicroservices::AnyMap GetProperties();
+  cppmicroservices::AnyMap GetProperties();
 
-      ~ServiceComponentCA16() = default;
+  ~ServiceComponentCA16() = default;
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-    };
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA20/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA20/src/ServiceImpl.cpp
@@ -5,15 +5,15 @@ namespace sample {
 
 void ServiceComponentCA20::Modified(
   const std::shared_ptr<ComponentContext>& /*context*/,
-    const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
+  const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 cppmicroservices::AnyMap ServiceComponentCA20::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA20/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA20/src/ServiceImpl.hpp
@@ -1,32 +1,29 @@
 #ifndef _SERVICE_IMPL_HPP_
 #define _SERVICE_IMPL_HPP_
 
-#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "TestInterfaces/Interfaces.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
-namespace sample
+namespace sample {
+class ServiceComponentCA20 : public test::CAInterface
 {
-  class ServiceComponentCA20 : public test::CAInterface
-    {
-    public:
-      ServiceComponentCA20(const std::shared_ptr<cppmicroservices::AnyMap>& props) 
-          : properties(*props)
-      {
-      }
-      void Modified(
-        const std::shared_ptr<ComponentContext>& context,
-        const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
-      cppmicroservices::AnyMap GetProperties();
- 
-      ~ServiceComponentCA20() = default;
+public:
+  ServiceComponentCA20(const std::shared_ptr<cppmicroservices::AnyMap>& props)
+    : properties(props)
+  {}
+  void Modified(const std::shared_ptr<ComponentContext>& context,
+                const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
+  cppmicroservices::AnyMap GetProperties();
 
-    private:
-      std::mutex propertiesLock;
-      cppmicroservices::AnyMap properties;
-    };
+  ~ServiceComponentCA20() = default;
+
+private:
+  std::mutex propertiesLock;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
+};
 }
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestBundleDSCA24/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA24/src/ServiceImpl.cpp
@@ -8,13 +8,13 @@ void ServiceComponentCA24::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 
 cppmicroservices::AnyMap ServiceComponentCA24::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA24/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA24/src/ServiceImpl.hpp
@@ -12,7 +12,7 @@ class ServiceComponentCA24 : public test::CAInterface
 {
 public:
   ServiceComponentCA24(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
+    : properties(props)
   {}
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,7 +21,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestBundleDSCA26/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA26/src/ServiceImpl.cpp
@@ -8,13 +8,13 @@ void ServiceComponentCA26::Modified(
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  properties = *configuration;
+  properties = configuration;
 }
 
 cppmicroservices::AnyMap ServiceComponentCA26::GetProperties()
 {
   std::lock_guard<std::mutex> lock(propertiesLock);
-  return properties;
+  return *properties;
 }
 
 }

--- a/compendium/test_bundles/TestBundleDSCA26/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSCA26/src/ServiceImpl.hpp
@@ -12,7 +12,7 @@ class ServiceComponentCA26 : public test::CAInterface
 {
 public:
   ServiceComponentCA26(const std::shared_ptr<cppmicroservices::AnyMap>& props)
-    : properties(*props)
+    : properties(props)
   {}
   void Modified(const std::shared_ptr<ComponentContext>& context,
                 const std::shared_ptr<cppmicroservices::AnyMap>& configuration);
@@ -21,7 +21,7 @@ public:
 
 private:
   std::mutex propertiesLock;
-  cppmicroservices::AnyMap properties;
+  std::shared_ptr<cppmicroservices::AnyMap> properties;
 };
 }
 

--- a/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
+++ b/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
@@ -87,13 +87,13 @@ public:
 
 class US_TestInterfaces_EXPORT TestBundleDSDependent
 {
-  public:
+public:
   virtual ~TestBundleDSDependent();
 };
 
 class US_TestInterfaces_EXPORT TestBundleDSUpstreamDependency
 {
-  public:
+public:
   virtual ~TestBundleDSUpstreamDependency();
 };
 


### PR DESCRIPTION
Any files which were edited also has their indentation fixed.

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>