### PR TITLE
Housekeeping

### DIFF
--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
@@ -63,7 +63,7 @@ public:
       } catch (...) {
         auto exceptionPtr = std::current_exception();
         std::string msg =
-          "An exception has occured while trying to shutdown "
+          "An exception has occurred while trying to shutdown "
           "the fallback cppmicroservices::async::AsyncWorkService "
           "instance.";
         logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,

--- a/framework/test/bundles/CMakeLists.txt
+++ b/framework/test/bundles/CMakeLists.txt
@@ -3,7 +3,6 @@
 #-----------------------------------------------------------------------------
 
 include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/../driver
   ${CMAKE_CURRENT_SOURCE_DIR}/../gtest
   ${CMAKE_CURRENT_SOURCE_DIR}/../util
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party


### PR DESCRIPTION
# Description

This PR aims to cleanup a spelling mistake in addition to an incorrect inclusion of a directory that does not exist anymore when building test bundles.

# Brief overview of changes

- Fixed spelling of "occured" in SCRAsyncWorkService.cpp (changed it to "occurred")
- Removed `${CMAKE_CURRENT_SOURCE_DIR}/../driver` from list of include directories for all of the framework test bundle targets