### PR TITLE
Fix bug in FindResources() for data-only bundles

### DIFF
--- a/framework/src/bundle/BundleResourceContainer.cpp
+++ b/framework/src/bundle/BundleResourceContainer.cpp
@@ -65,7 +65,7 @@ BundleResourceContainer::BundleResourceContainer(
       m_SortedToplevelDirs.insert(b.first);
     }
   } else {
-    OpenContainer();
+    OpenAndInitializeContainer();
   }
 }
 
@@ -90,7 +90,7 @@ std::vector<std::string> BundleResourceContainer::GetTopLevelDirs() const
 
 bool BundleResourceContainer::GetStat(BundleResourceContainer::Stat& stat)
 {
-  OpenContainer();
+  OpenAndInitializeContainer();
   int fileIndex =
     mz_zip_reader_locate_file(const_cast<mz_zip_archive*>(&m_ZipArchive),
                               stat.filePath.c_str(),
@@ -105,7 +105,7 @@ bool BundleResourceContainer::GetStat(BundleResourceContainer::Stat& stat)
 bool BundleResourceContainer::GetStat(int index,
                                       BundleResourceContainer::Stat& stat)
 {
-  OpenContainer();
+  OpenAndInitializeContainer();
   if (index >= 0) {
     mz_zip_archive_file_stat zipStat;
     if (!mz_zip_reader_file_stat(
@@ -135,7 +135,7 @@ bool BundleResourceContainer::GetStat(int index,
 std::unique_ptr<void, void (*)(void*)> BundleResourceContainer::GetData(
   int index)
 {
-  OpenContainer();
+  OpenAndInitializeContainer();
   std::unique_lock<std::mutex> l(m_ZipFileStreamMutex);
   void* data = mz_zip_reader_extract_to_heap(
     const_cast<mz_zip_archive*>(&m_ZipArchive), index, nullptr, 0);
@@ -179,7 +179,7 @@ void BundleResourceContainer::FindNodes(
   std::vector<std::string> names;
   std::vector<uint32_t> indices;
 
-  OpenContainer();
+  OpenAndInitializeContainer();
 
   this->GetChildren(path, true, names, indices);
 
@@ -260,7 +260,7 @@ bool BundleResourceContainer::Matches(const std::string& name,
   return true;
 }
 
-void BundleResourceContainer::OpenContainer() const
+void BundleResourceContainer::OpenAndInitializeContainer() const
 {
   std::lock_guard<std::mutex> lock(m_ZipFileMutex);
   if (!m_IsContainerOpen) {

--- a/framework/src/bundle/BundleResourceContainer.h
+++ b/framework/src/bundle/BundleResourceContainer.h
@@ -118,7 +118,7 @@ private:
   /// Opens the zip file so that data can be accessed.
   /// This function is thread-safe.
   /// Throws std::runtime_error if the underlying zip file cannot be opened.
-  void OpenContainer() const;
+  void OpenAndInitializeContainer() const;
 
   const std::string m_Location;
   mutable mz_zip_archive m_ZipArchive;

--- a/framework/src/bundle/BundleResourceContainer.h
+++ b/framework/src/bundle/BundleResourceContainer.h
@@ -107,25 +107,25 @@ private:
     }
   };
 
-  void InitSortedEntries();
+  void InitSortedEntries() const;
 
   bool Matches(const std::string& name, const std::string& filePattern) const;
 
   /// Initialize miniz with the resource zip file information.
   /// throws std::runtime_error if the underlying zip file cannot be opened or read.
-  void InitMiniz();
+  void InitMiniz() const;
 
   /// Opens the zip file so that data can be accessed.
   /// This function is thread-safe.
   /// Throws std::runtime_error if the underlying zip file cannot be opened.
-  void OpenContainer();
+  void OpenContainer() const;
 
   const std::string m_Location;
-  mz_zip_archive m_ZipArchive;
-  std::unique_ptr<BundleObjFile> m_ObjFile;
+  mutable mz_zip_archive m_ZipArchive;
+  mutable std::unique_ptr<BundleObjFile> m_ObjFile;
 
-  std::set<NameIndexPair, PairComp> m_SortedEntries;
-  std::set<std::string> m_SortedToplevelDirs;
+  mutable std::set<NameIndexPair, PairComp> m_SortedEntries;
+  mutable std::set<std::string> m_SortedToplevelDirs;
 
   // This is used to synchronize miniz file stream API calls.
   // Working with file streams is stateful (e.g. current read position)
@@ -134,8 +134,8 @@ private:
 
   // Synchronize opening/closing the underlying zip file. Only one thread
   // should open the underlying zip file.
-  std::mutex m_ZipFileMutex;
-  bool m_IsContainerOpen;
+  mutable std::mutex m_ZipFileMutex;
+  mutable bool m_IsContainerOpen;
 };
 }
 

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -149,14 +149,17 @@ long long HighPrecisionTimer::ElapsedMicro()
 
 #endif
 
-Bundle InstallLib(BundleContext frameworkCtx, const std::string& libName)
+Bundle InstallLib(BundleContext frameworkCtx,
+                  const std::string& libName,
+                  const cppmicroservices::AnyMap& bundleManifest)
 {
   std::vector<Bundle> bundles;
 
 #if defined(US_BUILD_SHARED_LIBS)
   bundles =
     frameworkCtx.InstallBundles(LIB_PATH + util::DIR_SEP + US_LIB_PREFIX +
-                                libName + US_LIB_POSTFIX + US_LIB_EXT);
+                                  libName + US_LIB_POSTFIX + US_LIB_EXT,
+                                bundleManifest);
 #else
   bundles = frameworkCtx.GetBundles();
 #endif

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -161,6 +161,7 @@ Bundle InstallLib(BundleContext frameworkCtx,
                                   libName + US_LIB_POSTFIX + US_LIB_EXT,
                                 bundleManifest);
 #else
+  US_UNUSED(bundleManifest);
   bundles = frameworkCtx.GetBundles();
 #endif
 

--- a/framework/test/util/TestUtils.h
+++ b/framework/test/util/TestUtils.h
@@ -79,7 +79,11 @@ private:
 
 // Helper function to install bundles, given a framework's bundle context and the name of the library.
 // Assumes that test bundles are within the same directory during unit testing.
-Bundle InstallLib(BundleContext frameworkCtx, const std::string& libName);
+Bundle InstallLib(
+  BundleContext frameworkCtx,
+  const std::string& libName,
+  const cppmicroservices::AnyMap& bundleManifest = cppmicroservices::AnyMap(
+    cppmicroservices::any_map::UNORDERED_MAP_CASEINSENSITIVE_KEYS));
 
 /*
 * Change to destination directory specified by destdir


### PR DESCRIPTION
When a bundle is installed with the optional manifest argument, the bundle isn't fopen'd automatically. In the case of data-only bundles, it is never fopen'd and the BundleResourceContainer is never initialized.

A call to FindResources() on a data-only bundle who was installed via `InstallBundles()` with the optional manifest will result in 0 resources always being returned.

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>