### PR TITLE
Fix LDAP performance for matching [DO NOT MERGE]

### DIFF
--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -94,8 +94,7 @@ void ComponentContextImpl::InitializeServicesCache()
   }
 }
 
-std::unordered_map<std::string, cppmicroservices::Any>
-ComponentContextImpl::GetProperties() const
+ServiceProperties ComponentContextImpl::GetProperties() const
 {
   const auto configManagerPtr = configManager.lock();
   if (!configManagerPtr) {

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -68,8 +68,7 @@ public:
    * \return a map of string and cppmicroservices::Any key-value pairs
    * \throws {@link ComponentException} if this {@link ComponentContext} is invalid
    */
-  std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
-    const override;
+  ServiceProperties GetProperties() const override;
 
   /**
    * Returns the service object for the specified reference name.

--- a/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
@@ -83,8 +83,7 @@ public:
   /**
    * Returns a map with properties specific to this component configuration
    */
-  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
-    const = 0;
+  virtual ServiceProperties GetProperties() const = 0;
 
   /**
    * Returns the bundle that contains this component

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -127,8 +127,7 @@ void ComponentConfigurationImpl::Stop()
   configListenerTokens.clear();
 }
 
-std::unordered_map<std::string, cppmicroservices::Any>
-ComponentConfigurationImpl::GetProperties() const
+ServiceProperties ComponentConfigurationImpl::GetProperties() const
 {
   if (metadata->factoryComponentID.empty()) {
     // This is not a factory component
@@ -311,7 +310,8 @@ public:
   SatisfiedFunctor(std::string skipKeyName)
     : state(true)
     , skipKey(std::move(skipKeyName))
-  {}
+  {
+  }
   SatisfiedFunctor(const SatisfiedFunctor& cpy) = default;
   SatisfiedFunctor(SatisfiedFunctor&& cpy) = default;
   SatisfiedFunctor& operator=(const SatisfiedFunctor& cpy) = default;

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -56,7 +56,8 @@ struct ListenerToken final
   ListenerToken(std::string pid, const ListenerTokenId tokenId)
     : pid(std::move(pid))
     , tokenId(std::move(tokenId))
-  {}
+  {
+  }
   std::string pid;
   ListenerTokenId tokenId;
 };
@@ -122,8 +123,7 @@ public:
    * These properties must include \c ComponentConstants::COMPONENT_NAME and
    * \c ComponentConstants::COMPONENT_ID
    */
-  std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
-    const override;
+  ServiceProperties GetProperties() const override;
 
   /** @copydoc ComponentConfiguration::GetBundle()
    *
@@ -140,7 +140,7 @@ public:
    */
   ComponentState GetConfigState() const override;
 
-   /**
+  /**
    * This method returns the {@link ConfigurationNotifier} object 
    */
   std::shared_ptr<ConfigurationNotifier> GetConfigNotifier() const

--- a/compendium/DeclarativeServices/src/metadata/ComponentMetadata.hpp
+++ b/compendium/DeclarativeServices/src/metadata/ComponentMetadata.hpp
@@ -28,6 +28,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <cppmicroservices/ServiceProperties.h>
+
 #include "ReferenceMetadata.hpp"
 #include "ServiceMetadata.hpp"
 
@@ -45,7 +47,8 @@ struct ComponentMetadata
     : activateMethodName("Activate")
     , deactivateMethodName("Deactivate")
     , modifiedMethodName("Modified")
-  {}
+  {
+  }
 
   std::string name;
   bool enabled{ true };
@@ -56,11 +59,11 @@ struct ComponentMetadata
   std::string modifiedMethodName;
   std::vector<ReferenceMetadata> refsMetadata;
   ServiceMetadata serviceMetadata;
-  std::unordered_map<std::string, cppmicroservices::Any> properties;
+  ServiceProperties properties;
   std::string configurationPolicy;
   std::vector<std::string> configurationPids;
   std::string factoryComponentID;
-  std::unordered_map<std::string, cppmicroservices::Any> factoryComponentProperties;
+  ServiceProperties factoryComponentProperties;
 };
 }
 }

--- a/compendium/DeclarativeServices/test/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/Mocks.hpp
@@ -39,54 +39,63 @@
 namespace cppmicroservices {
 namespace scrimpl {
 namespace metadata {
-  inline std::ostream& operator<<(std::ostream& os, const ComponentMetadata& metadata)
-  {
-    os << "ComponentMetadata[name = " << metadata.name << "]" << std::endl
-       << "\tenabled: " << metadata.enabled << std::endl
-       << "\timmediate: " << metadata.immediate << std::endl
-       << "\timplClassName: " << metadata.implClassName << std::endl
-       << "\tactivateMethodName: " << metadata.activateMethodName << std::endl
-       << "\tdeactivateMethodName: " << metadata.deactivateMethodName << std::endl
-       << "\tmodifiedMethodName: " << metadata.modifiedMethodName << std::endl;
+inline std::ostream& operator<<(std::ostream& os,
+                                const ComponentMetadata& metadata)
+{
+  os << "ComponentMetadata[name = " << metadata.name << "]" << std::endl
+     << "\tenabled: " << metadata.enabled << std::endl
+     << "\timmediate: " << metadata.immediate << std::endl
+     << "\timplClassName: " << metadata.implClassName << std::endl
+     << "\tactivateMethodName: " << metadata.activateMethodName << std::endl
+     << "\tdeactivateMethodName: " << metadata.deactivateMethodName << std::endl
+     << "\tmodifiedMethodName: " << metadata.modifiedMethodName << std::endl;
 
-    os << "\trefsMetaData[size = " << metadata.refsMetadata.size() << "]: [" << std::endl;
-    for (const auto& rMeta : metadata.refsMetadata) {
-      os << "\t\tReferenceMetadata[name = " << rMeta.name << "]" << std::endl
-	 << "\t\t\ttarget: " << rMeta.target << std::endl
-	 << "\t\t\tinterfaceName: " << rMeta.interfaceName << std::endl
-	 << "\t\t\tcardinality: " << rMeta.cardinality << std::endl
-	 << "\t\t\tpolicy: " << rMeta.policy << std::endl
-	 << "\t\t\tpolicyOption: " << rMeta.policyOption << std::endl
-	 << "\t\t\tscope: " << rMeta.scope << std::endl
-	 << "\t\t\tminCardinality: " << rMeta.minCardinality << std::endl
-	 << "\t\t\tmaxCardinality: " << rMeta.maxCardinality << std::endl;
-    }
-    os << "\t]" << std::endl;
-
-    os << "\tserviceMetadata:" << std::endl
-       << "\t\tServiceMetadata: [" << std::endl
-       << "\t\t\tinterfaces[size = " << metadata.serviceMetadata.interfaces.size() << "]: [" << std::endl;
-    for (const auto& interface : metadata.serviceMetadata.interfaces) {
-      bool isLast = interface != metadata.serviceMetadata.interfaces.back();
-      os << "\t\t\t\t" << interface << (isLast ? "" : ",") << std::endl;
-    }
-    os << "\t\t\t]," << std::endl
-       << "\t\t\tscope: " << metadata.serviceMetadata.scope << std::endl
-       << "\t\t]" << std::endl;
-
-    os << "\tproperties: [size = " << metadata.properties.size() << "] not shown" << std::endl;
-    os << "\tconfigurationPolicy: " << metadata.configurationPolicy << std::endl;
-    os << "\tconfigurationPids[size = " << metadata.configurationPids.size() << "]: [" << std::endl;
-    for (const auto& pid : metadata.configurationPids) {
-      bool isLast = pid != metadata.configurationPids.back();
-      os << "\t\t" << pid << (isLast ? "" : ",") << std::endl;
-    }
-    os << "\t" << "]" << std::endl
-       << "\t" << "factoryComponentID: " << metadata.factoryComponentID << std::endl;
-    os << "\tfactoryComponentProperties: [size = " << metadata.factoryComponentProperties.size() << "] not shown" << std::endl;
-
-    return os;
+  os << "\trefsMetaData[size = " << metadata.refsMetadata.size() << "]: ["
+     << std::endl;
+  for (const auto& rMeta : metadata.refsMetadata) {
+    os << "\t\tReferenceMetadata[name = " << rMeta.name << "]" << std::endl
+       << "\t\t\ttarget: " << rMeta.target << std::endl
+       << "\t\t\tinterfaceName: " << rMeta.interfaceName << std::endl
+       << "\t\t\tcardinality: " << rMeta.cardinality << std::endl
+       << "\t\t\tpolicy: " << rMeta.policy << std::endl
+       << "\t\t\tpolicyOption: " << rMeta.policyOption << std::endl
+       << "\t\t\tscope: " << rMeta.scope << std::endl
+       << "\t\t\tminCardinality: " << rMeta.minCardinality << std::endl
+       << "\t\t\tmaxCardinality: " << rMeta.maxCardinality << std::endl;
   }
+  os << "\t]" << std::endl;
+
+  os << "\tserviceMetadata:" << std::endl
+     << "\t\tServiceMetadata: [" << std::endl
+     << "\t\t\tinterfaces[size = " << metadata.serviceMetadata.interfaces.size()
+     << "]: [" << std::endl;
+  for (const auto& interface : metadata.serviceMetadata.interfaces) {
+    bool isLast = interface != metadata.serviceMetadata.interfaces.back();
+    os << "\t\t\t\t" << interface << (isLast ? "" : ",") << std::endl;
+  }
+  os << "\t\t\t]," << std::endl
+     << "\t\t\tscope: " << metadata.serviceMetadata.scope << std::endl
+     << "\t\t]" << std::endl;
+
+  os << "\tproperties: [size = " << metadata.properties.size() << "] not shown"
+     << std::endl;
+  os << "\tconfigurationPolicy: " << metadata.configurationPolicy << std::endl;
+  os << "\tconfigurationPids[size = " << metadata.configurationPids.size()
+     << "]: [" << std::endl;
+  for (const auto& pid : metadata.configurationPids) {
+    bool isLast = pid != metadata.configurationPids.back();
+    os << "\t\t" << pid << (isLast ? "" : ",") << std::endl;
+  }
+  os << "\t"
+     << "]" << std::endl
+     << "\t"
+     << "factoryComponentID: " << metadata.factoryComponentID << std::endl;
+  os << "\tfactoryComponentProperties: [size = "
+     << metadata.factoryComponentProperties.size() << "] not shown"
+     << std::endl;
+
+  return os;
+}
 } // namespace metadata
 
 namespace dummy {
@@ -145,20 +154,24 @@ class FakeLogger : public cppmicroservices::logservice::LogService
 public:
   void Log(cppmicroservices::logservice::SeverityLevel,
            const std::string&) override
-  {}
+  {
+  }
   void Log(cppmicroservices::logservice::SeverityLevel,
            const std::string&,
            const std::exception_ptr) override
-  {}
+  {
+  }
   void Log(const ServiceReferenceBase&,
            cppmicroservices::logservice::SeverityLevel,
            const std::string&) override
-  {}
+  {
+  }
   void Log(const ServiceReferenceBase&,
            cppmicroservices::logservice::SeverityLevel,
            const std::string&,
            const std::exception_ptr) override
-  {}
+  {
+  }
 };
 
 class MockComponentManager : public ComponentManager
@@ -234,7 +247,8 @@ public:
     std::shared_ptr<cppmicroservices::logservice::LogService> logger,
     const std::string& configName)
     : ReferenceManagerBaseImpl(metadata, bc, logger, configName)
-  {}
+  {
+  }
 
   MOCK_CONST_METHOD0(GetReferenceName, std::string(void));
   MOCK_CONST_METHOD0(GetReferenceScope, std::string(void));
@@ -255,9 +269,7 @@ public:
 class MockComponentConfiguration : public ComponentConfiguration
 {
 public:
-  MOCK_CONST_METHOD0(
-    GetProperties,
-    std::unordered_map<std::string, cppmicroservices::Any>(void));
+  MOCK_CONST_METHOD0(GetProperties, ServiceProperties(void));
   MOCK_CONST_METHOD0(GetAllDependencyManagers,
                      std::vector<std::shared_ptr<ReferenceManager>>(void));
   MOCK_CONST_METHOD1(GetDependencyManager,
@@ -333,10 +345,9 @@ class MockComponentContextImpl : public ComponentContextImpl
 public:
   MockComponentContextImpl(const std::weak_ptr<ComponentConfiguration>& cm)
     : ComponentContextImpl(cm)
-  {}
-  MOCK_CONST_METHOD0(
-    GetProperties,
-    std::unordered_map<std::string, cppmicroservices::Any>(void));
+  {
+  }
+  MOCK_CONST_METHOD0(GetProperties, ServiceProperties(void));
   MOCK_CONST_METHOD0(GetBundleContext, cppmicroservices::BundleContext(void));
   MOCK_CONST_METHOD0(GetUsingBundle, cppmicroservices::Bundle(void));
   MOCK_METHOD1(EnableComponent, void(const std::string&));
@@ -370,7 +381,8 @@ public:
                            notifier,
                            managers)
     , statechangecount(0)
-  {}
+  {
+  }
   virtual ~MockComponentManagerImpl() = default;
   void SetState(const std::shared_ptr<ComponentManagerState>& newState)
   {
@@ -413,7 +425,8 @@ public:
                                  notifier,
                                  managers)
     , statechangecount(0)
-  {}
+  {
+  }
   virtual ~MockComponentConfigurationImpl() = default;
   MOCK_METHOD0(GetFactory, std::shared_ptr<ServiceFactory>(void));
   MOCK_METHOD1(
@@ -454,7 +467,8 @@ class MockAsyncWorkService : public cppmicroservices::async::AsyncWorkService
 public:
   MockAsyncWorkService()
     : cppmicroservices::async::AsyncWorkService()
-  {}
+  {
+  }
 
   MOCK_METHOD1(post, void(std::packaged_task<void()>&&));
 };

--- a/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
@@ -55,7 +55,8 @@ class ComponentContextImplTest : public ::testing::Test
 protected:
   ComponentContextImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~ComponentContextImplTest() = default;
 
   virtual void SetUp() { framework.Start(); }
@@ -111,7 +112,7 @@ TEST_F(ComponentContextImplTest, VerifyComponentProperties)
     std::make_shared<testing::NiceMock<MockComponentConfiguration>>();
   std::shared_ptr<ComponentContext> ctxt =
     std::make_shared<ComponentContextImpl>(mockConfig);
-  std::unordered_map<std::string, cppmicroservices::Any> fakeProps;
+  ServiceProperties fakeProps;
   fakeProps["foo"] = std::string("bar");
   EXPECT_CALL(*mockConfig, GetProperties())
     .Times(1)

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
@@ -36,7 +36,8 @@ class ServiceComponentRuntimeImplTest : public ::testing::Test
 protected:
   ServiceComponentRuntimeImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~ServiceComponentRuntimeImplTest() = default;
 
@@ -209,7 +210,7 @@ TEST_F(ServiceComponentRuntimeImplTest, GetComponentConfigurationDTOs)
     .WillRepeatedly(testing::Return(nullptr));
   EXPECT_CALL(*config1, GetId()).WillRepeatedly(testing::Return(100));
   EXPECT_CALL(*config2, GetId()).WillRepeatedly(testing::Return(200));
-  std::unordered_map<std::string, cppmicroservices::Any> emptyProperties;
+  ServiceProperties emptyProperties;
   EXPECT_CALL(*config1, GetProperties())
     .WillRepeatedly(testing::Return(emptyProperties));
   EXPECT_CALL(*config2, GetProperties())

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentContext.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/ComponentContext.hpp
@@ -65,8 +65,7 @@ public:
    *
    * @return The properties for this Component Context.
    */
-  virtual std::unordered_map<std::string, cppmicroservices::Any> GetProperties()
-    const = 0;
+  virtual ServiceProperties GetProperties() const = 0;
 
   /**
    * Returns the {@link BundleContext} of the bundle which contains this

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
@@ -25,6 +25,8 @@
 
 #include <iostream>
 
+#include <cppmicroservices/ServiceProperties.h>
+
 #include "ComponentDescriptionDTO.hpp"
 #include "SatisfiedReferenceDTO.hpp"
 #include "UnsatisfiedReferenceDTO.hpp"
@@ -108,7 +110,7 @@ struct US_ServiceComponent_EXPORT ComponentConfigurationDTO
    *
    * @see ComponentContext#GetProperties()
    */
-  std::unordered_map<std::string, cppmicroservices::Any> properties;
+  ServiceProperties properties;
 
   /**
    * The satisfied references.

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
@@ -27,6 +27,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <cppmicroservices/ServiceProperties.h>
+
 #include "BundleDTO.hpp"
 #include "ReferenceDTO.hpp"
 #include "cppmicroservices/Any.h"
@@ -118,7 +120,7 @@ struct US_ServiceComponent_EXPORT ComponentDescriptionDTO
    * These are declared in the \c property and \c properties
    * elements.
    */
-  std::unordered_map<std::string, cppmicroservices::Any> properties;
+  ServiceProperties properties;
 
   /**
    * The referenced services.

--- a/compendium/ServiceComponent/test/TestComponentInstance.cpp
+++ b/compendium/ServiceComponent/test/TestComponentInstance.cpp
@@ -68,20 +68,23 @@ public:
     : foo(nullptr)
     , bar(nullptr)
     , activated(false)
-  {}
+  {
+  }
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
                    const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
     , activated(false)
-  {}
+  {
+  }
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency2>& b)
     : foo(nullptr)
     , bar(b)
     , activated(false)
-  {}
+  {
+  }
 
   virtual ~TestServiceImpl1() {}
 
@@ -131,9 +134,7 @@ private:
 class MockComponentContext : public ComponentContext
 {
 public:
-  MOCK_CONST_METHOD0(
-    GetProperties,
-    std::unordered_map<std::string, cppmicroservices::Any>(void));
+  MOCK_CONST_METHOD0(GetProperties, cppmicroservices::ServiceProperties(void));
   MOCK_CONST_METHOD0(GetBundleContext, cppmicroservices::BundleContext(void));
   MOCK_CONST_METHOD0(GetUsingBundle, cppmicroservices::Bundle(void));
   MOCK_CONST_METHOD0(GetServiceReference,

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -151,8 +151,6 @@ public:
 
     iterator& operator++();
     iterator operator++(int);
-    iterator& operator--();
-    iterator operator--(int);
 
     bool operator==(const iterator& x) const;
     bool operator!=(const iterator& x) const;
@@ -225,8 +223,11 @@ public:
 
   any_map(map_type type);
   any_map(const ordered_any_map& m);
+  any_map(ordered_any_map&& m);
   any_map(const unordered_any_map& m);
+  any_map(unordered_any_map&& m);
   any_map(const unordered_any_cimap& m);
+  any_map(unordered_any_cimap&& m);
 
   any_map(const any_map& m);
   any_map& operator=(const any_map& m);

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -113,7 +113,8 @@ private:
 
     iterator_base(iter_type type)
       : type(type)
-    {}
+    {
+    }
 
   public:
     using value_type = any_map::value_type;

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -30,6 +30,7 @@
 
 namespace cppmicroservices {
 class LDAPExpr;
+class Properties;
 
 namespace detail {
 
@@ -299,6 +300,7 @@ protected:
 
 private:
   friend class LDAPExpr;
+  friend class Properties;
 
   ordered_any_map const& o_m() const;
   ordered_any_map& o_m();

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -151,6 +151,8 @@ public:
 
     iterator& operator++();
     iterator operator++(int);
+    iterator& operator--();
+    iterator operator--(int);
 
     bool operator==(const iterator& x) const;
     bool operator!=(const iterator& x) const;

--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 
 namespace cppmicroservices {
+class LDAPExpr;
 
 namespace detail {
 
@@ -297,6 +298,8 @@ protected:
   map_type type;
 
 private:
+  friend class LDAPExpr;
+
   ordered_any_map const& o_m() const;
   ordered_any_map& o_m();
   unordered_any_map const& uo_m() const;

--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -24,7 +24,6 @@
 #define CPPMICROSERVICES_SERVICEPROPERTIES_H
 
 #include "cppmicroservices/Any.h"
-#include "cppmicroservices/AnyMap.h"
 
 #include <string>
 #include <unordered_map>

--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -40,7 +40,7 @@ namespace cppmicroservices {
  *
  * Deprecated. Use AnyMap instead.
  */
-using ServiceProperties = cppmicroservices::any_map::unordered_any_cimap;
+using ServiceProperties = std::unordered_map<std::string, Any>;
 }
 
 #endif // CPPMICROSERVICES_SERVICEPROPERTIES_H

--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -24,6 +24,7 @@
 #define CPPMICROSERVICES_SERVICEPROPERTIES_H
 
 #include "cppmicroservices/Any.h"
+#include "cppmicroservices/AnyMap.h"
 
 #include <string>
 #include <unordered_map>
@@ -39,7 +40,7 @@ namespace cppmicroservices {
  *
  * Deprecated. Use AnyMap instead.
  */
-using ServiceProperties = std::unordered_map<std::string, Any>;
+using ServiceProperties = AnyMap::unordered_any_cimap;
 }
 
 #endif // CPPMICROSERVICES_SERVICEPROPERTIES_H

--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -24,6 +24,7 @@
 #define CPPMICROSERVICES_SERVICEPROPERTIES_H
 
 #include "cppmicroservices/Any.h"
+#include "cppmicroservices/AnyMap.h"
 
 #include <string>
 #include <unordered_map>
@@ -39,7 +40,7 @@ namespace cppmicroservices {
  *
  * Deprecated. Use AnyMap instead.
  */
-using ServiceProperties = std::unordered_map<std::string, Any>;
+using ServiceProperties = cppmicroservices::any_map::unordered_any_cimap;
 }
 
 #endif // CPPMICROSERVICES_SERVICEPROPERTIES_H

--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(_private_headers
   util/CFRLogger.h
   util/LDAPExpr.h
   util/Properties.h
+  util/PropsCheck.h
   util/Utils.h
 
   service/ServiceHooks.h
@@ -90,4 +91,3 @@ set(_private_headers
   bundle/CoreBundleContext.h
   bundle/Resolver.h
 )
-

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -451,13 +451,13 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
 
     // Check the cache
     const auto c = any_cast<std::vector<std::string>>(
-      props->Value_unlocked(Constants::OBJECTCLASS));
+      props->Value_unlocked(Constants::OBJECTCLASS).first);
     for (auto& objClass : c) {
       AddToSet_unlocked(set, receivers, OBJECTCLASS_IX, objClass);
     }
 
     auto service_id =
-      any_cast<long>(props->Value_unlocked(Constants::SERVICE_ID));
+      any_cast<long>(props->Value_unlocked(Constants::SERVICE_ID).first);
     AddToSet_unlocked(set,
                       receivers,
                       SERVICE_ID_IX,

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -80,7 +80,7 @@ Any ServiceReferenceBase::GetProperty(const std::string& key) const
 {
   auto l = d.load()->registration->properties.Lock();
   US_UNUSED(l);
-  return d.load()->registration->properties.Value_unlocked(key);
+  return d.load()->registration->properties.Value_unlocked(key).first;
 }
 
 void ServiceReferenceBase::GetPropertyKeys(std::vector<std::string>& keys) const
@@ -144,11 +144,14 @@ bool ServiceReferenceBase::operator<(
   {
     auto l = d.load()->registration->properties.Lock();
     US_UNUSED(l);
-    anyR1 = d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_RANKING);
+    anyR1 =
+      d.load()
+        ->registration->properties.Value_unlocked(Constants::SERVICE_RANKING)
+        .first;
     assert(anyR1.Empty() || anyR1.Type() == typeid(int));
-    anyId1 =
-      d.load()->registration->properties.Value_unlocked(Constants::SERVICE_ID);
+    anyId1 = d.load()
+               ->registration->properties.Value_unlocked(Constants::SERVICE_ID)
+               .first;
     assert(anyId1.Type() == typeid(long int));
   }
 
@@ -157,11 +160,14 @@ bool ServiceReferenceBase::operator<(
   {
     auto l = reference.d.load()->registration->properties.Lock();
     US_UNUSED(l);
-    anyR2 = reference.d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_RANKING);
+    anyR2 =
+      reference.d.load()
+        ->registration->properties.Value_unlocked(Constants::SERVICE_RANKING)
+        .first;
     assert(anyR2.Empty() || anyR2.Type() == typeid(int));
-    anyId2 = reference.d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_ID);
+    anyId2 = reference.d.load()
+               ->registration->properties.Value_unlocked(Constants::SERVICE_ID)
+               .first;
     assert(anyId2.Type() == typeid(long int));
   }
 

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -87,7 +87,8 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
     std::vector<std::string> classes =
       (registration->properties.Lock(),
        any_cast<std::vector<std::string>>(
-         registration->properties.Value_unlocked(Constants::OBJECTCLASS)));
+         registration->properties.Value_unlocked(Constants::OBJECTCLASS)
+           .first));
     for (auto clazz : classes) {
       if (smap->find(clazz) == smap->end() &&
           clazz != "org.cppmicroservices.factory") {

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -151,11 +151,11 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
 
     auto propsCopy(props);
     propsCopy[Constants::SERVICE_ID] =
-      d->properties.Value_unlocked(Constants::SERVICE_ID);
-    objectClasses = d->properties.Value_unlocked(Constants::OBJECTCLASS);
+      d->properties.Value_unlocked(Constants::SERVICE_ID).first;
+    objectClasses = d->properties.Value_unlocked(Constants::OBJECTCLASS).first;
     propsCopy[Constants::OBJECTCLASS] = objectClasses;
     propsCopy[Constants::SERVICE_SCOPE] =
-      d->properties.Value_unlocked(Constants::SERVICE_SCOPE);
+      d->properties.Value_unlocked(Constants::SERVICE_SCOPE).first;
 
     auto itr = propsCopy.find(Constants::SERVICE_RANKING);
     if (itr != propsCopy.end()) {
@@ -169,13 +169,14 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
       }
     }
 
-    auto oldRankAny = d->properties.Value_unlocked(Constants::SERVICE_RANKING);
+    auto oldRankAny =
+      d->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
     if (!oldRankAny.Empty()) {
       // since the old ranking is extracted from existing service properties
       // stored in the service registry, no need to type check before casting
       old_rank = any_cast<int>(oldRankAny);
     }
-    d->properties = Properties(std::move(AnyMap(std::move(propsCopy))));
+    d->properties = Properties(AnyMap(std::move(propsCopy)));
   }
   if (old_rank != new_rank) {
     auto classes = any_cast<std::vector<std::string>>(objectClasses);

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -148,6 +148,7 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
 
     auto l2 = d->properties.Lock();
     US_UNUSED(l2);
+
     auto propsCopy(props);
     propsCopy[Constants::SERVICE_ID] =
       d->properties.Value_unlocked(Constants::SERVICE_ID);
@@ -174,7 +175,7 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
       // stored in the service registry, no need to type check before casting
       old_rank = any_cast<int>(oldRankAny);
     }
-    d->properties = Properties(std::move(propsCopy));
+    d->properties = Properties(std::move(AnyMap(std::move(propsCopy))));
   }
   if (old_rank != new_rank) {
     auto classes = any_cast<std::vector<std::string>>(objectClasses);

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -72,7 +72,7 @@ Properties ServiceRegistry::CreateServiceProperties(
       std::make_pair(Constants::SERVICE_SCOPE, Constants::SCOPE_SINGLETON));
   }
 
-  return Properties(AnyMap(props));
+  return Properties(std::move(AnyMap(props)));
 }
 
 ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -72,7 +72,7 @@ Properties ServiceRegistry::CreateServiceProperties(
       std::make_pair(Constants::SERVICE_SCOPE, Constants::SCOPE_SINGLETON));
   }
 
-  return Properties(std::move(props));
+  return Properties(AnyMap(props));
 }
 
 ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -72,7 +72,7 @@ Properties ServiceRegistry::CreateServiceProperties(
       std::make_pair(Constants::SERVICE_SCOPE, Constants::SCOPE_SINGLETON));
   }
 
-  return Properties(std::move(AnyMap(props)));
+  return Properties(AnyMap(std::move(props)));
 }
 
 ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)
@@ -273,10 +273,11 @@ void ServiceRegistry::RemoveServiceRegistration_unlocked(
   {
     auto l2 = sr.d->properties.Lock();
     US_UNUSED(l2);
-    assert(sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).Type() ==
-           typeid(std::vector<std::string>));
+    assert(
+      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).first.Type() ==
+      typeid(std::vector<std::string>));
     classes = ref_any_cast<std::vector<std::string>>(
-      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS));
+      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).first);
   }
   services.erase(sr);
   serviceRegistrations.erase(

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -309,48 +309,6 @@ any_map::const_iter::iterator any_map::const_iter::operator++(int)
   return tmp;
 }
 
-any_map::const_iter::iterator& any_map::const_iter::operator--()
-{
-  switch (type) {
-    case ORDERED:
-      --o_it();
-      break;
-    case UNORDERED:
-      --uo_it();
-      break;
-    case UNORDERED_CI:
-      --uoci_it();
-      break;
-    case NONE:
-      throw std::logic_error("cannot decrement an invalid iterator");
-    default:
-      throw std::logic_error("invalid iterator type");
-  }
-
-  return *this;
-}
-
-any_map::const_iter::iterator any_map::const_iter::operator--(int)
-{
-  iterator tmp = *this;
-  switch (type) {
-    case ORDERED:
-      o_it()--;
-      break;
-    case UNORDERED:
-      uo_it()--;
-      break;
-    case UNORDERED_CI:
-      uoci_it()--;
-      break;
-    case NONE:
-      throw std::logic_error("cannot increment an invalid iterator");
-    default:
-      throw std::logic_error("invalid iterator type");
-  }
-  return tmp;
-}
-
 bool any_map::const_iter::operator==(const iterator& x) const
 {
   switch (type) {
@@ -617,16 +575,34 @@ any_map::any_map(const ordered_any_map& m)
   map.o = new ordered_any_map(m);
 }
 
+any_map::any_map(ordered_any_map&& m)
+  : type(map_type::ORDERED_MAP)
+{
+  map.o = new ordered_any_map(std::move(m));
+}
+
 any_map::any_map(const unordered_any_map& m)
   : type(map_type::UNORDERED_MAP)
 {
   map.uo = new unordered_any_map(m);
 }
 
+any_map::any_map(unordered_any_map&& m)
+  : type(map_type::UNORDERED_MAP)
+{
+  map.uo = new unordered_any_map(std::move(m));
+}
+
 any_map::any_map(const unordered_any_cimap& m)
   : type(map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
 {
   map.uoci = new unordered_any_cimap(m);
+}
+
+any_map::any_map(unordered_any_cimap&& m)
+  : type(map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
+{
+  map.uoci = new unordered_any_cimap(std::move(m));
 }
 
 any_map::any_map(const any_map& m)

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -309,6 +309,48 @@ any_map::const_iter::iterator any_map::const_iter::operator++(int)
   return tmp;
 }
 
+any_map::const_iter::iterator& any_map::const_iter::operator--()
+{
+  switch (type) {
+    case ORDERED:
+      --o_it();
+      break;
+    case UNORDERED:
+      --uo_it();
+      break;
+    case UNORDERED_CI:
+      --uoci_it();
+      break;
+    case NONE:
+      throw std::logic_error("cannot decrement an invalid iterator");
+    default:
+      throw std::logic_error("invalid iterator type");
+  }
+
+  return *this;
+}
+
+any_map::const_iter::iterator any_map::const_iter::operator--(int)
+{
+  iterator tmp = *this;
+  switch (type) {
+    case ORDERED:
+      o_it()--;
+      break;
+    case UNORDERED:
+      uo_it()--;
+      break;
+    case UNORDERED_CI:
+      uoci_it()--;
+      break;
+    case NONE:
+      throw std::logic_error("cannot increment an invalid iterator");
+    default:
+      throw std::logic_error("invalid iterator type");
+  }
+  return tmp;
+}
+
 bool any_map::const_iter::operator==(const iterator& x) const
 {
   switch (type) {

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -306,18 +306,9 @@ bool LDAPExpr::IsNull() const
 bool LDAPExpr::Evaluate(const PropertiesHandle& p, bool matchCase) const
 {
   if ((d->m_operator & SIMPLE) != 0) {
-    bool found = false;
-    auto v = p->Value_unlocked(d->m_attrName, &found);
-    return (!found) ? false : Compare(v, d->m_operator, d->m_attrValue);
-    /*
-    // try case sensitive match first
-    int index = p->FindCaseSensitive_unlocked(d->m_attrName);
-    if (index < 0 && !matchCase)
-      index = p->Find_unlocked(d->m_attrName);
-    return index < 0
-             ? false
-             : Compare(p->Value_unlocked(index), d->m_operator, d->m_attrValue);
-    */
+    auto v = p->Value_unlocked(d->m_attrName, matchCase);
+    return (!v.second) ? false
+                       : Compare(v.first, d->m_operator, d->m_attrValue);
   } else { // (d->m_operator & COMPLEX) != 0
     switch (d->m_operator) {
       case AND:
@@ -352,28 +343,13 @@ bool LDAPExpr::Evaluate(const AnyMap& p, bool matchCase) const
         return Compare(v->second, d->m_operator, d->m_attrValue);
       }
     } else {
-      auto v = p.find(d->m_attrName); //->Value_unlocked(d->m_attrName);
+      auto v = p.find(d->m_attrName);
       if (v == p.end() || v->second.Empty()) {
         return false;
       } else {
         return Compare(v->second, d->m_operator, d->m_attrValue);
       }
     }
-
-    /*
-    return (v != p.end() && v->second.Empty())
-             ? false
-             : Compare(v->second, d->m_operator, d->m_attrValue);
-             */
-    /*
-    // try case sensitive match first
-    int index = p->FindCaseSensitive_unlocked(d->m_attrName);
-    if (index < 0 && !matchCase)
-      index = p->Find_unlocked(d->m_attrName);
-    return index < 0
-             ? false
-             : Compare(p->Value_unlocked(index), d->m_operator, d->m_attrValue);
-    */
   } else { // (d->m_operator & COMPLEX) != 0
     switch (d->m_operator) {
       case AND:

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -344,8 +344,9 @@ bool LDAPExpr::Evaluate(const AnyMap& p, bool matchCase) const
 {
   if ((d->m_operator & SIMPLE) != 0) {
     if (!matchCase) {
-      auto v = p.uoci_m().find(d->m_attrName);
-      if (v == p.uoci_m().end() || v->second.Empty()) {
+      auto& m = p.uoci_m();
+      auto v = m.find(d->m_attrName);
+      if (v == m.end() || v->second.Empty()) {
         return false;
       } else {
         return Compare(v->second, d->m_operator, d->m_attrValue);

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -395,7 +395,7 @@ bool LDAPExpr::Evaluate(const AnyMap& p, bool matchCase) const
   }
 }
 
-bool LDAPExpr::Compare(const Any& obj, int op, const std::string& s) const
+bool LDAPExpr::Compare(const Any& obj, int op, const std::string_view s) const
 {
   if (obj.Empty())
     return false;
@@ -447,10 +447,10 @@ bool LDAPExpr::Compare(const Any& obj, int op, const std::string& s) const
     } else if (objType == typeid(float)) {
       errno = 0;
       char* endptr = nullptr;
-      double sFloat = strtod(s.c_str(), &endptr);
+      double sFloat = strtod(s.data(), &endptr);
       if ((errno == ERANGE &&
            (sFloat == 0 || sFloat == HUGE_VAL || sFloat == -HUGE_VAL)) ||
-          (errno != 0 && sFloat == 0) || endptr == s.c_str()) {
+          (errno != 0 && sFloat == 0) || endptr == s.data()) {
         return false;
       }
 
@@ -469,10 +469,10 @@ bool LDAPExpr::Compare(const Any& obj, int op, const std::string& s) const
     } else if (objType == typeid(double)) {
       errno = 0;
       char* endptr = nullptr;
-      double sDouble = strtod(s.c_str(), &endptr);
+      double sDouble = strtod(s.data(), &endptr);
       if ((errno == ERANGE &&
            (sDouble == 0 || sDouble == HUGE_VAL || sDouble == -HUGE_VAL)) ||
-          (errno != 0 && sDouble == 0) || endptr == s.c_str()) {
+          (errno != 0 && sDouble == 0) || endptr == s.data()) {
         return false;
       }
 
@@ -505,14 +505,14 @@ bool LDAPExpr::Compare(const Any& obj, int op, const std::string& s) const
 template<typename T>
 bool LDAPExpr::CompareIntegralType(const Any& obj,
                                    const int op,
-                                   const std::string& s) const
+                                   const std::string_view s) const
 {
   errno = 0;
   char* endptr = nullptr;
-  long longInt = strtol(s.c_str(), &endptr, 10);
+  long longInt = strtol(s.data(), &endptr, 10);
   if ((errno == ERANGE && (longInt == std::numeric_limits<long>::max() ||
                            longInt == std::numeric_limits<long>::min())) ||
-      (errno != 0 && longInt == 0) || endptr == s.c_str()) {
+      (errno != 0 && longInt == 0) || endptr == s.data()) {
     return false;
   }
 

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -306,8 +306,9 @@ bool LDAPExpr::IsNull() const
 bool LDAPExpr::Evaluate(const PropertiesHandle& p, bool matchCase) const
 {
   if ((d->m_operator & SIMPLE) != 0) {
-    auto v = p->Value_unlocked(d->m_attrName);
-    return (v.Empty()) ? false : Compare(v, d->m_operator, d->m_attrValue);
+    bool found = false;
+    auto v = p->Value_unlocked(d->m_attrName, &found);
+    return (!found) ? false : Compare(v, d->m_operator, d->m_attrValue);
     /*
     // try case sensitive match first
     int index = p->FindCaseSensitive_unlocked(d->m_attrName);

--- a/framework/src/util/LDAPExpr.h
+++ b/framework/src/util/LDAPExpr.h
@@ -147,13 +147,13 @@ private:
   static std::string ToLower(const std::string& str);
 
   //!
-  bool Compare(const Any& obj, int op, const std::string& s) const;
+  bool Compare(const Any& obj, int op, const std::string_view s) const;
 
   //!
   template<typename T>
   bool CompareIntegralType(const Any& obj,
                            const int op,
-                           const std::string& s) const;
+                           const std::string_view s) const;
 
   //!
   static bool CompareString(const std::string_view s1,

--- a/framework/src/util/LDAPExpr.h
+++ b/framework/src/util/LDAPExpr.h
@@ -25,6 +25,8 @@
 
 #include "cppmicroservices/FrameworkConfig.h"
 
+#include "cppmicroservices/AnyMap.h"
+
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -119,6 +121,8 @@ public:
 
   //! Evaluate this LDAP filter.
   bool Evaluate(const PropertiesHandle& p, bool matchCase) const;
+
+  bool Evaluate(const AnyMap& p, bool matchCase) const;
 
   //!
   const std::string ToString() const;

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -31,6 +31,14 @@
 
 #include <stdexcept>
 
+#ifdef US_PLATFORM_WINDOWS
+#  include <string.h>
+#  define ci_compare strnicmp
+#else
+#  include <strings.h>
+#  define ci_compare strncasecmp
+#endif
+
 namespace cppmicroservices {
 
 class LDAPFilterData
@@ -80,24 +88,74 @@ bool LDAPFilter::Match(const ServiceReferenceBase& reference) const
 
 bool LDAPFilter::Match(const Bundle& bundle) const
 {
-  return ((d)
-            ? d->ldapExpr.Evaluate(
-                PropertiesHandle(Properties(bundle.GetHeaders()), false), false)
-            : false);
+  auto& headers = bundle.GetHeaders();
+  std::vector<std::string> keys;
+  for (auto& [key, _] : headers) {
+    keys.emplace_back(key);
+  }
+
+  if (headers.size() > 0) {
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
+      }
+    }
+  }
+
+  return ((d) ? d->ldapExpr.Evaluate(bundle.GetHeaders(), false) : false);
 }
 
 bool LDAPFilter::Match(const AnyMap& dictionary) const
 {
-  return ((d) ? d->ldapExpr.Evaluate(
-                  PropertiesHandle(Properties(dictionary), false), false)
-              : false);
+  auto& headers = dictionary;
+  std::vector<std::string> keys;
+  for (auto& [key, _] : headers) {
+    keys.emplace_back(key);
+  }
+
+  if (headers.size() > 0) {
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
+      }
+    }
+  }
+
+  return ((d) ? d->ldapExpr.Evaluate(dictionary, false) : false);
 }
 
 bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 {
-  return ((d) ? d->ldapExpr.Evaluate(
-                  PropertiesHandle(Properties(dictionary), false), true)
-              : false);
+  auto& headers = dictionary;
+  std::vector<std::string> keys;
+  for (auto& [key, _] : headers) {
+    keys.emplace_back(key);
+  }
+
+  if (headers.size() > 0) {
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
+      }
+    }
+  }
+
+  return ((d) ? d->ldapExpr.Evaluate(dictionary, true) : false);
 }
 
 std::string LDAPFilter::ToString() const

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -88,74 +88,89 @@ bool LDAPFilter::Match(const ServiceReferenceBase& reference) const
 
 bool LDAPFilter::Match(const Bundle& bundle) const
 {
-  auto& headers = bundle.GetHeaders();
-  std::vector<std::string> keys;
-  for (auto& [key, _] : headers) {
-    keys.emplace_back(key);
-  }
+  if (d) {
+    auto& headers = bundle.GetHeaders();
+    std::vector<std::string> keys;
+    for (auto& [key, _] : headers) {
+      keys.emplace_back(key);
+    }
 
-  if (headers.size() > 1) {
-    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
-      for (uint32_t j = i + 1; j < keys.size(); ++j) {
-        if (keys[i].size() == keys[j].size() &&
-            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
-          std::string msg("Properties contain case variants of the key: ");
-          msg += keys[i];
-          throw std::runtime_error(msg.c_str());
+    if (headers.size() > 1) {
+      for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+        for (uint32_t j = i + 1; j < keys.size(); ++j) {
+          if (keys[i].size() == keys[j].size() &&
+              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
+                0) {
+            std::string msg("Properties contain case variants of the key: ");
+            msg += keys[i];
+            throw std::runtime_error(msg.c_str());
+          }
         }
       }
     }
-  }
 
-  return ((d) ? d->ldapExpr.Evaluate(bundle.GetHeaders(), false) : false);
+    return d->ldapExpr.Evaluate(bundle.GetHeaders(), false);
+  } else {
+    return false;
+  }
 }
 
 bool LDAPFilter::Match(const AnyMap& dictionary) const
 {
-  auto& headers = dictionary;
-  std::vector<std::string> keys;
-  for (auto& [key, _] : headers) {
-    keys.emplace_back(key);
-  }
+  if (d) {
+    auto& headers = dictionary;
+    std::vector<std::string> keys;
+    for (auto& [key, _] : headers) {
+      keys.emplace_back(key);
+    }
 
-  if (headers.size() > 1) {
-    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
-      for (uint32_t j = i + 1; j < keys.size(); ++j) {
-        if (keys[i].size() == keys[j].size() &&
-            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
-          std::string msg("Properties contain case variants of the key: ");
-          msg += keys[i];
-          throw std::runtime_error(msg.c_str());
+    if (headers.size() > 1) {
+      for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+        for (uint32_t j = i + 1; j < keys.size(); ++j) {
+          if (keys[i].size() == keys[j].size() &&
+              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
+                0) {
+            std::string msg("Properties contain case variants of the key: ");
+            msg += keys[i];
+            throw std::runtime_error(msg.c_str());
+          }
         }
       }
     }
-  }
 
-  return ((d) ? d->ldapExpr.Evaluate(dictionary, false) : false);
+    return d->ldapExpr.Evaluate(dictionary, false);
+  } else {
+    return false;
+  }
 }
 
 bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 {
-  auto& headers = dictionary;
-  std::vector<std::string> keys;
-  for (auto& [key, _] : headers) {
-    keys.emplace_back(key);
-  }
+  if (d) {
+    auto& headers = dictionary;
+    std::vector<std::string> keys;
+    for (auto& [key, _] : headers) {
+      keys.emplace_back(key);
+    }
 
-  if (headers.size() > 1) {
-    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
-      for (uint32_t j = i + 1; j < keys.size(); ++j) {
-        if (keys[i].size() == keys[j].size() &&
-            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
-          std::string msg("Properties contain case variants of the key: ");
-          msg += keys[i];
-          throw std::runtime_error(msg.c_str());
+    if (headers.size() > 1) {
+      for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+        for (uint32_t j = i + 1; j < keys.size(); ++j) {
+          if (keys[i].size() == keys[j].size() &&
+              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
+                0) {
+            std::string msg("Properties contain case variants of the key: ");
+            msg += keys[i];
+            throw std::runtime_error(msg.c_str());
+          }
         }
       }
     }
-  }
 
-  return ((d) ? d->ldapExpr.Evaluate(dictionary, true) : false);
+    return d->ldapExpr.Evaluate(dictionary, true);
+  } else {
+    return false;
+  }
 }
 
 std::string LDAPFilter::ToString() const

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -94,7 +94,7 @@ bool LDAPFilter::Match(const Bundle& bundle) const
     keys.emplace_back(key);
   }
 
-  if (headers.size() > 0) {
+  if (headers.size() > 1) {
     for (uint32_t i = 0; i < keys.size() - 1; ++i) {
       for (uint32_t j = i + 1; j < keys.size(); ++j) {
         if (keys[i].size() == keys[j].size() &&
@@ -118,7 +118,7 @@ bool LDAPFilter::Match(const AnyMap& dictionary) const
     keys.emplace_back(key);
   }
 
-  if (headers.size() > 0) {
+  if (headers.size() > 1) {
     for (uint32_t i = 0; i < keys.size() - 1; ++i) {
       for (uint32_t j = i + 1; j < keys.size(); ++j) {
         if (keys[i].size() == keys[j].size() &&
@@ -142,7 +142,7 @@ bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
     keys.emplace_back(key);
   }
 
-  if (headers.size() > 0) {
+  if (headers.size() > 1) {
     for (uint32_t i = 0; i < keys.size() - 1; ++i) {
       for (uint32_t j = i + 1; j < keys.size(); ++j) {
         if (keys[i].size() == keys[j].size() &&

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -90,17 +90,17 @@ bool LDAPFilter::Match(const Bundle& bundle) const
 {
   if (d) {
     auto& headers = bundle.GetHeaders();
-    std::vector<std::string> keys;
+    std::vector<std::string_view> keys(headers.size());
+    uint32_t currIndex = 0;
     for (auto& [key, _] : headers) {
-      keys.emplace_back(key);
+      keys[currIndex++] = key;
     }
 
     if (headers.size() > 1) {
       for (uint32_t i = 0; i < keys.size() - 1; ++i) {
         for (uint32_t j = i + 1; j < keys.size(); ++j) {
           if (keys[i].size() == keys[j].size() &&
-              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
-                0) {
+              ci_compare(keys[i].data(), keys[j].data(), keys[i].size()) == 0) {
             std::string msg("Properties contain case variants of the key: ");
             msg += keys[i];
             throw std::runtime_error(msg.c_str());
@@ -109,7 +109,7 @@ bool LDAPFilter::Match(const Bundle& bundle) const
       }
     }
 
-    return d->ldapExpr.Evaluate(bundle.GetHeaders(), false);
+    return d->ldapExpr.Evaluate(headers, false);
   } else {
     return false;
   }
@@ -118,18 +118,17 @@ bool LDAPFilter::Match(const Bundle& bundle) const
 bool LDAPFilter::Match(const AnyMap& dictionary) const
 {
   if (d) {
-    auto& headers = dictionary;
-    std::vector<std::string> keys;
-    for (auto& [key, _] : headers) {
-      keys.emplace_back(key);
+    std::vector<std::string_view> keys(dictionary.size());
+    uint32_t currIndex = 0;
+    for (auto& [key, _] : dictionary) {
+      keys[currIndex++] = key;
     }
 
-    if (headers.size() > 1) {
+    if (dictionary.size() > 1) {
       for (uint32_t i = 0; i < keys.size() - 1; ++i) {
         for (uint32_t j = i + 1; j < keys.size(); ++j) {
           if (keys[i].size() == keys[j].size() &&
-              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
-                0) {
+              ci_compare(keys[i].data(), keys[j].data(), keys[i].size()) == 0) {
             std::string msg("Properties contain case variants of the key: ");
             msg += keys[i];
             throw std::runtime_error(msg.c_str());
@@ -147,18 +146,17 @@ bool LDAPFilter::Match(const AnyMap& dictionary) const
 bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 {
   if (d) {
-    auto& headers = dictionary;
-    std::vector<std::string> keys;
-    for (auto& [key, _] : headers) {
-      keys.emplace_back(key);
+    std::vector<std::string_view> keys(dictionary.size());
+    uint32_t currIndex = 0;
+    for (auto& [key, _] : dictionary) {
+      keys[currIndex++] = key;
     }
 
-    if (headers.size() > 1) {
+    if (dictionary.size() > 1) {
       for (uint32_t i = 0; i < keys.size() - 1; ++i) {
         for (uint32_t j = i + 1; j < keys.size(); ++j) {
           if (keys[i].size() == keys[j].size() &&
-              ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) ==
-                0) {
+              ci_compare(keys[i].data(), keys[j].data(), keys[i].size()) == 0) {
             std::string msg("Properties contain case variants of the key: ");
             msg += keys[i];
             throw std::runtime_error(msg.c_str());

--- a/framework/src/util/LDAPFilter.cpp
+++ b/framework/src/util/LDAPFilter.cpp
@@ -83,11 +83,8 @@ bool LDAPFilter::Match(const Bundle& bundle) const
 {
   if (d) {
     auto& headers = bundle.GetHeaders();
-    if (auto result = props_check::IsInvalid(headers); result.first) {
-      std::string msg("Properties contain case variants of the key: ");
-      msg += result.second;
-      throw std::runtime_error(msg.c_str());
-    }
+
+    props_check::ValidateAnyMap(headers);
 
     return d->ldapExpr.Evaluate(headers, false);
   } else {
@@ -98,11 +95,7 @@ bool LDAPFilter::Match(const Bundle& bundle) const
 bool LDAPFilter::Match(const AnyMap& dictionary) const
 {
   if (d) {
-    if (auto result = props_check::IsInvalid(dictionary); result.first) {
-      std::string msg("Properties contain case variants of the key: ");
-      msg += result.second;
-      throw std::runtime_error(msg.c_str());
-    }
+    props_check::ValidateAnyMap(dictionary);
 
     return d->ldapExpr.Evaluate(dictionary, false);
   } else {
@@ -113,11 +106,7 @@ bool LDAPFilter::Match(const AnyMap& dictionary) const
 bool LDAPFilter::MatchCase(const AnyMap& dictionary) const
 {
   if (d) {
-    if (auto result = props_check::IsInvalid(dictionary); result.first) {
-      std::string msg("Properties contain case variants of the key: ");
-      msg += result.second;
-      throw std::runtime_error(msg.c_str());
-    }
+    props_check::ValidateAnyMap(dictionary);
 
     return d->ldapExpr.Evaluate(dictionary, true);
   } else {

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -33,47 +33,16 @@ namespace cppmicroservices {
 
 const Any Properties::emptyAny;
 
-Properties::Properties(AnyMap& p)
-  : props(p)
-{
-  if (p.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("Properties contain too many keys");
-  }
-
-  if (auto result = props_check::IsInvalid(props); result.first) {
-    std::string msg("Properties contain case variants of the key: ");
-    msg += result.second;
-    throw std::runtime_error(msg.c_str());
-  }
-}
-
 Properties::Properties(const AnyMap& p)
   : props(p)
 {
-  if (p.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("Properties contain too many keys");
-  }
-
-  if (auto result = props_check::IsInvalid(props); result.first) {
-    std::string msg("Properties contain case variants of the key: ");
-    msg += result.second;
-    throw std::runtime_error(msg.c_str());
-  }
+  props_check::ValidateAnyMap(props);
 }
 
 Properties::Properties(AnyMap&& p)
   : props(std::move(p))
 {
-  if (props.size() >
-      static_cast<std::size_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("Properties contain too many keys");
-  }
-
-  if (auto result = props_check::IsInvalid(props); result.first) {
-    std::string msg("Properties contain case variants of the key: ");
-    msg += result.second;
-    throw std::runtime_error(msg.c_str());
-  }
+  props_check::ValidateAnyMap(props);
 }
 
 Properties::Properties(Properties&& o)

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -45,18 +45,20 @@ Properties::Properties(AnyMap& p)
     throw std::runtime_error("Properties contain too many keys");
   }
 
-  std::vector<std::string> keys;
-  for (auto& [key, _] : p) {
-    keys.emplace_back(key);
-  }
+  if (p.size() > 1) {
+    std::vector<std::string> keys;
+    for (auto& [key, _] : p) {
+      keys.emplace_back(key);
+    }
 
-  for (uint32_t i = 0; i < keys.size() - 1; ++i) {
-    for (uint32_t j = i + 1; j < keys.size(); ++j) {
-      if (keys[i].size() == keys[j].size() &&
-          ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
-        std::string msg("Properties contain case variants of the key: ");
-        msg += keys[i];
-        throw std::runtime_error(msg.c_str());
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
       }
     }
   }
@@ -81,18 +83,20 @@ Properties::Properties(const AnyMap& p)
     throw std::runtime_error("Properties contain too many keys");
   }
 
-  std::vector<std::string> keys;
-  for (auto& [key, _] : p) {
-    keys.emplace_back(key);
-  }
+  if (p.size() > 1) {
+    std::vector<std::string> keys;
+    for (auto& [key, _] : p) {
+      keys.emplace_back(key);
+    }
 
-  for (uint32_t i = 0; i < keys.size() - 1; ++i) {
-    for (uint32_t j = i + 1; j < keys.size(); ++j) {
-      if (keys[i].size() == keys[j].size() &&
-          ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
-        std::string msg("Properties contain case variants of the key: ");
-        msg += keys[i];
-        throw std::runtime_error(msg.c_str());
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
       }
     }
   }

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -112,6 +112,7 @@ std::vector<std::string> Properties::Keys_unlocked() const
 {
   std::vector<std::string> result{};
   for (auto& [key, _] : props) {
+    US_UNUSED(_);
     result.push_back(key);
   }
   return result;

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -112,13 +112,19 @@ Properties& Properties::operator=(Properties&& o)
   return *this;
 }
 
-Any Properties::Value_unlocked(const std::string& key) const
+Any Properties::Value_unlocked(const std::string& key, bool* found) const
 {
-  auto itr = props.find(key);
-  if (itr == props.end()) {
+  auto itr = props.uoci_m().find(key);
+  if (itr == props.uoci_m().end()) {
+    if (found) {
+      *found = false;
+    }
     return emptyAny;
   }
 
+  if (found) {
+    *found = true;
+  }
   return itr->second;
   /*
   int i = Find_unlocked(key);

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -102,6 +102,33 @@ Properties::Properties(const AnyMap& p)
   }
 }
 
+Properties::Properties(AnyMap&& p)
+  : props(std::move(p))
+{
+  if (props.size() >
+      static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+    throw std::runtime_error("Properties contain too many keys");
+  }
+
+  if (props.size() > 1) {
+    std::vector<std::string> keys;
+    for (auto& [key, _] : props) {
+      keys.emplace_back(key);
+    }
+
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].c_str(), keys[j].c_str(), keys[i].size()) == 0) {
+          std::string msg("Properties contain case variants of the key: ");
+          msg += keys[i];
+          throw std::runtime_error(msg.c_str());
+        }
+      }
+    }
+  }
+}
+
 Properties::Properties(Properties&& o)
   : props(std::move(o.props))
 {}

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -25,6 +25,7 @@
 
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/AnyMap.h"
+#include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/detail/Threads.h"
 
 #include <string>
@@ -36,24 +37,26 @@ class Properties : public detail::MultiThreaded<>
 {
 
 public:
+  explicit Properties(AnyMap& props);
   explicit Properties(const AnyMap& props);
 
   Properties(Properties&& o);
   Properties& operator=(Properties&& o);
 
   Any Value_unlocked(const std::string& key) const;
-  Any Value_unlocked(int index) const;
+  //Any Value_unlocked(int index) const;
 
-  int Find_unlocked(const std::string& key) const;
-  int FindCaseSensitive_unlocked(const std::string& key) const;
+  //int Find_unlocked(const std::string& key) const;
+  //int FindCaseSensitive_unlocked(const std::string& key) const;
 
   std::vector<std::string> Keys_unlocked() const;
 
   void Clear_unlocked();
 
+  const AnyMap& GetProps() const { return props; };
+
 private:
-  std::vector<std::string> keys;
-  std::vector<Any> values;
+  AnyMap props;
 
   static const Any emptyAny;
 };

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -43,7 +43,7 @@ public:
   Properties(Properties&& o);
   Properties& operator=(Properties&& o);
 
-  Any Value_unlocked(const std::string& key) const;
+  Any Value_unlocked(const std::string& key, bool* found = nullptr) const;
   //Any Value_unlocked(int index) const;
 
   //int Find_unlocked(const std::string& key) const;

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -25,7 +25,6 @@
 
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/AnyMap.h"
-#include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/detail/Threads.h"
 
 #include <string>

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -44,17 +44,12 @@ public:
   Properties(Properties&& o);
   Properties& operator=(Properties&& o);
 
-  Any Value_unlocked(const std::string& key, bool* found = nullptr) const;
-  //Any Value_unlocked(int index) const;
-
-  //int Find_unlocked(const std::string& key) const;
-  //int FindCaseSensitive_unlocked(const std::string& key) const;
+  std::pair<Any, bool> Value_unlocked(const std::string& key,
+                                      bool matchCase = false) const;
 
   std::vector<std::string> Keys_unlocked() const;
 
   void Clear_unlocked();
-
-  const AnyMap& GetProps() const { return props; };
 
 private:
   AnyMap props;

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -36,7 +36,6 @@ class Properties : public detail::MultiThreaded<>
 {
 
 public:
-  explicit Properties(AnyMap& props);
   explicit Properties(const AnyMap& props);
   explicit Properties(AnyMap&& props);
 

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -39,6 +39,7 @@ class Properties : public detail::MultiThreaded<>
 public:
   explicit Properties(AnyMap& props);
   explicit Properties(const AnyMap& props);
+  explicit Properties(AnyMap&& props);
 
   Properties(Properties&& o);
   Properties& operator=(Properties&& o);

--- a/framework/src/util/PropsCheck.h
+++ b/framework/src/util/PropsCheck.h
@@ -67,9 +67,8 @@ inline void ValidateAnyMap(const cppmicroservices::AnyMap& am)
 {
   std::vector<std::string_view> keys(am.size());
   uint32_t currIndex = 0;
-  for (auto& [key, _] : am) {
-    US_UNUSED(_);
-    keys[currIndex++] = key;
+  for (auto& kv_pair : am) {
+    keys[currIndex++] = kv_pair.first;
   }
 
   if (am.size() > 1) {

--- a/framework/src/util/PropsCheck.h
+++ b/framework/src/util/PropsCheck.h
@@ -1,0 +1,66 @@
+/*=============================================================================
+
+ Library: CppMicroServices
+
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ =============================================================================*/
+
+#ifndef PROPSCHECK_H
+#define PROPSCHECK_H
+
+#ifdef US_PLATFORM_WINDOWS
+#  include <string.h>
+#  define ci_compare strnicmp
+#else
+#  include <strings.h>
+#  define ci_compare strncasecmp
+#endif
+
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "cppmicroservices/LDAPFilter.h"
+
+namespace cppmicroservices::props_check {
+inline std::pair<bool, std::string_view> IsInvalid(
+  const cppmicroservices::AnyMap& am)
+{
+  std::vector<std::string_view> keys(am.size());
+  uint32_t currIndex = 0;
+  for (auto& [key, _] : am) {
+    keys[currIndex++] = key;
+  }
+
+  if (am.size() > 1) {
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].data(), keys[j].data(), keys[i].size()) == 0) {
+          return std::make_pair(true, keys[i]);
+        }
+      }
+    }
+  }
+
+  return std::make_pair(false, "");
+}
+}
+
+#endif

--- a/framework/src/util/PropsCheck.h
+++ b/framework/src/util/PropsCheck.h
@@ -45,6 +45,7 @@ inline std::pair<bool, std::string_view> IsInvalid(
   std::vector<std::string_view> keys(am.size());
   uint32_t currIndex = 0;
   for (auto& [key, _] : am) {
+    US_UNUSED(_);
     keys[currIndex++] = key;
   }
 

--- a/framework/test/gtest/AnyMapTest.cpp
+++ b/framework/test/gtest/AnyMapTest.cpp
@@ -133,45 +133,6 @@ TEST(AnyMapTest, IteratorTest)
   EXPECT_THROW(niter++, std::logic_error);
 }
 
-TEST(AnyMapTest, AnyMapNewTest)
-{
-  AnyMap uoci_1(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
-  uoci_1["Service.pid"] = Any(1);
-
-  AnyMap uo_1(AnyMap::UNORDERED_MAP);
-  uo_1["Service.pid"] = Any(1);
-
-  // Case-sensitive search first
-  auto& uoci_om = uoci_1.uo_m();
-  auto csItr = uoci_om.find("service.pid");
-  if (csItr != uoci_om.end()) {
-    std::clog << "Found key 'service.pid' in uoci_om." << std::endl;
-  }
-
-  // Case-insensitive search after
-  auto& uoci_uoci = uoci_1.uoci_m();
-  auto ciItr = uoci_uoci.find("service.pid");
-  if (ciItr != uoci_uoci.end()) {
-    std::clog << "Found key 'service.pid' in uoci_uoci." << std::endl;
-  }
-
-  // Case-sensitive search first
-  auto& uo_om = uo_1.uo_m();
-  auto csItr2 = uo_om.find("service.pid");
-  if (csItr2 != uo_om.end()) {
-    std::clog << "Found key 'service.pid' in uo_om." << std::endl;
-  }
-
-  // Case-insensitive search after
-  auto& uo_uoci = uo_1.uoci_m();
-  auto ciItr2 = uo_uoci.find("service.pid");
-  if (ciItr2 != uo_uoci.end()) {
-    std::clog << "Found key 'service.pid' in uo_uoci." << std::endl;
-  }
-
-  ASSERT_TRUE(1 + 2 == 3);
-}
-
 TEST(AnyMapTest, AnyMap)
 {
   AnyMap::ordered_any_map o;

--- a/framework/test/gtest/AnyMapTest.cpp
+++ b/framework/test/gtest/AnyMapTest.cpp
@@ -133,6 +133,45 @@ TEST(AnyMapTest, IteratorTest)
   EXPECT_THROW(niter++, std::logic_error);
 }
 
+TEST(AnyMapTest, AnyMapNewTest)
+{
+  AnyMap uoci_1(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+  uoci_1["Service.pid"] = Any(1);
+
+  AnyMap uo_1(AnyMap::UNORDERED_MAP);
+  uo_1["Service.pid"] = Any(1);
+
+  // Case-sensitive search first
+  auto& uoci_om = uoci_1.uo_m();
+  auto csItr = uoci_om.find("service.pid");
+  if (csItr != uoci_om.end()) {
+    std::clog << "Found key 'service.pid' in uoci_om." << std::endl;
+  }
+
+  // Case-insensitive search after
+  auto& uoci_uoci = uoci_1.uoci_m();
+  auto ciItr = uoci_uoci.find("service.pid");
+  if (ciItr != uoci_uoci.end()) {
+    std::clog << "Found key 'service.pid' in uoci_uoci." << std::endl;
+  }
+
+  // Case-sensitive search first
+  auto& uo_om = uo_1.uo_m();
+  auto csItr2 = uo_om.find("service.pid");
+  if (csItr2 != uo_om.end()) {
+    std::clog << "Found key 'service.pid' in uo_om." << std::endl;
+  }
+
+  // Case-insensitive search after
+  auto& uo_uoci = uo_1.uoci_m();
+  auto ciItr2 = uo_uoci.find("service.pid");
+  if (ciItr2 != uo_uoci.end()) {
+    std::clog << "Found key 'service.pid' in uo_uoci." << std::endl;
+  }
+
+  ASSERT_TRUE(1 + 2 == 3);
+}
+
 TEST(AnyMapTest, AnyMap)
 {
   AnyMap::ordered_any_map o;


### PR DESCRIPTION
# Performance Summary
(NOTE: The benchmark being ran is `MatchFilterWithBundle/Complex`)
| Platform | Build Config | Time/CPU (ns) (dev) | Time/CPU (ns) (optimized) | Iterations | ~Speedup |
| --- | --- | --- | --- | --- | --- |
| win64 | Debug | `22779\|22741` | `6118\|6090` | `32` | `~3.72x` |
| win64 | Release | `1988\|1984` | `481\|481` | `32` | `~4.13x` |
| maca64 | Debug | `6005\|6004`| `3157\|3157` |  `32` | `~1.90x` |
| maca64 | Release | `723\|723` | `320\|320` | `32` | `~2.25x` |
| glnxa64 | Release | `721\|714` | `380\|378` | `32 ` | `~1.89x` |

# Benchmark Machine Info
### Win64 Benchmarking Details:
```
Run on (12 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1024 KiB (x6)
  L3 Unified 8448 KiB (x1)
```

### Maca64 Benchmarking Details (benchmarks performed on an M1 Pro chip):
(NOTE: According to google benchmark output, values for CPU speed are wrong due to an incompatibility with M1 Macs)
```
Run on (10 X 24.1001 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x10)
  L1 Instruction 128 KiB (x10)
  L2 Unified 4096 KiB (x5)
```

### Glnxa64 Benchmarking Details:
```
Run on (8 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x8)
  L1 Instruction 64 KiB (x8)
  L2 Unified 512 KiB (x8)
  L3 Unified 16384 KiB (x8)
```

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>