### PR TITLE
701 Fixes #653, Ensure that any BundleContext functions do not segfault if the bundle context is invalid

### DIFF
--- a/framework/include/cppmicroservices/BundleContext.h
+++ b/framework/include/cppmicroservices/BundleContext.h
@@ -180,6 +180,7 @@ public:
    * the Framework properties, the method returns an empty \c Any.
    *
    * @param key The name of the requested property.
+   * @throws std::runtime_error If this BundleContext is no longer valid.
    * @return The value of the requested property, or an empty \c Any if the
    *         property is undefined.
    */
@@ -188,6 +189,7 @@ public:
   /**
    * Returns all known properties.
    *
+   * @throws std::runtime_error If this BundleContext is no longer valid.
    * @return A map of all framework properties.
    */
   AnyMap GetProperties() const;
@@ -445,7 +447,7 @@ public:
    *         search.
    * @throws std::invalid_argument If the specified <code>filter</code>
    *         contains an invalid filter expression that cannot be parsed.
-   * @throws std::logic_error If this BundleContext is no longer valid.
+   * @throws std::runtime_error If this BundleContext is no longer valid.
    * @throws ServiceException If the service interface id of \c S is empty, see @ref gr_serviceinterface.
    *
    * @see GetServiceReferences(const std::string&, const std::string&)
@@ -641,6 +643,9 @@ public:
   template<class S>
   ServiceObjects<S> GetServiceObjects(const ServiceReference<S>& reference)
   {
+    if (!d) {
+      throw std::runtime_error("The bundle context is no longer valid");
+    }
     return ServiceObjects<S>(d, reference);
   }
 

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -74,12 +74,20 @@ BundleContext& BundleContext::operator=(std::nullptr_t)
 
 std::shared_ptr<detail::LogSink> BundleContext::GetLogSink() const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   return d->bundle->coreCtx->sink->shared_from_this();
 }
 
 Any BundleContext::GetProperty(const std::string& key) const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -94,6 +102,10 @@ Any BundleContext::GetProperty(const std::string& key) const
 
 AnyMap BundleContext::GetProperties() const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -107,6 +119,10 @@ AnyMap BundleContext::GetProperties() const
 
 Bundle BundleContext::GetBundle() const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -120,6 +136,10 @@ Bundle BundleContext::GetBundle() const
 
 Bundle BundleContext::GetBundle(long id) const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -134,6 +154,10 @@ Bundle BundleContext::GetBundle(long id) const
 
 std::vector<Bundle> BundleContext::GetBundles(const std::string& location) const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -151,6 +175,10 @@ std::vector<Bundle> BundleContext::GetBundles(const std::string& location) const
 
 std::vector<Bundle> BundleContext::GetBundles() const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -171,6 +199,10 @@ ServiceRegistrationU BundleContext::RegisterService(
   const InterfaceMapConstPtr& service,
   const ServiceProperties& properties)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -186,6 +218,10 @@ std::vector<ServiceReferenceU> BundleContext::GetServiceReferences(
   const std::string& clazz,
   const std::string& filter)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -201,6 +237,10 @@ std::vector<ServiceReferenceU> BundleContext::GetServiceReferences(
 
 ServiceReferenceU BundleContext::GetServiceReference(const std::string& clazz)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -263,6 +303,10 @@ std::shared_ptr<void> BundleContext::GetService(
                                 "valid input to GetService()");
   }
 
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -284,6 +328,10 @@ InterfaceMapConstPtr BundleContext::GetService(
                                 "valid input to GetService()");
   }
 
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -301,6 +349,10 @@ InterfaceMapConstPtr BundleContext::GetService(
 ListenerToken BundleContext::AddServiceListener(const ServiceListener& delegate,
                                                 const std::string& filter)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -314,6 +366,10 @@ ListenerToken BundleContext::AddServiceListener(const ServiceListener& delegate,
 
 void BundleContext::RemoveServiceListener(const ServiceListener& delegate)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -328,6 +384,10 @@ void BundleContext::RemoveServiceListener(const ServiceListener& delegate)
 
 ListenerToken BundleContext::AddBundleListener(const BundleListener& delegate)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -341,6 +401,10 @@ ListenerToken BundleContext::AddBundleListener(const BundleListener& delegate)
 
 void BundleContext::RemoveBundleListener(const BundleListener& delegate)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -355,6 +419,10 @@ void BundleContext::RemoveBundleListener(const BundleListener& delegate)
 ListenerToken BundleContext::AddFrameworkListener(
   const FrameworkListener& listener)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -368,6 +436,10 @@ ListenerToken BundleContext::AddFrameworkListener(
 
 void BundleContext::RemoveFrameworkListener(const FrameworkListener& listener)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -383,6 +455,10 @@ ListenerToken BundleContext::AddServiceListener(const ServiceListener& delegate,
                                                 void* data,
                                                 const std::string& filter)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -397,6 +473,10 @@ ListenerToken BundleContext::AddServiceListener(const ServiceListener& delegate,
 void BundleContext::RemoveServiceListener(const ServiceListener& delegate,
                                           void* data)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -412,6 +492,10 @@ void BundleContext::RemoveServiceListener(const ServiceListener& delegate,
 ListenerToken BundleContext::AddBundleListener(const BundleListener& delegate,
                                                void* data)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -426,6 +510,10 @@ ListenerToken BundleContext::AddBundleListener(const BundleListener& delegate,
 void BundleContext::RemoveBundleListener(const BundleListener& delegate,
                                          void* data)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -439,6 +527,10 @@ void BundleContext::RemoveBundleListener(const BundleListener& delegate,
 
 void BundleContext::RemoveListener(ListenerToken token)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -452,6 +544,10 @@ void BundleContext::RemoveListener(ListenerToken token)
 
 std::string BundleContext::GetDataFile(const std::string& filename) const
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
 
@@ -474,6 +570,10 @@ std::vector<Bundle> BundleContext::InstallBundles(
   const std::string& location,
   const cppmicroservices::AnyMap& bundleManifest)
 {
+  if (!d) {
+    throw std::runtime_error("The bundle context is no longer valid");
+  }
+
   d->CheckValid();
   auto b = (d->Lock(), d->bundle);
   // CONCURRENCY NOTE: This is a check-then-act situation,

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -1,0 +1,139 @@
+/*=============================================================================
+ 
+ Library: CppMicroServices
+ 
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ =============================================================================*/
+
+#include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/Bundle.h"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/ServiceObjects.h"
+#include "cppmicroservices/ServiceReference.h"
+
+#include <chrono>
+#include <gtest/gtest.h>
+
+namespace bc_tests {
+struct TestService
+{
+  virtual ~TestService() {}
+};
+}
+
+TEST(BundleContextTest, BundleContextThrowWhenInvalid)
+{
+  cppmicroservices::Framework framework =
+    cppmicroservices::FrameworkFactory().NewFramework();
+  ASSERT_TRUE(framework) << "The framework was not created successfully.";
+  framework.Start();
+
+  auto context = framework.GetBundleContext();
+  ASSERT_TRUE(context) << "The bundle context is not valid.";
+
+  // Register a service and get a service reference for testing
+  // GetService() later.
+  (void)context.RegisterService<bc_tests::TestService>(
+    std::make_shared<bc_tests::TestService>());
+  auto sRef = context.GetServiceReference<bc_tests::TestService>();
+  ASSERT_TRUE(sRef) << "The service reference is not valid.";
+
+  auto frameworkListenerToken = context.AddFrameworkListener(
+    [](const cppmicroservices::FrameworkEvent&) {});
+
+  framework.Stop();
+  framework.WaitForStop(std::chrono::milliseconds::zero());
+
+  auto context2 = framework.GetBundleContext();
+  ASSERT_FALSE(context2)
+    << "The bundle context is valid when it should not be.";
+
+  EXPECT_THROW({ (void)context2.GetProperty("bonjour"); }, std::runtime_error)
+    << "GetProperty() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetProperties(); }, std::runtime_error)
+    << "GetProperties() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetBundle(); }, std::runtime_error)
+    << "GetBundle() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetBundle(0); }, std::runtime_error)
+    << "GetBundle(int) on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetBundles("fake/path"); }, std::runtime_error)
+    << "GetBundles(string) on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetBundles(); }, std::runtime_error)
+    << "GetBundles() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    {
+      (void)context2.RegisterService<bc_tests::TestService>(
+        std::make_shared<bc_tests::TestService>());
+    },
+    std::runtime_error)
+    << "RegisterService() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    { (void)context2.GetServiceReferences<bc_tests::TestService>(); },
+    std::runtime_error)
+    << "GetServiceReferences(string) on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    { (void)context2.GetServiceReferences<bc_tests::TestService>(); },
+    std::runtime_error)
+    << "GetServiceReferences() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetServiceReference("hola"); },
+               std::runtime_error)
+    << "GetServiceReference(string) on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetServiceReference<bc_tests::TestService>(); },
+               std::runtime_error)
+    << "GetServiceReference() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.GetService<bc_tests::TestService>(sRef); },
+               std::runtime_error)
+    << "GetService() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    { (void)context2.GetServiceObjects<bc_tests::TestService>(sRef); },
+    std::runtime_error)
+    << "GetServiceObjects() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    {
+      (void)context2.AddServiceListener(
+        [](const cppmicroservices::ServiceEvent&) {});
+    },
+    std::runtime_error)
+    << "AddServiceListener() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    {
+      (void)context2.AddBundleListener(
+        [](const cppmicroservices::BundleEvent&) {});
+    },
+    std::runtime_error)
+    << "AddBundleListener() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    {
+      (void)context2.AddFrameworkListener(
+        [](const cppmicroservices::FrameworkEvent&) {});
+    },
+    std::runtime_error)
+    << "AddFrameworkListener() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ context2.RemoveListener(std::move(frameworkListenerToken)); },
+               std::runtime_error)
+    << "RemoveListener() on invalid BundleContext did not throw.";
+  EXPECT_THROW(
+    { (void)context2.GetDataFile("definitely/not/a/real/file/name.txt"); },
+    std::runtime_error)
+    << "GetDataFile() on invalid BundleContext did not throw.";
+  EXPECT_THROW({ (void)context2.InstallBundles("this/doesnt/matter"); },
+               std::runtime_error)
+    << "InstallBundles() on invalid BundleContext did not throw.";
+}

--- a/framework/test/gtest/CMakeLists.txt
+++ b/framework/test/gtest/CMakeLists.txt
@@ -31,6 +31,7 @@ set(_gtest_tests
   AnyTest.cpp
   AnyMapTest.cpp
   BundleActivatorTest.cpp
+  BundleContextTest.cpp
   BundleDeadLockTest.cpp
   BundleManifestTest.cpp
   BundleValidationTest.cpp


### PR DESCRIPTION
Cherry-picked #656 / https://github.com/CppMicroServices/CppMicroServices/commit/a240213a06871632a508390ce64535f0732a2459 without changes