### PR TITLE
Upgrade to CMake 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Extract the current version from the VERSION file
 file(STRINGS VERSION _version LIMIT_COUNT 1)
 
-set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.12.4)
+set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.17)
 
 cmake_minimum_required(VERSION ${US_CMAKE_MINIMUM_REQUIRED_VERSION})
 


### PR DESCRIPTION
# Description

This PR changes the minimum CMake version from 3.12.4 to 3.17. There are many more "modern" CMake features that can be eventually used to modernize our CMake files (e.g., `target_sources()`, `CMAKE_PROJECT_INCLUDE_BEFORE/AFTER`, `FetchContent`, `CMAKE_POLICY_DEFAULT_CMP<NNNN>`, etc.).

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>