### PR TITLE
Disable code signing for bundle with no c++ code

### DIFF
--- a/framework/test/bundles/libTestModuleWithEmbeddedZip/CMakeLists.txt
+++ b/framework/test/bundles/libTestModuleWithEmbeddedZip/CMakeLists.txt
@@ -12,6 +12,11 @@ set(_srcs foo.cpp)
 
 add_library(${PROJECT_NAME} ${_srcs})
 
+set_target_properties(${PROJECT_NAME}
+  PROPERTIES
+  XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+)
+
 if(CMAKE_CROSSCOMPILING)
     # Cross-compiled builds need to use the imported host version of usResourceCompiler
     include(${IMPORT_EXECUTABLES})


### PR DESCRIPTION
- Without this, cannot build on ARM macOS machines

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>