### PR TITLE
CFRlogger accessviolation

### DIFF
--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -92,7 +92,7 @@ CoreBundleContext::CoreBundleContext(
   , frameworkProperties(InitProperties(props))
   , workingDir(ref_any_cast<std::string>(
       frameworkProperties.at(Constants::FRAMEWORK_WORKING_DIR)))
-  , logger(nullptr)
+  , logger(std::make_shared<cppmicroservices::cfrimpl::CFRLogger>(this))
   , listeners(this)
   , services(this)
   , serviceHooks(this)
@@ -177,9 +177,7 @@ void CoreBundleContext::Init()
 
   bundleRegistry.Load();
 
-  // Initialize the CFRLogger. This is done here rather than in the constructor since
-  // we do not have access to a bundle context until this point.
-  logger = std::make_shared<cppmicroservices::cfrimpl::CFRLogger>(MakeBundleContext(systemBundle->bundleContext.Load().get()));
+  logger->Open();
 
   std::string execPath;
   try {
@@ -224,6 +222,7 @@ void CoreBundleContext::Init()
 void CoreBundleContext::Uninit0()
 {
   DIAG_LOG(*sink) << "uninit";
+  logger->Close();
   serviceHooks.Close();
   systemBundle->UninitSystemBundle();
 }

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -87,7 +87,7 @@ std::unordered_map<std::string, Any> InitProperties(
 
 CoreBundleContext::CoreBundleContext(
   const std::unordered_map<std::string, Any>& props,
-  std::ostream* logger)
+  std::ostream* diagLogger)
   : id(globalId++)
   , frameworkProperties(InitProperties(props))
   , workingDir(ref_any_cast<std::string>(
@@ -104,7 +104,7 @@ CoreBundleContext::CoreBundleContext(
 {
   auto enableDiagLog =
     any_cast<bool>(frameworkProperties.at(Constants::FRAMEWORK_LOG));
-  std::ostream* diagnosticLogger = (logger) ? logger : &std::clog;
+  std::ostream* diagnosticLogger = (diagLogger) ? diagLogger : &std::clog;
   sink = std::make_shared<detail::LogSink>(diagnosticLogger, enableDiagLog);
   systemBundle = std::shared_ptr<FrameworkPrivate>(new FrameworkPrivate(this));
   DIAG_LOG(*sink) << "created";

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -92,9 +92,9 @@ CoreBundleContext::CoreBundleContext(
   , frameworkProperties(InitProperties(props))
   , workingDir(ref_any_cast<std::string>(
       frameworkProperties.at(Constants::FRAMEWORK_WORKING_DIR)))
-  , logger(std::make_shared<cppmicroservices::cfrimpl::CFRLogger>(this))
   , listeners(this)
   , services(this)
+  , logger(std::make_shared<cppmicroservices::cfrimpl::CFRLogger>())
   , serviceHooks(this)
   , bundleHooks(this)
   , bundleRegistry(this)

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -98,14 +98,7 @@ public:
   */
   std::shared_ptr<detail::LogSink> sink;
 
-  /**
-   * A LogService for logging framework messages via
-   * a default or user-provided LogService that are intended to be
-   * visible outside of the framework.
-   */
-  std::shared_ptr<cppmicroservices::cfrimpl::CFRLogger> logger;
-
-  /**
+   /**
    * Bundle Storage
    */
   std::unique_ptr<BundleStorage> storage;
@@ -124,6 +117,13 @@ public:
    * All registered services in this framework.
    */
   ServiceRegistry services;
+
+  /**
+   * A LogService for logging framework messages via
+   * a default or user-provided LogService that are intended to be
+   * visible outside of the framework.
+   */
+  std::shared_ptr<cppmicroservices::cfrimpl::CFRLogger> logger;
 
   /**
    * All service hooks.

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -70,6 +70,18 @@ class CoreBundleContext
 {
 public:
   /**
+  * Please note: The order of the member variables in this class is important. When the 
+  * CoreBundleContext object is destroyed, it will call the destructors for the member 
+  * variables in the reverse order in which they are listed here. For example, serviceHooks 
+  * will be destroyed before the logger. The logger will be destroyed before the listeners, etc. 
+  * 
+  * The logger has a ServiceTracker member variable. When it is destroyed, the ServiceTracker::Close
+  * method is called to remove the ServiceListener. The logger object must be destroyed before the 
+  * listeners member variable is destroyed because when the listeners member variable is destroyed 
+  * it leaves the ServiceListeners data structures in an unusable state. If the logger object 
+  * destructor runs after the listeners object destructor, it results in an access violation. 
+  */
+  /**
    * Framework id.
    */
   int id;

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -29,7 +29,6 @@ namespace cfrimpl {
 CFRLogger::CFRLogger()
   : serviceTracker()
   , logService(nullptr)
-  , bOpen(false)
 {
 }
 
@@ -125,7 +124,6 @@ void CFRLogger::Open()
   }
   serviceTracker = std::make_unique<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>> (cfrContext, this);
   serviceTracker->Open();
-  bOpen = true;
 }
 
 void CFRLogger::Close() 
@@ -136,7 +134,6 @@ void CFRLogger::Close()
     serviceTracker->Close();
     serviceTracker.reset();
   }
-  bOpen = false;
 }
 
 } // cfrimpl

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -48,7 +48,7 @@ CFRLogger::AddingService(
   auto currLogger = std::atomic_load(&logService);
   std::shared_ptr<cppmicroservices::logservice::LogService> logger;
   if (!currLogger && reference) {
-    logger = GetBundleContext().GetService<cppmicroservices::logservice::LogService>(
+    logger = cfrContext.GetService<cppmicroservices::logservice::LogService>(
       reference);
     std::atomic_store(&logService, logger);
   }
@@ -78,11 +78,9 @@ void CFRLogger::RemovedService(
 
 void CFRLogger::Log(logservice::SeverityLevel level, const std::string& message)
 {
-  if (IsOpen()) {
-    auto currLogger = std::atomic_load(&logService);
-    if (currLogger) {
-      currLogger->Log(level, message);
-    }
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(level, message);
   }
 }
 
@@ -90,11 +88,9 @@ void CFRLogger::Log(logservice::SeverityLevel level,
                     const std::string& message,
                     const std::exception_ptr ex)
 {
-  if (IsOpen()) {
-    auto currLogger = std::atomic_load(&logService);
-    if (currLogger) {
-      currLogger->Log(level, message, ex);
-    }
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(level, message, ex);
   }
 }
 
@@ -102,11 +98,9 @@ void CFRLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
                     logservice::SeverityLevel level,
                     const std::string& message)
 {
-  if (IsOpen()) {
-    auto currLogger = std::atomic_load(&logService);
-    if (currLogger) {
-      currLogger->Log(sr, level, message);
-    }
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(sr, level, message);
   }
 }
 
@@ -115,11 +109,9 @@ void CFRLogger::Log(const cppmicroservices::ServiceReferenceBase& sr,
                     const std::string& message,
                     const std::exception_ptr ex)
 {
-   if (IsOpen()) {
-    auto currLogger = std::atomic_load(&logService);
-    if (currLogger) {
-      currLogger->Log(sr, level, message, ex);
-    }
+  auto currLogger = std::atomic_load(&logService);
+  if (currLogger) {
+    currLogger->Log(sr, level, message, ex);
   }
 }
 
@@ -127,8 +119,9 @@ void CFRLogger::Open()
 {
   auto l = this->Lock();
   US_UNUSED(l);
+  cfrContext = std::move(GetBundleContext());
   serviceTracker.reset(
-    new cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService> (GetBundleContext(), this));
+    new cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService> (cfrContext, this));
   serviceTracker->Open();
   bOpen = true;
 }

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -119,7 +119,7 @@ void CFRLogger::Open()
 {
   auto l = this->Lock();
   US_UNUSED(l);
-  cfrContext = std::move(GetBundleContext());
+  cfrContext = GetBundleContext();
   serviceTracker.reset(
     new cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService> (cfrContext, this));
   serviceTracker->Open();

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -26,7 +26,7 @@
 
 namespace cppmicroservices {
 namespace cfrimpl {
-CFRLogger::CFRLogger(cppmicroservices::CoreBundleContext*)
+CFRLogger::CFRLogger()
   : serviceTracker()
   , logService(nullptr)
   , bOpen(false)
@@ -120,8 +120,10 @@ void CFRLogger::Open()
   auto l = this->Lock();
   US_UNUSED(l);
   cfrContext = GetBundleContext();
-  serviceTracker.reset(
-    new cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService> (cfrContext, this));
+  if (!cfrContext) {
+    return;
+  }
+  serviceTracker = std::make_unique<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>> (cfrContext, this);
   serviceTracker->Open();
   bOpen = true;
 }
@@ -137,9 +139,5 @@ void CFRLogger::Close()
   bOpen = false;
 }
 
-bool CFRLogger::IsOpen() const 
-{
-  return bOpen;
-}
 } // cfrimpl
 } // cppmicroservices

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -26,9 +26,8 @@
 
 namespace cppmicroservices {
 namespace cfrimpl {
-CFRLogger::CFRLogger(cppmicroservices::CoreBundleContext* context)
-  : cfrContext(context)
-  , serviceTracker()
+CFRLogger::CFRLogger(cppmicroservices::CoreBundleContext*)
+  : serviceTracker()
   , logService(nullptr)
   , bOpen(false)
 {

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -51,7 +51,7 @@ class CFRLogger final
       cppmicroservices::logservice::LogService>
 {
 public:
-  CFRLogger(cppmicroservices::CoreBundleContext* context);
+  CFRLogger(cppmicroservices::CoreBundleContext*);
   CFRLogger(const CFRLogger&) = delete;
   CFRLogger(CFRLogger&&) = delete;
   CFRLogger& operator=(const CFRLogger&) = delete;
@@ -91,7 +91,6 @@ public:
   bool IsOpen() const;
 
 private:
-  cppmicroservices::CoreBundleContext *cfrContext;
   std::unique_ptr<
     cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
     serviceTracker;

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -46,11 +46,12 @@ namespace cfrimpl {
  */
 class CFRLogger final
   : public cppmicroservices::logservice::LogService
+  , public detail::MultiThreaded<>
   , public cppmicroservices::ServiceTrackerCustomizer<
       cppmicroservices::logservice::LogService>
 {
 public:
-  explicit CFRLogger(cppmicroservices::BundleContext context);
+  CFRLogger(cppmicroservices::CoreBundleContext* context);
   CFRLogger(const CFRLogger&) = delete;
   CFRLogger(CFRLogger&&) = delete;
   CFRLogger& operator=(const CFRLogger&) = delete;
@@ -83,13 +84,19 @@ public:
     const ServiceReference<cppmicroservices::logservice::LogService>& reference,
     const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
     override;
+  
+  // methods for the CFRLogger class
+  void Open();
+  void Close();
+  bool IsOpen() const;
 
 private:
-  cppmicroservices::BundleContext cfrContext;
+  cppmicroservices::CoreBundleContext *cfrContext;
   std::unique_ptr<
     cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
     serviceTracker;
   std::shared_ptr<cppmicroservices::logservice::LogService> logService;
+  std::atomic<bool> bOpen;
 };
 } // cfrimpl
 } // cppmicroservices

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -95,7 +95,6 @@ private:
     cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
     serviceTracker;
   std::shared_ptr<cppmicroservices::logservice::LogService> logService;
-  std::atomic<bool> bOpen;
 };
 } // cfrimpl
 } // cppmicroservices

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -91,6 +91,7 @@ public:
   bool IsOpen() const;
 
 private:
+  cppmicroservices::BundleContext cfrContext;
   std::unique_ptr<
     cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>
     serviceTracker;

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -51,7 +51,7 @@ class CFRLogger final
       cppmicroservices::logservice::LogService>
 {
 public:
-  CFRLogger(cppmicroservices::CoreBundleContext*);
+  CFRLogger();
   CFRLogger(const CFRLogger&) = delete;
   CFRLogger(CFRLogger&&) = delete;
   CFRLogger& operator=(const CFRLogger&) = delete;
@@ -88,7 +88,6 @@ public:
   // methods for the CFRLogger class
   void Open();
   void Close();
-  bool IsOpen() const;
 
 private:
   cppmicroservices::BundleContext cfrContext;


### PR DESCRIPTION
A couple of small bugs were detected in CFRLogger and some inconsistencies with the way CFRLogger was being initialized in CoreBundleContext.cpp, as compared to other Service Trackers (like ServiceHook) so this PR is addressing those issues. 

In the existing code, the CoreBundleContext::Init method initialized the logger as follows:
logger = std::make_shared<cppmicroservices::cfrimpl::CFRLogger>(MakeBundleContext(systemBundle->bundleContext.Load().get()));
Every time the CoreBundleContext::Init method ran it would destroy the old CFRLogger object and create a new one. This was inefficent. Also I think the intention was to create one CFRLogger object when CoreBundleContext was constructed and destroy it when it was destructed. 

To fix this, Open and Close methods were introduced. The CFRLogger is constructed when the CoreBundleContext object is constructed, opened when the CoreBundleContext::Init method is run and closed when the CoreBundleContext::Uninit0 method is run. It is destroyed when the CoreBundleContext object is destroyed. Only one object exists for the lifetime of CoreBundleContext. This implementation is consistent with the ServiceHooks implementation