### PR TITLE
Allow ResourceCompiler to accept Unicode Command-line arguments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark.git
 	update = merge
+[submodule "third_party/boost/nowide"]
+	path = third_party/boost/nowide
+	url = https://github.com/boostorg/nowide.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ endif()
 # Compile libraries here if you do not want -Werror or /WX on
 #-----------------------------------------------------------------------------
 add_subdirectory(third_party/absl)
+add_subdirectory(third_party/boost/nowide)
 #-----------------------------------------------------------------------------
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${US_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,7 +630,9 @@ endif()
 # Compile libraries here if you do not want -Werror or /WX on
 #-----------------------------------------------------------------------------
 add_subdirectory(third_party/absl)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
 add_subdirectory(third_party/boost/nowide)
+set(BUILD_SHARED_LIBS ${_us_build_shared} CACHE BOOL "Build shared libraries" FORCE)
 #-----------------------------------------------------------------------------
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${US_CXX_FLAGS}")

--- a/tools/rc/CMakeLists.txt
+++ b/tools/rc/CMakeLists.txt
@@ -13,6 +13,9 @@ if(WIN32)
     target_link_libraries(${US_RCC_EXECUTABLE_TARGET} Shlwapi)
 endif()
 
+target_link_libraries(${US_RCC_EXECUTABLE_TARGET} nowide::nowide)
+target_include_directories(${US_RCC_EXECUTABLE_TARGET} PRIVATE ${CppMicroServices_SOURCE_DIR}/third_party/boost/nowide/include)
+
 set_property(TARGET ${US_RCC_EXECUTABLE_TARGET} APPEND PROPERTY
              COMPILE_DEFINITIONS "MINIZ_NO_ARCHIVE_READING_API;MINIZ_NO_ZLIB_COMPATIBLE_NAMES")
 

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -35,6 +35,9 @@
 #include <utility>
 #include <vector>
 
+#include <nowide/args.hpp>
+#include <nowide/fstream.hpp>
+
 #include "optionparser.h"
 #include "json/json.h"
 
@@ -789,6 +792,8 @@ static int checkSanity(option::Parser& parse, option::Option* options)
 
 int main(int argc, char** argv)
 {
+  nowide::args _(argc, argv);
+
   const int BUNDLE_MANIFEST_VALIDATION_ERROR_CODE(2);
 
   int compressionLevel = MZ_DEFAULT_LEVEL; //default compression level;
@@ -889,7 +894,7 @@ int main(int argc, char** argv)
     if (bundleFileOpt) {
       validateManifestsInArchive(zipFile);
       std::string bundleBinaryFile(bundleFileOpt->arg);
-      std::ofstream outFileStream(
+      nowide::ofstream outFileStream(
         bundleBinaryFile, std::ios::ate | std::ios::binary | std::ios::app);
       std::ifstream zipFileStream(zipFile, std::ios::in | std::ios::binary);
       if (outFileStream.is_open() && zipFileStream.is_open()) {


### PR DESCRIPTION
This PR introduces the Boost NoWide library into the codebase to allow for the ResourceCompiler to accept unicode command-line arguments.