### PR TITLE
Added missing include for <thread>

### DIFF
--- a/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
@@ -42,6 +42,7 @@
 #include "boost/asio/thread_pool.hpp"
 
 #include <future>
+#include <thread>
 
 #include "ConfigurationAdminTestingConfig.h"
 

--- a/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
@@ -42,6 +42,7 @@
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
 #include <future>
+#include <thread>
 
 namespace test {
 

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -37,6 +37,7 @@
 #include <chrono>
 #include <future>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 
 #include "gmock/gmock.h"


### PR DESCRIPTION
- Fixes compilation issue when using GCC 11

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>