### PR TITLE
701 - Add log messages when shared library loading throws an exception (#690)

### DIFF
--- a/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
@@ -110,6 +110,11 @@ GetComponentCreatorDeletors(
                     ToString(fromBundle.GetBundleId()) +
                     " (location=" + bundleLoc + ")");
     } catch (const std::system_error& ex) {
+      logger->Log(logservice::SeverityLevel::LOG_INFO,
+                  "Failed loading shared library for Bundle #" +
+                    ToString(fromBundle.GetBundleId()) +
+                    " (location=" + bundleLoc + ")",
+                  std::make_exception_ptr(ex));
       // SharedLibrary::Load() will throw a std::system_error when a shared library
       // fails to load. Creating a SharedLibraryException here to throw with fromBundle information.
       throw cppmicroservices::SharedLibraryException(

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -507,6 +507,10 @@ std::exception_ptr BundlePrivate::Start0()
       res = std::make_exception_ptr(cppmicroservices::SharedLibraryException(
         ex.code(), ex.what(), thisBundle));
     } catch (...) {
+      coreCtx->logger->Log(logservice::SeverityLevel::LOG_INFO,
+                           "Failed to start Bundle #" + util::ToString(id) +
+                             " (location=" + location + ")",
+                           std::current_exception());
       res = std::make_exception_ptr(std::runtime_error(
         "Bundle #" + util::ToString(id) + " (location= " + location +
         ") start failed: " + util::GetLastExceptionStr()));


### PR DESCRIPTION
Cherry-picked 5ca9d90466169449200f727f79a3958198818884 / #690 without changes.