### PR TITLE
701 Fix failure with initializing a component config after a config update

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -197,7 +197,7 @@ void ComponentConfigurationImpl::Initialize()
         configListenerTokens.emplace_back(listenerToken);
       }
       configManager->Initialize();
-      if (referenceManagers.empty() && configManager->IsConfigSatisfied()) {
+      if (AreReferencesSatisfied() && configManager->IsConfigSatisfied()) {
         GetState()->Register(*this);
       }
     }

--- a/compendium/DeclarativeServices/test/TestUtils.cpp
+++ b/compendium/DeclarativeServices/test/TestUtils.cpp
@@ -149,6 +149,22 @@ std::string GetConfigAdminRuntimePluginFilePath()
   return PathToLib(libName);
 }
 
+void InstallAndStartConfigAdmin(::cppmicroservices::BundleContext frameworkCtx)
+{
+  std::vector<cppmicroservices::Bundle> bundles;
+  auto cmPluginPath = test::GetConfigAdminRuntimePluginFilePath();
+
+  #if defined(US_BUILD_SHARED_LIBS)
+  bundles = frameworkCtx.InstallBundles(cmPluginPath);
+#else
+  bundles = frameworkCtx.GetBundles();
+#endif
+
+  for (auto b : bundles) {
+    b.Start();
+  }
+}
+
 bool isBundleLoadedInThisProcess(std::string bundleName)
 {
 #if defined(US_PLATFORM_WINDOWS)


### PR DESCRIPTION
Cherry-picked #666 / https://github.com/CppMicroServices/CppMicroServices/commit/49028dd3eb6e30aa22a4ecda4725b785561b23f2 without changes