### PR TITLE
Fixed sporadic race conditions during framework shutdown

### DIFF
--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -218,7 +218,10 @@ void BundlePrivate::FinalizeActivation()
 {
   switch (GetUpdatedState()) {
     case Bundle::STATE_INSTALLED: {
-      std::rethrow_exception(resolveFailException);
+      if(resolveFailException) {
+        std::rethrow_exception(resolveFailException);
+      }
+      break;
     }
     case Bundle::STATE_STARTING: {
       if (operation == OP_ACTIVATING) {
@@ -570,7 +573,10 @@ void BundlePrivate::StartFailed()
   coreCtx->listeners.BundleChanged(BundleEvent(
     BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
   RemoveBundleResources();
-  bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>())->Invalidate();
+  auto oldBundleContext = bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
+  if (oldBundleContext) {
+    oldBundleContext->Invalidate();
+  }
   state = Bundle::STATE_RESOLVED;
   coreCtx->listeners.BundleChanged(BundleEvent(
     BundleEvent::BUNDLE_STOPPED, MakeBundle(this->shared_from_this())));

--- a/framework/src/bundle/BundleStorageMemory.cpp
+++ b/framework/src/bundle/BundleStorageMemory.cpp
@@ -91,8 +91,8 @@ std::vector<long> BundleStorageMemory::GetStartOnLaunchBundles() const
 
 void BundleStorageMemory::Close()
 {
-  // Not need to lock "archives" here: at this point, the framework
-  // is going down and no other threads can access it.
+  auto l = archives.Lock();
+  US_UNUSED(l);
   archives.v.clear();
 }
 }

--- a/framework/src/service/ServiceHooks.cpp
+++ b/framework/src/service/ServiceHooks.cpp
@@ -86,8 +86,7 @@ void ServiceHooks::Open()
 {
   auto l = this->Lock();
   US_UNUSED(l);
-  listenerHookTracker.reset(
-    new ServiceTracker<ServiceListenerHook>(GetBundleContext(), this));
+  listenerHookTracker = std::make_unique<ServiceTracker<ServiceListenerHook>>(GetBundleContext(), this);
   listenerHookTracker->Open();
 
   bOpen = true;
@@ -99,7 +98,6 @@ void ServiceHooks::Close()
   US_UNUSED(l);
   if (listenerHookTracker) {
     listenerHookTracker->Close();
-    listenerHookTracker.reset();
   }
 
   bOpen = false;

--- a/framework/src/service/ServiceHooks.h
+++ b/framework/src/service/ServiceHooks.h
@@ -33,8 +33,8 @@ namespace cppmicroservices {
 struct ServiceListenerHook;
 
 class ServiceHooks
-  : private detail::MultiThreaded<>
-  , private ServiceTrackerCustomizer<ServiceListenerHook>
+  : public detail::MultiThreaded<>
+  , public ServiceTrackerCustomizer<ServiceListenerHook>
 {
 
 private:

--- a/framework/test/gtest/BundleTest.cpp
+++ b/framework/test/gtest/BundleTest.cpp
@@ -1,4 +1,4 @@
-﻿/*=============================================================================
+/*=============================================================================
 
   Library: CppMicroServices
 
@@ -42,6 +42,7 @@
 #include "TestingConfig.h"
 
 #include <chrono>
+#include <future>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -917,5 +918,52 @@ TEST_F(BundleTest, TestBundleStreamOperator)
   ASSERT_TRUE(bundle);
   std::cout << &bundle;
 }
+
+#if defined(US_BUILD_SHARED_LIBS) && defined(US_ENABLE_THREADING_SUPPORT)
+// This test is designed to be run in a loop to find race conditions
+// when shutting down the framework when other framework operations are
+// happening.
+TEST_F(BundleTest, TestFrameworkAccessDuringFrameworkShutdown) {
+
+    std::promise<void> frameworkshuttingdown;
+    std::future<void> waitForShuttingDown = frameworkshuttingdown.get_future();
+    
+    std::atomic_bool keepLooping = true;
+
+    auto frameworkAccessThread = std::async(std::launch::async, [this, &keepLooping, waitForIt = std::move(waitForShuttingDown)]() {
+      waitForIt.wait();
+
+      while (keepLooping) {
+          auto token = framework.GetBundleContext().AddBundleListener([](const cppmicroservices::BundleEvent& evt) {
+              if (evt.GetType() == cppmicroservices::BundleEvent::Type::BUNDLE_STOPPING && evt.GetBundle().GetBundleId() == 0) {
+                  return;
+                }
+              });
+          auto bundle = InstallLib(framework.GetBundleContext(), "TestBundleA");
+          bundle.Start();
+          const auto& map = bundle.GetHeaders();
+          ASSERT_TRUE(!map.empty());
+          framework.GetBundleContext().RemoveListener(std::move(token));
+          bundle.Stop();
+          bundle.Uninstall();
+      }
+    } );
+
+    frameworkshuttingdown.set_value();
+    framework.Stop();
+    auto evt = framework.WaitForStop(std::chrono::milliseconds::zero());
+    keepLooping = false;
+
+    // some of the framework operations can throw based on the point at which
+    // framework shutdown is happening. Catch any of those and continue, those
+    // exceptions are not relevant to this test.
+    try {
+      frameworkAccessThread.get();
+    }
+    catch (...) {}
+
+    ASSERT_EQ(evt.GetType(), cppmicroservices::FrameworkEvent::Type::FRAMEWORK_STOPPED);
+}
+#endif
 
 US_MSVC_POP_WARNING


### PR DESCRIPTION
Fixed a number of races that can occur while one thread is performing various framework operations and another thread is shutting down the framework.

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>