### PR TITLE
Add support for null values to AnyMap

### DIFF
--- a/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
+++ b/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
@@ -121,6 +121,16 @@ TEST_F(TestMetadataParserImplV1, ParseValidManifest)
   ASSERT_THAT(configuration.properties, ::testing::SizeIs(3));
 }
 
+TEST_F(TestMetadataParserImplV1, ParseManifestNullValue)
+{
+  auto metadataParser = MetadataParserFactory::Create(1, GetLogger());
+  auto configurations = metadataParser->ParseAndGetConfigurationMetadata(
+    ManifestHelper::GetTestManifest("manifest_null_value"));
+  ASSERT_THAT(configurations, ::testing::SizeIs(1));
+  const auto& configuration = configurations[0];
+  ASSERT_EQ(configuration.pid, std::string("test"));
+  ASSERT_THAT(configuration.properties, ::testing::SizeIs(1));
+}
 TEST_F(TestMetadataParserImplV1, ParseManifestEmptyProps)
 {
   auto metadataParser = MetadataParserFactory::Create(1, GetLogger());

--- a/compendium/ConfigurationAdmin/test/manifest.json
+++ b/compendium/ConfigurationAdmin/test/manifest.json
@@ -31,6 +31,17 @@
         }]
       }
     },
+    "manifest_null_value": {
+      "cm": {
+        "version": 1,
+        "configurations": [{
+          "pid": "test",
+          "properties": {
+             "optional 'license_type' property": null
+           }
+        }]
+      }
+    },
     "manifest_empty_props": {
       "cm": {
         "version": 1,

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -28,6 +28,22 @@
 #include <string>
 #include <unordered_map>
 
+/* rapidjson supports null values in a .json file. The AnyMap class does not support null values. 
+ * A value saved in the AnyMap must have a valid type and null is not a valid type. The NullValue 
+ * object allows us to save a null value in the AnyMap. 
+ */
+namespace cppmicroservices {
+  struct NullValue
+  {
+    std::string ToString() { return ""; };
+    friend std::ostream& operator<<(std::ostream& os, const NullValue& nv)
+    {
+      return os << ""
+                << "\n";
+    }
+  };
+}
+
 namespace cppmicroservices {
 
 namespace detail {

--- a/framework/src/bundle/BundleManifest.cpp
+++ b/framework/src/bundle/BundleManifest.cpp
@@ -98,6 +98,8 @@ Any ParseJsonValue(const rapidjson::Value& jsonValue, bool ci)
     return Any(jsonValue.GetInt());
   } else if (jsonValue.IsDouble()) {
     return Any(jsonValue.GetDouble());
+  } else if (jsonValue.IsNull()) {
+    return Any(cppmicroservices::NullValue());
   }
 
   return Any();


### PR DESCRIPTION
rapidjson supports null values but AnyMap did not. This change adds support for null values to the AnyMap class. Signed-off-by: The MathWorks, Inc. <pelliott@mathworks.com>