### PR TITLE
701 - Disable code signing for bundle with no c++ code (#697)

### DIFF
--- a/framework/test/bundles/libTestModuleWithEmbeddedZip/CMakeLists.txt
+++ b/framework/test/bundles/libTestModuleWithEmbeddedZip/CMakeLists.txt
@@ -12,6 +12,14 @@ set(_srcs foo.cpp)
 
 add_library(${PROJECT_NAME} ${_srcs})
 
+# Disable code-signing on macOS if appending resources.
+if (APPLE)
+  set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+  )
+endif()
+
 if(CMAKE_CROSSCOMPILING)
     # Cross-compiled builds need to use the imported host version of usResourceCompiler
     include(${IMPORT_EXECUTABLES})


### PR DESCRIPTION
Cherry-picked 703f32611a4b0d32adb6176a7498a59c8299131d / #697 without changes.

Explicitly skipped #696 for the C++14 branch, as the problem fixed there is (afaics) already solved (slightly differently) in the spdlog 1.10.0 that is integrated on the C++14 branch.