### PR TITLE
Add using statement to Binders.hpp

### DIFF
--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/Binders.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/Binders.hpp
@@ -27,6 +27,9 @@
 #include <vector>
 
 #include <cppmicroservices/ServiceReference.h>
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+
+using ComponentContext = cppmicroservices::service::component::ComponentContext;
 
 namespace cppmicroservices {
 namespace service {

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
@@ -29,11 +29,11 @@
 #include <tuple>
 #include <vector>
 
+#include "Binders.hpp"
 #include "ComponentInstance.hpp"
+#include "cppmicroservices/AnyMap.h"
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
-#include "Binders.hpp"
-#include "cppmicroservices/AnyMap.h"
 
 namespace cppmicroservices {
 namespace service {


### PR DESCRIPTION
Add a using statement to "Binders.hpp" to remove dependence on include order.

Fixes #567