### PR TITLE
Support arm64 on macOS

### DIFF
--- a/util/include/cppmicroservices/util/BundleMachOFile.h
+++ b/util/include/cppmicroservices/util/BundleMachOFile.h
@@ -249,6 +249,8 @@ namespace cppmicroservices
         ident[1] = CPU_TYPE_X86;
 #    elif defined(__arm__) || defined(_M_ARM)
         ident[1] = CPU_TYPE_ARM;
+#    elif defined(__arm64__)
+        ident[1] = CPU_TYPE_ARM64;
 #    endif
 
         return ident;


### PR DESCRIPTION
Fixes #674 

Add support for arm64 on macOS

Signed-off-by: The MathWorks, Inc. <jdicleme@mathworks.com>