### PR TITLE
Make a small performance improvement

### DIFF
--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -100,7 +100,7 @@ namespace cppmicroservices
 
         std::vector<std::string> classes;
         // Check if service implements claimed classes and that they exist.
-        for (auto i : *service)
+        for (auto& i : *service)
         {
             if (i.first.empty() || (!isFactory && i.second == nullptr))
             {


### PR DESCRIPTION
stop copying the std::pair in the range-based for. This helps improve the speed of RegisterService