### PR TITLE
Clang-format git hook pre-commit enforcement

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Run clang-format pre-commit hook
+sh .githooks/pre-commit-clang-format-hook

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -19,7 +19,7 @@ against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
 # Get clang-format output and store it for later checking
-clangformatoutput=$(git clang-format --diff --staged -q)
+clangformatoutput=$(git clang-format --style=file --diff --staged -q)
 
 # Redirect output to stderr
 exec 1>&2

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -10,13 +10,13 @@ if [ ! -x "$CLANG_FORMAT" ]; then
   exit 1
 fi
 
-if git rev-parse --verify HEAD >/dev/null 2>&1 ;
-then
-against=HEAD
-else
+#if git rev-parse --verify HEAD >/dev/null 2>&1 ;
+#then
+#against=HEAD
+#else
 # Initial commit: diff against an empty tree object
-against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
-fi
+#against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+#fi
 
 # Get clang-format output and store it for later checking
 clangformatoutput=$(git clang-format --style=file --diff --staged -q)

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -28,7 +28,7 @@ if [ "$clangformatoutput" != "" ];
 then
   printf "Error.\n";
   printf "clang-format detected that changes have been made and are not properly formatted!\n"
-  printf "Please run \`git clang-format --staged\`, re-stage modified files, and commit.\n"
+  printf "Please run \`git clang-format --style=file --staged\`, re-stage modified files, and commit.\n"
   exit 1
 else
   printf "Success.\n";

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+printf "Running clang-format pre-commit hook... ";
+
+CLANG_FORMAT=$(which clang-format)
+
+if [ ! -x "$CLANG_FORMAT" ]; then
+  printf "Error.\n";
+  printf "The clang-format cannot be found in your PATH. Please ensure clang-format is installed and on the PATH."
+  exit 1
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1 ;
+then
+against=HEAD
+else
+# Initial commit: diff against an empty tree object
+against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Get clang-format output and store it for later checking
+clangformatoutput=$(git clang-format --diff --staged -q)
+
+# Redirect output to stderr
+exec 1>&2
+
+if [ "$clangformatoutput" != "" ];
+then
+  printf "Error.\n";
+  printf "clang-format detected that changes have been made and are not properly formatted!\n"
+  printf "Please run \`git clang-format --staged\`, re-stage modified files, and commit.\n"
+  exit 1
+else
+  printf "Success.\n";
+fi

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -10,14 +10,6 @@ if [ ! -x "$CLANG_FORMAT" ]; then
   exit 1
 fi
 
-#if git rev-parse --verify HEAD >/dev/null 2>&1 ;
-#then
-#against=HEAD
-#else
-# Initial commit: diff against an empty tree object
-#against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
-#fi
-
 # Get clang-format output and store it for later checking
 clangformatoutput=$(git clang-format --style=file --diff --staged -q)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,19 @@ foreach(policy ${policies_new})
 endforeach()
 
 #-----------------------------------------------------------------------------
+# Setup git hooks
+#-----------------------------------------------------------------------------
+find_package(Git)
+if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  execute_process(COMMAND ${GIT_EXECUTABLE} config core.hooksPath "${PROJECT_SOURCE_DIR}/.githooks"
+                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                          RESULT_VARIABLE GIT_CONFIGMOD_RESULT)
+  if (NOT GIT_CONFIGMOD_RESULT EQUAL "0")
+    message(WARNING "Command `git config core.hooksPath ${PROJECT_SOURCE_DIR}/.githooks` failed with ${GIT_CONFIGMOD_RESULT}")
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------
 # Check minimum required compiler versions
 #------------------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -239,3 +239,6 @@ with the LLVM distribution of `clang-format`.
 
 If this is not feasible for you, you can specify `--no-verify` when committing your changes. This is heavily discouraged
 and you must provide a justification as to why you are unable to format your commit.
+
+We reserve the right to reject any pull requests that are not properly formatted and do not have a
+valid justification specified.

--- a/README.rst
+++ b/README.rst
@@ -223,3 +223,18 @@ file for details about the contribution process.
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/master
 .. |Code Coverage Status (development)| image:: https://img.shields.io/codecov/c/github/CppMicroServices/CppMicroServices/development.svg?style=flat-square
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/development
+
+Git Hooks General Information
+-----------------------------
+
+The CppMicroServices repository defines its git hooks in the `.githooks` directory. This directory is
+set as the directory for git hooks via executing `git config core.hooksPath <path>` in our `CMakeLists.txt` file.
+
+Git Hooks Failure Help
+----------------------
+
+If the clang-format pre-commit hook fails because `clang-format` is not installed, please install it and
+put it on the path. Similarly, if `git-clang-format` is not installed, do the same. `git-clang-format` comes
+with the LLVM distribution of `clang-format`.
+
+If this is not feasible for you, you can specify `--no-verify` when committing your changes. This is heavily discouraged.

--- a/README.rst
+++ b/README.rst
@@ -237,4 +237,5 @@ If the clang-format pre-commit hook fails because `clang-format` is not installe
 put it on the path. Similarly, if `git-clang-format` is not installed, do the same. `git-clang-format` comes
 with the LLVM distribution of `clang-format`.
 
-If this is not feasible for you, you can specify `--no-verify` when committing your changes. This is heavily discouraged.
+If this is not feasible for you, you can specify `--no-verify` when committing your changes. This is heavily discouraged
+and you must provide a justification as to why you are unable to format your commit.

--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -1,0 +1,4 @@
+{
+    "DisableFormat": true,
+    "SortIncludes": false,
+}


### PR DESCRIPTION
NOTE: This PR must be merged after #759 .

This PR introduces a pre-commit git hook to ensure that the committed files are formatted properly. This means that clang-format/git-clang-format must be installed.

Git hooks are normally a local thing that are not tracked by the remote repo as they are normally placed in the `.git/hooks` directory. I did some research online and found that a common strategy is to have an install script that copies the SCM controlled hook scripts into the proper location. Another strategy was to simply update the `core.hooksPath` git setting only for the local repository via CMake. I opted for this solution as it runs automatically upon the first CMake configure of the project.

Technically this check can be "ignored" by running `git commit ... --no-verify` but this is heavily discouraged.

On failure for missing install, the commit will fail and report the following:
```
Running clang-format pre-commit hook... Error.
The clang-format cannot be found in your PATH. Please ensure clang-format is installed and on the PATH.
```

On failure for non-formatted code being committed, the commit will fail and report the following:
```
Running clang-format pre-commit hook... Error.
clang-format detected that changes have been made and are not properly formatted!
Please run `git clang-format --style=file --staged`, re-stage modified files, and commit.
```

On successful commit, the commit will succeed and report the following:
```
Running clang-format pre-commit hook... Success.
```