### PR TITLE
Change CA threadpool to use 1 thread

### DIFF
--- a/.github/workflows/build_and_test_nix.yml
+++ b/.github/workflows/build_and_test_nix.yml
@@ -53,7 +53,9 @@ jobs:
         submodules: true
     
     - name: Install Dependencies
-      run: sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind lld
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install valgrind lld
       
     - name: Build and Test
       run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake
@@ -81,7 +83,9 @@ jobs:
          submodules: true
 
     - name: Install Dependencies
-      run: sudo apt-get install -y valgrind
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y valgrind
       if: ${{matrix.os == 'ubuntu-18.04'}}
 
     - name: Build And Test

--- a/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
@@ -50,7 +50,7 @@ public:
 
   void Initialize()
   {
-    threadpool = std::make_shared<boost::asio::thread_pool>(2);
+    threadpool = std::make_shared<boost::asio::thread_pool>(1);
   }
 
   void Shutdown()


### PR DESCRIPTION
- Modified CMAsyncWorkService.cpp implementation to use 1 thread

- Updated TestConfigAdmin.cpp to remove the notion of a
  polling condition for waiting on Update() notifications

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>