### PR TITLE
701 - Updated CI to use macos-12 and Ubuntu 20.04 (#711)(#654)

### DIFF
--- a/.github/workflows/build_and_test_nix.yml
+++ b/.github/workflows/build_and_test_nix.yml
@@ -32,13 +32,13 @@ jobs:
       run: |
         sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         sudo apt-get update
-        sudo apt-get -yq --no-install-suggests --no-install-recommends install gcc-5 g++-5 valgrind
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install gcc-7 g++-7 valgrind
       
     - name: Build and Test
       run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake
       env:
-        CC: gcc-5
-        CXX: g++-5
+        CC: gcc-7
+        CXX: g++-7
 
   linux_clang_build:
     name: Build and Test [ubuntu-18.04, Supported Clang]
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macOS-10.15, macos-11]
+        os: [ubuntu-20.04, macOS-11, macos-12]
         # build configurations:
         # 0 = threading ON / shared lib ON
         # 1 = threading ON / shared lib OFF
@@ -86,7 +86,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y valgrind
-      if: ${{matrix.os == 'ubuntu-18.04'}}
+      if: ${{matrix.os == 'ubuntu-20.04'}}
 
     - name: Build And Test
       run: ctest -VV -S ${{github.workspace}}/cmake/usCTestScript_github.cmake

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@
 .. rubric:: Continuous Integration Status
 
 +-------------+---------------------------+--------------------------------------+----------------------------------------+
-| Branch      | GCC 5.5 and 7.5.0         | Visual Studio 2019                   |                                        |
+| Branch      | GCC 7.5.0 and 9.4.0       | Visual Studio 2019                   |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Xcode 12.4                | Visual Studio 2022                   |                                        |
+|             | Clang 9.0                 | Visual Studio 2022                   |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Xcode 13.0                | MinGW-w64                            |                                        |
+|             | Xcode 13.2                | MinGW-w64                            |                                        |
 |             +---------------------------+--------------------------------------+----------------------------------------+
-|             | Clang 9.0                 |                                      |                                        |
+|             | Xcode 13.4                |                                      |                                        |
 +=============+===========================+======================================+========================================+
 | master      | |BuildAndTestNix(master)| | |BuildAndTestWindows(master)|        | |Code Coverage Status|                 |
 +-------------+---------------------------+--------------------------------------+----------------------------------------+
@@ -54,25 +54,25 @@ Supported Platforms
 The library makes use of C++14 language and library features and compiles
 on many different platforms.
 
-Recommended minimum required compiler versions:
-
-- GCC 5.5
-- Clang 9.0
-- Clang from Xcode 12.0
-- Visual Studio 2019
-
-You may use older compilers, but certain functionality may not be
-available. Check the warnings printed during configuration of
-your build tree. The following are the absolute minimum requirements:
+Recommended absolute minimum required compiler versions:
 
 - GCC 5.1
 - Clang 9.0
-- Clang from Xcode 12.0
+- Clang from Xcode 10.0 (not tested)
 - Visual Studio 2017 (MSVC++ 15.0) (no longer tested in CI)
+
+Not all of the absolute minimum compiler versions are tested (as noted). We test and recommend
+the following compilers:
+
+- GCC 7.5.0
+- GCC 9.4.0
+- Clang 9.0
+- Clang from Xcode 12.0 and 13.0
+- Visual Studio 2019 and 2022
 
 Recommended minimum required CMake version:
 
-- CMake 3.12.4 
+- CMake 3.17.0
 
 For all CI builds through GitHub Actions, the CMake version (and
 version of other provided software) we use is determined by the 
@@ -82,21 +82,22 @@ For information about the specific versions of software the runners
 use, please see the following resources:
 
 - `ubuntu-18.04 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md>`
-- `macos-10.15 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md>`
+- `ubuntu-20.04 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md>`
 - `macos-11 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md>`
+- `macos-12 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md>`
 - `windows-2019 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md>`
 - `windows-2022 Runner Information <https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md>`
 
 Below is a list of tested compiler/OS combinations:
 
-- GCC 5.5 (Ubuntu 18.04) via GitHub Actions
-- GCC 7.5.0 (Ubuntu 18.04) via GitHub Actions
-- Clang 9.0 (Ubuntu 18.04) via GitHub Actions
-- Apple Clang, Xcode 12.0.1 (OS X 10.15.7) via GitHub Actions
-- Apple Clang, Xcode 13.0.0 (OS X 11.0) via GitHub Actions
-- Visual Studio 2019 via GitHub Actions
-- Visual Studio 2022 via GitHub Actions
-- MinGW-w64 via GitHub Actions
+- GCC 7.5.0 (Ubuntu 18.04)
+- GCC 9.4.0 (Ubuntu 20.04)
+- Clang 9.0 (Ubuntu 18.04)
+- Apple Clang, Xcode 13.2.0 (OS X 11.6.8)
+- Apple Clang, Xcode 13.4.0 (OS X 12.5.0)
+- Visual Studio 2019
+- Visual Studio 2022
+- MinGW-w64
 
 Legal
 -----


### PR DESCRIPTION
Cherry-picked 0835cf0e40c5249c9d9db640f0fc0f8d3c292f8b / #711.

Resolved merge conflicts by combining this with the C++17-independent parts of #654, updating at least "build_nix" to Ubuntu 20.04, as 18.04 support ends sooner rather than later. This implies switching from gcc-5 as the minimum tested variant to gcc-7.

Please double-check whether these changes do make sense for the current CI setup.