### PR TITLE
Improve service dependency error logging

### DIFF
--- a/compendium/DeclarativeServices/test/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/CMakeLists.txt
@@ -78,6 +78,7 @@ set(_declarativeservices_tests
   TestRegistrationManager.cpp
   TestSCRBundleExtension.cpp
   TestServiceComponentRuntimeImpl.cpp
+  TestServiceDependencyErrorLogging.cpp
   TestServiceMetadataParserV1.cpp
   TestSetConfiguration.cpp
   TestSingletonComponentConfiguration.cpp
@@ -102,6 +103,14 @@ include_directories(${PROJECT_BINARY_DIR}/include
   ${CppMicroServices_BINARY_DIR}/compendium/CM/include
   )
 
+set(_logservice_additional_srcs
+  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src/LogServiceImpl.cpp
+  )
+
+set(_logservice_additional_hdrs
+  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src/LogServiceImpl.hpp
+  )
+
 set(_additional_srcs
   TestUtils.cpp
   ../src/SCRActivator.cpp
@@ -123,7 +132,9 @@ usFunctionGetResourceSource(
 
 add_executable(${us_declarativeservices_test_exe_name}
   ${_declarativeservices_tests}
-  ${_additional_srcs})
+  ${_additional_srcs}
+  ${_logservice_additional_srcs}
+  ${_logservice_additional_hdrs})
 
 if (US_COMPILER_MSVC AND BUILD_SHARED_LIBS)
   target_compile_options(${us_declarativeservices_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
@@ -140,7 +151,9 @@ set_property(
   )
 
 target_include_directories(${us_declarativeservices_test_exe_name}
-  PRIVATE $<TARGET_PROPERTY:util,INCLUDE_DIRECTORIES>)
+  PRIVATE $<TARGET_PROPERTY:util,INCLUDE_DIRECTORIES>
+  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src
+  ${CppMicroServices_SOURCE_DIR}/third_party/spdlog/include)
 
 # Disable deprecation warnings.
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR

--- a/compendium/DeclarativeServices/test/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/CMakeLists.txt
@@ -103,14 +103,6 @@ include_directories(${PROJECT_BINARY_DIR}/include
   ${CppMicroServices_BINARY_DIR}/compendium/CM/include
   )
 
-set(_logservice_additional_srcs
-  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src/LogServiceImpl.cpp
-  )
-
-set(_logservice_additional_hdrs
-  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src/LogServiceImpl.hpp
-  )
-
 set(_additional_srcs
   TestUtils.cpp
   ../src/SCRActivator.cpp
@@ -132,9 +124,7 @@ usFunctionGetResourceSource(
 
 add_executable(${us_declarativeservices_test_exe_name}
   ${_declarativeservices_tests}
-  ${_additional_srcs}
-  ${_logservice_additional_srcs}
-  ${_logservice_additional_hdrs})
+  ${_additional_srcs})
 
 if (US_COMPILER_MSVC AND BUILD_SHARED_LIBS)
   target_compile_options(${us_declarativeservices_test_exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
@@ -151,9 +141,7 @@ set_property(
   )
 
 target_include_directories(${us_declarativeservices_test_exe_name}
-  PRIVATE $<TARGET_PROPERTY:util,INCLUDE_DIRECTORIES>
-  ${CppMicroServices_SOURCE_DIR}/compendium/LogServiceImpl/src
-  ${CppMicroServices_SOURCE_DIR}/third_party/spdlog/include)
+  PRIVATE $<TARGET_PROPERTY:util,INCLUDE_DIRECTORIES>)
 
 # Disable deprecation warnings.
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR

--- a/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
@@ -1,0 +1,204 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  =============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include "../src/manager/ComponentConfigurationImpl.hpp"
+#include "../src/manager/ReferenceManager.hpp"
+#include "../src/manager/SingletonComponentConfiguration.hpp"
+#include "../src/metadata/ComponentMetadata.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/ServiceInterface.h"
+
+#include <ostream>
+#include <regex>
+#include <string>
+
+#include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/spdlog.h>
+#include "LogServiceImpl.hpp"
+
+namespace ls = cppmicroservices::logservice;
+
+static const std::string sinkFormat = "[%T] [%P:%t] %n (%^%l%$): %v";
+static const std::string log_preamble(
+  "\\[([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})\\] "
+  "\\[([0-9]{1,9}):([0-9]{1,9})\\] cppmicroservices::testing::logservice "
+  "\\((debug|trace|info|warning|error)\\): ");
+
+namespace cppmicroservices {
+namespace scrimpl {
+
+class ServiceDependencyErrorLoggingTest : public ::testing::Test
+{
+
+public:
+  bool ContainsRegex(const std::string& regex)
+  {
+    std::string text = oss.str();
+    std::smatch m;
+    bool found = std::regex_search(text, m, std::regex(regex));
+    oss.str("");
+    return found;
+  }
+
+  std::shared_ptr<ls::LogServiceImpl> GetLogger() { return _impl; }
+  std::ostringstream& GetStream() { return oss; }
+
+protected:
+  ServiceDependencyErrorLoggingTest()
+      : framework(cppmicroservices::FrameworkFactory().NewFramework())
+  {
+    _impl = std::make_shared<ls::LogServiceImpl>(
+      "cppmicroservices::testing::logservice");
+  }
+
+  virtual ~ServiceDependencyErrorLoggingTest() = default;
+
+  virtual void SetUp()
+  {
+    framework.Start();
+    _sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+    _sink->set_pattern(sinkFormat);
+    _impl->AddSink(_sink);
+  }
+
+  virtual void TearDown()
+  {
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
+    _sink.reset();
+    _impl.reset();
+  }
+
+ cppmicroservices::Framework& GetFramework() { return framework; }
+
+private:
+  std::ostringstream oss;
+  spdlog::sink_ptr _sink;
+  std::shared_ptr<ls::LogServiceImpl> _impl;
+
+public:
+  cppmicroservices::Framework framework;
+};
+
+TEST_F(ServiceDependencyErrorLoggingTest, ProperLoggerUsage)
+{
+  auto logger = GetLogger();
+  logger->Log(ls::SeverityLevel::LOG_DEBUG, "Bonjour!");
+  EXPECT_TRUE(ContainsRegex(log_preamble + "Bonjour!"));
+}
+
+TEST_F(ServiceDependencyErrorLoggingTest, TestServiceDependencyLDAPFilter)
+{
+  auto serviceImpllogger = GetLogger();
+ 
+  GetFramework().GetBundleContext()
+    .RegisterService<cppmicroservices::logservice::LogService>(
+      serviceImpllogger);
+
+  auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
+
+  mockMetadata->serviceMetadata.interfaces = {
+    us_service_interface_iid<dummy::ServiceImpl>()
+  };
+
+  // reference meta data for ServiceImpl
+  metadata::ReferenceMetadata rm1;
+  rm1.name = "Reference1";
+  rm1.interfaceName = "cppmicroservices::scrimpl::dummy::Reference1";
+  rm1.target = "(scheme=abc)";
+  mockMetadata->refsMetadata.push_back(rm1);
+
+  auto mockRegistry = std::make_shared<MockComponentRegistry>();
+  auto logger = std::make_shared<SCRLogger>(framework.GetBundleContext());
+  auto asyncWorkService =
+    std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
+      framework.GetBundleContext(), logger);
+  auto notifier = std::make_shared<ConfigurationNotifier>(
+    framework.GetBundleContext(), serviceImpllogger, asyncWorkService);
+  auto managers =
+    std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
+
+  {
+    auto refmockMetadata = std::make_shared<metadata::ComponentMetadata>();
+    refmockMetadata->serviceMetadata.interfaces = {
+      us_service_interface_iid<dummy::Reference1>()
+    };
+    // Test for wrong LDAP filter values, actual LDAP string should be "abc" as per ServiceImpl reference properties
+    refmockMetadata->properties.insert(
+      std::make_pair("scheme", Any(std::string("abcd"))));
+    auto fakeCompConfig =
+      std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
+                                                            framework,
+                                                            mockRegistry,
+                                                            serviceImpllogger,
+                                                            notifier,
+                                                            managers);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
+    fakeCompConfig->Initialize();
+    auto serviceRefFakeCompConfig =
+      std::make_shared<SingletonComponentConfigurationImpl>(refmockMetadata,
+                                                            framework,
+                                                            mockRegistry,
+                                                            serviceImpllogger,
+                                                            notifier,
+                                                            managers);
+    serviceRefFakeCompConfig->Initialize();
+    EXPECT_TRUE(ContainsRegex("reference LDAP filter doesn't match"));
+  }
+
+  {
+    auto refmockMetadata = std::make_shared<metadata::ComponentMetadata>();
+    refmockMetadata->serviceMetadata.interfaces = {
+      us_service_interface_iid<dummy::Reference1>()
+    };
+    // Test for correct LDAP filter values
+    refmockMetadata->properties.insert(
+      std::make_pair("scheme", Any(std::string("abc"))));
+    auto fakeCompConfig =
+      std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
+                                                            framework,
+                                                            mockRegistry,
+                                                            serviceImpllogger,
+                                                            notifier,
+                                                            managers);
+    EXPECT_EQ(fakeCompConfig->GetConfigState(),
+              ComponentState::UNSATISFIED_REFERENCE);
+    fakeCompConfig->Initialize();
+    auto serviceRefFakeCompConfig =
+      std::make_shared<SingletonComponentConfigurationImpl>(refmockMetadata,
+                                                            framework,
+                                                            mockRegistry,
+                                                            serviceImpllogger,
+                                                            notifier,
+                                                            managers);
+    serviceRefFakeCompConfig->Initialize();
+    EXPECT_FALSE(ContainsRegex("reference LDAP filter doesn't match"));
+  }
+}
+}
+}

--- a/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
@@ -144,7 +144,7 @@ TEST_F(ServiceDependencyErrorLoggingTest, TestServiceDependencyLDAPFilter)
     serviceRefFakeCompConfig->Initialize();
     using ::testing::ContainsRegex;
     EXPECT_THAT(
-      customLogger->GetLoggerMessage(), ContainsRegex("doesn't match service reference properties"));
+      customLogger->GetLoggerMessage(), ContainsRegex("Service listener matching LDAP filter could not be found"));
     fakeCompConfig->Deactivate();
     fakeCompConfig->Stop();
     serviceRefFakeCompConfig->Deactivate();

--- a/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceDependencyErrorLogging.cpp
@@ -169,6 +169,10 @@ TEST_F(ServiceDependencyErrorLoggingTest, TestServiceDependencyLDAPFilter)
                                                             managers);
     serviceRefFakeCompConfig->Initialize();
     EXPECT_TRUE(ContainsRegex("reference LDAP filter doesn't match"));
+    fakeCompConfig->Deactivate();
+    fakeCompConfig->Stop();
+    serviceRefFakeCompConfig->Deactivate();
+    serviceRefFakeCompConfig->Stop();
   }
 
   {
@@ -198,6 +202,10 @@ TEST_F(ServiceDependencyErrorLoggingTest, TestServiceDependencyLDAPFilter)
                                                             managers);
     serviceRefFakeCompConfig->Initialize();
     EXPECT_FALSE(ContainsRegex("reference LDAP filter doesn't match"));
+    fakeCompConfig->Deactivate();
+    fakeCompConfig->Stop();
+    serviceRefFakeCompConfig->Deactivate();
+    serviceRefFakeCompConfig->Stop();
   }
 }
 }

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -446,16 +446,18 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
       const LDAPExpr& ldapExpr = sse.GetLDAPExpr();
       if (ldapExpr.IsNull() || ldapExpr.Evaluate(props, false)) {
         set.insert(sse);
-      } else {
-        if (evt.GetType() == ServiceEvent::SERVICE_REGISTERED) {
-          const std::string msg =
-            sse.GetBundleContext().GetBundle().GetSymbolicName() +
-            " reference LDAP filter doesn't match " +
-            ref.GetBundle().GetSymbolicName() + " component's properties.\n";
+      } else if (evt.GetType() == ServiceEvent::SERVICE_REGISTERED) {
+        const std::string msg =
+          "References LDAP filter value in key 'target' of " +
+          sse.GetBundleContext().GetBundle().GetSymbolicName() +
+          " manifest doesn't match service reference properties'." +
+          "\nPlease verify ldap filter value '" + sse.GetLDAPExpr().ToString() +
+          "' in " + ref.GetBundle().GetSymbolicName() +
+          " manifest components 'properties' map.";
+
           coreCtx->logger->Log(
             cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, msg);
         }
-      }
     }
 
     // Check the cache

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -447,7 +447,20 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
       if (ldapExpr.IsNull() || ldapExpr.Evaluate(props, false)) {
         set.insert(sse);
       } else if (evt.GetType() == ServiceEvent::SERVICE_REGISTERED) {
-        const std::string msg = "Service listener matching LDAP filter could not be found using LDAP filter: " + sse.GetFilter();
+        // get the props key and value for logging
+        std::string propsKeyValues{};
+
+        auto key = props->Keys_unlocked();
+        for (auto k : key) {
+          auto val = props->Value_unlocked(k).ToString();
+          propsKeyValues += k + " : " + val + ", ";
+        }
+
+        const std::string msg =
+          "Service listener matching LDAP filter could "
+          "not be found using LDAP filter: " +
+          sse.GetFilter() + ". Please verify the LDAP filter value in service properties: " + "{" + propsKeyValues + "}";
+
           coreCtx->logger->Log(
             cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, msg);
         }

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -452,7 +452,7 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
 
         auto key = props->Keys_unlocked();
         for (auto k : key) {
-          auto val = props->Value_unlocked(k).ToString();
+          auto val = props->Value_unlocked(k).first.ToString();
           propsKeyValues += k + " : " + val + ", ";
         }
 
@@ -463,7 +463,7 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
 
           coreCtx->logger->Log(
             cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, msg);
-        }
+      }
     }
 
     // Check the cache

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -446,6 +446,15 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
       const LDAPExpr& ldapExpr = sse.GetLDAPExpr();
       if (ldapExpr.IsNull() || ldapExpr.Evaluate(props, false)) {
         set.insert(sse);
+      } else {
+        if (evt.GetType() == ServiceEvent::SERVICE_REGISTERED) {
+          const std::string msg =
+            sse.GetBundleContext().GetBundle().GetSymbolicName() +
+            " reference LDAP filter doesn't match " +
+            ref.GetBundle().GetSymbolicName() + " component's properties.\n";
+          coreCtx->logger->Log(
+            cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, msg);
+        }
       }
     }
 

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -447,14 +447,7 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
       if (ldapExpr.IsNull() || ldapExpr.Evaluate(props, false)) {
         set.insert(sse);
       } else if (evt.GetType() == ServiceEvent::SERVICE_REGISTERED) {
-        const std::string msg =
-          "References LDAP filter value in key 'target' of " +
-          sse.GetBundleContext().GetBundle().GetSymbolicName() +
-          " manifest doesn't match service reference properties'." +
-          "\nPlease verify ldap filter value '" + sse.GetLDAPExpr().ToString() +
-          "' in " + ref.GetBundle().GetSymbolicName() +
-          " manifest components 'properties' map.";
-
+        const std::string msg = "Service listener matching LDAP filter could not be found using LDAP filter: " + sse.GetFilter();
           coreCtx->logger->Log(
             cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, msg);
         }


### PR DESCRIPTION
This PR improves service dependency error logging by enabling DEBUG log to show the cause of error when a service fails to find it's dependency because of typo/misspelled in it's LDAP filter or the service properties.

Signed-off-by: The MathWorks, Inc. kunalk@mathworks.com