### PR TITLE
701 - Ensure ~SCRBundleExtension does not throw (#761)

### DIFF
--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -152,7 +152,7 @@ void SCRActivator::CreateExtension(const cppmicroservices::Bundle& bundle)
     try {
       auto const& scrMap =
         ref_any_cast<cppmicroservices::AnyMap>(headers.at(SERVICE_COMPONENT));
-      auto ba = std::make_unique<SCRBundleExtension>(bundle.GetBundleContext(),
+      auto ba = std::make_unique<SCRBundleExtension>(bundle,
                                                      scrMap,
                                                      componentRegistry,
                                                      logger,

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -51,7 +51,7 @@ class SCRBundleExtension
 {
 public:
   SCRBundleExtension(
-    const cppmicroservices::BundleContext& bundleContext,
+    const cppmicroservices::Bundle& bundle,
     const cppmicroservices::AnyMap& scrMetadata,
     const std::shared_ptr<ComponentRegistry>& registry,
     const std::shared_ptr<LogService>& logger,
@@ -70,7 +70,7 @@ private:
 
   void DisableAndRemoveAllComponentManagers();
 
-  cppmicroservices::BundleContext bundleContext;
+  cppmicroservices::Bundle bundle_;
   std::shared_ptr<ComponentRegistry> registry;
   std::shared_ptr<LogService> logger;
   std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;


### PR DESCRIPTION
Cherry-picked #761 / c83f29019aad090ef77f26adaf2e7dc7b0a31cbf without changes.