### PR TITLE
701 ListConfigurations fix for empty configuration objects. (#682)

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -124,7 +124,11 @@ public:
                           const std::string& instanceName) override;
 
   /**
-   * Used to list all of the available {@code Configuration} objects.
+   * Used to list all of the {@code Configuration} objects that exist in the
+   * ConfigurationAdmin repository with a pid that matches the filter expression 
+   * (if provided).
+   * All of the {@code Configuration} objects returned have been updated at least
+   * once by ConfigurationAdmin.
    *
    * See {@code ConfigurationAdmin#ListConfigurations}
    */

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -36,19 +36,20 @@ namespace cmimpl {
 ConfigurationImpl::ConfigurationImpl(ConfigurationAdminPrivate* configAdmin,
                                      std::string thePid,
                                      std::string theFactoryPid,
-                                     AnyMap props)
+                                     AnyMap props,
+                                     const unsigned long cCount)
   : configAdminImpl(configAdmin)
   , pid(std::move(thePid))
   , factoryPid(std::move(theFactoryPid))
   , properties(std::move(props))
-  , changeCount{ 0u }
+  , changeCount{ cCount }
   , removed{ false }
 {
   assert(configAdminImpl != nullptr &&
          "Invalid ConfigurationAdminPrivate pointer");
   // constructing a configuration object with properties is the equivalent
   // of a Create and an Update operation.
-  if (properties.size() > 0) {
+  if ((properties.size() > 0) && (changeCount == 0u)) {
     changeCount++;
   }
 }

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.hpp
@@ -44,7 +44,8 @@ public:
   ConfigurationImpl(ConfigurationAdminPrivate* configAdminImpl,
                     std::string pid,
                     std::string factoryPid,
-                    AnyMap properties);
+                    AnyMap properties,
+                    const unsigned long cCount = 0);
   ~ConfigurationImpl() override = default;
   ConfigurationImpl(const ConfigurationImpl&) = delete;
   ConfigurationImpl& operator=(const ConfigurationImpl&) = delete;


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/c4a8d6246067a7a26cc71826641aac8377dde6fc / #682 without changes.