### PR TITLE
Fix inheritance for ComponentException

### DIFF
--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentException.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentException.hpp
@@ -47,7 +47,7 @@ namespace component {
  *
  * Exception which may be thrown by Service Component Runtime.
  */
-class US_ServiceComponent_EXPORT ComponentException final : std::runtime_error
+class US_ServiceComponent_EXPORT ComponentException final : public std::runtime_error
 {
 public:
   /**


### PR DESCRIPTION
Not inheriting through public inheritance means that this exception type can't be caught by the `std::exception` nor `std::runtime_error` types in a catch.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>