### PR TITLE
Fix compilation issue for arm macOS native compilation

### DIFF
--- a/third_party/patches/spdlogv1.x.patch
+++ b/third_party/patches/spdlogv1.x.patch
@@ -11,3 +11,16 @@ index 87c8c5a0..759021ac 100644
 
              long int hours = (24 * days) + (localtm.tm_hour - gmtm.tm_hour);
              long int mins = (60 * hours) + (localtm.tm_min - gmtm.tm_min);
+             
+diff --git a/third_party/spdlog/include/spdlog/details/log_msg.h b/third_party/spdlog/include/spdlog/details/log_msg.h
+index 834ca4df..c1071d91 100644
+--- a/third_party/spdlog/include/spdlog/details/log_msg.h
++++ b/third_party/spdlog/include/spdlog/details/log_msg.h
+@@ -14,7 +14,6 @@ struct SPDLOG_API log_msg
+     log_msg(log_clock::time_point log_time, source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
+     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
+     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);
+-    log_msg(const log_msg &other) = default;
+
+     string_view_t logger_name;
+     level::level_enum level{level::off};

--- a/third_party/spdlog/include/spdlog/details/log_msg.h
+++ b/third_party/spdlog/include/spdlog/details/log_msg.h
@@ -14,7 +14,6 @@ struct SPDLOG_API log_msg
     log_msg(log_clock::time_point log_time, source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);
-    log_msg(const log_msg &other) = default;
 
     string_view_t logger_name;
     level::level_enum level{level::off};


### PR DESCRIPTION
Compiling CppMicroServices natively on an M1 mac fails with the following warning-as-error message:
```cpp
In file included from /Users/alexander/Development/CppMicroServices/compendium/LogServiceImpl/src/LogServiceImpl.cpp:3:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/stdout_color_sinks.h:9:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/ansicolor_sink.h:8:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/sink.h:6:
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg.h:17:5: error: definition of implicit copy assignment operator for 'log_msg' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
    log_msg(const log_msg &other) = default;
    ^
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg_buffer-inl.h:36:14: note: in implicit copy assignment operator for 'spdlog::details::log_msg' first required here
    log_msg::operator=(other);
             ^
In file included from /Users/alexander/Development/CppMicroServices/compendium/LogServiceImpl/src/LogServiceImpl.cpp:3:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/stdout_color_sinks.h:9:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/ansicolor_sink.h:8:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/sink.h:6:
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg.h:17:5: error: definition of implicit copy assignment operator for 'log_msg' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
    log_msg(const log_msg &other) = default;
    ^
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg_buffer-inl.h:36:14: note: in implicit copy assignment operator for 'spdlog::details::log_msg' first required here
    log_msg::operator=(other);
In file included from /Users/alexander/Development/CppMicroServices/compendium/LogServiceImpl/test/TestLogService.cpp:21:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/ostream_sink.h:7:
In file included from /Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/sinks/base_sink.h:13:
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg.h:17:5: error: definition of implicit copy assignment operator for 'log_msg' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
    log_msg(const log_msg &other) = default;
    ^
/Users/alexander/Development/CppMicroServices/third_party/spdlog/include/spdlog/details/log_msg_buffer-inl.h:36:14: note: in implicit copy assignment operator for 'spdlog::details::log_msg' first required here
    log_msg::operator=(other);
```

This PR fixes this issue by removing the explicitly defined, defaulted copy constructor for `spdlog::details::log_msg`.

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>