### PR TITLE
fix building problems on encode in Visual Studio 2022

### DIFF
--- a/third_party/cppmicroservices_pe.h
+++ b/third_party/cppmicroservices_pe.h
@@ -24,7 +24,7 @@
 // available PE/COFF format document:
 //
 // Microsoft Portable Executable and Common Object File Format Specification
-// Revision 8.3 – February 6, 2013
+// Revision 8.3 - February 6, 2013
 //
 // http://msdn.microsoft.com/en-us/windows/hardware/gg463119.aspx
 

--- a/third_party/spdlog/include/spdlog/fmt/bundled/core.h
+++ b/third_party/spdlog/include/spdlog/fmt/bundled/core.h
@@ -324,7 +324,11 @@ FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
   return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
 
+#ifdef _MSC_VER
+__pragma(warning(suppress : 4566)) constexpr unsigned char micro[] = "\u00B5";
+#else
 constexpr unsigned char micro[] = "\u00B5";
+#endif
 
 template <typename Char> constexpr bool is_unicode() {
   return FMT_UNICODE || sizeof(Char) != 1 ||


### PR DESCRIPTION
Fix two files:

1. change  unicode letter in comment to plain ascii in third_party/cppmicroservices_pe.h
2. add encode error ignoring in third_party/spdlog/include/spdlog/fmt/bundled/core.h