### PR TITLE
Fix warning suppression leakage to non-CppMicroServices code inside translation units 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,8 +472,10 @@ if(MSVC)
 
   if (${MSVC_VERSION} LESS 1910)
     # For googletest on MSVC versions less than MSVC 2017
-    # 'identifier' : decorated name length exceeded, name was truncated
-    set(disabled_warnings ${disabled_warnings} 4503)
+    # - (4503) 'identifier' : decorated name length exceeded, name was truncated
+    # Additionally, on MSVC versions less than MSVC 2015
+    # - (4996) all deprecation warnings (pragma push/pop for disablign the warning does not work)
+    set(disabled_warnings ${disabled_warnings} 4503 4996)
   endif()
 
   foreach(wd ${disabled_warnings})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,7 +474,7 @@ if(MSVC)
     # For googletest on MSVC versions less than MSVC 2017
     # - (4503) 'identifier' : decorated name length exceeded, name was truncated
     # Additionally, on MSVC versions less than MSVC 2015
-    # - (4996) all deprecation warnings (pragma push/pop for disablign the warning does not work)
+    # - (4996) all deprecation warnings (pragma push/pop for disabling the warning does not work)
     set(disabled_warnings ${disabled_warnings} 4503 4996)
   endif()
 

--- a/cmake/GlobalConfig.h.in
+++ b/cmake/GlobalConfig.h.in
@@ -121,7 +121,7 @@ _Pragma ("GCC diagnostic pop")
 #endif
 
 // Do not warn about the usage of deprecated unsafe functions
-US_MSVC_DISABLE_WARNING(4996)
+// US_MSVC_DISABLE_WARNING(4996)
 
 // Mark a variable or expression result as unused
 #define US_UNUSED(x) (void)(x)

--- a/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.cpp
+++ b/compendium/test_bundles/DSSpellChecker/src/SpellCheckImpl.cpp
@@ -23,6 +23,8 @@
 #include "cppmicroservices/BundleContext.h"
 #include <map>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 namespace DSSpellCheck {
 /**
@@ -73,3 +75,5 @@ std::vector<std::string> SpellCheckImpl::Check(const std::string& passage)
   return errorList;
 }
 }
+
+US_MSVC_POP_WARNING

--- a/doc/src/tutorial/spellcheckservice/Activator.cpp
+++ b/doc/src/tutorial/spellcheckservice/Activator.cpp
@@ -33,9 +33,6 @@
 #include <map>
 #include <memory>
 
-// This is to disable warning 4996 on MSVC 2015. The below warning
-// suppression does not work when compiling with MSVC 2015
-US_MSVC_PUSH_DISABLE_WARNING(34996)
 US_MSVC_PUSH_DISABLE_WARNING(4996)
 
 using namespace cppmicroservices;

--- a/doc/src/tutorial/spellcheckservice/Activator.cpp
+++ b/doc/src/tutorial/spellcheckservice/Activator.cpp
@@ -33,6 +33,9 @@
 #include <map>
 #include <memory>
 
+// This is to disable warning 4996 on MSVC 2015. The below warning
+// suppression does not work when compiling with MSVC 2015
+US_MSVC_PUSH_DISABLE_WARNING(34996)
 US_MSVC_PUSH_DISABLE_WARNING(4996)
 
 using namespace cppmicroservices;

--- a/doc/src/tutorial/spellcheckservice/Activator.cpp
+++ b/doc/src/tutorial/spellcheckservice/Activator.cpp
@@ -33,6 +33,8 @@
 #include <map>
 #include <memory>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 namespace {
@@ -225,6 +227,8 @@ public:
   }
 };
 }
+
+US_MSVC_POP_WARNING
 
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(Activator)
 //![Activator]

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -32,6 +32,8 @@
 #  define ci_compare strncasecmp
 #endif
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 const Any Properties::emptyAny;
@@ -117,3 +119,5 @@ void Properties::Clear_unlocked()
   values.clear();
 }
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleActivatorTest.cpp
+++ b/framework/test/gtest/BundleActivatorTest.cpp
@@ -32,6 +32,8 @@
 
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 class BundleActivatorTest : public ::testing::Test
@@ -148,3 +150,5 @@ TEST_F(BundleActivatorTest, PropertyTrueWithClass)
     "cppmicroservices::TestBundleAService");
   EXPECT_TRUE(ref);
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleActivatorTest.cpp
+++ b/framework/test/gtest/BundleActivatorTest.cpp
@@ -32,8 +32,6 @@
 
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 class BundleActivatorTest : public ::testing::Test
@@ -150,5 +148,3 @@ TEST_F(BundleActivatorTest, PropertyTrueWithClass)
     "cppmicroservices::TestBundleAService");
   EXPECT_TRUE(ref);
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -34,8 +34,6 @@
 #include "TestingConfig.h"
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 // conflicts with FrameworkEvent::GetMessage
 #undef GetMessage
 
@@ -298,5 +296,3 @@ TEST_F(BundleHooksTest, TestFindHookFailure)
   eventHookReg.Unregister();
   framework.GetBundleContext().RemoveListener(std::move(fwkListenerToken));
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -34,6 +34,8 @@
 #include "TestingConfig.h"
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 // conflicts with FrameworkEvent::GetMessage
 #undef GetMessage
 
@@ -296,3 +298,5 @@ TEST_F(BundleHooksTest, TestFindHookFailure)
   eventHookReg.Unregister();
   framework.GetBundleContext().RemoveListener(std::move(fwkListenerToken));
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleManifestTest.cpp
+++ b/framework/test/gtest/BundleManifestTest.cpp
@@ -39,8 +39,6 @@
 
 #include <iostream>
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 namespace {
@@ -461,5 +459,3 @@ TEST_F(BundleManifestTest, DirectManifestInstallAndStartMultiStatic)
   }
 }
 #endif
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleManifestTest.cpp
+++ b/framework/test/gtest/BundleManifestTest.cpp
@@ -39,6 +39,8 @@
 
 #include <iostream>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 namespace {
@@ -459,3 +461,5 @@ TEST_F(BundleManifestTest, DirectManifestInstallAndStartMultiStatic)
   }
 }
 #endif
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleTest.cpp
+++ b/framework/test/gtest/BundleTest.cpp
@@ -46,6 +46,8 @@
 
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 using namespace cppmicroservices::testing;
 
@@ -915,3 +917,5 @@ TEST_F(BundleTest, TestBundleStreamOperator)
   ASSERT_TRUE(bundle);
   std::cout << &bundle;
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/BundleTest.cpp
+++ b/framework/test/gtest/BundleTest.cpp
@@ -46,8 +46,6 @@
 
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 using namespace cppmicroservices::testing;
 
@@ -917,5 +915,3 @@ TEST_F(BundleTest, TestBundleStreamOperator)
   ASSERT_TRUE(bundle);
   std::cout << &bundle;
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -107,7 +107,7 @@ usFunctionGetResourceSource(TARGET ${us_gtest_test_exe_name} OUT _additional_src
 add_executable(${us_gtest_test_exe_name} ${_gtest_tests} ${_additional_srcs} ${_third_party_srcs})
 
 if (US_COMPILER_MSVC AND BUILD_SHARED_LIBS)
-  target_compile_options(${us_gtest_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
+  target_compile_options(${us_gtest_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY /wd4996)
 endif()
 
 # Needed for ResourceCompilerTest

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -107,7 +107,7 @@ usFunctionGetResourceSource(TARGET ${us_gtest_test_exe_name} OUT _additional_src
 add_executable(${us_gtest_test_exe_name} ${_gtest_tests} ${_additional_srcs} ${_third_party_srcs})
 
 if (US_COMPILER_MSVC AND BUILD_SHARED_LIBS)
-  target_compile_options(${us_gtest_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY /wd4996)
+  target_compile_options(${us_gtest_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
 endif()
 
 # Needed for ResourceCompilerTest

--- a/framework/test/gtest/FrameworkListenerTest.cpp
+++ b/framework/test/gtest/FrameworkListenerTest.cpp
@@ -35,8 +35,6 @@
 #include <thread>
 #include <vector>
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 TEST(FrameworkListenerTest, testStartStopFrameworkEvents)
@@ -304,5 +302,3 @@ TEST(FrameworkListenerTest, testDeadLock)
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 #endif
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/FrameworkListenerTest.cpp
+++ b/framework/test/gtest/FrameworkListenerTest.cpp
@@ -35,6 +35,8 @@
 #include <thread>
 #include <vector>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 TEST(FrameworkListenerTest, testStartStopFrameworkEvents)
@@ -302,3 +304,5 @@ TEST(FrameworkListenerTest, testDeadLock)
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 #endif
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -61,6 +61,8 @@ using cppmicroservices::testing::TempDir;
 #  define US_TYPE_OPERATIONS_AVAILABLE 1
 #endif
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 TEST(FrameworkTest, Ctor)
 {
 #if US_TYPE_OPERATIONS_AVAILABLE
@@ -757,3 +759,5 @@ TEST(FrameworkTest, ShutdownAndStart)
 
   ASSERT_EQ(startCount, 1); // "One framework start notification"
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -61,8 +61,6 @@ using cppmicroservices::testing::TempDir;
 #  define US_TYPE_OPERATIONS_AVAILABLE 1
 #endif
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 TEST(FrameworkTest, Ctor)
 {
 #if US_TYPE_OPERATIONS_AVAILABLE
@@ -759,5 +757,3 @@ TEST(FrameworkTest, ShutdownAndStart)
 
   ASSERT_EQ(startCount, 1); // "One framework start notification"
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/InvalidBundleTest.cpp
+++ b/framework/test/gtest/InvalidBundleTest.cpp
@@ -27,6 +27,8 @@
 #include "gtest/gtest.h"
 #include <stdexcept>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 TEST(InvalidBundle, GetBundleIdFromInvalidBundle)
@@ -142,3 +144,5 @@ TEST(InvalidBundle, GetBundleVersionFromInvalidBundle)
   Bundle b;
   EXPECT_THROW(b.GetVersion(), std::invalid_argument);
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/InvalidBundleTest.cpp
+++ b/framework/test/gtest/InvalidBundleTest.cpp
@@ -27,8 +27,6 @@
 #include "gtest/gtest.h"
 #include <stdexcept>
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 TEST(InvalidBundle, GetBundleIdFromInvalidBundle)
@@ -144,5 +142,3 @@ TEST(InvalidBundle, GetBundleVersionFromInvalidBundle)
   Bundle b;
   EXPECT_THROW(b.GetVersion(), std::invalid_argument);
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/MultipleListenersTest.cpp
+++ b/framework/test/gtest/MultipleListenersTest.cpp
@@ -37,8 +37,6 @@
 #include <bitset>
 #include <future>
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 namespace {
@@ -505,5 +503,3 @@ TEST_F(MultipleListenersTest, testConcurrentAdd)
 }
 
 #endif
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/MultipleListenersTest.cpp
+++ b/framework/test/gtest/MultipleListenersTest.cpp
@@ -37,6 +37,8 @@
 #include <bitset>
 #include <future>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 namespace {
@@ -503,3 +505,5 @@ TEST_F(MultipleListenersTest, testConcurrentAdd)
 }
 
 #endif
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/ServiceHooksTest.cpp
+++ b/framework/test/gtest/ServiceHooksTest.cpp
@@ -40,8 +40,6 @@
 
 #include <unordered_set>
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 // conflicts with FrameworkEvent::GetMessage
 #undef GetMessage
 
@@ -629,5 +627,3 @@ TEST_F(ServiceHooksTest, TestListenerHookFailure)
   listenerHookReg.Unregister();
   framework.GetBundleContext().RemoveListener(std::move(fwkListenerToken));
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/ServiceHooksTest.cpp
+++ b/framework/test/gtest/ServiceHooksTest.cpp
@@ -40,6 +40,8 @@
 
 #include <unordered_set>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 // conflicts with FrameworkEvent::GetMessage
 #undef GetMessage
 
@@ -627,3 +629,5 @@ TEST_F(ServiceHooksTest, TestListenerHookFailure)
   listenerHookReg.Unregister();
   framework.GetBundleContext().RemoveListener(std::move(fwkListenerToken));
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/ServiceListenerTest.cpp
+++ b/framework/test/gtest/ServiceListenerTest.cpp
@@ -36,8 +36,6 @@
 
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 using namespace cppmicroservices::testing;
 
@@ -376,5 +374,3 @@ TEST_F(ServiceListenerTest, frameSL25a)
   context.RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
   sListen.clearEvents();
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/ServiceListenerTest.cpp
+++ b/framework/test/gtest/ServiceListenerTest.cpp
@@ -36,6 +36,8 @@
 
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 using namespace cppmicroservices::testing;
 
@@ -374,3 +376,5 @@ TEST_F(ServiceListenerTest, frameSL25a)
   context.RemoveServiceListener(&sListen, &TestServiceListener::serviceChanged);
   sListen.clearEvents();
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/StaticBundleTest.cpp
+++ b/framework/test/gtest/StaticBundleTest.cpp
@@ -37,6 +37,8 @@
 #include "TestingConfig.h"
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 using namespace cppmicroservices;
 
 namespace {
@@ -248,3 +250,5 @@ TEST(StaticBundleTest, testStaticBundle)
   }
 }
 }
+
+US_MSVC_POP_WARNING

--- a/framework/test/gtest/StaticBundleTest.cpp
+++ b/framework/test/gtest/StaticBundleTest.cpp
@@ -37,8 +37,6 @@
 #include "TestingConfig.h"
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 using namespace cppmicroservices;
 
 namespace {
@@ -250,5 +248,3 @@ TEST(StaticBundleTest, testStaticBundle)
   }
 }
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/gtest/TestUtilListenerHelpers.h
+++ b/framework/test/gtest/TestUtilListenerHelpers.h
@@ -28,8 +28,6 @@
 #include "cppmicroservices/ServiceEvent.h"
 #include "gtest/gtest.h"
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 namespace cppmicroservices {
 
 template<class Receiver>
@@ -90,7 +88,5 @@ private:
   CallbackType callback;
 };
 }
-
-US_MSVC_POP_WARNING
 
 #endif // CPPMICROSERVICES_TESTUTILBUNDLELISTENER_H

--- a/framework/test/gtest/TestUtilListenerHelpers.h
+++ b/framework/test/gtest/TestUtilListenerHelpers.h
@@ -28,6 +28,8 @@
 #include "cppmicroservices/ServiceEvent.h"
 #include "gtest/gtest.h"
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 template<class Receiver>
@@ -88,5 +90,7 @@ private:
   CallbackType callback;
 };
 }
+
+US_MSVC_POP_WARNING
 
 #endif // CPPMICROSERVICES_TESTUTILBUNDLELISTENER_H

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -45,8 +45,6 @@ limitations under the License.
 #include <fcntl.h>
 #include <sys/stat.h> // mkdir, _S_IREAD, etc.
 
-US_MSVC_PUSH_DISABLE_WARNING(4996)
-
 namespace cppmicroservices {
 
 namespace testing {
@@ -486,5 +484,3 @@ Bundle GetBundle(const std::string& bsn, BundleContext context)
 }
 }
 }
-
-US_MSVC_POP_WARNING

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -45,6 +45,8 @@ limitations under the License.
 #include <fcntl.h>
 #include <sys/stat.h> // mkdir, _S_IREAD, etc.
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 namespace testing {
@@ -484,3 +486,5 @@ Bundle GetBundle(const std::string& bsn, BundleContext context)
 }
 }
 }
+
+US_MSVC_POP_WARNING

--- a/httpservice/src/HttpServletRequest.cpp
+++ b/httpservice/src/HttpServletRequest.cpp
@@ -36,6 +36,8 @@
 #  define timegm(x) (_mkgmtime(x))
 #endif
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 HttpServletRequestPrivate::HttpServletRequestPrivate(
@@ -329,3 +331,5 @@ HttpServletRequest::HttpServletRequest(HttpServletRequestPrivate* d)
   : d(d)
 {}
 }
+
+US_MSVC_POP_WARNING

--- a/httpservice/src/HttpServletResponse.cpp
+++ b/httpservice/src/HttpServletResponse.cpp
@@ -34,6 +34,8 @@
 #include <stdexcept>
 #include <vector>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 HttpServletResponsePrivate::HttpServletResponsePrivate(
@@ -421,3 +423,5 @@ HttpServletResponse::HttpServletResponse(HttpServletResponsePrivate* d)
   : d(d)
 {}
 }
+
+US_MSVC_POP_WARNING

--- a/util/src/BundleObjFile.cpp
+++ b/util/src/BundleObjFile.cpp
@@ -25,6 +25,8 @@
 #include <cstring>
 #include <utility>
 
+US_MSVC_PUSH_DISABLE_WARNING(4996)
+
 namespace cppmicroservices {
 
 InvalidObjFileException::InvalidObjFileException(std::string what,
@@ -41,3 +43,5 @@ const char* InvalidObjFileException::what() const noexcept
   return m_What.c_str();
 }
 }
+
+US_MSVC_POP_WARNING


### PR DESCRIPTION
### Description
GlobalConfig.h (before this change) has some code which unconditionally suppresses MSVC warning C4996. This on its own is fine but the issue is that if GlobalConfig.h is directly or indirectly included in any translation unit, then the warning suppression will not only suppress warnings coming from CppMicroServices, but other libraries and code as well.

### Brief overview of changes
- Removed call to US_MSVC_DISABLE_WARNING (the comment above it seems to indicate that we thought it was for "deprecated, unsafe functions" but in reality it's for all deprecated functions)
- Disabled C4996 for MSVC compilers older than 2017 (US_MSVC_PUSH_DISABLE_WARNING and corresponding pop do not seem to work)

### Concrete example of what these changes fix
Functions `__declspec(deprecated) void foo(int a)` and `[[deprecated]] void foobar(char c)` and `__attribute__((deprecated)) void bonjour(const std::string& msg)` exist. `foo` and `foobar` hypothetically exist inside of the CppMicroServices library and are marked as deprecated. `bonjour` exists in another DSO (not CppMicroServices and not a library that a developer wrote (e.g., some-cool-library)).

The header in CppMicroServices where `foo` and `foobar` are declared includes GlobalConfig.h (directly or indirectly) for some of the utilities that it provides.

A developer wishes to use `foo` and `foobar` in their implementation file and since warning C4996 is disabled, they will not receive a compilation warning/error about using deprecated functions. The same developer also wishes to use `bonjour` in that same implementation file (doesn't have to be the same file but merely the same translation unit). The developer didn't check the documentation of some-cool-library and doesn't know that `bonjour` is actually a deprecated function. They write code which calls `bonjour` and they do not receive a warning/error saying that the function is deprecated because of GlobalConfig.h being directly/indirectly included and globally disabling the warning.

This is undesired and these changes aim to fix this.
