### PR TITLE
Switch to using operator== for UpdateIfDifferent

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -145,11 +145,7 @@ ConfigurationImpl::UpdateWithoutNotificationIfDifferent(AnyMap newProperties)
   if (removed) {
     throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
   }
-  std::ostringstream existingProps;
-  std::ostringstream newProps;
-  cppmicroservices::any_value_to_string(existingProps, properties);
-  cppmicroservices::any_value_to_string(newProps, newProperties);
-  if (existingProps.str() == newProps.str()) {
+  if (properties == newProperties) {
     return std::pair<bool, unsigned long>{ false, 0u };
   }
   properties = std::move(newProperties);


### PR DESCRIPTION
Now that `cppmicroservice::Any` supports `operator==`, switch to using that instead of string conversion for determining if the AnyMap has changed in `UpdateIfDifferent`. The existing unittest for `UpdateIfDifferent` provides coverage of this and continues to pass.

Signed-off-by: Conor Burgess <cburgess@mathworks.com>