### PR TITLE
701 - Fixed sporadic race conditions during framework shutdown (#725)

### DIFF
--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -218,7 +218,10 @@ void BundlePrivate::FinalizeActivation()
 {
   switch (GetUpdatedState()) {
     case Bundle::STATE_INSTALLED: {
-      std::rethrow_exception(resolveFailException);
+      if(resolveFailException) {
+        std::rethrow_exception(resolveFailException);
+      }
+      break;
     }
     case Bundle::STATE_STARTING: {
       if (operation == OP_ACTIVATING) {
@@ -570,7 +573,10 @@ void BundlePrivate::StartFailed()
   coreCtx->listeners.BundleChanged(BundleEvent(
     BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
   RemoveBundleResources();
-  bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>())->Invalidate();
+  auto oldBundleContext = bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
+  if (oldBundleContext) {
+    oldBundleContext->Invalidate();
+  }
   state = Bundle::STATE_RESOLVED;
   coreCtx->listeners.BundleChanged(BundleEvent(
     BundleEvent::BUNDLE_STOPPED, MakeBundle(this->shared_from_this())));

--- a/framework/src/bundle/BundleStorageMemory.cpp
+++ b/framework/src/bundle/BundleStorageMemory.cpp
@@ -91,8 +91,8 @@ std::vector<long> BundleStorageMemory::GetStartOnLaunchBundles() const
 
 void BundleStorageMemory::Close()
 {
-  // Not need to lock "archives" here: at this point, the framework
-  // is going down and no other threads can access it.
+  auto l = archives.Lock();
+  US_UNUSED(l);
   archives.v.clear();
 }
 }

--- a/framework/src/service/ServiceHooks.cpp
+++ b/framework/src/service/ServiceHooks.cpp
@@ -86,8 +86,7 @@ void ServiceHooks::Open()
 {
   auto l = this->Lock();
   US_UNUSED(l);
-  listenerHookTracker.reset(
-    new ServiceTracker<ServiceListenerHook>(GetBundleContext(), this));
+  listenerHookTracker = std::make_unique<ServiceTracker<ServiceListenerHook>>(GetBundleContext(), this);
   listenerHookTracker->Open();
 
   bOpen = true;
@@ -99,7 +98,6 @@ void ServiceHooks::Close()
   US_UNUSED(l);
   if (listenerHookTracker) {
     listenerHookTracker->Close();
-    listenerHookTracker.reset();
   }
 
   bOpen = false;

--- a/framework/src/service/ServiceHooks.h
+++ b/framework/src/service/ServiceHooks.h
@@ -33,8 +33,8 @@ namespace cppmicroservices {
 struct ServiceListenerHook;
 
 class ServiceHooks
-  : private detail::MultiThreaded<>
-  , private ServiceTrackerCustomizer<ServiceListenerHook>
+  : public detail::MultiThreaded<>
+  , public ServiceTrackerCustomizer<ServiceListenerHook>
 {
 
 private:


### PR DESCRIPTION
Cherry-picked 4f18659f7daa6930d5010b5b2f848a488b64e2e6 / #727.

The original code produced this build-error with my gcc-11.3 installation:

```
CppMicroServices/src/framework/test/gtest/BundleTest.cpp:934:34: error: use of deleted function ‘std::atomic<bool>::atomic(const std::atomic<bool>&)’
  934 |   std::atomic_bool keepLooping = true;
      |                                  ^~~~
In file included from CppMicroServices/src/framework/include/cppmicroservices/ServiceReferenceBase.h:29,
                 from CppMicroServices/src/framework/include/cppmicroservices/ServiceReference.h:27,
                 from CppMicroServices/src/framework/include/cppmicroservices/ServiceRegistrationBase.h:27,
                 from CppMicroServices/src/framework/include/cppmicroservices/ServiceRegistration.h:26,
                 from CppMicroServices/src/framework/include/cppmicroservices/BundleContext.h:31,
                 from CppMicroServices/src/framework/include/cppmicroservices/BundleActivator.h:30,
                 from CppMicroServices/src/framework/test/gtest/BundleTest.cpp:24:
/usr/include/c++/11/atomic:72:5: note: declared here
   72 |     atomic(const atomic&) = delete;
      |     ^~~~~~
/usr/include/c++/11/atomic:76:15: note:   after user-defined conversion: ‘constexpr std::atomic<bool>::atomic(bool)’
   76 |     constexpr atomic(bool __i) noexcept : _M_base(__i) { }
      |               ^~~~~~
```

Changing the offending line to `std::atomic_bool keepLooping{ true };` fixed that issue. Additionally added <atomic> include for correctness sake and ran clang-format on BundleTest.cpp.
