### PR TITLE
701 Update DS and CA versions

### DIFF
--- a/compendium/ConfigurationAdmin/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/CMakeLists.txt
@@ -37,7 +37,7 @@ add_compile_definitions(BOOST_DATE_TIME_NO_LIB)
 add_compile_definitions(BOOST_REGEX_NO_LIB)
 
 usMacroCreateBundle(ConfigurationAdmin
-  VERSION "1.1.2"
+  VERSION "1.3.0"
   DEPENDS Framework
   TARGET ConfigurationAdmin
   SYMBOLIC_NAME configuration_admin

--- a/compendium/DeclarativeServices/CMakeLists.txt
+++ b/compendium/DeclarativeServices/CMakeLists.txt
@@ -39,7 +39,7 @@ add_compile_definitions(BOOST_REGEX_NO_LIB)
 
 
 usMacroCreateBundle(DeclarativeServices
-  VERSION "1.2.1"
+  VERSION "1.3.1"
   DEPENDS Framework
   TARGET DeclarativeServices
   SYMBOLIC_NAME declarative_services


### PR DESCRIPTION
this is basically catching up with #668

I thought a bit about whether the component versions should be the same as for 3.7.2 or different, and in the end decided to use the same component versions as the API is the same (ABI is a different topic, but I'm not sure whether that should play into the VERSION here). If you disagree, please let me know what you would prefer.

The example change and the slightly different overall VERSION update from #668 I already merged when setting the overall VERSION to 3.6.1.