### PR TITLE
ListConfigurations fix for empty configuration objects.

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -124,7 +124,11 @@ public:
                           const std::string& instanceName) override;
 
   /**
-   * Used to list all of the available {@code Configuration} objects.
+   * Used to list all of the {@code Configuration} objects that exist in the
+   * ConfigurationAdmin repository with a pid that matches the filter expression 
+   * (if provided).
+   * All of the {@code Configuration} objects returned have been updated at least
+   * once by ConfigurationAdmin.
    *
    * See {@code ConfigurationAdmin#ListConfigurations}
    */

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -36,19 +36,20 @@ namespace cmimpl {
 ConfigurationImpl::ConfigurationImpl(ConfigurationAdminPrivate* configAdmin,
                                      std::string thePid,
                                      std::string theFactoryPid,
-                                     AnyMap props)
+                                     AnyMap props,
+                                     const unsigned long cCount)
   : configAdminImpl(configAdmin)
   , pid(std::move(thePid))
   , factoryPid(std::move(theFactoryPid))
   , properties(std::move(props))
-  , changeCount{ 0u }
+  , changeCount{ cCount }
   , removed{ false }
 {
   assert(configAdminImpl != nullptr &&
          "Invalid ConfigurationAdminPrivate pointer");
   // constructing a configuration object with properties is the equivalent
   // of a Create and an Update operation.
-  if (properties.size() > 0) {
+  if ((properties.size() > 0) && (changeCount == 0u)) {
     changeCount++;
   }
 }

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
@@ -44,7 +44,8 @@ public:
   ConfigurationImpl(ConfigurationAdminPrivate* configAdminImpl,
                     std::string pid,
                     std::string factoryPid,
-                    AnyMap properties);
+                    AnyMap properties,
+                    const unsigned long cCount = 0);
   ~ConfigurationImpl() override = default;
   ConfigurationImpl(const ConfigurationImpl&) = delete;
   ConfigurationImpl& operator=(const ConfigurationImpl&) = delete;

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -307,17 +307,18 @@ TEST_F(TestConfigurationAdminImpl, VerifyListConfigurations)
   EXPECT_EQ(res2[0]->GetPid(), pid2);
   EXPECT_TRUE(res3.empty());
 
-  // ListConfigurations should not return empty config objects (i.e. those with no 
-  // properties) unless the configuration object has been updated.
+  // ListConfigurations can return empty config objects (those with no properties) but
+  // only if the configuration has been updated at least once. Nothing should
+  // be returned here because the configuration object has not been updated.
   const auto emptyConfig = configAdmin.GetConfiguration("test.pid.emptyconfig");
   const auto emptyConfigResult =
     configAdmin.ListConfigurations("(pid=test.pid.emptyconfig)");
   EXPECT_TRUE(emptyConfigResult.empty());
 
-  // ListConfigurations should not return empty config objects when returning
-  // all available configs unless the configuration object has been updated.
-  const auto allConfigsResult =
-    configAdmin.ListConfigurations();
+  // ListConfigurations can return empty config objects (those with no properties) but
+  // only if the configuration has been updated at least once. In this example,
+  // only two configurations have been updated at least once.
+  const auto allConfigsResult = configAdmin.ListConfigurations();
   EXPECT_EQ(allConfigsResult.size(), 2ul);
 
   //ListConfigurations should return empty config objects if the config
@@ -327,7 +328,15 @@ TEST_F(TestConfigurationAdminImpl, VerifyListConfigurations)
   configs.push_back(metadata::ConfigurationMetadata(
     "test.pid3", AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }));
   auto result = configAdmin.AddConfigurations(std::move(configs));
-  const auto allConfigs = configAdmin.ListConfigurations();
+  auto allConfigs = configAdmin.ListConfigurations();
+  EXPECT_EQ(allConfigs.size(), 3ul);
+
+  //If the properties for a configuration object are removed, ListConfigurations
+  //should still include that configuration object in the result list.
+  cppmicroservices::AnyMap props(
+    cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  EXPECT_NO_THROW(conf1->Update(props).get());
+  allConfigs = configAdmin.ListConfigurations();
   EXPECT_EQ(allConfigs.size(), 3ul);
 }
 

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -307,17 +307,28 @@ TEST_F(TestConfigurationAdminImpl, VerifyListConfigurations)
   EXPECT_EQ(res2[0]->GetPid(), pid2);
   EXPECT_TRUE(res3.empty());
 
-  // ListConfigurations should not return empty config objects (i.e. those with no properties)
+  // ListConfigurations should not return empty config objects (i.e. those with no 
+  // properties) unless the configuration object has been updated.
   const auto emptyConfig = configAdmin.GetConfiguration("test.pid.emptyconfig");
   const auto emptyConfigResult =
     configAdmin.ListConfigurations("(pid=test.pid.emptyconfig)");
   EXPECT_TRUE(emptyConfigResult.empty());
 
   // ListConfigurations should not return empty config objects when returning
-  // all available configs
+  // all available configs unless the configuration object has been updated.
   const auto allConfigsResult =
     configAdmin.ListConfigurations();
   EXPECT_EQ(allConfigsResult.size(), 2ul);
+
+  //ListConfigurations should return empty config objects if the config
+  //object was defined in a manifest.json file and added using AddConfigurations.
+  //Adding a configuration object this way counts as a create and update operation.
+  std::vector<metadata::ConfigurationMetadata> configs;
+  configs.push_back(metadata::ConfigurationMetadata(
+    "test.pid3", AnyMap{ AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }));
+  auto result = configAdmin.AddConfigurations(std::move(configs));
+  const auto allConfigs = configAdmin.ListConfigurations();
+  EXPECT_EQ(allConfigs.size(), 3ul);
 }
 
 TEST_F(TestConfigurationAdminImpl, VerifyAddConfigurations)


### PR DESCRIPTION
ListConfigurations should include configuration objects with no properties as long as those configuration objects have been updated at least once. A configuration object that is created from metadata counts as an object that has been updated at least once. Signed-off-by: The MathWorks, Inc. <pelliott@mathworks.com>