### PR TITLE
701 - Fix deadlock in ConfigurationAdminImpl::RemoveConfigurations (#745)

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -539,7 +539,6 @@ void ConfigurationAdminImpl::RemoveConfigurations(
     }
     ++idx;
   }
-  WaitForAllAsync();
 }
 
 std::shared_future<void> ConfigurationAdminImpl::NotifyConfigurationUpdated(

--- a/compendium/test_bundles/CMakeLists.txt
+++ b/compendium/test_bundles/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(DSFrenchDictionary)
 add_subdirectory(EnglishDictionary)
 
 add_subdirectory(ManagedServiceAndFactoryBundle)
+add_subdirectory(TestBundleManagedServiceDeadlock)
 add_subdirectory(TestBundleManagedServiceFactory)
 add_subdirectory(TestBundleNestedBundleStartManagedService)
 add_subdirectory(TestBundleMultipleManagedService)

--- a/compendium/test_bundles/TestBundleManagedServiceDeadlock/CMakeLists.txt
+++ b/compendium/test_bundles/TestBundleManagedServiceDeadlock/CMakeLists.txt
@@ -1,0 +1,6 @@
+usFunctionCreateDSTestBundle(TestBundleManagedServiceDeadlock)
+
+usFunctionCreateTestBundleWithResources(TestBundleManagedServiceDeadlock
+  RESOURCES manifest.json
+  BUNDLE_SYMBOLIC_NAME TestBundleManagedServiceDeadlock
+  OTHER_LIBRARIES usTestInterfaces usServiceComponent cm)

--- a/compendium/test_bundles/TestBundleManagedServiceDeadlock/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleManagedServiceDeadlock/resources/manifest.json
@@ -1,0 +1,16 @@
+{
+  "bundle.symbolic_name": "TestBundleManagedServiceDeadlock",
+  "bundle.name": "TestBundleManagedServiceDeadlock",
+  "bundle.activator": false,
+   "cm": {
+    "version": 1,
+    "configurations": [
+      {
+        "pid": "cm.testdeadlock",
+        "properties": {
+          "anInt": 2
+        }
+      } 
+    ]
+  }
+}


### PR DESCRIPTION
Cherry-picked c141557e1f85784ffe778b0a155d3fe21c2c939d / #745 without changes.