### PR TITLE
Factory Configuration Bug Fix

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
@@ -155,7 +155,7 @@ void ConfigurationNotifier::CreateFactoryComponent(
   // component except the factory component itself.
   newMetadata->configurationPids.clear();
   for (const auto& basePid : oldMetadata->configurationPids) {
-    if (basePid != factoryName) {
+    if (basePid != oldMetadata->configurationPids[0])  {
       newMetadata->configurationPids.emplace_back(basePid);
     }
   }

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
@@ -102,10 +102,10 @@ public:
     cppmicroservices::service::cm::ConfigurationEventType type,
     std::shared_ptr<cppmicroservices::AnyMap> properties);
 
-private:
   void CreateFactoryComponent(const std::string& factoryName,
                               const std::string& pid,
                               std::shared_ptr<ComponentConfigurationImpl>& mgr);
+private:
 
   using TokenMap = std::unordered_map<ListenerTokenId, Listener>;
 

--- a/compendium/DeclarativeServices/test/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/TestFactoryPid.cpp
@@ -137,6 +137,49 @@ TEST_F(tServiceComponent, testFactoryPidConstructionNameDifferentThanClass)
   auto instance = GetInstance<test::CAInterface>();
   ASSERT_TRUE(instance) << "GetService failed for CAInterface";
 
+
+}
+
+/* testFactoryConfigBeforeInstall
+   This test creates the configuration objects for the factory instances
+   before the factory component has been installed and started. 
+   Once the factory component is installed and started the instances 
+   associated with the configuration objects should be registered
+   automatically by DS.
+*/
+TEST_F(tServiceComponent, testFactoryConfigBeforeInstall)
+{
+  std::string configurationPid = "ServiceComponentPid";
+
+  // Get a service reference to ConfigAdmin to create the factory component instances.
+  auto configAdminService =
+      GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
+  ASSERT_TRUE(configAdminService) << "GetService failed for ConfigurationAdmin";
+
+  // Create some factory configuration objects.
+  auto const count = 5;
+  for (int i = 0; i < count; i++) {
+    // Create the factory configuration object
+    auto factoryConfig =
+        configAdminService->CreateFactoryConfiguration(configurationPid);
+    
+    // Update the properties for the factory configuration object
+    cppmicroservices::AnyMap props(
+        cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+    const std::string instanceId{ "instance" + std::to_string(i)};
+    props["uniqueProp"] = instanceId;
+    auto fut = factoryConfig->Update(props);
+    fut.get();
+  }
+
+  // Start the test bundle containing the factory component. This will
+  // cause DS to register the factory instances. 
+  cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSCA21");
+   
+  //Request service references to the new component instances. This will
+  //cause DS to construct the factory instances.
+  auto instances = GetInstances<test::CAInterface>();
+  EXPECT_EQ(instances.size(), count);
  }
 }
 

--- a/compendium/DeclarativeServices/test/TestFixture.hpp
+++ b/compendium/DeclarativeServices/test/TestFixture.hpp
@@ -169,6 +169,21 @@ public:
     return context.GetService<T>(instanceRef);
   }
 
+  template<class T>
+    std::vector<std::shared_ptr<T>> GetInstances()
+    {
+      std::vector<cppmicroservices::ServiceReference<T>> instanceRefs;
+      std::vector<std::shared_ptr<T>> instances;
+      instanceRefs = context.GetServiceReferences<T>();
+      if (instanceRefs.size() <= 0) {
+        return std::vector<std::shared_ptr<T>>();
+      }
+      for (const auto& ref : instanceRefs) {
+        instances.push_back(context.GetService<T>(ref));
+      }
+      return instances;
+    }
+
   std::vector<scr::dto::ComponentConfigurationDTO> GetComponentConfigs(
     const cppmicroservices::Bundle& testBundle,
     const std::string& componentName,


### PR DESCRIPTION
When factory configurations are created before the bundle containing the factory component is installed and started, DS should find those configurations in the Configuration Admin repository and register them as part of the factory component startup. Signed-off-by The MathWorks, Inc. <pelliott@mathworks.com>