### PR TITLE
Update version numbers for CppMicroServices upgrade

### DIFF
--- a/compendium/ConfigurationAdmin/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/CMakeLists.txt
@@ -37,7 +37,7 @@ add_compile_definitions(BOOST_DATE_TIME_NO_LIB)
 add_compile_definitions(BOOST_REGEX_NO_LIB)
 
 usMacroCreateBundle(ConfigurationAdmin
-  VERSION "1.3.0"
+  VERSION "1.3.1"
   DEPENDS Framework
   TARGET ConfigurationAdmin
   SYMBOLIC_NAME configuration_admin

--- a/compendium/DeclarativeServices/CMakeLists.txt
+++ b/compendium/DeclarativeServices/CMakeLists.txt
@@ -39,7 +39,7 @@ add_compile_definitions(BOOST_REGEX_NO_LIB)
 
 
 usMacroCreateBundle(DeclarativeServices
-  VERSION "1.3.1"
+  VERSION "1.4.0"
   DEPENDS Framework
   TARGET DeclarativeServices
   SYMBOLIC_NAME declarative_services


### PR DESCRIPTION
Update version numbers in preparation for upgrading CppMicroServices to version 3.7.3. Signed-off-by The MathWorks, Inc. <pelliott@mathworks.com>