### PR TITLE
Updated CI to use macos-12

### DIFF
--- a/.github/workflows/build_and_test_nix.yml
+++ b/.github/workflows/build_and_test_nix.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-10.15, macos-11]
+        os: [ubuntu-20.04, macOS-11, macos-12]
         # build configurations:
         # 0 = threading ON / shared lib ON
         # 1 = threading ON / shared lib OFF

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@
 +-------------+---------------------------+--------------------------------------+----------------------------------------+
 | Branch      | GCC 7.5.0 and 9.4.0       | Visual Studio 2019                   |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Xcode 12.4                | Visual Studio 2022                   |                                        |
+|             | Clang 9.0                 | Visual Studio 2022                   |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Xcode 13.0                | MinGW-w64                            |                                        |
+|             | Xcode 13.2                | MinGW-w64                            |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Clang 9.0                 |                                      |                                        |
+|             | Xcode 13.4                |                                      |                                        |
 +=============+===========================+======================================+========================================+
 | master      | |BuildAndTestNix(master)| | |BuildAndTestWindows(master)|        | |Code Coverage Status|                 |
 +-------------+---------------------------+--------------------------------------+----------------------------------------+
@@ -66,12 +66,12 @@ the following compilers:
 
 - GCC 9.4.0
 - Clang 9.0
-- Clang from Xcode 12.0 and 13.0
+- Clang from Xcode 13.2 and 13.4
 - Visual Studio 2019 and 2022
 
 Recommended minimum required CMake version:
 
-- CMake 3.12.4 
+- CMake 3.17.0
 
 For all CI builds through GitHub Actions, the CMake version (and
 version of other provided software) we use is determined by the 
@@ -82,8 +82,8 @@ use, please see the following resources:
 
 - `ubuntu-18.04 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md>`
 - `ubuntu-20.04 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md>`
-- `macos-10.15 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md>`
 - `macos-11 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md>`
+- `macos-12 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md>`
 - `windows-2019 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md>`
 - `windows-2022 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md>`
 
@@ -92,8 +92,8 @@ Below is a list of tested compiler/OS combinations:
 - GCC 7.5.0 (Ubuntu 18.04)
 - GCC 9.4.0 (Ubuntu 20.04)
 - Clang 9.0 (Ubuntu 18.04)
-- Apple Clang, Xcode 12.0.1 (OS X 10.15.7)
-- Apple Clang, Xcode 13.0.0 (OS X 11.0)
+- Apple Clang, Xcode 13.2.0 (OS X 11.6.8)
+- Apple Clang, Xcode 13.4.0 (OS X 12.5.0)
 - Visual Studio 2019
 - Visual Studio 2022
 - MinGW-w64


### PR DESCRIPTION
macos-10.X is now deprecated in GitHub Actions CI.

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>