### PR TITLE
701 - Improve performance of LDAP matching - C++14 variant (#704)

### DIFF
--- a/framework/include/cppmicroservices/AnyMap.h
+++ b/framework/include/cppmicroservices/AnyMap.h
@@ -29,6 +29,8 @@
 #include <unordered_map>
 
 namespace cppmicroservices {
+class Properties;
+class LDAPExpr;
 
 namespace detail {
 
@@ -111,7 +113,8 @@ private:
 
     iterator_base(iter_type type)
       : type(type)
-    {}
+    {
+    }
 
   public:
     using value_type = any_map::value_type;
@@ -221,8 +224,11 @@ public:
 
   any_map(map_type type);
   any_map(const ordered_any_map& m);
+  any_map(ordered_any_map&& m);
   any_map(const unordered_any_map& m);
+  any_map(unordered_any_map&& m);
   any_map(const unordered_any_cimap& m);
+  any_map(unordered_any_cimap&& m);
 
   any_map(const any_map& m);
   any_map& operator=(const any_map& m);
@@ -297,6 +303,30 @@ protected:
   map_type type;
 
 private:
+  friend class Properties;
+  friend class LDAPExpr;
+
+  // Private "fast" and type-checked functions for working with map iterators
+  // and finding elements (these functions should only be called in a context)
+  // where the type of the map is guaranteed.
+  //
+  // These functions bypass the creation of "any_map::iterator" and "any_map::const_iterator"
+  // objects as construction of those are slow. Once the AnyMap class is refactored, these
+  // functions will likely be unnecessary as the begin(), end(), and find() functions will
+  // inherently do what these functions do.
+  ordered_any_map::const_iterator beginOM_TypeChecked() const;
+  ordered_any_map::const_iterator endOM_TypeChecked() const;
+  ordered_any_map::const_iterator findOM_TypeChecked(const key_type& key) const;
+  unordered_any_map::const_iterator beginUO_TypeChecked() const;
+  unordered_any_map::const_iterator endUO_TypeChecked() const;
+  unordered_any_map::const_iterator findUO_TypeChecked(
+    const key_type& key) const;
+  unordered_any_cimap::const_iterator beginUOCI_TypeChecked() const;
+  unordered_any_cimap::const_iterator endUOCI_TypeChecked() const;
+  unordered_any_cimap::const_iterator findUOCI_TypeChecked(
+    const key_type& key) const;
+  // =========================================================================
+
   ordered_any_map const& o_m() const;
   ordered_any_map& o_m();
   unordered_any_map const& uo_m() const;

--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(_srcs
   util/LDAPFilter.cpp
   util/LDAPProp.cpp
   util/Properties.cpp
+  util/PropsCheck.cpp
   util/SecurityException.cpp
   util/SharedLibrary.cpp
   util/SharedLibraryException.cpp
@@ -65,6 +66,7 @@ set(_private_headers
   util/CFRLogger.h
   util/LDAPExpr.h
   util/Properties.h
+  util/PropsCheck.h
   util/Utils.h
 
   service/ServiceHooks.h
@@ -90,4 +92,3 @@ set(_private_headers
   bundle/CoreBundleContext.h
   bundle/Resolver.h
 )
-

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -451,13 +451,13 @@ void ServiceListeners::GetMatchingServiceListeners(const ServiceEvent& evt,
 
     // Check the cache
     const auto c = any_cast<std::vector<std::string>>(
-      props->Value_unlocked(Constants::OBJECTCLASS));
+      props->Value_unlocked(Constants::OBJECTCLASS).first);
     for (auto& objClass : c) {
       AddToSet_unlocked(set, receivers, OBJECTCLASS_IX, objClass);
     }
 
     auto service_id =
-      any_cast<long>(props->Value_unlocked(Constants::SERVICE_ID));
+      any_cast<long>(props->Value_unlocked(Constants::SERVICE_ID).first);
     AddToSet_unlocked(set,
                       receivers,
                       SERVICE_ID_IX,

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -80,7 +80,7 @@ Any ServiceReferenceBase::GetProperty(const std::string& key) const
 {
   auto l = d.load()->registration->properties.Lock();
   US_UNUSED(l);
-  return d.load()->registration->properties.Value_unlocked(key);
+  return d.load()->registration->properties.Value_unlocked(key).first;
 }
 
 void ServiceReferenceBase::GetPropertyKeys(std::vector<std::string>& keys) const
@@ -144,11 +144,14 @@ bool ServiceReferenceBase::operator<(
   {
     auto l = d.load()->registration->properties.Lock();
     US_UNUSED(l);
-    anyR1 = d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_RANKING);
+    anyR1 =
+      d.load()
+        ->registration->properties.Value_unlocked(Constants::SERVICE_RANKING)
+        .first;
     assert(anyR1.Empty() || anyR1.Type() == typeid(int));
-    anyId1 =
-      d.load()->registration->properties.Value_unlocked(Constants::SERVICE_ID);
+    anyId1 = d.load()
+               ->registration->properties.Value_unlocked(Constants::SERVICE_ID)
+               .first;
     assert(anyId1.Type() == typeid(long int));
   }
 
@@ -157,11 +160,14 @@ bool ServiceReferenceBase::operator<(
   {
     auto l = reference.d.load()->registration->properties.Lock();
     US_UNUSED(l);
-    anyR2 = reference.d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_RANKING);
+    anyR2 =
+      reference.d.load()
+        ->registration->properties.Value_unlocked(Constants::SERVICE_RANKING)
+        .first;
     assert(anyR2.Empty() || anyR2.Type() == typeid(int));
-    anyId2 = reference.d.load()->registration->properties.Value_unlocked(
-      Constants::SERVICE_ID);
+    anyId2 = reference.d.load()
+               ->registration->properties.Value_unlocked(Constants::SERVICE_ID)
+               .first;
     assert(anyId2.Type() == typeid(long int));
   }
 

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -87,7 +87,8 @@ InterfaceMapConstPtr ServiceReferenceBasePrivate::GetServiceFromFactory(
     std::vector<std::string> classes =
       (registration->properties.Lock(),
        any_cast<std::vector<std::string>>(
-         registration->properties.Value_unlocked(Constants::OBJECTCLASS)));
+         registration->properties.Value_unlocked(Constants::OBJECTCLASS)
+           .first));
     for (auto clazz : classes) {
       if (smap->find(clazz) == smap->end() &&
           clazz != "org.cppmicroservices.factory") {

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -49,7 +49,8 @@ ServiceRegistrationBase::ServiceRegistrationBase(
     ++d->ref;
 }
 
-ServiceRegistrationBase::ServiceRegistrationBase(ServiceRegistrationBase&& reg) noexcept
+ServiceRegistrationBase::ServiceRegistrationBase(
+  ServiceRegistrationBase&& reg) noexcept
   : d(nullptr)
 {
   std::swap(d, reg.d);
@@ -148,13 +149,14 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
 
     auto l2 = d->properties.Lock();
     US_UNUSED(l2);
+
     auto propsCopy(props);
     propsCopy[Constants::SERVICE_ID] =
-      d->properties.Value_unlocked(Constants::SERVICE_ID);
-    objectClasses = d->properties.Value_unlocked(Constants::OBJECTCLASS);
+      d->properties.Value_unlocked(Constants::SERVICE_ID).first;
+    objectClasses = d->properties.Value_unlocked(Constants::OBJECTCLASS).first;
     propsCopy[Constants::OBJECTCLASS] = objectClasses;
     propsCopy[Constants::SERVICE_SCOPE] =
-      d->properties.Value_unlocked(Constants::SERVICE_SCOPE);
+      d->properties.Value_unlocked(Constants::SERVICE_SCOPE).first;
 
     auto itr = propsCopy.find(Constants::SERVICE_RANKING);
     if (itr != propsCopy.end()) {
@@ -168,13 +170,14 @@ void ServiceRegistrationBase::SetProperties(const ServiceProperties& props)
       }
     }
 
-    auto oldRankAny = d->properties.Value_unlocked(Constants::SERVICE_RANKING);
+    auto oldRankAny =
+      d->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
     if (!oldRankAny.Empty()) {
       // since the old ranking is extracted from existing service properties
       // stored in the service registry, no need to type check before casting
       old_rank = any_cast<int>(oldRankAny);
     }
-    d->properties = Properties(std::move(propsCopy));
+    d->properties = Properties(AnyMap(std::move(propsCopy)));
   }
   if (old_rank != new_rank) {
     auto classes = any_cast<std::vector<std::string>>(objectClasses);

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -72,7 +72,7 @@ Properties ServiceRegistry::CreateServiceProperties(
       std::make_pair(Constants::SERVICE_SCOPE, Constants::SCOPE_SINGLETON));
   }
 
-  return Properties(std::move(props));
+  return Properties(AnyMap(std::move(props)));
 }
 
 ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)
@@ -273,10 +273,11 @@ void ServiceRegistry::RemoveServiceRegistration_unlocked(
   {
     auto l2 = sr.d->properties.Lock();
     US_UNUSED(l2);
-    assert(sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).Type() ==
-           typeid(std::vector<std::string>));
+    assert(
+      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).first.Type() ==
+      typeid(std::vector<std::string>));
     classes = ref_any_cast<std::vector<std::string>>(
-      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS));
+      sr.d->properties.Value_unlocked(Constants::OBJECTCLASS).first);
   }
   services.erase(sr);
   serviceRegistrations.erase(

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -25,6 +25,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/string_view.h"
 
+#include <cassert>
 #include <stdexcept>
 
 namespace cppmicroservices {
@@ -579,16 +580,34 @@ any_map::any_map(const ordered_any_map& m)
   map.o = new ordered_any_map(m);
 }
 
+any_map::any_map(ordered_any_map&& m)
+  : type(map_type::ORDERED_MAP)
+{
+  map.o = new ordered_any_map(std::move(m));
+}
+
 any_map::any_map(const unordered_any_map& m)
   : type(map_type::UNORDERED_MAP)
 {
   map.uo = new unordered_any_map(m);
 }
 
+any_map::any_map(unordered_any_map&& m)
+  : type(map_type::UNORDERED_MAP)
+{
+  map.uo = new unordered_any_map(std::move(m));
+}
+
 any_map::any_map(const unordered_any_cimap& m)
   : type(map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
 {
   map.uoci = new unordered_any_cimap(m);
+}
+
+any_map::any_map(unordered_any_cimap&& m)
+  : type(map_type::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
+{
+  map.uoci = new unordered_any_cimap(std::move(m));
 }
 
 any_map::any_map(const any_map& m)
@@ -839,6 +858,78 @@ any_map::const_iterator any_map::find(const key_type& key) const
   }
 }
 
+any_map::ordered_any_map::const_iterator any_map::beginOM_TypeChecked() const
+{
+  assert(type == ORDERED_MAP && "You are calling beginOM_TypeChecked() on map "
+                                "whose type is not ORDERED_MAP.");
+  return map.o->begin();
+}
+
+any_map::ordered_any_map::const_iterator any_map::endOM_TypeChecked() const
+{
+  assert(type == ORDERED_MAP && "You are calling endOM_TypeChecked() on map "
+                                "whose type is not ORDERED_MAP.");
+  return map.o->end();
+}
+
+any_map::ordered_any_map::const_iterator any_map::findOM_TypeChecked(
+  const key_type& key) const
+{
+  assert(type == ORDERED_MAP && "You are calling findOM_TypeChecked() on map "
+                                "whose type is not ORDERED_MAP.");
+  return map.o->find(key);
+}
+
+any_map::unordered_any_map::const_iterator any_map::beginUO_TypeChecked() const
+{
+  assert(type == UNORDERED_MAP &&
+         "You are calling beginUO_TypeChecked() on map "
+         "whose type is not UNORDERED_MAP.");
+  return map.uo->begin();
+}
+
+any_map::unordered_any_map::const_iterator any_map::endUO_TypeChecked() const
+{
+  assert(type == UNORDERED_MAP && "You are calling endUO_TypeChecked() on map "
+                                  "whose type is not UNORDERED_MAP.");
+  return map.uo->end();
+}
+
+any_map::unordered_any_map::const_iterator any_map::findUO_TypeChecked(
+  const key_type& key) const
+{
+  assert(type == UNORDERED_MAP && "You are calling findUO_TypeChecked() on map "
+                                  "whose type is not UNORDERED_MAP.");
+  return map.uo->find(key);
+}
+
+any_map::unordered_any_cimap::const_iterator any_map::beginUOCI_TypeChecked()
+  const
+{
+  assert(type == UNORDERED_MAP_CASEINSENSITIVE_KEYS &&
+         "You are calling beginUOCI_TypeChecked() on map "
+         "whose type is not UNORDERED_MAP_CASEINSENSITIVE_KEYS.");
+  return map.uoci->begin();
+}
+
+any_map::unordered_any_cimap::const_iterator any_map::endUOCI_TypeChecked()
+  const
+{
+  assert(type == UNORDERED_MAP_CASEINSENSITIVE_KEYS &&
+         "You are calling endUOCI_TypeChecked() on map "
+         "whose type is not UNORDERED_MAP_CASEINSENSITIVE_KEYS.");
+  return map.uoci->end();
+}
+
+any_map::unordered_any_cimap::const_iterator any_map::findUOCI_TypeChecked(
+  const key_type& key) const
+{
+  assert(type == UNORDERED_MAP_CASEINSENSITIVE_KEYS &&
+         "You are calling findUOCI_TypeChecked() on map "
+         "whose type is not UNORDERED_MAP_CASEINSENSITIVE_KEYS.");
+  return map.uoci->find(key);
+}
+
 any_map::size_type any_map::erase(const key_type& key)
 {
   switch (type) {
@@ -938,31 +1029,38 @@ void any_map::destroy() noexcept
 
 AnyMap::AnyMap(map_type type)
   : any_map(type)
-{}
+{
+}
 
 AnyMap::AnyMap(const ordered_any_map& m)
   : any_map(m)
-{}
+{
+}
 
 AnyMap::AnyMap(ordered_any_map&& m)
   : any_map(std::move(m))
-{}
+{
+}
 
 AnyMap::AnyMap(const unordered_any_map& m)
   : any_map(m)
-{}
+{
+}
 
 AnyMap::AnyMap(unordered_any_map&& m)
   : any_map(std::move(m))
-{}
+{
+}
 
 AnyMap::AnyMap(const unordered_any_cimap& m)
   : any_map(m)
-{}
+{
+}
 
 AnyMap::AnyMap(unordered_any_cimap&& m)
   : any_map(std::move(m))
-{}
+{
+}
 
 AnyMap::map_type AnyMap::GetType() const
 {

--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -29,6 +29,8 @@
 
 #include "Properties.h"
 
+#include "PropsCheck.h"
+
 #include <cctype>
 #include <cerrno>
 #include <cmath>
@@ -137,14 +139,16 @@ public:
     , m_args(std::move(args))
     , m_attrName()
     , m_attrValue()
-  {}
+  {
+  }
 
   LDAPExprData(int op, std::string attrName, std::string attrValue)
     : m_operator(op)
     , m_args()
     , m_attrName(std::move(attrName))
     , m_attrValue(std::move(attrValue))
-  {}
+  {
+  }
 
   LDAPExprData(const LDAPExprData& other)
 
@@ -158,7 +162,8 @@ public:
 
 LDAPExpr::LDAPExpr()
   : d()
-{}
+{
+}
 
 LDAPExpr::LDAPExpr(const std::string& filter)
   : d()
@@ -180,13 +185,15 @@ LDAPExpr::LDAPExpr(const std::string& filter)
 
 LDAPExpr::LDAPExpr(int op, const std::vector<LDAPExpr>& args)
   : d(new LDAPExprData(op, args))
-{}
+{
+}
 
 LDAPExpr::LDAPExpr(int op,
                    const std::string& attrName,
                    const std::string& attrValue)
   : d(new LDAPExprData(op, attrName, attrValue))
-{}
+{
+}
 
 LDAPExpr::LDAPExpr(const LDAPExpr&) = default;
 
@@ -306,13 +313,87 @@ bool LDAPExpr::IsNull() const
 bool LDAPExpr::Evaluate(const PropertiesHandle& p, bool matchCase) const
 {
   if ((d->m_operator & SIMPLE) != 0) {
-    // try case sensitive match first
-    int index = p->FindCaseSensitive_unlocked(d->m_attrName);
-    if (index < 0 && !matchCase)
-      index = p->Find_unlocked(d->m_attrName);
-    return index < 0
-             ? false
-             : Compare(p->Value_unlocked(index), d->m_operator, d->m_attrValue);
+    auto v = p->Value_unlocked(d->m_attrName, matchCase);
+    return (!v.second) ? false
+                       : Compare(v.first, d->m_operator, d->m_attrValue);
+  } else { // (d->m_operator & COMPLEX) != 0
+    switch (d->m_operator) {
+      case AND:
+        for (const auto& m_arg : d->m_args) {
+          if (!m_arg.Evaluate(p, matchCase))
+            return false;
+        }
+        return true;
+      case OR:
+        for (const auto& m_arg : d->m_args) {
+          if (m_arg.Evaluate(p, matchCase))
+            return true;
+        }
+        return false;
+      case NOT:
+        return !d->m_args[0].Evaluate(p, matchCase);
+      default:
+        return false; // Cannot happen
+    }
+  }
+}
+
+bool LDAPExpr::Evaluate(const AnyMap& p, bool matchCase) const
+{
+  if ((d->m_operator & SIMPLE) != 0) {
+    if (p.GetType() == AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+      auto itr = p.findUOCI_TypeChecked(d->m_attrName);
+      if (!matchCase && itr != p.endUOCI_TypeChecked()) {
+        return Compare(itr->second, d->m_operator, d->m_attrValue);
+      } else if (matchCase && itr != p.endUOCI_TypeChecked() &&
+                 itr->first == d->m_attrName) {
+        return Compare(itr->second, d->m_operator, d->m_attrValue);
+      } else {
+        return false;
+      }
+    } else if (p.GetType() == AnyMap::UNORDERED_MAP) {
+      auto itr = p.findUO_TypeChecked(d->m_attrName);
+      if (itr != p.endUO_TypeChecked()) {
+        return Compare(itr->second, d->m_operator, d->m_attrValue);
+      }
+
+      if (!matchCase) {
+        std::string const lower = LDAPExpr::ToLower(d->m_attrName);
+        for (auto itr = p.beginUO_TypeChecked(); itr != p.endUO_TypeChecked();
+             ++itr) {
+          if (itr->first == lower) {
+            return Compare(p.findUO_TypeChecked(lower)->second,
+                           d->m_operator,
+                           d->m_attrValue);
+          }
+        }
+        return false;
+      }
+
+      return false;
+    } else if (p.GetType() == AnyMap::ORDERED_MAP) {
+      auto itr = p.findOM_TypeChecked(d->m_attrName);
+      if (itr != p.endOM_TypeChecked()) {
+        return Compare(itr->second, d->m_operator, d->m_attrValue);
+      }
+
+      if (!matchCase) {
+        std::string const lower = LDAPExpr::ToLower(d->m_attrName);
+        for (auto itr = p.beginOM_TypeChecked(); itr != p.endOM_TypeChecked();
+             ++itr) {
+          if (itr->first == lower) {
+            return Compare(p.findOM_TypeChecked(lower)->second,
+                           d->m_operator,
+                           d->m_attrValue);
+          }
+        }
+        return false;
+      }
+
+      return false;
+    } else {
+      return false;
+    }
   } else { // (d->m_operator & COMPLEX) != 0
     switch (d->m_operator) {
       case AND:

--- a/framework/src/util/LDAPExpr.h
+++ b/framework/src/util/LDAPExpr.h
@@ -32,6 +32,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cppmicroservices/AnyMap.h"
+
 namespace cppmicroservices {
 
 class Any;
@@ -121,6 +123,12 @@ public:
 
   //! Evaluate this LDAP filter.
   bool Evaluate(const PropertiesHandle& p, bool matchCase) const;
+
+  // Evaluate this LDAP filter directly on an AnyMap rather than a PropertiesHandle.
+  //
+  // This function was added as an optimization since passing an AnyMap to the constructor of a
+  // PropertiesHandle causes unnecessary copies to occurr.
+  bool Evaluate(const AnyMap& p, bool matchCase) const;
 
   //!
   const std::string ToString() const;

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -24,13 +24,9 @@
 
 #include <limits>
 #include <stdexcept>
-#ifdef US_PLATFORM_WINDOWS
-#  include <string.h>
-#  define ci_compare strnicmp
-#else
-#  include <strings.h>
-#  define ci_compare strncasecmp
-#endif
+#include <utility>
+
+#include "PropsCheck.h"
 
 US_MSVC_PUSH_DISABLE_WARNING(4996)
 
@@ -38,85 +34,143 @@ namespace cppmicroservices {
 
 const Any Properties::emptyAny;
 
-Properties::Properties(const AnyMap& p)
+void Properties::PopulateCaseInsensitiveLookupMap()
 {
-  if (p.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("Properties contain too many keys");
-  }
-
-  keys.reserve(p.size());
-  values.reserve(p.size());
-
-  for (auto& iter : p) {
-    if (Find_unlocked(iter.first) > -1) {
-      std::string msg("Properties contain case variants of the key: ");
-      msg += iter.first;
-      throw std::runtime_error(msg.c_str());
+  if (props.GetType() == AnyMap::ORDERED_MAP) {
+    for (auto itr = props.beginOM_TypeChecked();
+         itr != props.endOM_TypeChecked();
+         ++itr) {
+      caseInsensitiveLookup[props_check::ToLower(itr->first)] = itr->first;
     }
-    keys.push_back(iter.first);
-    values.push_back(iter.second);
+  } else if (props.GetType() == AnyMap::UNORDERED_MAP) {
+    for (auto itr = props.beginUO_TypeChecked();
+         itr != props.endUO_TypeChecked();
+         ++itr) {
+      caseInsensitiveLookup[props_check::ToLower(itr->first)] = itr->first;
+    }
+  } else {
+    throw std::runtime_error("Unsupported map type.");
+  }
+}
+
+// NOTE: UNORDERED_MAP_CASEINSENSITIVE_KEYS AnyMaps inherently can never be invalid given that
+// they can _never_ contain some pair of keys which are only different in case. Because of this,
+// the validation check is not performed on these map types. Additionally, those types of maps
+// are already case insensitive so populating and using the case insensitive lookup map is
+// unnecessary.
+
+Properties::Properties(const AnyMap& p)
+  : props(p)
+{
+  if (p.GetType() != AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+    props_check::ValidateAnyMap(p);
+
+    PopulateCaseInsensitiveLookupMap();
+  }
+}
+
+Properties::Properties(AnyMap&& p)
+  : props(std::move(p))
+{
+  if (props.GetType() != AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+    props_check::ValidateAnyMap(props);
+
+    PopulateCaseInsensitiveLookupMap();
   }
 }
 
 Properties::Properties(Properties&& o) noexcept
-  : keys(std::move(o.keys))
-  , values(std::move(o.values))
-{}
+  : props(std::move(o.props))
+{
+  if (props.GetType() != AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+    PopulateCaseInsensitiveLookupMap();
+  }
+}
 
 Properties& Properties::operator=(Properties&& o) noexcept
 {
-  keys = std::move(o.keys);
-  values = std::move(o.values);
+  props = std::move(o.props);
+  if (props.GetType() != AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+    PopulateCaseInsensitiveLookupMap();
+  }
   return *this;
 }
 
-Any Properties::Value_unlocked(const std::string& key) const
+// This function has been modified to perform both the "find" and "lookup" operations rather than
+// just the "lookup" as originally written.
+//
+// This code has been made more verbose as to extract the most performance out of it. If we know
+// the map type for which we are operating on, then we can safely call the "*_TypeChecked()"
+// version of certain functions on the map to bypass using the slow functions that return
+// "any_map::iterator" or "any_map::const_iterator".
+std::pair<Any, bool> Properties::Value_unlocked(const std::string& key,
+                                                bool matchCase) const
 {
-  int i = Find_unlocked(key);
-  if (i < 0) {
-    return emptyAny;
-  }
-  return values[i];
-}
-
-Any Properties::Value_unlocked(int index) const
-{
-  if (index < 0 || static_cast<std::size_t>(index) >= values.size()) {
-    return emptyAny;
-  }
-  return values[static_cast<std::size_t>(index)];
-}
-
-int Properties::Find_unlocked(const std::string& key) const
-{
-  for (std::size_t i = 0; i < keys.size(); ++i) {
-    if (key.size() == keys[i].size() &&
-        ci_compare(key.c_str(), keys[i].c_str(), key.size()) == 0) {
-      return static_cast<int>(i);
+  if (props.GetType() == AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS) {
+    auto itr = props.findUOCI_TypeChecked(key);
+    if (itr != props.endUOCI_TypeChecked()) {
+      if (!matchCase) {
+        return std::make_pair(itr->second, true);
+      } else if (matchCase && itr->first == key) {
+        return std::make_pair(itr->second, true);
+      } else {
+        return std::make_pair(emptyAny, false);
+      }
+    } else {
+      return std::make_pair(emptyAny, false);
     }
-  }
-  return -1;
-}
-
-int Properties::FindCaseSensitive_unlocked(const std::string& key) const
-{
-  for (std::size_t i = 0; i < keys.size(); ++i) {
-    if (key == keys[i]) {
-      return static_cast<int>(i);
+  } else if (props.GetType() == AnyMap::UNORDERED_MAP) {
+    auto itr = props.findUO_TypeChecked(key);
+    if (itr != props.endUO_TypeChecked()) {
+      return std::make_pair(itr->second, true);
     }
+
+    if (!matchCase) {
+      auto ciItr = caseInsensitiveLookup.find(key);
+      if (ciItr != caseInsensitiveLookup.end()) {
+        return std::make_pair(
+          props.findUO_TypeChecked(ciItr->second.data())->second, true);
+      } else {
+        return std::make_pair(emptyAny, false);
+      }
+    }
+
+    return std::make_pair(emptyAny, false);
+  } else if (props.GetType() == AnyMap::ORDERED_MAP) {
+    auto itr = props.findOM_TypeChecked(key);
+    if (itr != props.endOM_TypeChecked()) {
+      return std::make_pair(itr->second, true);
+    }
+
+    if (!matchCase) {
+      auto ciItr = caseInsensitiveLookup.find(key);
+      if (ciItr != caseInsensitiveLookup.end()) {
+        return std::make_pair(
+          props.findOM_TypeChecked(ciItr->second.data())->second, true);
+      } else {
+        return std::make_pair(emptyAny, false);
+      }
+    }
+
+    return std::make_pair(emptyAny, false);
+  } else {
+    throw std::runtime_error("Unknown AnyMap type.");
   }
-  return -1;
 }
 
 std::vector<std::string> Properties::Keys_unlocked() const
 {
-  return keys;
+  std::vector<std::string> result{};
+  for (const auto& kv_pair : props) {
+    result.push_back(kv_pair.first);
+  }
+
+  return result;
 }
 
 void Properties::Clear_unlocked()
 {
-  keys.clear();
-  values.clear();
+  props.clear();
 }
 }
 

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -23,6 +23,7 @@
 #ifndef CPPMICROSERVICES_PROPERTIES_H
 #define CPPMICROSERVICES_PROPERTIES_H
 
+#include "absl/strings/string_view.h"
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/AnyMap.h"
 #include "cppmicroservices/detail/Threads.h"
@@ -37,25 +38,38 @@ class Properties : public detail::MultiThreaded<>
 
 public:
   explicit Properties(const AnyMap& props);
+  explicit Properties(AnyMap&& props);
 
   Properties(Properties&& o) noexcept;
   Properties& operator=(Properties&& o) noexcept;
 
-  Any Value_unlocked(const std::string& key) const;
-  Any Value_unlocked(int index) const;
-
-  int Find_unlocked(const std::string& key) const;
-  int FindCaseSensitive_unlocked(const std::string& key) const;
+  std::pair<Any, bool> Value_unlocked(const std::string& key,
+                                      bool matchCase = false) const;
 
   std::vector<std::string> Keys_unlocked() const;
 
   void Clear_unlocked();
 
 private:
-  std::vector<std::string> keys;
-  std::vector<Any> values;
+  // An AnyMap is used to store the properties rather than 2 vectors (one for keys
+  // and the other for values) as previously done in the past. This reduces the number of
+  // copies and allows for finds to leverage a map find vs vector find.
+  AnyMap props;
+
+  // A case-insensitive map which maps all-lowercased keys to the original key values. This
+  // allows for efficient case-insensitive lookups in map types that are not inherently
+  // case insensitive.
+  std::unordered_map<std::string,
+                     absl::string_view,
+                     detail::any_map_cihash,
+                     detail::any_map_ciequal>
+    caseInsensitiveLookup;
 
   static const Any emptyAny;
+
+  // Helper that populates the case-insensitive lookup map when the provided AnyMap is not
+  // already case insensitive.
+  void PopulateCaseInsensitiveLookupMap();
 };
 
 class PropertiesHandle
@@ -64,12 +78,14 @@ public:
   PropertiesHandle(const Properties& props, bool lock)
     : props(props)
     , l(lock ? props.Lock() : Properties::UniqueLock())
-  {}
+  {
+  }
 
   PropertiesHandle(PropertiesHandle&& o) noexcept
     : props(o.props)
     , l(std::move(o.l))
-  {}
+  {
+  }
 
   const Properties* operator->() const { return &props; }
 

--- a/framework/src/util/PropsCheck.cpp
+++ b/framework/src/util/PropsCheck.cpp
@@ -1,0 +1,77 @@
+/*=============================================================================
+
+ Library: CppMicroServices
+
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ =============================================================================*/
+
+#include "PropsCheck.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace cppmicroservices {
+namespace props_check {
+namespace {
+const Any emptyAny;
+}
+
+/**
+ * @brief Validates that the provided AnyMap conforms to the same constraints that
+ * those stored in Property objects have.
+ * 
+ * The provided AnyMap is said to be valid if there exists no pairs of two keys
+ * which differ in case only (e.g., "service.feature", "Service.feature"). If this
+ * condition is not true, this function throws as defined below.
+ * 
+ * @param am The AnyMap to validate
+ * @throws std::runtime_error Thrown when `am` is invalid (described above)
+ */
+void ValidateAnyMap(const cppmicroservices::AnyMap& am)
+{
+  std::vector<absl::string_view> keys(am.size());
+  uint32_t currIndex = 0;
+  for (auto& kv_pair : am) {
+    keys[currIndex++] = kv_pair.first;
+  }
+
+  if (am.size() > 1) {
+    // NOTE: A solution involving iterations rather than "raw for-loops" was previously
+    // tested but ended up being slower than the solution below.
+    for (uint32_t i = 0; i < keys.size() - 1; ++i) {
+      for (uint32_t j = i + 1; j < keys.size(); ++j) {
+        if (keys[i].size() == keys[j].size() &&
+            ci_compare(keys[i].data(), keys[j].data(), keys[i].size()) == 0) {
+          std::string msg = absl::StrCat(
+            "Properties contain case variants of the key: ", keys[i]);
+          throw std::runtime_error(msg.c_str());
+        }
+      }
+    }
+  }
+}
+
+std::string ToLower(const std::string& s)
+{
+  std::string sNew = s;
+  std::transform(sNew.begin(), sNew.end(), sNew.begin(), [](char c) {
+    return ::tolower(c);
+  });
+  return sNew;
+}
+}
+}

--- a/framework/src/util/PropsCheck.h
+++ b/framework/src/util/PropsCheck.h
@@ -1,0 +1,75 @@
+/*=============================================================================
+
+ Library: CppMicroServices
+
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ =============================================================================*/
+
+/*
+  File: PropsCheck.h
+
+  This file contains shared utility functions for validating that maps provided to
+  the Property class are indeed valid (e.g., no pairs of keys which differ in case only).
+  The code contained in this file has been extracted from other individual files to promote
+  code reusability while reducing the amount of code duplication that exists so that maintenance
+  is easier.
+  
+  Functions defined here are intended for internal use; no external clients of the core
+  framework should be capable/allowed of calling these functions.
+ */
+
+#ifndef PROPSCHECK_H
+#define PROPSCHECK_H
+
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "cppmicroservices/AnyMap.h"
+#include "cppmicroservices/LDAPFilter.h"
+
+#ifdef US_PLATFORM_WINDOWS
+#  include <string.h>
+#  define ci_compare strnicmp
+#else
+#  include <strings.h>
+#  define ci_compare strncasecmp
+#endif
+
+namespace cppmicroservices {
+
+namespace props_check {
+/**
+ * @brief Validates that the provided AnyMap conforms to the same constraints that
+ * those stored in Property objects have.
+ * 
+ * The provided AnyMap is said to be valid if there exists no pairs of two keys
+ * which differ in case only (e.g., "service.feature", "Service.feature"). If this
+ * condition is not true, this function throws as defined below.
+ * 
+ * @param am The AnyMap to validate
+ * @throws std::runtime_error Thrown when `am` is invalid (described above)
+ */
+void ValidateAnyMap(const cppmicroservices::AnyMap& am);
+
+std::string ToLower(const std::string& s);
+}
+}
+
+#endif


### PR DESCRIPTION
Cherry-picked 27e035d594185e23f5f2ac6a8d29d690d3e471bf / #704.
Adapted to C++14 (absl::string_view instead of std::string_view, moved init-statements out of selection statements). Moved one such init-statement (`std::string const lower = LDAPExpr::ToLower(d->m_attrName)`) out of an inner loop in two places as it looks unchanged over the loop. Ran clang-format on changed files.

Signed-off-by: The MathWorks, Inc. <alchrist@mathworks.com>
Signed-off-by: Ingmar Sittl <ingmar.sittl@elektrobit.com>

I've attached a diff between the original commit diff (https://github.com/CppMicroServices/CppMicroServices/commit/27e035d594185e23f5f2ac6a8d29d690d3e471bf.patch) and the adaptation diff(https://github.com/insi-eb/CppMicroServices-cpp14/compare/c++14-compliant...701-ldap-performance-new-2), as that might be helpful in reviewing the adaptations, see comment below

