### PR TITLE
Multiple services and factory services in bundle dependent on same configuration pid

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -602,12 +602,15 @@ std::shared_future<void> ConfigurationAdminImpl::NotifyConfigurationUpdated(
     std::for_each(managedServiceWrappers.begin(),
                   managedServiceWrappers.end(),
                   [&](const auto& managedServiceWrapper) {
-                  if (managedServiceWrapper->pid == pid) {
-                    notifyServiceUpdated(pid,
-                                      *(managedServiceWrapper->trackedService),
-                                      properties,
-                                      *logger);
-                  }
+                    // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
+                    // that we aren't tracking. We must be careful not to dereference these!
+                    if ((managedServiceWrapper) && (managedServiceWrapper->pid == pid)) {
+                        notifyServiceUpdated(
+                          pid,
+                          *(managedServiceWrapper->trackedService),
+                          properties,
+                          *logger);
+                    }
                   });
 
     const auto factoryPid = getFactoryPid(pid);
@@ -620,17 +623,22 @@ std::shared_future<void> ConfigurationAdminImpl::NotifyConfigurationUpdated(
       std::for_each(managedServiceFactoryWrappers.begin(),
                     managedServiceFactoryWrappers.end(),
                     [&](const auto& managedServiceFactoryWrapper) {
-                    if (managedServiceFactoryWrapper->pid == factoryPid) {
-                      if (removed) {
-                        notifyServiceRemoved(pid,
-                            *(managedServiceFactoryWrapper->trackedService), *logger);
-                      } else {
-                        notifyServiceUpdated(pid,
-                            *(managedServiceFactoryWrapper->trackedService),
-                            properties,
-                            *logger);
-                      }
-                    }
+                    // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
+                    // that we aren't tracking. We must be careful not to dereference these!
+                       if ((managedServiceFactoryWrapper) && (managedServiceFactoryWrapper->pid == factoryPid)) {
+                         if (removed) {
+                            notifyServiceRemoved(
+                              pid,
+                              *(managedServiceFactoryWrapper->trackedService),
+                              *logger);
+                         } else {
+                            notifyServiceUpdated(
+                              pid,
+                              *(managedServiceFactoryWrapper->trackedService),
+                              properties,
+                              *logger);
+                         }
+                       }
                     });
   });
 }

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -601,7 +601,7 @@ std::shared_future<void> ConfigurationAdminImpl::NotifyConfigurationUpdated(
     const auto managedServiceWrappers = managedServiceTracker.GetServices();
     std::for_each(managedServiceWrappers.begin(),
                   managedServiceWrappers.end(),
-                  [&](auto& managedServiceWrapper) {
+                  [&](const auto& managedServiceWrapper) {
                   if (managedServiceWrapper->pid == pid) {
                     notifyServiceUpdated(pid,
                                       *(managedServiceWrapper->trackedService),
@@ -619,7 +619,7 @@ std::shared_future<void> ConfigurationAdminImpl::NotifyConfigurationUpdated(
       managedServiceFactoryTracker.GetServices();
       std::for_each(managedServiceFactoryWrappers.begin(),
                     managedServiceFactoryWrappers.end(),
-                    [&](auto& managedServiceFactoryWrapper) {
+                    [&](const auto& managedServiceFactoryWrapper) {
                     if (managedServiceFactoryWrapper->pid == factoryPid) {
                       if (removed) {
                         notifyServiceRemoved(pid,

--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 set(_test_bundles
   ManagedServiceAndFactoryBundle
   TestBundleManagedServiceFactory
+  TestBundleMultipleManagedServiceFactory
   )
 
 target_link_libraries(${us_configurationadmin_test_exe_name}

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -98,10 +98,9 @@ std::vector<std::shared_ptr<::test::TestManagedServiceInterface>>
 getManagedServices(cppmicroservices::BundleContext& ctx)
 {
   auto srs = ctx.GetServiceReferences<::test::TestManagedServiceInterface>();
-  std::vector<std::shared_ptr<::test::TestManagedServiceInterface>> services(
-    srs.size());
-  for (uint32_t i = 0; i < services.size(); ++i) {
-    services[i] = ctx.GetService<::test::TestManagedServiceInterface>(srs[i]);
+  std::vector<std::shared_ptr<::test::TestManagedServiceInterface>> services;
+  for (const auto& sr: srs) {
+    services.push_back( ctx.GetService<::test::TestManagedServiceInterface>(sr));
   }
 
   return services;
@@ -118,10 +117,9 @@ std::vector<std::shared_ptr<::test::TestManagedServiceFactory>>
 getManagedServiceFactories(cppmicroservices::BundleContext& ctx)
 {
   auto srs = ctx.GetServiceReferences<::test::TestManagedServiceFactory>();
-  std::vector<std::shared_ptr<::test::TestManagedServiceFactory>> factories(
-    srs.size());
-  for (uint32_t i = 0; i < factories.size(); ++i) {
-    factories[i] = ctx.GetService<::test::TestManagedServiceFactory>(srs[i]);
+  std::vector<std::shared_ptr<::test::TestManagedServiceFactory>> factories;
+  for (const auto& sr : srs) {
+    factories.push_back(ctx.GetService<::test::TestManagedServiceFactory>(sr));
   }
 
   return factories;

--- a/compendium/test_bundles/CMakeLists.txt
+++ b/compendium/test_bundles/CMakeLists.txt
@@ -59,4 +59,5 @@ add_subdirectory(EnglishDictionary)
 
 add_subdirectory(ManagedServiceAndFactoryBundle)
 add_subdirectory(TestBundleManagedServiceFactory)
+add_subdirectory(TestBundleMultipleManagedService)
 add_subdirectory(TestBundleMultipleManagedServiceFactory)

--- a/compendium/test_bundles/CMakeLists.txt
+++ b/compendium/test_bundles/CMakeLists.txt
@@ -59,3 +59,4 @@ add_subdirectory(EnglishDictionary)
 
 add_subdirectory(ManagedServiceAndFactoryBundle)
 add_subdirectory(TestBundleManagedServiceFactory)
+add_subdirectory(TestBundleMultipleManagedServiceFactory)

--- a/compendium/test_bundles/TestBundleMultipleManagedService/CMakeLists.txt
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/CMakeLists.txt
@@ -1,0 +1,7 @@
+usFunctionCreateDSTestBundle(TestBundleMultipleManagedService)
+
+usFunctionCreateTestBundleWithResources(TestBundleMultipleManagedService
+  SOURCES src/ManagedServiceImpl.cpp ${_glue_file}
+  RESOURCES manifest.json
+  BUNDLE_SYMBOLIC_NAME TestBundleMultipleManagedService
+  OTHER_LIBRARIES usTestInterfaces usServiceComponent cm)

--- a/compendium/test_bundles/TestBundleMultipleManagedService/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/resources/manifest.json
@@ -1,0 +1,34 @@
+{
+  "bundle.symbolic_name": "TestBundleMultipleManagedService",
+  "bundle.name": "TestBundleMultipleManagedService",
+  "bundle.activator": false,
+  "scr": {
+    "version": 1,
+    "components": [
+      {
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceImpl3",
+        "properties": {
+          "service.pid": "cm.testservice"
+        },
+        "service": {
+          "interfaces": [
+            "test::TestManagedServiceInterface",
+            "cppmicroservices::service::cm::ManagedService"
+          ]
+        }
+      },
+      {
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceImpl4",
+        "properties": {
+          "service.pid": "cm.testservice"
+        },
+        "service": {
+          "interfaces": [
+            "test::TestManagedServiceInterface",
+            "cppmicroservices::service::cm::ManagedService"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
@@ -14,7 +14,7 @@ TestManagedServiceImpl3::TestManagedServiceImpl3()
 
 TestManagedServiceImpl3::~TestManagedServiceImpl3() = default;
 
-void TestManagedServiceImpl3::Updated(AnyMap const& properties)
+void TestManagedServiceImpl3::Updated(AnyMap const& )
 {
   std::lock_guard<std::mutex> lk(m_counterMtx);
   m_counter++;
@@ -32,7 +32,7 @@ TestManagedServiceImpl4::TestManagedServiceImpl4()
 
 TestManagedServiceImpl4::~TestManagedServiceImpl4() = default;
 
-void TestManagedServiceImpl4::Updated(AnyMap const& properties)
+void TestManagedServiceImpl4::Updated(AnyMap const&)
 {
   std::lock_guard<std::mutex> lk(m_counterMtx);
   m_counter++;

--- a/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
@@ -1,0 +1,49 @@
+#include "ManagedServiceImpl.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceImpl3::TestManagedServiceImpl3()
+  : m_counter{ 0 }
+{}
+
+TestManagedServiceImpl3::~TestManagedServiceImpl3() = default;
+
+void TestManagedServiceImpl3::Updated(AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  m_counter++;
+}
+
+int TestManagedServiceImpl3::getCounter()
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  return m_counter;
+}
+
+TestManagedServiceImpl4::TestManagedServiceImpl4()
+  : m_counter{ 0 }
+{}
+
+TestManagedServiceImpl4::~TestManagedServiceImpl4() = default;
+
+void TestManagedServiceImpl4::Updated(AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  m_counter++;
+}
+
+int TestManagedServiceImpl4::getCounter()
+{
+  std::lock_guard<std::mutex> lk(m_counterMtx);
+  return m_counter;
+}
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.hpp
@@ -1,0 +1,52 @@
+#include <cppmicroservices/AnyMap.h>
+#include <cppmicroservices/cm/ManagedService.hpp>
+
+#include "TestInterfaces/Interfaces.hpp"
+
+#include <mutex>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceImpl3
+  : public ::test::TestManagedServiceInterface
+  , public cppmicroservices::service::cm::ManagedService
+{
+public:
+  TestManagedServiceImpl3();
+
+  virtual ~TestManagedServiceImpl3();
+
+  void Updated(AnyMap const& properties) override;
+
+  int getCounter() override;
+
+private:
+  int m_counter;
+  std::mutex m_counterMtx;
+};
+
+class TestManagedServiceImpl4
+  : public ::test::TestManagedServiceInterface
+  , public cppmicroservices::service::cm::ManagedService
+{
+public:
+  TestManagedServiceImpl4();
+
+  virtual ~TestManagedServiceImpl4();
+
+  void Updated(AnyMap const& properties) override;
+
+  int getCounter() override;
+
+private:
+  int m_counter;
+  std::mutex m_counterMtx;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedService/src/ServiceComponents.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/src/ServiceComponents.hpp
@@ -1,0 +1,6 @@
+#ifndef ServiceComponents_hpp
+#define ServiceComponents_hpp
+
+#include "ManagedServiceImpl.hpp"
+
+#endif /* ServiceComponents_hpp */

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/CMakeLists.txt
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/CMakeLists.txt
@@ -1,0 +1,7 @@
+usFunctionCreateDSTestBundle(TestBundleMultipleManagedServiceFactory)
+
+usFunctionCreateTestBundleWithResources(TestBundleMultipleManagedServiceFactory
+  SOURCES src/ManagedServiceFactoryImpl3.cpp src/ManagedServiceFactoryServiceImpl3.cpp src/ManagedServiceFactoryImpl4.cpp src/ManagedServiceFactoryServiceImpl4.cpp ${_glue_file}
+  RESOURCES manifest.json
+  BUNDLE_SYMBOLIC_NAME TestBundleMultipleManagedServiceFactory
+  OTHER_LIBRARIES usTestInterfaces usServiceComponent cm)

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/resources/manifest.json
@@ -1,0 +1,34 @@
+{
+  "bundle.symbolic_name": "TestBundleMultipleManagedServiceFactory",
+  "bundle.name": "TestBundleMultipleManagedServiceFactory",
+  "bundle.activator": false,
+  "scr": {
+    "version": 1,
+    "components": [
+      {
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceFactoryImpl3",
+        "properties": {
+          "service.pid": "cm.testfactory"
+        },
+        "service": {
+          "interfaces": [
+            "test::TestManagedServiceFactory",
+            "cppmicroservices::service::cm::ManagedServiceFactory"
+          ]
+        }
+      },
+      {
+        "implementation-class": "cppmicroservices::service::cm::test::TestManagedServiceFactoryImpl4",
+        "properties": {
+          "service.pid": "cm.testfactory"
+        },
+        "service": {
+          "interfaces": [
+            "test::TestManagedServiceFactory",
+            "cppmicroservices::service::cm::ManagedServiceFactory"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
@@ -17,7 +17,7 @@ void TestManagedServiceFactoryImpl3::Activate(
 }
 
 void TestManagedServiceFactoryImpl3::Updated(std::string const& pid,
-                                             AnyMap const& properties)
+                                             AnyMap const& )
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   m_updatedCallCount[pid] += 1;

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
@@ -20,11 +20,7 @@ void TestManagedServiceFactoryImpl3::Updated(std::string const& pid,
                                              AnyMap const& properties)
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
-  if (properties.empty()) {
-    m_updatedCallCount[pid] -= 1;
-  } else {
-    m_updatedCallCount[pid] += 1;
-  }
+  m_updatedCallCount[pid] += 1;
 }
 
 void TestManagedServiceFactoryImpl3::Removed(std::string const& pid)
@@ -52,7 +48,7 @@ TestManagedServiceFactoryImpl3::create(std::string const& config)
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   try {
     return std::make_shared<TestManagedServiceFactoryServiceImpl3>(
-      m_updatedCallCount.at(config));
+    m_updatedCallCount.at(config));
   } catch (...) {
     return nullptr;
   }

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
@@ -1,0 +1,64 @@
+#include "ManagedServiceFactoryImpl3.hpp"
+
+#include <iostream>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryImpl3::~TestManagedServiceFactoryImpl3() = default;
+
+void TestManagedServiceFactoryImpl3::Activate(
+  const std::shared_ptr<cppmicroservices::service::component::ComponentContext>&
+    context)
+{
+  bundleContext_ = context->GetBundleContext();
+}
+
+void TestManagedServiceFactoryImpl3::Updated(std::string const& pid,
+                                             AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  if (properties.empty()) {
+    m_updatedCallCount[pid] -= 1;
+  } else {
+    m_updatedCallCount[pid] += 1;
+  }
+}
+
+void TestManagedServiceFactoryImpl3::Removed(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  ++m_removedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl3::getUpdatedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  return m_updatedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl3::getRemovedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  return m_removedCallCount[pid];
+}
+
+std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface>
+TestManagedServiceFactoryImpl3::create(std::string const& config)
+{
+
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  try {
+    return std::make_shared<TestManagedServiceFactoryServiceImpl3>(
+      m_updatedCallCount.at(config));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.hpp
@@ -1,0 +1,52 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+#include "ManagedServiceFactoryServiceImpl3.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+#include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/cm/ManagedServiceFactory.hpp>
+
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryImpl3
+  : public ::test::TestManagedServiceFactory
+  , public ::cppmicroservices::service::cm::ManagedServiceFactory
+{
+
+public:
+  virtual ~TestManagedServiceFactoryImpl3();
+
+  void Activate(
+    const std::shared_ptr<
+      cppmicroservices::service::component::ComponentContext>& context);
+
+  void Updated(std::string const& pid, AnyMap const& properties) override;
+
+  void Removed(std::string const& pid) override;
+
+  int getUpdatedCounter(std::string const& pid) override;
+
+  int getRemovedCounter(std::string const& pid) override;
+
+  std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> create(
+    std::string const& config) override;
+
+private:
+  std::map<std::string, int> m_updatedCallCount;
+  std::map<std::string, int> m_removedCallCount;
+  cppmicroservices::BundleContext bundleContext_;
+  std::mutex m_updatedMtx;
+  std::mutex m_removedMtx;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
@@ -20,11 +20,7 @@ void TestManagedServiceFactoryImpl4::Updated(std::string const& pid,
                                              AnyMap const& properties)
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
-  if (properties.empty()) {
-    m_updatedCallCount[pid] -= 1;
-  } else {
-    m_updatedCallCount[pid] += 1;
-  }
+  m_updatedCallCount[pid] += 1;
 }
 
 void TestManagedServiceFactoryImpl4::Removed(std::string const& pid)
@@ -52,7 +48,7 @@ TestManagedServiceFactoryImpl4::create(std::string const& config)
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   try {
     return std::make_shared<TestManagedServiceFactoryServiceImpl4>(
-      m_updatedCallCount.at(config));
+    m_updatedCallCount.at(config));
   } catch (...) {
     return nullptr;
   }

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
@@ -17,7 +17,7 @@ void TestManagedServiceFactoryImpl4::Activate(
 }
 
 void TestManagedServiceFactoryImpl4::Updated(std::string const& pid,
-                                             AnyMap const& properties)
+                                             AnyMap const& )
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   m_updatedCallCount[pid] += 1;

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
@@ -1,0 +1,64 @@
+#include "ManagedServiceFactoryImpl4.hpp"
+
+#include <iostream>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryImpl4::~TestManagedServiceFactoryImpl4() = default;
+
+void TestManagedServiceFactoryImpl4::Activate(
+  const std::shared_ptr<cppmicroservices::service::component::ComponentContext>&
+    context)
+{
+  bundleContext_ = context->GetBundleContext();
+}
+
+void TestManagedServiceFactoryImpl4::Updated(std::string const& pid,
+                                             AnyMap const& properties)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  if (properties.empty()) {
+    m_updatedCallCount[pid] -= 1;
+  } else {
+    m_updatedCallCount[pid] += 1;
+  }
+}
+
+void TestManagedServiceFactoryImpl4::Removed(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  ++m_removedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl4::getUpdatedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  return m_updatedCallCount[pid];
+}
+
+int TestManagedServiceFactoryImpl4::getRemovedCounter(std::string const& pid)
+{
+  std::lock_guard<std::mutex> lk(m_removedMtx);
+  return m_removedCallCount[pid];
+}
+
+std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface>
+TestManagedServiceFactoryImpl4::create(std::string const& config)
+{
+
+  std::lock_guard<std::mutex> lk(m_updatedMtx);
+  try {
+    return std::make_shared<TestManagedServiceFactoryServiceImpl4>(
+      m_updatedCallCount.at(config));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.hpp
@@ -1,0 +1,51 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+#include "ManagedServiceFactoryServiceImpl4.hpp"
+#include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+#include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/cm/ManagedServiceFactory.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryImpl4
+  : public ::test::TestManagedServiceFactory
+  , public ::cppmicroservices::service::cm::ManagedServiceFactory
+{
+
+public:
+  virtual ~TestManagedServiceFactoryImpl4();
+
+  void Activate(
+    const std::shared_ptr<
+      cppmicroservices::service::component::ComponentContext>& context);
+
+  void Updated(std::string const& pid, AnyMap const& properties) override;
+
+  void Removed(std::string const& pid) override;
+
+  int getUpdatedCounter(std::string const& pid) override;
+
+  int getRemovedCounter(std::string const& pid) override;
+
+  std::shared_ptr<::test::TestManagedServiceFactoryServiceInterface> create(
+    std::string const& config) override;
+
+private:
+  std::map<std::string, int> m_updatedCallCount;
+  std::map<std::string, int> m_removedCallCount;
+  cppmicroservices::BundleContext bundleContext_;
+  std::mutex m_updatedMtx;
+  std::mutex m_removedMtx;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.cpp
@@ -1,0 +1,24 @@
+#include "ManagedServiceFactoryServiceImpl3.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryServiceImpl3::TestManagedServiceFactoryServiceImpl3(
+  int initialValue)
+  : value{ initialValue }
+{}
+
+TestManagedServiceFactoryServiceImpl3::
+  ~TestManagedServiceFactoryServiceImpl3() = default;
+
+int TestManagedServiceFactoryServiceImpl3::getValue()
+{
+  return value;
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.hpp
@@ -1,0 +1,24 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryServiceImpl3
+  : public ::test::TestManagedServiceFactoryServiceInterface
+{
+public:
+  TestManagedServiceFactoryServiceImpl3(int initialValue);
+  ~TestManagedServiceFactoryServiceImpl3();
+
+  int getValue() override;
+
+private:
+  int value;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.cpp
@@ -1,0 +1,24 @@
+#include "ManagedServiceFactoryServiceImpl4.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+TestManagedServiceFactoryServiceImpl4::TestManagedServiceFactoryServiceImpl4(
+  int initialValue)
+  : value{ initialValue }
+{}
+
+TestManagedServiceFactoryServiceImpl4::
+  ~TestManagedServiceFactoryServiceImpl4() = default;
+
+int TestManagedServiceFactoryServiceImpl4::getValue()
+{
+  return value;
+}
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.hpp
@@ -1,0 +1,24 @@
+#include "TestInterfaces/Interfaces.hpp"
+
+namespace cppmicroservices {
+namespace service {
+namespace cm {
+namespace test {
+
+class TestManagedServiceFactoryServiceImpl4
+  : public ::test::TestManagedServiceFactoryServiceInterface
+{
+public:
+  TestManagedServiceFactoryServiceImpl4(int initialValue);
+  ~TestManagedServiceFactoryServiceImpl4();
+
+  int getValue() override;
+
+private:
+  int value;
+};
+
+} // namespace test
+} // namespace cm
+} // namespace service
+} // namespace cppmicroservices

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ServiceComponents.hpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ServiceComponents.hpp
@@ -1,0 +1,7 @@
+#ifndef ServiceComponents_hpp
+#define ServiceComponents_hpp
+
+#include "ManagedServiceFactoryImpl3.hpp"
+#include "ManagedServiceFactoryImpl4.hpp"
+
+#endif /* ServiceComponents_hpp */


### PR DESCRIPTION
Multiple services and service factories can be dependent on the same configuration object and should be notified if the configuration object changes. Right now only one will be notified. This pull request fixes this problem in Configuration Admin for any service implementing the ManagedService interface or the ManagedServiceFactory interface. All services implementing those interfaces should be notified when configuration objects on which they are dependent change. 
