### PR TITLE
Test case for concurrent DS GetService calls

### DIFF
--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -63,6 +63,8 @@ BundleOrPrototypeComponentConfigurationImpl::CreateAndActivateComponentInstance(
 {
   if (GetState()->GetValue() !=
       service::component::runtime::dto::ComponentState::ACTIVE) {
+    GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
+                     "Activate failed. Component no longer in Active State.");
     return nullptr;
   }
   auto compInstCtxtPairList = compInstanceMap.lock();

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -74,6 +74,8 @@ SingletonComponentConfigurationImpl::CreateAndActivateComponentInstance(
   auto instanceContextPair = data.lock();
   if (GetState()->GetValue() !=
       service::component::runtime::dto::ComponentState::ACTIVE) {
+    GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
+                     "Activate failed. Component no longer in Active State.");
     return nullptr;
   }
 

--- a/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
@@ -52,14 +52,7 @@ std::shared_ptr<ComponentInstance> CCActiveState::Activate(
         }
       });
       std::lock_guard<std::mutex> lock(oneAtATimeMutex);
-      // Make sure the state didn't change while we were waiting
-      auto currentState = mgr.GetState();
-      if (currentState->GetValue() !=
-          service::component::runtime::dto::ComponentState::ACTIVE) {
-        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
-                    "Activate failed. Component no longer in Active State.");
-        return nullptr;
-      }
+
       // no state change, already in active state. create and return a ComponentInstance object
       // This could throw; a scope guard is put in place to call latch.CountDown().
       instance = mgr.CreateAndActivateComponentInstance(clientBundle);


### PR DESCRIPTION
This test is designed to find race conditions in Declarative Services when multiple threads all try to get the same service.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>