### PR TITLE
Fix ListConfigurations returning empty config objects

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -345,7 +345,9 @@ ConfigurationAdminImpl::ListConfigurations(const std::string& filter)
     if (filter.empty()) {
       result.reserve(configurations.size());
       for (const auto& it : configurations) {
-        result.push_back(it.second);
+        if (!it.second->GetProperties().empty()) {
+          result.push_back(it.second);
+        }
       }
       return result;
     }
@@ -357,12 +359,16 @@ ConfigurationAdminImpl::ListConfigurations(const std::string& filter)
     };
 
     for (const auto& it : configurations) {
+      // empty configurations (those with an empty set of properties) cannot be
+      // returned.
+      if (it.second->GetProperties().empty()) {
+        continue;
+      }
       /* Create an AnyMap containing the pid or factoryPid so that the ldap filter 
-	 * functionality can be used to match the pid to the 
-	 * input parameter. Easy way to do the comparison since input parameter could 
-	 * contain a regular expression 
-	 */
-
+	   * functionality can be used to match the pid to the 
+	   * input parameter. Easy way to do the comparison since input parameter could 
+	   * contain a regular expression 
+	   */
       pidMap["pid"] = it.first;
 
       if (ldap.Match(pidMap)) {

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -290,17 +290,20 @@ TEST_F(TestConfigurationAdminImpl, VerifyListConfigurations)
   const auto conf1 = configAdmin.GetConfiguration(pid1);
   const auto conf2 = configAdmin.GetConfiguration(pid2);
 
+  auto props1 = conf1->GetProperties();
+  props1["foo"] = std::string{ "baz" };
+  EXPECT_NO_THROW(conf1->Update(props1).get());
+
   auto props2 = conf2->GetProperties();
   props2["foo"] = std::string{ "bar" };
-  std::shared_future<void> fut;
-  EXPECT_NO_THROW(fut = conf2->Update(props2));
-  fut.get();
+  EXPECT_NO_THROW(conf2->Update(props2).get());
+
   const auto res1 = configAdmin.ListConfigurations();
   const auto res2 = configAdmin.ListConfigurations("(foo=bar)");
   const auto res3 = configAdmin.ListConfigurations("(foobar=baz)");
 
-  EXPECT_EQ(res1.size(), 2);
-  EXPECT_EQ(res2.size(), 1);
+  EXPECT_EQ(res1.size(), 2ul);
+  EXPECT_EQ(res2.size(), 1ul);
   EXPECT_EQ(res2[0]->GetPid(), pid2);
   EXPECT_TRUE(res3.empty());
 

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -303,6 +303,18 @@ TEST_F(TestConfigurationAdminImpl, VerifyListConfigurations)
   EXPECT_EQ(res2.size(), 1);
   EXPECT_EQ(res2[0]->GetPid(), pid2);
   EXPECT_TRUE(res3.empty());
+
+  // ListConfigurations should not return empty config objects (i.e. those with no properties)
+  const auto emptyConfig = configAdmin.GetConfiguration("test.pid.emptyconfig");
+  const auto emptyConfigResult =
+    configAdmin.ListConfigurations("(pid=test.pid.emptyconfig)");
+  EXPECT_TRUE(emptyConfigResult.empty());
+
+  // ListConfigurations should not return empty config objects when returning
+  // all available configs
+  const auto allConfigsResult =
+    configAdmin.ListConfigurations();
+  EXPECT_EQ(allConfigsResult.size(), 2ul);
 }
 
 TEST_F(TestConfigurationAdminImpl, VerifyAddConfigurations)

--- a/compendium/DeclarativeServices/src/manager/ConfigurationManager.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationManager.cpp
@@ -69,7 +69,7 @@ void ConfigurationManager::Initialize()
     for (const auto& pid : metadata->configurationPids) {
       if (configProperties.find(pid) == configProperties.end()) {
         auto config = configAdmin->ListConfigurations("(pid=" + pid + ")");
-        if (config.size() > 0) {
+        if (config.size() > 0 && config.front()->GetChangeCount() > 0) {
           auto properties = config.front()->GetProperties();
           configProperties.emplace(pid, properties);
           for (const auto& item : properties) {

--- a/compendium/DeclarativeServices/src/manager/ConfigurationManager.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationManager.cpp
@@ -69,7 +69,7 @@ void ConfigurationManager::Initialize()
     for (const auto& pid : metadata->configurationPids) {
       if (configProperties.find(pid) == configProperties.end()) {
         auto config = configAdmin->ListConfigurations("(pid=" + pid + ")");
-        if (config.size() > 0 && config.front()->GetChangeCount() > 0) {
+        if (config.size() > 0) {
           auto properties = config.front()->GetProperties();
           configProperties.emplace(pid, properties);
           for (const auto& item : properties) {


### PR DESCRIPTION
Per OSGi standard, ListConfigurations should only return config objects containing properties (i.e. not an empty config).

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>