### PR TITLE
701 - configurations using the same pid are not updated properly (#754)

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -88,6 +88,11 @@ public:
     return lastUpdatedChangeCountPerPid[pid] < changeCount;
   }
 
+  void removeLastUpdatedChangeCount(const std::string& pid) noexcept {
+    std::unique_lock<std::mutex> lock(updatedChangeCountMutex);
+    (void)lastUpdatedChangeCountPerPid.erase(pid);
+  }
+
 private:
   std::string pid;
   std::shared_ptr<TrackedServiceType> trackedService;
@@ -194,7 +199,8 @@ public:
    */
   std::shared_future<void> NotifyConfigurationRemoved(
     const std::string& pid,
-    std::uintptr_t configurationId) override;
+    std::uintptr_t configurationId,
+    unsigned long changeCount) override;
 
   // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedService
   std::shared_ptr<

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminPrivate.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminPrivate.hpp
@@ -105,7 +105,8 @@ public:
    */
   virtual std::shared_future<void> NotifyConfigurationRemoved(
     const std::string& pid,
-    std::uintptr_t configurationId) = 0;
+    std::uintptr_t configurationId,
+    unsigned long changeCount) = 0;
 };
 } // cmimpl
 } // cppmicroservices

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -143,7 +143,7 @@ std::shared_future<void> ConfigurationImpl::Remove()
   std::lock_guard<std::mutex> lk{ configAdminMutex };
   if (configAdminImpl) {
     auto fut = configAdminImpl->NotifyConfigurationRemoved(
-      pid, reinterpret_cast<std::uintptr_t>(this));
+      pid, reinterpret_cast<std::uintptr_t>(this), changeCount);
     configAdminImpl = nullptr;
     return fut;
   }

--- a/compendium/ConfigurationAdmin/test/Mocks.hpp
+++ b/compendium/ConfigurationAdmin/test/Mocks.hpp
@@ -123,8 +123,8 @@ public:
   MOCK_METHOD1(RemoveConfigurations, void(std::vector<ConfigurationAddedInfo>));
   MOCK_METHOD2(NotifyConfigurationUpdated,
                std::shared_future<void>(const std::string&, const unsigned long));
-  MOCK_METHOD2(NotifyConfigurationRemoved,
-               std::shared_future<void>(const std::string&, std::uintptr_t));
+  MOCK_METHOD3(NotifyConfigurationRemoved,
+               std::shared_future<void>(const std::string&, std::uintptr_t, unsigned long));
 };
 
 namespace async {

--- a/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
@@ -69,7 +69,7 @@ TEST(TestConfigurationImpl, ThrowsWhenRemoved)
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
   EXPECT_CALL(
     *mockConfigAdmin,
-    NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(&conf)))
+    NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(&conf), testing::_))
     .Times(1);
   EXPECT_NO_THROW(conf.Remove());
   EXPECT_THROW(conf.GetPid(), std::runtime_error);
@@ -95,7 +95,7 @@ TEST(TestConfigurationImpl, NoCallbacksAfterInvalidate)
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
   EXPECT_CALL(*mockConfigAdmin,
-              NotifyConfigurationRemoved(testing::_, testing::_))
+              NotifyConfigurationRemoved(testing::_, testing::_, testing::_))
     .Times(0);
   EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(testing::_, testing::_))
     .Times(0);
@@ -164,7 +164,7 @@ TEST(TestConfigurationImpl, VerifyRemoveWithoutNotificationIfChangeCountEquals)
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
   EXPECT_CALL(*mockConfigAdmin,
-              NotifyConfigurationRemoved(testing::_, testing::_))
+              NotifyConfigurationRemoved(testing::_, testing::_, testing::_))
     .Times(0);
   EXPECT_FALSE(conf.RemoveWithoutNotificationIfChangeCountEquals(0ul));
   EXPECT_TRUE(conf.RemoveWithoutNotificationIfChangeCountEquals(1ul));


### PR DESCRIPTION
Cherry-picked #754 / 0b4f93e6f23b1591ffffbe4ee234a428feff55fa without changes.