### PR TITLE
Check for existing AsyncWorkService before creating fallback in {SCR|CM}AsyncWorkService

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
@@ -63,7 +63,7 @@ public:
       } catch (...) {
         auto exceptionPtr = std::current_exception();
         std::string msg =
-          "An exception has occured while trying to shutdown "
+          "An exception has occurred while trying to shutdown "
           "the fallback cppmicroservices::async::AsyncWorkService "
           "instance.";
         logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
@@ -102,9 +102,20 @@ CMAsyncWorkService::CMAsyncWorkService(
   : scrContext(context)
   , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<
                      cppmicroservices::async::AsyncWorkService>>(context, this))
-  , asyncWorkService(std::make_shared<FallbackAsyncWorkService>(logger_))
+  , asyncWorkService(nullptr)
   , logger(logger_)
 {
+  if (auto asyncWSSRef =
+        context
+          .GetServiceReference<cppmicroservices::async::AsyncWorkService>();
+      asyncWSSRef) {
+    asyncWorkService =
+      context.GetService<cppmicroservices::async::AsyncWorkService>(
+        asyncWSSRef);
+  } else {
+    asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger_);
+  }
+
   serviceTracker->Open();
 }
 

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
@@ -98,13 +98,24 @@ private:
 
 SCRAsyncWorkService::SCRAsyncWorkService(
   cppmicroservices::BundleContext context,
-  const std::shared_ptr<SCRLogger>& logger_)
+  const std::shared_ptr<cppmicroservices::logservice::LogService>& logger_)
   : scrContext(context)
   , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<
                      cppmicroservices::async::AsyncWorkService>>(context, this))
-  , asyncWorkService(std::make_shared<FallbackAsyncWorkService>(logger_))
+  , asyncWorkService(nullptr)
   , logger(logger_)
 {
+  if (auto asyncWSSRef =
+        context
+          .GetServiceReference<cppmicroservices::async::AsyncWorkService>();
+      asyncWSSRef) {
+    asyncWorkService =
+      context.GetService<cppmicroservices::async::AsyncWorkService>(
+        asyncWSSRef);
+  } else {
+    asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger_);
+  }
+
   serviceTracker->Open();
 }
 

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
@@ -48,8 +48,9 @@ class SCRAsyncWorkService final
       cppmicroservices::async::AsyncWorkService>
 {
 public:
-  explicit SCRAsyncWorkService(cppmicroservices::BundleContext context,
-                               const std::shared_ptr<SCRLogger>& logger_);
+  explicit SCRAsyncWorkService(
+    cppmicroservices::BundleContext context,
+    const std::shared_ptr<cppmicroservices::logservice::LogService>& logger_);
   SCRAsyncWorkService(const SCRAsyncWorkService&) noexcept = delete;
   SCRAsyncWorkService(SCRAsyncWorkService&&) noexcept = delete;
   SCRAsyncWorkService& operator=(const SCRAsyncWorkService&) noexcept = delete;
@@ -85,7 +86,7 @@ private:
     cppmicroservices::ServiceTracker<cppmicroservices::async::AsyncWorkService>>
     serviceTracker;
   std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService;
-  std::shared_ptr<SCRLogger> logger;
+  std::shared_ptr<cppmicroservices::logservice::LogService> logger;
 };
 }
 }


### PR DESCRIPTION
# Description

With how the code exists before this change, it was always the case that the `FallbackAsyncWorkService` will be created, even if there exists a registered service implementation of `cppmicroservices::async::AsyncWorkService` in the framework. This change modifies the behavior of `{SCR|CM}AsyncWorkService` to first check to see if an AsyncWorkService is already present, and if so, uses that. If one is not present, it will still create the fallback.

# Potential future work
This change also brings `SCRAsyncWorkService` and `CMASyncWorkService` closer in terms of code parity. It appears that there could be a need for extracting the `{SCR|CM}AsyncWorkService` classes into a compendium services utility library which provides an instance of this class for each compendium service that wants one. The only differences in the code between both is the type of the class and the number of threads for the fallback to use (which can be made configurable via the constructor).

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>