### PR TITLE
701 - Run clang-format on all files

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -102,7 +102,7 @@ std::shared_future<void> ConfigurationImpl::Update(AnyMap newProperties)
   }
   std::lock_guard<std::mutex> lk{ configAdminMutex };
   if (configAdminImpl) {
-   return configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
+    return configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
   }
   std::promise<void> ready;
   std::shared_future<void> fut = ready.get_future();

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
@@ -34,7 +34,8 @@ namespace metadata {
 MetadataParserImplV1::MetadataParserImplV1(
   std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
   : logger(std::move(lggr))
-{}
+{
+}
 
 std::vector<ConfigurationMetadata>
 MetadataParserImplV1::ParseAndGetConfigurationMetadata(

--- a/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
@@ -57,7 +57,8 @@ class TestAsyncWorkServiceEndToEnd
 public:
   TestAsyncWorkServiceEndToEnd()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   void SetUp() override
   {
@@ -146,7 +147,8 @@ class AsyncWorkServiceInline : public cppmicroservices::async::AsyncWorkService
 public:
   AsyncWorkServiceInline()
     : cppmicroservices::async::AsyncWorkService()
-  {}
+  {
+  }
 
   void post(std::packaged_task<void()>&& task) override { task(); }
 };
@@ -157,7 +159,8 @@ class AsyncWorkServiceStdAsync
 public:
   AsyncWorkServiceStdAsync()
     : cppmicroservices::async::AsyncWorkService()
-  {}
+  {
+  }
 
   void post(std::packaged_task<void()>&& task) override
   {

--- a/compendium/ConfigurationAdmin/test/TestCMActivator.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMActivator.cpp
@@ -44,7 +44,8 @@ class TestCMActivator : public ::testing::Test
 protected:
   TestCMActivator()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~TestCMActivator() override = default;
 
   void SetUp() override { framework.Start(); }

--- a/compendium/ConfigurationAdmin/test/TestCMBundleExtension.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMBundleExtension.cpp
@@ -42,7 +42,8 @@ class TestCMBundleExtension : public ::testing::Test
 protected:
   TestCMBundleExtension()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~TestCMBundleExtension() = default;
 
   void SetUp() override { framework.Start(); }

--- a/compendium/ConfigurationAdmin/test/TestCMLogger.cpp
+++ b/compendium/ConfigurationAdmin/test/TestCMLogger.cpp
@@ -44,7 +44,8 @@ class TestCMLogger : public ::testing::Test
 protected:
   TestCMLogger()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   ~TestCMLogger() override = default;
 
@@ -70,16 +71,14 @@ TEST_F(TestCMLogger, VerifyWithoutLoggerService)
   // check that calling log method is safe even if a LogService is unavailable
   EXPECT_NO_THROW({
     logger.Log(SeverityLevel::LOG_DEBUG, "sample log message");
-    logger.Log(
-      SeverityLevel::LOG_DEBUG,
-      "sample log message",
-      std::make_exception_ptr(std::runtime_error("error occured")));
+    logger.Log(SeverityLevel::LOG_DEBUG,
+               "sample log message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
     logger.Log(dummyRef, SeverityLevel::LOG_DEBUG, "sample log message");
-    logger.Log(
-      dummyRef,
-      SeverityLevel::LOG_DEBUG,
-      "sample log message",
-      std::make_exception_ptr(std::runtime_error("error occured")));
+    logger.Log(dummyRef,
+               SeverityLevel::LOG_DEBUG,
+               "sample log message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
   });
 }
 
@@ -106,18 +105,16 @@ TEST_F(TestCMLogger, VerifyWithLoggerService)
     // exercise methods on instance of CMLogger
     CMLogger logger(bundleContext);
     logger.Log(SeverityLevel::LOG_DEBUG, "some sample debug message");
-    logger.Log(
-      SeverityLevel::LOG_ERROR,
-      "some sample error message",
-      std::make_exception_ptr(std::runtime_error("error occured")));
+    logger.Log(SeverityLevel::LOG_ERROR,
+               "some sample error message",
+               std::make_exception_ptr(std::runtime_error("error occured")));
     cppmicroservices::ServiceReferenceU dummyRef;
     logger.Log(
       dummyRef, SeverityLevel::LOG_WARNING, "some sample warning message");
-    logger.Log(
-      dummyRef,
-      SeverityLevel::LOG_ERROR,
-      "some sample error message with service reference",
-      std::make_exception_ptr(std::runtime_error("error occured")));
+    logger.Log(dummyRef,
+               SeverityLevel::LOG_ERROR,
+               "some sample error message with service reference",
+               std::make_exception_ptr(std::runtime_error("error occured")));
     reg.Unregister();
   });
 }

--- a/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigAdmin.cpp
@@ -78,8 +78,9 @@ void InstallAndStartDSAndConfigAdmin(::cppmicroservices::BundleContext& ctx)
   }
 }
 
-std::vector<cppmicroservices::Bundle> InstallBundles(cppmicroservices::BundleContext& ctx,
-        const std::string& bundleName)
+std::vector<cppmicroservices::Bundle> InstallBundles(
+  cppmicroservices::BundleContext& ctx,
+  const std::string& bundleName)
 {
   std::string path = PathToLib(bundleName);
   return ctx.InstallBundles(path);
@@ -108,8 +109,8 @@ getManagedServices(cppmicroservices::BundleContext& ctx)
 {
   auto srs = ctx.GetServiceReferences<::test::TestManagedServiceInterface>();
   std::vector<std::shared_ptr<::test::TestManagedServiceInterface>> services;
-  for (const auto& sr: srs) {
-    services.push_back( ctx.GetService<::test::TestManagedServiceInterface>(sr));
+  for (const auto& sr : srs) {
+    services.push_back(ctx.GetService<::test::TestManagedServiceInterface>(sr));
   }
 
   return services;
@@ -201,7 +202,8 @@ class ConfigAdminTests : public ::testing::Test
 public:
   ConfigAdminTests()
     : m_framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   void SetUp() override
   {
@@ -546,7 +548,6 @@ TEST_F(ConfigAdminTests, testRemoveFactoryConfiguration)
   configuration_config1->UpdateIfDifferent(props).second.get();
   expectedCount_config1 = initConfiguredCount_config1;
   EXPECT_EQ(serviceFactory->getUpdatedCounter("cm.testfactory~config1"), 7);
-
 }
 // This test confirms that if an object exists in the configuration repository
 // but has not yet been Updated prior to the start of the ManagedServiceFactory
@@ -584,39 +585,50 @@ TEST_F(ConfigAdminTests, testDuplicateUpdated)
 /// <summary>
 /// Used by ConfigAdminTests.testConcurrentDuplicateManagedServiceUpdated
 /// </summary>
-namespace cppmicroservices { namespace test {
-    class TestManagedServiceInterface : public cppmicroservices::service::cm::ManagedService {
-    public:
-        virtual ~TestManagedServiceInterface() noexcept = default;
+namespace cppmicroservices {
+namespace test {
+class TestManagedServiceInterface
+  : public cppmicroservices::service::cm::ManagedService
+{
+public:
+  virtual ~TestManagedServiceInterface() noexcept = default;
 
-        void Updated(const cppmicroservices::AnyMap&) override = 0;
-        virtual unsigned long getUpdatedMethodCallCount() noexcept = 0;
-    };
+  void Updated(const cppmicroservices::AnyMap&) override = 0;
+  virtual unsigned long getUpdatedMethodCallCount() noexcept = 0;
+};
 
-    class TestManagedService : public TestManagedServiceInterface {
-    public:
-        TestManagedService() : updatedCount_{0} {}
-        virtual ~TestManagedService() noexcept = default;
+class TestManagedService : public TestManagedServiceInterface
+{
+public:
+  TestManagedService()
+    : updatedCount_{ 0 }
+  {
+  }
+  virtual ~TestManagedService() noexcept = default;
 
-        void Updated(const cppmicroservices::AnyMap& props) override {
-            std::unique_lock<std::mutex> lock(updatedCountMutex_);
-            // empty properties can be sent when stopping the configadmin
-            // service. For the purpose of this test we only want to
-            // update the count when non-empty properties have been sent.
-            if(!props.empty()) {
-              updatedCount_++;
-            }
-        }
+  void Updated(const cppmicroservices::AnyMap& props) override
+  {
+    std::unique_lock<std::mutex> lock(updatedCountMutex_);
+    // empty properties can be sent when stopping the configadmin
+    // service. For the purpose of this test we only want to
+    // update the count when non-empty properties have been sent.
+    if (!props.empty()) {
+      updatedCount_++;
+    }
+  }
 
-        unsigned long getUpdatedMethodCallCount() noexcept override {
-            std::unique_lock<std::mutex> lock(updatedCountMutex_);
-            return updatedCount_;
-        }
-    private:
-        unsigned long updatedCount_;
-        std::mutex updatedCountMutex_;
-    };
-}}
+  unsigned long getUpdatedMethodCallCount() noexcept override
+  {
+    std::unique_lock<std::mutex> lock(updatedCountMutex_);
+    return updatedCount_;
+  }
+
+private:
+  unsigned long updatedCount_;
+  std::mutex updatedCountMutex_;
+};
+}
+}
 
 // This test simulates sending a config update when two threads are
 // racing to register a ManagedService and update the configuration
@@ -753,7 +765,8 @@ TEST_F(ConfigAdminTests, testConcurrentDuplicateManagedServiceFactoryUpdated)
 /// DS bundle with a ManagedService service within its Activate method. This test
 /// is meant to simulate nested calls to Configuration Admin's service trackers
 /// and test for deadlocks.
-TEST_F(ConfigAdminTests, testNestedBundleInstallAndStart) {
+TEST_F(ConfigAdminTests, testNestedBundleInstallAndStart)
+{
   auto f = GetFramework();
   auto ctx = f.GetBundleContext();
 
@@ -761,17 +774,19 @@ TEST_F(ConfigAdminTests, testNestedBundleInstallAndStart) {
   // happen within the Activate of TestBundleNestedBundleStartManagedService
   // It is done this way so that the test bundles don't have to have knowledge
   // about the paths to test bundles.
-  auto bundles = ctx.InstallBundles(PathToLib("ManagedServiceAndFactoryBundle"));
+  auto bundles =
+    ctx.InstallBundles(PathToLib("ManagedServiceAndFactoryBundle"));
   ASSERT_EQ(1ul, bundles.size());
 
   // This bundle's Activate method has a call to start TestBundleManagedService, which will trigger
   // a call to Config Admin's service tracker.
-  auto const numBundles =
-    installAndStartTestBundles(ctx, "TestBundleNestedBundleStartManagedService");
+  auto const numBundles = installAndStartTestBundles(
+    ctx, "TestBundleNestedBundleStartManagedService");
   ASSERT_EQ(numBundles, 1ul);
 }
 
-TEST_F(ConfigAdminTests, testMultipleManagedServicesInBundleGetUpdate) {
+TEST_F(ConfigAdminTests, testMultipleManagedServicesInBundleGetUpdate)
+{
   auto f = GetFramework();
   auto ctx = f.GetBundleContext();
 
@@ -781,21 +796,17 @@ TEST_F(ConfigAdminTests, testMultipleManagedServicesInBundleGetUpdate) {
 
   auto services = getManagedServices(ctx);
   ASSERT_EQ(services.size(), 2ul);
-  std::for_each(std::begin(services),
-                std::end(services),
-                [](auto& service) { ASSERT_NE(service, nullptr); });
+  std::for_each(std::begin(services), std::end(services), [](auto& service) {
+    ASSERT_NE(service, nullptr);
+  });
 
-  auto sharedConfiguration =
-    m_configAdmin->GetConfiguration("cm.testservice");
+  auto sharedConfiguration = m_configAdmin->GetConfiguration("cm.testservice");
   ASSERT_EQ(sharedConfiguration->GetPid(), "cm.testservice");
   ASSERT_TRUE(sharedConfiguration->GetProperties().empty());
 
-  std::for_each(std::begin(services),
-                std::end(services),
-                [](auto& service) {
-                  ASSERT_EQ(service->getCounter(),
-                            0);
-                });
+  std::for_each(std::begin(services), std::end(services), [](auto& service) {
+    ASSERT_EQ(service->getCounter(), 0);
+  });
 
   cppmicroservices::AnyMap props(
     cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
@@ -804,12 +815,9 @@ TEST_F(ConfigAdminTests, testMultipleManagedServicesInBundleGetUpdate) {
   auto fut = sharedConfiguration->Update(props);
   fut.get();
 
-  std::for_each(std::begin(services),
-                std::end(services),
-                [](auto& service) {
-                  ASSERT_EQ(service->getCounter(),
-                            1);
-                });
+  std::for_each(std::begin(services), std::end(services), [](auto& service) {
+    ASSERT_EQ(service->getCounter(), 1);
+  });
 }
 
 TEST_F(ConfigAdminTests, testMultipleManagedFactoriesInBundleGetUpdate)
@@ -863,7 +871,7 @@ class TestManagedServiceInterface2
 {
 public:
   virtual ~TestManagedServiceInterface2() noexcept = default;
-  void Updated(const cppmicroservices::AnyMap&) override = 0; 
+  void Updated(const cppmicroservices::AnyMap&) override = 0;
 };
 
 class TestManagedServiceImpl : public TestManagedServiceInterface2
@@ -871,12 +879,13 @@ class TestManagedServiceImpl : public TestManagedServiceInterface2
 public:
   TestManagedServiceImpl(cppmicroservices::Framework& framework)
     : m_framework(framework)
-   {}
+  {
+  }
   virtual ~TestManagedServiceImpl() noexcept = default;
 
   void Updated(const cppmicroservices::AnyMap& props) override
-  { 
-    // The Updated method is called for both Updated and Removed operations. 
+  {
+    // The Updated method is called for both Updated and Removed operations.
     // For the Removed operations, the properties are empty.
     if (props.empty()) {
       auto ctx = m_framework.GetBundleContext();
@@ -936,20 +945,20 @@ TEST_F(ConfigAdminTests, testManagedServiceRemoveConfigurationsDeadlock)
   // is updated or removed.
   cppmicroservices::ServiceProperties serviceProperties;
   serviceProperties["service.pid"] =
-  cppmicroservices::Any(std::string("cm.testdeadlock"));
-      (void)
-        ctx.RegisterService<cppmicroservices::test::TestManagedServiceInterface2,
-                            cppmicroservices::service::cm::ManagedService>(
-          std::make_shared<cppmicroservices::test::TestManagedServiceImpl>(f),
-          serviceProperties);
- 
+    cppmicroservices::Any(std::string("cm.testdeadlock"));
+  (void)
+    ctx.RegisterService<cppmicroservices::test::TestManagedServiceInterface2,
+                        cppmicroservices::service::cm::ManagedService>(
+      std::make_shared<cppmicroservices::test::TestManagedServiceImpl>(f),
+      serviceProperties);
+
   // Stop the bundle containing the cm.testdeadlock configuration object. This causes
   // ConfigurationAdminImpl::RemoveConfigurations to execute. It sends an Updated notification
   // to the TestManagedServiceImpl service. With the WaitForAllAsync method present in
-  // in RemoveConfigurations, the bundle Stop command won't return until the Updated 
-  // notification is complete. Unfortunately, the Updated method also tries to stop the 
+  // in RemoveConfigurations, the bundle Stop command won't return until the Updated
+  // notification is complete. Unfortunately, the Updated method also tries to stop the
   // bundle and a deadlock results.
   for (auto& b : bundles) {
-     b.Stop();
+    b.Stop();
   }
 }

--- a/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationAdminImpl.cpp
@@ -84,7 +84,8 @@ class TestConfigurationAdminImpl : public ::testing::Test
 protected:
   TestConfigurationAdminImpl()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   ~TestConfigurationAdminImpl() override = default;
 
@@ -610,7 +611,7 @@ TEST_F(TestConfigurationAdminImpl, VerifyManagedServiceFactoryNotification)
     std::make_shared<MockManagedServiceFactory>();
   // setup expectations.
   // mockManagedServiceFactory will receive one Updated notification
-  // and one Removed Notification. 
+  // and one Removed Notification.
   // mockManagedServiceFactory2 will receive two Updated notifications.
   // mockManagedServiceFactory3 will receive no notifications.
   EXPECT_CALL(*mockManagedServiceFactory,
@@ -707,10 +708,10 @@ TEST_F(TestConfigurationAdminImpl, VerifyManagedServiceFactoryNotification)
 
   configAdmin.WaitForAllAsync();
 }
-// This test confirms that when ConfigurationAdmin shuts down the appropriate 
+// This test confirms that when ConfigurationAdmin shuts down the appropriate
 // Removed notifications should be sent to the ManagedService and ManagedFactoryServices.
-// Configuration objects will be added to the repository but never updated so when 
-// ConfigurationAdmin shuts down no Remove notifications should be sent to the 
+// Configuration objects will be added to the repository but never updated so when
+// ConfigurationAdmin shuts down no Remove notifications should be sent to the
 // ManagedServices or ManagedServiceFactorys
 TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotification)
 {
@@ -731,9 +732,9 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotification)
   auto mockManagedServiceFactory2 =
     std::make_shared<MockManagedServiceFactory>();
   // setup expectations.
-  // Test registers two mockManagedServices and two mockManagedFactoryServices 
+  // Test registers two mockManagedServices and two mockManagedFactoryServices
   // Configuration objects are created but never updated so no Updated or Removed
-  // notifications should be sent to the services when ConfigurationAdmin 
+  // notifications should be sent to the services when ConfigurationAdmin
   // shuts down.
 
   // ManagedServices do not have a Removed method. Updated is called with empty
@@ -797,11 +798,11 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotification)
 
     EXPECT_TRUE(factoryInvokedZeroTimes);
     // ConfigurationAdminImpl was constructed in this scope so the next statement will
-    // cause it to be shut down. 
-    // The configuration objects that were added to the repository were never updated 
-    // so no Removed notifications will be sent to the ManagedServices or the 
-    // ManagedFactoryServices. Removed notifications can only be sent if an Updated 
-    // notification has been previously sent. 
+    // cause it to be shut down.
+    // The configuration objects that were added to the repository were never updated
+    // so no Removed notifications will be sent to the ManagedServices or the
+    // ManagedFactoryServices. Removed notifications can only be sent if an Updated
+    // notification has been previously sent.
   }
 
   std::unique_lock<std::mutex> ul{ counterMutex };
@@ -823,7 +824,8 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotification)
 // Configuration objects will be added to the repository and updated so when
 // ConfigurationAdmin shuts down  Remove notifications should be sent to the
 // ManagedServices and ManagedServiceFactories
-TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotificationWithUpdate)
+TEST_F(TestConfigurationAdminImpl,
+       VerifyConfigAdminStartupShutdownNotificationWithUpdate)
 {
   auto bundleContext = GetFramework().GetBundleContext();
   auto fakeLogger = std::make_shared<FakeLogger>();
@@ -838,7 +840,7 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotificationW
   std::condition_variable counterCV;
   auto msCounter = 0u;
   auto msfCounter = 0u;
- 
+
   auto f = [&counterMutex, &counterCV, &msCounter] {
     {
       std::lock_guard<std::mutex> lk{ counterMutex };
@@ -859,17 +861,16 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotificationW
     std::make_shared<MockManagedServiceFactory>();
   // setup expectations.
   // The test registers a mockManagedService and a mockManagedFactoryService.
-  // Configuration objects are created and updated so each of the services 
-  // should receive one Updated notification and one Removed notification. 
+  // Configuration objects are created and updated so each of the services
+  // should receive one Updated notification and one Removed notification.
 
-  // For the mockManagedService the Updated method is used for both Updated 
+  // For the mockManagedService the Updated method is used for both Updated
   // and Removed. The Removed notification calls Updated with empty properties.
   EXPECT_CALL(*mockManagedService, Updated(AnyMapEquals(props))).Times(1);
   EXPECT_CALL(*mockManagedService, Updated(AnyMapEquals(emptyProps)))
-    .WillOnce(testing::InvokeWithoutArgs(f)); 
-  EXPECT_CALL(
-    *mockManagedServiceFactory,
-    Updated(std::string{ "factory~instance1" }, AnyMapEquals(props)))
+    .WillOnce(testing::InvokeWithoutArgs(f));
+  EXPECT_CALL(*mockManagedServiceFactory,
+              Updated(std::string{ "factory~instance1" }, AnyMapEquals(props)))
     .Times(1);
   EXPECT_CALL(*mockManagedServiceFactory,
               Removed(std::string{ "factory~instance1" }))
@@ -924,7 +925,7 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotificationW
     // The configuration objects that were added to the repository were updated
     // so Removed notifications will be sent to the ManagedServices and the
     // ManagedFactoryServices. Removed notifications must be sent if an Updated
-    // notification has been previously sent. 
+    // notification has been previously sent.
   }
 
   std::unique_lock<std::mutex> ul{ counterMutex };
@@ -938,7 +939,6 @@ TEST_F(TestConfigurationAdminImpl, VerifyConfigAdminStartupShutdownNotificationW
 
   reg1.Unregister();
   reg2.Unregister();
-
 }
 TEST_F(TestConfigurationAdminImpl, VerifyManagedServiceExceptionsAreLogged)
 {
@@ -1066,7 +1066,7 @@ TEST_F(TestConfigurationAdminImpl, VerifyManagedServiceExceptionsAreLogged)
     .WillOnce(
       testing::DoAll(testing::InvokeWithoutArgs(f),
                      testing::Throw(std::runtime_error("An exception"))));
-  
+
   // Update is called without any properties for a Remove operation
   EXPECT_CALL(*mockManagedService, Updated(AnyMapEquals(emptyProps)))
     .WillOnce(

--- a/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/TestConfigurationImpl.cpp
@@ -67,9 +67,9 @@ TEST(TestConfigurationImpl, ThrowsWhenRemoved)
   std::string pid{ "test~instance" };
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
-  EXPECT_CALL(
-    *mockConfigAdmin,
-    NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(&conf), testing::_))
+  EXPECT_CALL(*mockConfigAdmin,
+              NotifyConfigurationRemoved(
+                pid, reinterpret_cast<std::uintptr_t>(&conf), testing::_))
     .Times(1);
   EXPECT_NO_THROW(conf.Remove());
   EXPECT_THROW(conf.GetPid(), std::runtime_error);
@@ -97,7 +97,8 @@ TEST(TestConfigurationImpl, NoCallbacksAfterInvalidate)
   EXPECT_CALL(*mockConfigAdmin,
               NotifyConfigurationRemoved(testing::_, testing::_, testing::_))
     .Times(0);
-  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(testing::_, testing::_))
+  EXPECT_CALL(*mockConfigAdmin,
+              NotifyConfigurationUpdated(testing::_, testing::_))
     .Times(0);
   EXPECT_NO_THROW(conf.Invalidate());
   EXPECT_NO_THROW(conf.Update(props));
@@ -116,7 +117,8 @@ TEST(TestConfigurationImpl, VerifyUpdate)
   std::string pid{ "test~instance" };
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
-  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_)).Times(1);
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_))
+    .Times(1);
   EXPECT_NO_THROW(conf.Update(props));
 }
 
@@ -129,7 +131,8 @@ TEST(TestConfigurationImpl, VerifyUpdateIfDifferent)
   std::string pid{ "test~instance" };
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
-  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_)).Times(1);
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_))
+    .Times(1);
   auto result = conf.UpdateIfDifferent(props);
   EXPECT_FALSE(result.first);
   props["bar"] = std::string("baz");
@@ -146,7 +149,8 @@ TEST(TestConfigurationImpl, VerifyUpdateWithoutNotificationIfDifferent)
   std::string pid{ "test~instance" };
   std::string factoryPid{ "test" };
   ConfigurationImpl conf{ mockConfigAdmin.get(), pid, factoryPid, props };
-  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_)).Times(0);
+  EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_))
+    .Times(0);
   EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props),
             std::make_pair(false, 0ul));
   props["bar"] = std::string("baz");

--- a/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
+++ b/compendium/ConfigurationAdmin/test/TestMetadataParserImplV1.cpp
@@ -96,7 +96,8 @@ class TestMetadataParserImplV1 : public ::testing::Test
 protected:
   TestMetadataParserImplV1()
     : logger(std::make_shared<FakeLogger>())
-  {}
+  {
+  }
   ~TestMetadataParserImplV1() override = default;
 
 private:
@@ -161,7 +162,8 @@ struct MetadataInvalidManifestState
   MetadataInvalidManifestState(std::string manifest, std::string errorOut)
     : manifestName(std::move(manifest))
     , errorOutput(std::move(errorOut))
-  {}
+  {
+  }
 
   std::string manifestName;
   std::string errorOutput;
@@ -184,7 +186,8 @@ private:
 protected:
   TestInvalidMetadata()
     : logger(std::make_shared<FakeLogger>())
-  {}
+  {
+  }
 
   ~TestInvalidMetadata() override = default;
 

--- a/compendium/DeclarativeServices/src/ConfigurationListenerImpl.cpp
+++ b/compendium/DeclarativeServices/src/ConfigurationListenerImpl.cpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#include "cppmicroservices/SecurityException.h"
 #include "ConfigurationListenerImpl.hpp"
+#include "cppmicroservices/SecurityException.h"
 #include "cppmicroservices/cm/ConfigurationAdmin.hpp"
 
 namespace cppmicroservices {
@@ -86,10 +86,10 @@ void ConfigurationListenerImpl::configurationEvent(
     auto ptr = std::make_shared<cppmicroservices::AnyMap>(properties);
     configNotifier->NotifyAllListeners(pid, type, ptr);
   } catch (const cppmicroservices::SecurityException&) {
-    logger->Log(
-      cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-      "Security exception while executing ConfigurationListener::configEvent method.",
-      std::current_exception());
+    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                "Security exception while executing "
+                "ConfigurationListener::configEvent method.",
+                std::current_exception());
     throw;
   } catch (...) {
     logger->Log(

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
@@ -104,10 +104,11 @@ SCRBundleExtension::~SCRBundleExtension()
 {
   try {
     DisableAndRemoveAllComponentManagers();
-  } catch(...) {
+  } catch (...) {
     logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
-                "Exception while removing component managers for bundle " + 
-                bundle_.GetSymbolicName(), std::current_exception());
+                "Exception while removing component managers for bundle " +
+                  bundle_.GetSymbolicName(),
+                std::current_exception());
   }
   managers->clear();
   registry.reset();
@@ -122,7 +123,8 @@ void SCRBundleExtension::DisableAndRemoveAllComponentManagers()
     auto fut = compManager->Disable();
     registry->RemoveComponentManager(compManager);
     try {
-      fut.get(); // since this happens when the bundle is stopped. Wait until the disable is finished on the other thread.
+      fut
+        .get(); // since this happens when the bundle is stopped. Wait until the disable is finished on the other thread.
     } catch (...) {
       std::string errMsg("An exception occurred while disabling "
                          "component manager: ");

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -23,8 +23,8 @@
 #include "cppmicroservices/SecurityException.h"
 #include "cppmicroservices/SharedLibraryException.h"
 
-#include "BundleOrPrototypeComponentConfiguration.hpp"
 #include "../ComponentRegistry.hpp"
+#include "BundleOrPrototypeComponentConfiguration.hpp"
 #include "ComponentManager.hpp"
 
 namespace cppmicroservices {
@@ -44,7 +44,8 @@ BundleOrPrototypeComponentConfigurationImpl::
                                logger,
                                configNotifier,
                                managers)
-{}
+{
+}
 
 std::shared_ptr<ServiceFactory>
 BundleOrPrototypeComponentConfigurationImpl::GetFactory()
@@ -149,7 +150,9 @@ InterfaceMapConstPtr BundleOrPrototypeComponentConfigurationImpl::GetService(
   const cppmicroservices::ServiceRegistrationBase& registration)
 {
   // if activation passed, return the interface map from the instance
-  std::shared_ptr<cppmicroservices::service::component::detail::ComponentInstance> compInstance;
+  std::shared_ptr<
+    cppmicroservices::service::component::detail::ComponentInstance>
+    compInstance;
   try {
     compInstance = Activate(bundle);
   } catch (const cppmicroservices::SecurityException&) {
@@ -159,7 +162,8 @@ InterfaceMapConstPtr BundleOrPrototypeComponentConfigurationImpl::GetService(
     std::for_each(
       compMgrs.begin(),
       compMgrs.end(),
-      [this](const std::shared_ptr<cppmicroservices::scrimpl::ComponentManager>& compMgr) {
+      [this](const std::shared_ptr<cppmicroservices::scrimpl::ComponentManager>&
+               compMgr) {
         try {
           compMgr->Disable().get();
         } catch (...) {

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -204,20 +204,22 @@ void ComponentConfigurationImpl::Initialize()
       // were created before the factory component was started. If so, create the factory
       // component instances.
       if (!metadata->factoryComponentID.empty()) {
-        auto sr = this->bundle.GetBundleContext().GetServiceReference<
-            cppmicroservices::service::cm::ConfigurationAdmin>();
+        auto sr = this->bundle.GetBundleContext()
+                    .GetServiceReference<
+                      cppmicroservices::service::cm::ConfigurationAdmin>();
         if (!sr) {
           throw std::runtime_error("ComponentConfigurationImpl - Could not get "
-              "ConfigurationAdmin service reference");
+                                   "ConfigurationAdmin service reference");
         }
         auto configAdmin =
-           this->bundle.GetBundleContext()
+          this->bundle.GetBundleContext()
             .GetService<cppmicroservices::service::cm::ConfigurationAdmin>(sr);
         if (!configAdmin) {
           throw std::runtime_error("ComponentConfigurationImpl - Could not get "
                                    "ConfigurationAdmin service");
         }
-        auto configs = configAdmin->ListConfigurations("(pid=" + metadata->configurationPids[0] + "~*)");
+        auto configs = configAdmin->ListConfigurations(
+          "(pid=" + metadata->configurationPids[0] + "~*)");
         std::shared_ptr<ComponentConfigurationImpl> mgr = shared_from_this();
         if (!configs.empty()) {
           for (const auto& config : configs) {
@@ -336,7 +338,8 @@ public:
   SatisfiedFunctor(std::string skipKeyName)
     : state(true)
     , skipKey(std::move(skipKeyName))
-  {}
+  {
+  }
   SatisfiedFunctor(const SatisfiedFunctor& cpy) = default;
   SatisfiedFunctor(SatisfiedFunctor&& cpy) = default;
   SatisfiedFunctor& operator=(const SatisfiedFunctor& cpy) = default;
@@ -439,7 +442,7 @@ void ComponentConfigurationImpl::LoadComponentCreatorDestructor()
 {
   if (newCompInstanceFunc == nullptr || deleteCompInstanceFunc == nullptr) {
     auto instanceName = GetMetadata()->instanceName;
-    
+
     std::tie(newCompInstanceFunc, deleteCompInstanceFunc) =
       GetComponentCreatorDeletors(instanceName, GetBundle(), logger);
   }

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
@@ -22,8 +22,8 @@
 
 #include "ComponentManagerImpl.hpp"
 #include "ConcurrencyUtil.hpp"
-#include "cppmicroservices/SharedLibraryException.h"
 #include "cppmicroservices/SecurityException.h"
+#include "cppmicroservices/SharedLibraryException.h"
 #include "states/CMDisabledState.hpp"
 #include "states/CMEnabledState.hpp"
 #include "states/ComponentManagerState.hpp"

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
@@ -20,11 +20,11 @@
 
   =============================================================================*/
 
+#include "ConfigurationNotifier.hpp"
 #include "../ComponentRegistry.hpp"
 #include "../metadata/ComponentMetadata.hpp"
 #include "ComponentConfigurationImpl.hpp"
 #include "ComponentManagerImpl.hpp"
-#include "ConfigurationNotifier.hpp"
 #include "cppmicroservices/SecurityException.h"
 #include "cppmicroservices/SharedLibraryException.h"
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
@@ -154,7 +154,7 @@ void ConfigurationNotifier::CreateFactoryComponent(
   // component except the factory component itself.
   newMetadata->configurationPids.clear();
   for (const auto& basePid : oldMetadata->configurationPids) {
-    if (basePid != oldMetadata->configurationPids[0])  {
+    if (basePid != oldMetadata->configurationPids[0]) {
       newMetadata->configurationPids.emplace_back(basePid);
     }
   }

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
@@ -69,7 +69,8 @@ ReferenceManagerBaseImpl::ReferenceManagerBaseImpl(
       logger,
       configName,
       CreateBindingPolicy(*this, metadata.policy, metadata.policyOption))
-{}
+{
+}
 
 ReferenceManagerBaseImpl::ReferenceManagerBaseImpl(
   const metadata::ReferenceMetadata& metadata,
@@ -276,7 +277,8 @@ void ReferenceManagerBaseImpl::BatchNotifyAllListeners(
         listenerPair.second(notification);
       } catch (...) {
         logger->Log(SeverityLevel::LOG_ERROR,
-                    "Exception caught while notifying service reference listeners for reference name " +
+                    "Exception caught while notifying service reference "
+                    "listeners for reference name " +
                       notification.senderName,
                     std::current_exception());
       }

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -21,8 +21,8 @@
   =============================================================================*/
 
 #include "SingletonComponentConfiguration.hpp"
-#include "ComponentManager.hpp"
 #include "../ComponentRegistry.hpp"
+#include "ComponentManager.hpp"
 #include "ReferenceManager.hpp"
 #include "ReferenceManagerImpl.hpp"
 #include "RegistrationManager.hpp"
@@ -53,7 +53,8 @@ SingletonComponentConfigurationImpl::SingletonComponentConfigurationImpl(
                                logger,
                                configNotifier,
                                managers)
-{}
+{
+}
 
 std::shared_ptr<ServiceFactory>
 SingletonComponentConfigurationImpl::GetFactory()
@@ -151,14 +152,20 @@ InterfaceMapConstPtr SingletonComponentConfigurationImpl::GetService(
   const cppmicroservices::ServiceRegistrationBase& registration)
 {
   // if activation passed, return the interface map from the instance
-  std::shared_ptr<cppmicroservices::service::component::detail::ComponentInstance> compInstance;
+  std::shared_ptr<
+    cppmicroservices::service::component::detail::ComponentInstance>
+    compInstance;
   try {
     compInstance = Activate(bundle);
   } catch (const cppmicroservices::SecurityException&) {
     auto compManagerRegistry = GetRegistry();
-    auto compMgrs = compManagerRegistry->GetComponentManagers(registration.GetReference().GetBundle().GetBundleId());
-    std::for_each(compMgrs.begin(),
-                  compMgrs.end(), [this](const std::shared_ptr<cppmicroservices::scrimpl::ComponentManager>& compMgr) {
+    auto compMgrs = compManagerRegistry->GetComponentManagers(
+      registration.GetReference().GetBundle().GetBundleId());
+    std::for_each(
+      compMgrs.begin(),
+      compMgrs.end(),
+      [this](const std::shared_ptr<cppmicroservices::scrimpl::ComponentManager>&
+               compMgr) {
         try {
           compMgr->Disable().get();
         } catch (...) {

--- a/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCRegisteredState.cpp
@@ -37,13 +37,14 @@ CCRegisteredState::CCRegisteredState()
 
 CCRegisteredState::CCRegisteredState(std::shared_future<void> blockUntil)
   : ready(std::move(blockUntil))
-{}
+{
+}
 
 std::shared_ptr<ComponentInstance> CCRegisteredState::Activate(
   ComponentConfigurationImpl& mgr,
   const cppmicroservices::Bundle& clientBundle)
 {
- 
+
   auto activeState = std::make_shared<CCActiveState>();
   auto currState = shared_from_this();
   bool success = false;

--- a/compendium/DeclarativeServices/src/manager/states/CCSatisfiedState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCSatisfiedState.cpp
@@ -36,7 +36,7 @@ CCSatisfiedState::CCSatisfiedState()
 
 void CCSatisfiedState::Deactivate(ComponentConfigurationImpl& mgr)
 {
-  
+
   auto currentState = shared_from_this();
   std::packaged_task<void(void)> task([&mgr]() {
     mgr.UnregisterService();

--- a/compendium/DeclarativeServices/src/manager/states/CCUnsatisfiedReferenceState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCUnsatisfiedReferenceState.cpp
@@ -39,7 +39,8 @@ CCUnsatisfiedReferenceState::CCUnsatisfiedReferenceState()
 CCUnsatisfiedReferenceState::CCUnsatisfiedReferenceState(
   std::shared_future<void> blockUntil)
   : ready(std::move(blockUntil))
-{}
+{
+}
 
 void CCUnsatisfiedReferenceState::Register(ComponentConfigurationImpl& mgr)
 {

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
@@ -24,8 +24,8 @@
 #include "../ComponentConfigurationFactory.hpp"
 #include "../ComponentManagerImpl.hpp"
 #include "CMDisabledState.hpp"
-#include "cppmicroservices/SharedLibraryException.h"
 #include "cppmicroservices/SecurityException.h"
+#include "cppmicroservices/SharedLibraryException.h"
 
 namespace cppmicroservices {
 namespace scrimpl {

--- a/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
@@ -154,7 +154,7 @@ MetadataParserImplV1::CreateComponentMetadata(const AnyMap& metadata) const
   object = ObjectValidator(metadata, "configuration-pid", /*isOptional=*/true);
   if (object.KeyExists()) {
     configPid = true;
-    if (configPolicy ) {
+    if (configPolicy) {
       const auto configPids =
         object.GetValue<std::vector<cppmicroservices::Any>>();
       std::transform(

--- a/compendium/DeclarativeServices/test/ActivatorTest.cpp
+++ b/compendium/DeclarativeServices/test/ActivatorTest.cpp
@@ -48,7 +48,8 @@ class ActivatorTest : public ::testing::Test
 protected:
   ActivatorTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~ActivatorTest() = default;
 

--- a/compendium/DeclarativeServices/test/SCRLoggerTest.cpp
+++ b/compendium/DeclarativeServices/test/SCRLoggerTest.cpp
@@ -44,7 +44,8 @@ class SCRLoggerTest : public ::testing::Test
 protected:
   SCRLoggerTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~SCRLoggerTest() = default;
 
   virtual void SetUp() { framework.Start(); }

--- a/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/test/TestAsyncWorkService.cpp
@@ -56,7 +56,8 @@ class TestAsyncWorkServiceEndToEnd
 public:
   TestAsyncWorkServiceEndToEnd()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   void SetUp() override
   {
@@ -86,7 +87,8 @@ class AsyncWorkServiceInline : public cppmicroservices::async::AsyncWorkService
 public:
   AsyncWorkServiceInline()
     : cppmicroservices::async::AsyncWorkService()
-  {}
+  {
+  }
 
   void post(std::packaged_task<void()>&& task) override { task(); }
 };
@@ -97,7 +99,8 @@ class AsyncWorkServiceStdAsync
 public:
   AsyncWorkServiceStdAsync()
     : cppmicroservices::async::AsyncWorkService()
-  {}
+  {
+  }
 
   void post(std::packaged_task<void()>&& task) override
   {

--- a/compendium/DeclarativeServices/test/TestBindingPolicies.cpp
+++ b/compendium/DeclarativeServices/test/TestBindingPolicies.cpp
@@ -74,7 +74,8 @@ class InterfaceImpl : public Interface1
 public:
   InterfaceImpl(std::string str)
     : str_(std::move(str))
-  {}
+  {
+  }
   virtual ~InterfaceImpl() = default;
   virtual std::string Description() { return str_; }
 
@@ -105,7 +106,8 @@ class BindingPolicyTest : public ::testing::TestWithParam<Policy>
 protected:
   BindingPolicyTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~BindingPolicyTest() = default;
 
@@ -152,7 +154,8 @@ class DynamicRefPolicyTest : public ::testing::TestWithParam<DynamicRefPolicy>
 protected:
   DynamicRefPolicyTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~DynamicRefPolicyTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestBundleStartOrder.cpp
+++ b/compendium/DeclarativeServices/test/TestBundleStartOrder.cpp
@@ -47,7 +47,8 @@ protected:
   TestBundleStartOrder()
     : ::testing::Test()
     , framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~TestBundleStartOrder() = default;
 
   virtual void SetUp() { framework.Start(); }
@@ -66,7 +67,8 @@ class BundleName final
 public:
   BundleName(std::string name)
     : lookingFor(std::move(name))
-  {}
+  {
+  }
 
   ~BundleName() = default;
 

--- a/compendium/DeclarativeServices/test/TestBundleValidation.cpp
+++ b/compendium/DeclarativeServices/test/TestBundleValidation.cpp
@@ -29,8 +29,8 @@ limitations under the License.
 #include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/SecurityException.h"
 
-#include "cppmicroservices/cm/ConfigurationAdmin.hpp"
 #include "cppmicroservices/cm/Configuration.hpp"
+#include "cppmicroservices/cm/ConfigurationAdmin.hpp"
 
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
@@ -42,10 +42,12 @@ limitations under the License.
 
 TEST(TestBundleValidation, BundleValidationFailure)
 {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle& b) -> bool {
-    if (b.GetSymbolicName() == "declarative_services" || 
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle& b) -> bool {
+    if (b.GetSymbolicName() == "declarative_services" ||
         b.GetSymbolicName() == "configuration_admin") {
       return true;
     }
@@ -62,8 +64,9 @@ TEST(TestBundleValidation, BundleValidationFailure)
 
   test::InstallAndStartDS(f.GetBundleContext());
 
-  auto sDSSvcRef =
-    f.GetBundleContext().GetServiceReference<cppmicroservices::service::component::runtime::ServiceComponentRuntime>();
+  auto sDSSvcRef = f.GetBundleContext()
+                     .GetServiceReference<cppmicroservices::service::component::
+                                            runtime::ServiceComponentRuntime>();
   ASSERT_TRUE(sDSSvcRef);
   auto dsRuntimeService =
     f.GetBundleContext()
@@ -99,20 +102,24 @@ TEST(TestBundleValidation, BundleValidationFailure)
     });
 
   ASSERT_NO_THROW(bundleIter->Start());
-  
+
   struct Interface1Impl final : public test::Interface1
   {
     std::string Description() override { return "foo"; }
   };
-  auto Interface1SvcReg = f.GetBundleContext().RegisterService<test::Interface1>(std::make_shared<Interface1Impl>());
+  auto Interface1SvcReg =
+    f.GetBundleContext().RegisterService<test::Interface1>(
+      std::make_shared<Interface1Impl>());
 
   auto svcRef = f.GetBundleContext().GetServiceReference<test::Interface2>();
   ASSERT_TRUE(svcRef);
-  ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef), cppmicroservices::SecurityException);
+  ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef),
+               cppmicroservices::SecurityException);
 
   // a bundle validation function which returns false must cause the
   // service component not to be enabled
-  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(*bundleIter, "sample::ServiceComponent6");
+  auto compDesc = dsRuntimeService->GetComponentDescriptionDTO(
+    *bundleIter, "sample::ServiceComponent6");
   ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
 
   // delayed components won't throw when enabled. they should throw on first
@@ -125,7 +132,8 @@ TEST(TestBundleValidation, BundleValidationFailure)
   ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef),
                cppmicroservices::SecurityException);
 
-  compDesc = dsRuntimeService->GetComponentDescriptionDTO(*bundleIter, "sample::ServiceComponent6");
+  compDesc = dsRuntimeService->GetComponentDescriptionDTO(
+    *bundleIter, "sample::ServiceComponent6");
   ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
   Interface1SvcReg.Unregister();
 
@@ -150,11 +158,11 @@ TEST(TestBundleValidation, BundleValidationFailure)
     std::make_shared<Interface1Impl>());
   svcRef = f.GetBundleContext().GetServiceReference<test::Interface2>();
   ASSERT_TRUE(svcRef);
-  ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef), cppmicroservices::SecurityException);
+  ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef),
+               cppmicroservices::SecurityException);
   ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
   auto enableCompFuture = dsRuntimeService->EnableComponent(compDesc);
-  ASSERT_THROW(enableCompFuture.get(),
-               cppmicroservices::SecurityException);
+  ASSERT_THROW(enableCompFuture.get(), cppmicroservices::SecurityException);
   Interface1SvcReg.Unregister();
 
   // test starting a prototype scope service component
@@ -193,14 +201,15 @@ TEST(TestBundleValidation, BundleValidationFailure)
 
   auto sCMSvcRef =
     f.GetBundleContext()
-                     .GetServiceReference<cppmicroservices::service::cm::ConfigurationAdmin>();
+      .GetServiceReference<cppmicroservices::service::cm::ConfigurationAdmin>();
   ASSERT_TRUE(sCMSvcRef);
   auto cmRuntimeService =
     f.GetBundleContext()
       .GetService<cppmicroservices::service::cm::ConfigurationAdmin>(sCMSvcRef);
   ASSERT_TRUE(cmRuntimeService);
 
-  auto config = cmRuntimeService->GetConfiguration("sample::ServiceComponentCA02");
+  auto config =
+    cmRuntimeService->GetConfiguration("sample::ServiceComponentCA02");
   cppmicroservices::AnyMap configObj(cppmicroservices::AnyMap::UNORDERED_MAP);
   configObj["foo"] = std::string("bar");
   auto updateFuture = config->Update(configObj);
@@ -219,7 +228,6 @@ TEST(TestBundleValidation, BundleValidationFailure)
     *bundleIter, "sample::ServiceComponentCA02");
   ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
   config->Remove().get();
-
 
   // test starting an immediate activation ds component with a required configuration policy
   test::InstallLib(f.GetBundleContext(), "TestBundleDSCA03");
@@ -251,18 +259,17 @@ TEST(TestBundleValidation, BundleValidationFailure)
     *bundleIter, "sample::ServiceComponentCA03");
   ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
 
-
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 
 TEST(TestBundleValidation, BundleValidationSuccess)
 {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle&) -> bool {
-    return true;
-  };
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle&) -> bool { return true; };
   cppmicroservices::FrameworkConfiguration configuration{
     { cppmicroservices::Constants::FRAMEWORK_BUNDLE_VALIDATION_FUNC,
       validationFunc }
@@ -285,7 +292,8 @@ TEST(TestBundleValidation, BundleValidationSuccess)
   // a bundle validation function which returns true must cause the
   // Framework to start the bundle and it should be loaded
   // into the process.
-  ASSERT_EQ(bundleIter->GetState(), cppmicroservices::Bundle::State::STATE_ACTIVE);
+  ASSERT_EQ(bundleIter->GetState(),
+            cppmicroservices::Bundle::State::STATE_ACTIVE);
 
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
@@ -293,9 +301,11 @@ TEST(TestBundleValidation, BundleValidationSuccess)
 
 TEST(TestBundleValidation, BundleValidationFunctionException)
 {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle& b) -> bool {
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle& b) -> bool {
     if (b.GetSymbolicName() == "declarative_services") {
       return true;
     }
@@ -313,7 +323,8 @@ TEST(TestBundleValidation, BundleValidationFunctionException)
   bool receivedBundleValidationErrorEvent{ false };
   bool receivedSecondBundleValidationErrorEvent{ false };
   auto token = f.GetBundleContext().AddFrameworkListener(
-    [&receivedBundleValidationErrorEvent, &receivedSecondBundleValidationErrorEvent](
+    [&receivedBundleValidationErrorEvent,
+     &receivedSecondBundleValidationErrorEvent](
       const cppmicroservices::FrameworkEvent& evt) {
       if (evt.GetType() ==
             cppmicroservices::FrameworkEvent::Type::FRAMEWORK_ERROR &&

--- a/compendium/DeclarativeServices/test/TestCCActiveState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCActiveState.cpp
@@ -43,7 +43,8 @@ class CCActiveStateTest : public ::testing::Test
 protected:
   CCActiveStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~CCActiveStateTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestCCRegisteredState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCRegisteredState.cpp
@@ -40,7 +40,8 @@ class CCRegisteredStateTest : public ::testing::Test
 protected:
   CCRegisteredStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~CCRegisteredStateTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestCCUnsatisfiedReferenceState.cpp
+++ b/compendium/DeclarativeServices/test/TestCCUnsatisfiedReferenceState.cpp
@@ -40,7 +40,8 @@ class CCUnsatisfiedReferenceStateTest : public ::testing::Test
 protected:
   CCUnsatisfiedReferenceStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~CCUnsatisfiedReferenceStateTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentConfigurationImpl.cpp
@@ -52,7 +52,8 @@ class ComponentConfigurationImplTest : public ::testing::Test
 protected:
   ComponentConfigurationImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~ComponentConfigurationImplTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentContextImpl.cpp
@@ -55,7 +55,8 @@ class ComponentContextImplTest : public ::testing::Test
 protected:
   ComponentContextImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~ComponentContextImplTest() = default;
 
   virtual void SetUp() { framework.Start(); }

--- a/compendium/DeclarativeServices/test/TestComponentManagerDisabledState.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerDisabledState.cpp
@@ -36,7 +36,8 @@ class CMDisabledStateTest : public ::testing::Test
 protected:
   CMDisabledStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~CMDisabledStateTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestComponentManagerEnabledState.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerEnabledState.cpp
@@ -40,7 +40,8 @@ class CMEnabledStateTest : public ::testing::Test
 protected:
   CMEnabledStateTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~CMEnabledStateTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentManagerImpl.cpp
@@ -134,7 +134,8 @@ class ComponentManagerImplParameterizedTest
 protected:
   ComponentManagerImplParameterizedTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~ComponentManagerImplParameterizedTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
+++ b/compendium/DeclarativeServices/test/TestComponentRegistry.cpp
@@ -61,7 +61,8 @@ public:
     : ComponentManager()
     , mBundleId(++id)
     , mName(GenRandomString())
-  {}
+  {
+  }
   ~FakeComponentManager(){};
   unsigned long GetBundleId() const override { return mBundleId; }
   std::string GetName() const override { return mName; }
@@ -91,7 +92,8 @@ protected:
   ComponentRegistryTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
     , registry(std::make_shared<ComponentRegistry>())
-  {}
+  {
+  }
   virtual ~ComponentRegistryTest() = default;
 
   virtual void SetUp()

--- a/compendium/DeclarativeServices/test/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/TestFactoryPid.cpp
@@ -110,7 +110,6 @@ TEST_F(tServiceComponent, testFactoryPidConstructionNameDifferentThanClass)
   std::string configurationPid = "ServiceComponentPid";
   cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSCA21");
 
-  
   // Get a service reference to ConfigAdmin to create the factory component instance.
   auto configAdminService =
     GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
@@ -131,13 +130,11 @@ TEST_F(tServiceComponent, testFactoryPidConstructionNameDifferentThanClass)
   props["uniqueProp"] = instanceId;
   auto fut = factoryConfig->Update(props);
   fut.get();
-  
+
   //Request a service reference to the new component instance. This will
   //cause DS to construct the instance with the updated properties.
   auto instance = GetInstance<test::CAInterface>();
   ASSERT_TRUE(instance) << "GetService failed for CAInterface";
-
-
 }
 
 /* testFactoryConfigBeforeInstall
@@ -153,7 +150,7 @@ TEST_F(tServiceComponent, testFactoryConfigBeforeInstall)
 
   // Get a service reference to ConfigAdmin to create the factory component instances.
   auto configAdminService =
-      GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
+    GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
   ASSERT_TRUE(configAdminService) << "GetService failed for ConfigurationAdmin";
 
   // Create some factory configuration objects.
@@ -161,25 +158,24 @@ TEST_F(tServiceComponent, testFactoryConfigBeforeInstall)
   for (int i = 0; i < count; i++) {
     // Create the factory configuration object
     auto factoryConfig =
-        configAdminService->CreateFactoryConfiguration(configurationPid);
-    
+      configAdminService->CreateFactoryConfiguration(configurationPid);
+
     // Update the properties for the factory configuration object
     cppmicroservices::AnyMap props(
-        cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
-    const std::string instanceId{ "instance" + std::to_string(i)};
+      cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+    const std::string instanceId{ "instance" + std::to_string(i) };
     props["uniqueProp"] = instanceId;
     auto fut = factoryConfig->Update(props);
     fut.get();
   }
 
   // Start the test bundle containing the factory component. This will
-  // cause DS to register the factory instances. 
+  // cause DS to register the factory instances.
   cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSCA21");
-   
+
   //Request service references to the new component instances. This will
   //cause DS to construct the factory instances.
   auto instances = GetInstances<test::CAInterface>();
   EXPECT_EQ(instances.size(), count);
- }
 }
-
+}

--- a/compendium/DeclarativeServices/test/TestFailedBoundServiceActivation.cpp
+++ b/compendium/DeclarativeServices/test/TestFailedBoundServiceActivation.cpp
@@ -40,7 +40,8 @@ class FailedBoundServiceActivationTest
 public:
   FailedBoundServiceActivationTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   void SetUp() override
   {

--- a/compendium/DeclarativeServices/test/TestMetadataParserImplV1.cpp
+++ b/compendium/DeclarativeServices/test/TestMetadataParserImplV1.cpp
@@ -87,7 +87,8 @@ class MetadataParserImplV1Test : public ::testing::Test
 protected:
   MetadataParserImplV1Test()
     : logger(std::make_shared<FakeLogger>())
-  {}
+  {
+  }
   ~MetadataParserImplV1Test() = default;
   std::shared_ptr<FakeLogger> logger;
 
@@ -174,7 +175,8 @@ struct MetadataInvalidManifestState
     : manifestName(std::move(manifestName))
     , errorOutput(std::move(_errorOutput))
     , isPartial(_isPartial)
-  {}
+  {
+  }
 
   std::string manifestName;
   std::string errorOutput;
@@ -199,7 +201,8 @@ protected:
 
   InvalidMetadataTest()
     : logger(std::make_shared<FakeLogger>())
-  {}
+  {
+  }
 
   ~InvalidMetadataTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestReferenceManagerImpl.cpp
@@ -77,7 +77,8 @@ class ReferenceManagerImplTest
 protected:
   ReferenceManagerImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~ReferenceManagerImplTest() = default;
 
   virtual void SetUp() { framework.Start(); }

--- a/compendium/DeclarativeServices/test/TestReferenceMetadataParserV1.cpp
+++ b/compendium/DeclarativeServices/test/TestReferenceMetadataParserV1.cpp
@@ -70,7 +70,8 @@ struct ReferenceMetadataParserValidState
     , target(_target)
     , minCardinality(_minCardinality)
     , maxCardinality(_maxCardinality)
-  {}
+  {
+  }
 
   std::size_t metadataIndex;
   std::string interface;
@@ -325,7 +326,8 @@ struct ReferenceMetadataParserInvalidState
     : metadataIndex(_metadataIndex)
     , errorOutput(_errorOutput)
     , isPartial(_isPartial)
-  {}
+  {
+  }
 
   std::size_t metadataIndex;
   std::string errorOutput;

--- a/compendium/DeclarativeServices/test/TestRegistrationManager.cpp
+++ b/compendium/DeclarativeServices/test/TestRegistrationManager.cpp
@@ -90,7 +90,8 @@ class RegistrationManagerTest : public ::testing::Test
 protected:
   RegistrationManagerTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~RegistrationManagerTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestSCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/test/TestSCRBundleExtension.cpp
@@ -49,7 +49,8 @@ class SCRBundleExtensionTest : public ::testing::Test
 protected:
   SCRBundleExtensionTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~SCRBundleExtensionTest() = default;
 
   void SetUp() override { framework.Start(); }
@@ -171,35 +172,32 @@ TEST_F(SCRBundleExtensionTest, CtorWithValidArgs)
 
 // Simulate a DS bundle is stopped before DS is able to cleanup the data associated
 // with the bundle.
-TEST_F(SCRBundleExtensionTest, DtorNoThrow) {
-    auto bundle = test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI1");
-      ASSERT_TRUE(static_cast<bool>(bundle));
-      auto fakeRegistry = std::make_shared<ComponentRegistry>();
-      auto fakeLogger = std::make_shared<FakeLogger>();
-      auto asyncWorkService =
-        std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
-          GetFramework().GetBundleContext(), fakeLogger);
-      auto notifier = std::make_shared<ConfigurationNotifier>(
-        GetFramework().GetBundleContext(), fakeLogger, asyncWorkService);
-      auto const& headers = ref_any_cast<cppmicroservices::AnyMap>(
-        bundle.GetHeaders().at("scr"));
-    
-    EXPECT_NO_THROW(
-    {
-      SCRBundleExtension bundleExt(bundle,
-                                   headers,
-                                   fakeRegistry,
-                                   fakeLogger,
-                                   asyncWorkService,
-                                   notifier);
-      // stop the bundle prior to ~SCRBundleExtension being called. ~SCRBundleExtension
-      // attempts to access the Bundle object, so make sure accessing an invalid
-      // Bundle object doesn't throw.
-      bundle.Stop();
-    });
+TEST_F(SCRBundleExtensionTest, DtorNoThrow)
+{
+  auto bundle = test::InstallAndStartBundle(GetFramework().GetBundleContext(),
+                                            "TestBundleDSTOI1");
+  ASSERT_TRUE(static_cast<bool>(bundle));
+  auto fakeRegistry = std::make_shared<ComponentRegistry>();
+  auto fakeLogger = std::make_shared<FakeLogger>();
+  auto asyncWorkService =
+    std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
+      GetFramework().GetBundleContext(), fakeLogger);
+  auto notifier = std::make_shared<ConfigurationNotifier>(
+    GetFramework().GetBundleContext(), fakeLogger, asyncWorkService);
+  auto const& headers =
+    ref_any_cast<cppmicroservices::AnyMap>(bundle.GetHeaders().at("scr"));
 
-    asyncWorkService->StopTracking();
-    fakeRegistry->Clear();
+  EXPECT_NO_THROW({
+    SCRBundleExtension bundleExt(
+      bundle, headers, fakeRegistry, fakeLogger, asyncWorkService, notifier);
+    // stop the bundle prior to ~SCRBundleExtension being called. ~SCRBundleExtension
+    // attempts to access the Bundle object, so make sure accessing an invalid
+    // Bundle object doesn't throw.
+    bundle.Stop();
+  });
+
+  asyncWorkService->StopTracking();
+  fakeRegistry->Clear();
 }
 }
 }

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntime.cpp
@@ -44,7 +44,8 @@ protected:
   TestServiceComponentRuntime()
     : ::testing::Test()
     , framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~TestServiceComponentRuntime() = default;
 
   virtual void SetUp() { framework.Start(); }

--- a/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceComponentRuntimeImpl.cpp
@@ -36,7 +36,8 @@ class ServiceComponentRuntimeImplTest : public ::testing::Test
 protected:
   ServiceComponentRuntimeImplTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~ServiceComponentRuntimeImplTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestServiceMetadataParserV1.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceMetadataParserV1.cpp
@@ -54,7 +54,8 @@ struct ServiceMetadataParserValidState
     : metadataIndex(_metadataIndex)
     , serviceScope(_serviceScope)
     , interfaces(_interfaces)
-  {}
+  {
+  }
 
   std::size_t metadataIndex;
   std::string serviceScope;
@@ -159,7 +160,8 @@ struct ServiceMetadataParserInvalidState
     : metadataIndex(_metadataIndex)
     , errorOutput(_errorOutput)
     , isPartial(_isPartial)
-  {}
+  {
+  }
 
   std::size_t metadataIndex;
   std::string errorOutput;

--- a/compendium/DeclarativeServices/test/TestServiceProvider.cpp
+++ b/compendium/DeclarativeServices/test/TestServiceProvider.cpp
@@ -20,8 +20,8 @@
 
 =============================================================================*/
 
-#include "TestFixture.hpp"
 #include "ConcurrencyTestUtil.hpp"
+#include "TestFixture.hpp"
 #include "TestInterfaces/Interfaces.hpp"
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/ServiceObjects.h"
@@ -298,16 +298,19 @@ TEST_F(tServiceComponent, testMultipleInterfaces) //DS_TOI_16
  *  containing the exception with the Log Service, if present, and the
  *  component configuration is not activated.
  */
-TEST_F(tServiceComponent, testServiceCtorThrow) {
+TEST_F(tServiceComponent, testServiceCtorThrow)
+{
   auto bundle = test::InstallAndStartBundle(framework.GetBundleContext(),
-                              "TestBundleDSUpstreamDependencyA");
+                                            "TestBundleDSUpstreamDependencyA");
   auto compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(
     bundle, "dependent::TestBundleDSUpstreamDependencyImpl");
 
-  auto compConfigDTO = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
+  auto compConfigDTO =
+    dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(compConfigDTO.size(), 1);
-  EXPECT_EQ(compConfigDTO[0].state, cppmicroservices::service::component::runtime::
-                                 dto::ComponentState::SATISFIED);
+  EXPECT_EQ(compConfigDTO[0].state,
+            cppmicroservices::service::component::runtime::dto::ComponentState::
+              SATISFIED);
 
   auto ctxt = framework.GetBundleContext();
   auto sRef = ctxt.GetServiceReference<test::TestBundleDSUpstreamDependency>();
@@ -318,23 +321,27 @@ TEST_F(tServiceComponent, testServiceCtorThrow) {
   // the component configuration must not be active.
   compConfigDTO = dsRuntimeService->GetComponentConfigurationDTOs(compDescDTO);
   EXPECT_EQ(compConfigDTO.size(), 1);
-  EXPECT_EQ(compConfigDTO[0].state, cppmicroservices::service::component::runtime::
-                                 dto::ComponentState::SATISFIED);
+  EXPECT_EQ(compConfigDTO[0].state,
+            cppmicroservices::service::component::runtime::dto::ComponentState::
+              SATISFIED);
 }
 
-TEST_F(tServiceComponent, testConcurrentGetServiceOnLazilyLoadedService) {
+TEST_F(tServiceComponent, testConcurrentGetServiceOnLazilyLoadedService)
+{
   auto bundle = test::InstallAndStartBundle(framework.GetBundleContext(),
                                             "TestBundleDSTOI16");
   ASSERT_TRUE(bundle);
 
-  std::function<cppmicroservices::InterfaceMapConstPtr()> func = [&bundle]() { 
-      auto context = bundle.GetBundleContext();
-      std::vector<cppmicroservices::ServiceReferenceU> serviceReferences = bundle.GetRegisteredServices();
-      return context.GetService(serviceReferences.front());
+  std::function<cppmicroservices::InterfaceMapConstPtr()> func = [&bundle]() {
+    auto context = bundle.GetBundleContext();
+    std::vector<cppmicroservices::ServiceReferenceU> serviceReferences =
+      bundle.GetRegisteredServices();
+    return context.GetService(serviceReferences.front());
   };
   auto results = ConcurrentInvoke(func);
-  ASSERT_TRUE(std::all_of(results.begin(),
-                          results.end(),
+  ASSERT_TRUE(
+    std::all_of(results.begin(),
+                results.end(),
                 [](cppmicroservices::InterfaceMapConstPtr& p) { return !!p; }));
 
   bundle.Uninstall();

--- a/compendium/DeclarativeServices/test/TestSharedLibraryException.cpp
+++ b/compendium/DeclarativeServices/test/TestSharedLibraryException.cpp
@@ -45,7 +45,8 @@ class SharedLibraryExceptionTest : public ::testing::Test
 protected:
   SharedLibraryExceptionTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~SharedLibraryExceptionTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/TestSingletonComponentConfiguration.cpp
@@ -39,7 +39,8 @@ class SingletonComponentConfigurationTest : public ::testing::Test
 protected:
   SingletonComponentConfigurationTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~SingletonComponentConfigurationTest() = default;
 

--- a/compendium/DeclarativeServices/test/TestUpdateConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/TestUpdateConfiguration.cpp
@@ -87,28 +87,30 @@ TEST_F(tServiceComponent, testConcurrentUpdateConfigAndActivateService)
     GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
   ASSERT_TRUE(configAdminService)
     << "GetService failed for ConfigurationAdmin.";
-  
+
   std::promise<void> go;
   std::shared_future<void> ready(go.get_future());
   std::vector<std::promise<void>> readies(2);
 
-  auto updateConfigFuture = std::async(std::launch::async, [&ready, &readies, &configAdminService]() {
+  auto updateConfigFuture =
+    std::async(std::launch::async, [&ready, &readies, &configAdminService]() {
       readies[0].set_value();
       ready.wait();
-    auto configuration =
-      configAdminService->GetConfiguration("sample::ServiceComponentCA02");
-    configuration->UpdateIfDifferent(
-      std::unordered_map<std::string, cppmicroservices::Any>{
-        { "foo", true } });
-  });
+      auto configuration =
+        configAdminService->GetConfiguration("sample::ServiceComponentCA02");
+      configuration->UpdateIfDifferent(
+        std::unordered_map<std::string, cppmicroservices::Any>{
+          { "foo", true } });
+    });
 
-  auto activateServiceFuture = std::async(std::launch::async, [this, &ready, &readies, &ctx]() {
+  auto activateServiceFuture =
+    std::async(std::launch::async, [this, &ready, &readies, &ctx]() {
       readies[1].set_value();
       ready.wait();
-    auto testBundle = ::test::InstallAndStartBundle(ctx, "TestBundleDSCA02");
-    ASSERT_TRUE(testBundle);
-    auto instance = GetInstance<test::CAInterface>();
-  });
+      auto testBundle = ::test::InstallAndStartBundle(ctx, "TestBundleDSCA02");
+      ASSERT_TRUE(testBundle);
+      auto instance = GetInstance<test::CAInterface>();
+    });
 
   readies[0].get_future().wait();
   readies[1].get_future().wait();
@@ -134,25 +136,28 @@ TEST_F(tServiceComponent, testActivateServiceWithEmptyConfigProps)
     << "GetService failed for ConfigurationAdmin.";
 
   auto configuration =
-        configAdminService->GetConfiguration("sample::ServiceComponentCA02");
+    configAdminService->GetConfiguration("sample::ServiceComponentCA02");
 
   auto testBundle = ::test::InstallAndStartBundle(ctx, "TestBundleDSCA02");
   ASSERT_TRUE(testBundle);
 
   scr::dto::ComponentDescriptionDTO compDescDTO;
-  auto compConfigs = GetComponentConfigs(testBundle, svcComponentName, compDescDTO);
+  auto compConfigs =
+    GetComponentConfigs(testBundle, svcComponentName, compDescDTO);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";
   EXPECT_EQ(compConfigs.at(0).state,
             scr::dto::ComponentState::UNSATISFIED_REFERENCE)
     << "UNSATISFIED_REFERENCE is expected because configuration object is not "
        "created.";
-  
-  auto instance = GetInstance<test::CAInterface>();
-  ASSERT_FALSE(instance) << "GetService returned a valid service with an empty config for CAInterface";
 
-  configuration->UpdateIfDifferent(
-        std::unordered_map<std::string, cppmicroservices::Any>{
-          { "foo", true } }).second.get();
+  auto instance = GetInstance<test::CAInterface>();
+  ASSERT_FALSE(instance) << "GetService returned a valid service with an empty "
+                            "config for CAInterface";
+
+  configuration
+    ->UpdateIfDifferent(
+      std::unordered_map<std::string, cppmicroservices::Any>{ { "foo", true } })
+    .second.get();
 
   compConfigs = GetComponentConfigs(testBundle, svcComponentName, compDescDTO);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected.";
@@ -160,7 +165,8 @@ TEST_F(tServiceComponent, testActivateServiceWithEmptyConfigProps)
     << "SATISFIED is exepected since configuration object is created.";
 
   instance = GetInstance<test::CAInterface>();
-  ASSERT_TRUE(instance) << "GetService failed to return a service for CAInterface";
+  ASSERT_TRUE(instance)
+    << "GetService failed to return a service for CAInterface";
 
   compConfigs = GetComponentConfigs(testBundle, svcComponentName, compDescDTO);
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected.";
@@ -229,7 +235,7 @@ TEST_F(tServiceComponent, testConfigObjectInManifestResolvesService)
            std::chrono::steady_clock::now() - startTime) <= TIMEOUT) {
     service = GetInstance<test::CAInterface>();
   }
-   ASSERT_TRUE(service) << "GetService failed for CAInterface";
+  ASSERT_TRUE(service) << "GetService failed for CAInterface";
 
   auto compConfigs =
     GetComponentConfigs(testBundle, componentName, compDescDTO);
@@ -298,8 +304,9 @@ TEST_F(tServiceComponent, testUpdateConfigBeforeStartingBundleAndManifest)
   ASSERT_TRUE(result);
 
   // GetService to make component active
-  std::shared_ptr<test::CAInterface> instance = GetInstance<test::CAInterface>();
- 
+  std::shared_ptr<test::CAInterface> instance =
+    GetInstance<test::CAInterface>();
+
   ASSERT_TRUE(instance) << "GetService failed for CAInterface";
 
   auto compConfigs =
@@ -307,7 +314,7 @@ TEST_F(tServiceComponent, testUpdateConfigBeforeStartingBundleAndManifest)
   EXPECT_EQ(compConfigs.size(), 1ul) << "One default config expected";
   ASSERT_EQ(compConfigs.at(0).state, scr::dto::ComponentState::ACTIVE)
     << "Component state should be ACTIVE";
-  
+
   testBundle.Stop();
 }
 /**

--- a/compendium/DeclarativeServices/test/TestUtils.cpp
+++ b/compendium/DeclarativeServices/test/TestUtils.cpp
@@ -154,7 +154,7 @@ void InstallAndStartConfigAdmin(::cppmicroservices::BundleContext frameworkCtx)
   std::vector<cppmicroservices::Bundle> bundles;
   auto cmPluginPath = test::GetConfigAdminRuntimePluginFilePath();
 
-  #if defined(US_BUILD_SHARED_LIBS)
+#if defined(US_BUILD_SHARED_LIBS)
   bundles = frameworkCtx.InstallBundles(cmPluginPath);
 #else
   bundles = frameworkCtx.GetBundles();

--- a/compendium/ServiceComponent/src/ComponentException.cpp
+++ b/compendium/ServiceComponent/src/ComponentException.cpp
@@ -27,11 +27,13 @@ namespace service {
 namespace component {
 ComponentException::ComponentException(const std::string& message)
   : std::runtime_error(message)
-{}
+{
+}
 
 ComponentException::ComponentException(const char* message)
   : std::runtime_error(message)
-{}
+{
+}
 
 ComponentException::~ComponentException() noexcept {}
 }

--- a/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
@@ -42,7 +42,8 @@ public:
   TestServiceImpl() = delete;
   TestServiceImpl(const std::shared_ptr<ServiceDependency>& d)
     : dep(d)
-  {}
+  {
+  }
   virtual ~TestServiceImpl() = default;
 
 private:

--- a/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
@@ -53,7 +53,8 @@ public:
                    const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
-  {}
+  {
+  }
 
   virtual ~TestServiceImpl1() = default;
 

--- a/compendium/ServiceComponent/test/TestCompInst_RefOrder.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_RefOrder.cpp
@@ -54,7 +54,8 @@ public:
                    const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
-  {}
+  {
+  }
 
   virtual ~TestServiceImpl1() = default;
 

--- a/compendium/ServiceComponent/test/TestComponentInstance.cpp
+++ b/compendium/ServiceComponent/test/TestComponentInstance.cpp
@@ -68,20 +68,23 @@ public:
     : foo(nullptr)
     , bar(nullptr)
     , activated(false)
-  {}
+  {
+  }
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency1>& f,
                    const std::shared_ptr<ServiceDependency2>& b)
     : foo(f)
     , bar(b)
     , activated(false)
-  {}
+  {
+  }
 
   TestServiceImpl1(const std::shared_ptr<ServiceDependency2>& b)
     : foo(nullptr)
     , bar(b)
     , activated(false)
-  {}
+  {
+  }
 
   virtual ~TestServiceImpl1() {}
 

--- a/compendium/test_bundles/DSGraph01/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph01/src/ServiceImpl.cpp
@@ -6,7 +6,8 @@ DSGraph01Impl::DSGraph01Impl(const std::shared_ptr<test::DSGraph02>& g02,
   : test::DSGraph01()
   , graph02(g02)
   , graph03(g03)
-{}
+{
+}
 
 DSGraph01Impl::~DSGraph01Impl() = default;
 

--- a/compendium/test_bundles/DSGraph02/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph02/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ DSGraph02Impl::DSGraph02Impl(const std::shared_ptr<test::DSGraph04>& g04,
                              const std::shared_ptr<test::DSGraph05>& g05)
   : graph04(g04)
   , graph05(g05)
-{}
+{
+}
 
 DSGraph02Impl::~DSGraph02Impl() = default;
 

--- a/compendium/test_bundles/DSGraph03/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph03/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ DSGraph03Impl::DSGraph03Impl(const std::shared_ptr<test::DSGraph06>& g06,
                              const std::shared_ptr<test::DSGraph07>& g07)
   : graph06(g06)
   , graph07(g07)
-{}
+{
+}
 
 DSGraph03Impl::~DSGraph03Impl() = default;
 

--- a/compendium/test_bundles/DSGraph04/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph04/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ DSGraph04Impl::~DSGraph04Impl() = default;
 
 DSGraph04Impl::DSGraph04Impl(const std::shared_ptr<test::DSGraph05>& g05)
   : graph05(g05)
-{}
+{
+}
 std::string DSGraph04Impl::Description()
 {
   return STRINGIZE(US_BUNDLE_NAME);

--- a/compendium/test_bundles/DSGraph05/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph05/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ DSGraph05Impl::~DSGraph05Impl() = default;
 
 DSGraph05Impl::DSGraph05Impl(const std::shared_ptr<test::DSGraph06>& g06)
   : graph06(g06)
-{}
+{
+}
 std::string DSGraph05Impl::Description()
 {
   return STRINGIZE(US_BUNDLE_NAME);

--- a/compendium/test_bundles/DSGraph06/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/DSGraph06/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ DSGraph06Impl::~DSGraph06Impl() = default;
 
 DSGraph06Impl::DSGraph06Impl(const std::shared_ptr<test::DSGraph07>& g07)
   : graph07(g07)
-{}
+{
+}
 std::string DSGraph06Impl::Description()
 {
   return STRINGIZE(US_BUNDLE_NAME);

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceFactoryServiceImpl.cpp
@@ -8,7 +8,8 @@ namespace test {
 TestManagedServiceFactoryServiceImpl::TestManagedServiceFactoryServiceImpl(
   int initialValue)
   : value{ initialValue }
-{}
+{
+}
 
 TestManagedServiceFactoryServiceImpl::~TestManagedServiceFactoryServiceImpl() =
   default;

--- a/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/ManagedServiceAndFactoryBundle/src/ManagedServiceImpl.cpp
@@ -10,7 +10,8 @@ namespace test {
 
 TestManagedServiceImpl::TestManagedServiceImpl()
   : m_counter{ 0 }
-{}
+{
+}
 
 TestManagedServiceImpl::~TestManagedServiceImpl() = default;
 

--- a/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSCA08/src/ServiceImpl.cpp
@@ -6,7 +6,8 @@ namespace sample {
 ServiceComponentCA08::ServiceComponentCA08(
   const std::shared_ptr<cppmicroservices::AnyMap>& props)
   : properties(props)
-{}
+{
+}
 void ServiceComponentCA08::Modified(
   const std::shared_ptr<ComponentContext>& /*context*/,
   const std::shared_ptr<cppmicroservices::AnyMap>& configuration)

--- a/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGMU/src/ServiceComponentDynamicGreedyMandatoryUnary.cpp
@@ -5,11 +5,13 @@ namespace sample {
 
 void ServiceComponentDynamicGreedyMandatoryUnary::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponentDynamicGreedyMandatoryUnary::Deactivate(
   const std::shared_ptr<ComponentContext>&)
-{}
+{
+}
 
 std::string ServiceComponentDynamicGreedyMandatoryUnary::ExtendedDescription()
 {

--- a/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDGOU/src/ServiceComponentDynamicGreedyOptionalUnary.cpp
@@ -5,11 +5,13 @@ namespace sample {
 
 void ServiceComponentDynamicGreedyOptionalUnary::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponentDynamicGreedyOptionalUnary::Deactivate(
   const std::shared_ptr<ComponentContext>&)
-{}
+{
+}
 
 std::string ServiceComponentDynamicGreedyOptionalUnary::ExtendedDescription()
 {

--- a/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDRMU/src/ServiceComponentDynamicReluctantMandatoryUnary.cpp
@@ -5,11 +5,13 @@ namespace sample {
 
 void ServiceComponentDynamicReluctantMandatoryUnary::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponentDynamicReluctantMandatoryUnary::Deactivate(
   const std::shared_ptr<ComponentContext>&)
-{}
+{
+}
 
 std::string
 ServiceComponentDynamicReluctantMandatoryUnary::ExtendedDescription()

--- a/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
+++ b/compendium/test_bundles/TestBundleDSDROU/src/ServiceComponentDynamicReluctantOptionalUnary.cpp
@@ -5,11 +5,13 @@ namespace sample {
 
 void ServiceComponentDynamicReluctantOptionalUnary::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponentDynamicReluctantOptionalUnary::Deactivate(
   const std::shared_ptr<ComponentContext>&)
-{}
+{
+}
 
 std::string ServiceComponentDynamicReluctantOptionalUnary::ExtendedDescription()
 {

--- a/compendium/test_bundles/TestBundleDSDependent/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSDependent/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ TestBundleDSDependentImpl::TestBundleDSDependentImpl(
   const std::shared_ptr<test::TestBundleDSUpstreamDependency>& c)
   : test::TestBundleDSDependent()
   , ref(c)
-{}
+{
+}
 
 TestBundleDSDependentImpl::~TestBundleDSDependentImpl() = default;
 }

--- a/compendium/test_bundles/TestBundleDSDependentNoInject/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSDependentNoInject/src/ServiceImpl.cpp
@@ -3,7 +3,8 @@
 namespace dependent {
 TestBundleDSDependentNoInjectImpl::TestBundleDSDependentNoInjectImpl()
   : test::TestBundleDSDependent()
-{}
+{
+}
 
 TestBundleDSDependentNoInjectImpl::~TestBundleDSDependentNoInjectImpl() =
   default;

--- a/compendium/test_bundles/TestBundleDSDependentOptional/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSDependentOptional/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ TestBundleDSDependentOptionalImpl::TestBundleDSDependentOptionalImpl(
   const std::shared_ptr<test::TestBundleDSUpstreamDependency>& c)
   : test::TestBundleDSDependent()
   , ref(c)
-{}
+{
+}
 
 TestBundleDSDependentOptionalImpl::~TestBundleDSDependentOptionalImpl() =
   default;

--- a/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI5/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ namespace sample {
 
 void ServiceComponent5::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponent5::Deactivate(const std::shared_ptr<ComponentContext>&) {}
 

--- a/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSTOI7/src/ServiceImpl.cpp
@@ -5,7 +5,8 @@ namespace sample {
 
 void ServiceComponent7::Activate(
   const std::shared_ptr<ComponentContext>& /*ctxt*/)
-{}
+{
+}
 
 void ServiceComponent7::Deactivate(const std::shared_ptr<ComponentContext>&) {}
 

--- a/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSa/src/ServiceImpl.cpp
@@ -3,7 +3,8 @@
 namespace sample {
 ServiceComponent::ServiceComponent(std::shared_ptr<test::Interface1> interface1)
   : m_interface1(std::move(interface1))
-{}
+{
+}
 
 std::string ServiceComponent::Description()
 {

--- a/compendium/test_bundles/TestBundleManagedServiceFactory/src/ManagedServiceFactoryImpl2.cpp
+++ b/compendium/test_bundles/TestBundleManagedServiceFactory/src/ManagedServiceFactoryImpl2.cpp
@@ -17,14 +17,13 @@ void TestManagedServiceFactoryImpl2::Activate(
 }
 
 void TestManagedServiceFactoryImpl2::Updated(std::string const& pid,
-                                            AnyMap const& properties)
+                                             AnyMap const& properties)
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   if (properties.empty()) {
     m_updatedCallCount[pid] -= 1;
   } else {
     m_updatedCallCount[pid] += 1;
-
   }
 }
 

--- a/compendium/test_bundles/TestBundleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl2.cpp
+++ b/compendium/test_bundles/TestBundleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl2.cpp
@@ -8,10 +8,11 @@ namespace test {
 TestManagedServiceFactoryServiceImpl2::TestManagedServiceFactoryServiceImpl2(
   int initialValue)
   : value{ initialValue }
-{}
+{
+}
 
-TestManagedServiceFactoryServiceImpl2::~TestManagedServiceFactoryServiceImpl2() =
-  default;
+TestManagedServiceFactoryServiceImpl2::
+  ~TestManagedServiceFactoryServiceImpl2() = default;
 
 int TestManagedServiceFactoryServiceImpl2::getValue()
 {

--- a/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedService/src/ManagedServiceImpl.cpp
@@ -10,11 +10,12 @@ namespace test {
 
 TestManagedServiceImpl3::TestManagedServiceImpl3()
   : m_counter{ 0 }
-{}
+{
+}
 
 TestManagedServiceImpl3::~TestManagedServiceImpl3() = default;
 
-void TestManagedServiceImpl3::Updated(AnyMap const& )
+void TestManagedServiceImpl3::Updated(AnyMap const&)
 {
   std::lock_guard<std::mutex> lk(m_counterMtx);
   m_counter++;
@@ -28,7 +29,8 @@ int TestManagedServiceImpl3::getCounter()
 
 TestManagedServiceImpl4::TestManagedServiceImpl4()
   : m_counter{ 0 }
-{}
+{
+}
 
 TestManagedServiceImpl4::~TestManagedServiceImpl4() = default;
 

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl3.cpp
@@ -17,7 +17,7 @@ void TestManagedServiceFactoryImpl3::Activate(
 }
 
 void TestManagedServiceFactoryImpl3::Updated(std::string const& pid,
-                                             AnyMap const& )
+                                             AnyMap const&)
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   m_updatedCallCount[pid] += 1;
@@ -48,7 +48,7 @@ TestManagedServiceFactoryImpl3::create(std::string const& config)
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   try {
     return std::make_shared<TestManagedServiceFactoryServiceImpl3>(
-    m_updatedCallCount.at(config));
+      m_updatedCallCount.at(config));
   } catch (...) {
     return nullptr;
   }

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryImpl4.cpp
@@ -17,7 +17,7 @@ void TestManagedServiceFactoryImpl4::Activate(
 }
 
 void TestManagedServiceFactoryImpl4::Updated(std::string const& pid,
-                                             AnyMap const& )
+                                             AnyMap const&)
 {
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   m_updatedCallCount[pid] += 1;
@@ -48,7 +48,7 @@ TestManagedServiceFactoryImpl4::create(std::string const& config)
   std::lock_guard<std::mutex> lk(m_updatedMtx);
   try {
     return std::make_shared<TestManagedServiceFactoryServiceImpl4>(
-    m_updatedCallCount.at(config));
+      m_updatedCallCount.at(config));
   } catch (...) {
     return nullptr;
   }

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl3.cpp
@@ -8,7 +8,8 @@ namespace test {
 TestManagedServiceFactoryServiceImpl3::TestManagedServiceFactoryServiceImpl3(
   int initialValue)
   : value{ initialValue }
-{}
+{
+}
 
 TestManagedServiceFactoryServiceImpl3::
   ~TestManagedServiceFactoryServiceImpl3() = default;

--- a/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.cpp
+++ b/compendium/test_bundles/TestBundleMultipleManagedServiceFactory/src/ManagedServiceFactoryServiceImpl4.cpp
@@ -8,7 +8,8 @@ namespace test {
 TestManagedServiceFactoryServiceImpl4::TestManagedServiceFactoryServiceImpl4(
   int initialValue)
   : value{ initialValue }
-{}
+{
+}
 
 TestManagedServiceFactoryServiceImpl4::
   ~TestManagedServiceFactoryServiceImpl4() = default;

--- a/compendium/test_bundles/TestBundleNestedBundleStartManagedService/src/ManagedServiceFactoryImpl.cpp
+++ b/compendium/test_bundles/TestBundleNestedBundleStartManagedService/src/ManagedServiceFactoryImpl.cpp
@@ -33,7 +33,6 @@ void TestManagedServiceFactoryImpl::Updated(std::string const& pid,
     m_updatedCallCount[pid] -= 1;
   } else {
     m_updatedCallCount[pid] += 1;
-
   }
 }
 

--- a/compendium/test_bundles/TestBundleNestedBundleStartManagedService/src/ManagedServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleNestedBundleStartManagedService/src/ManagedServiceImpl.cpp
@@ -32,7 +32,8 @@ namespace test {
 
 TestManagedServiceImpl::TestManagedServiceImpl()
   : m_counter{ 0 }
-{ }
+{
+}
 
 TestManagedServiceImpl::~TestManagedServiceImpl() = default;
 
@@ -48,16 +49,16 @@ void TestManagedServiceImpl::Updated(AnyMap const& properties)
 }
 
 void TestManagedServiceImpl::Activate(
-  const std::shared_ptr<
-    cppmicroservices::service::component::ComponentContext>& ctx)
+  const std::shared_ptr<cppmicroservices::service::component::ComponentContext>&
+    ctx)
 {
   auto installedBundles = ctx->GetBundleContext().GetBundles();
-  auto testBundleIter =
-    std::find_if(installedBundles.begin(),
-                 installedBundles.end(),
-                 [](const cppmicroservices::Bundle& b) {
-                   return (b.GetSymbolicName() == "ManagedServiceAndFactoryBundle");
-                 });
+  auto testBundleIter = std::find_if(
+    installedBundles.begin(),
+    installedBundles.end(),
+    [](const cppmicroservices::Bundle& b) {
+      return (b.GetSymbolicName() == "ManagedServiceAndFactoryBundle");
+    });
   assert(testBundleIter != installedBundles.end());
   testBundleIter->Start();
 }

--- a/compendium/test_bundles/TestInterfaces/src/Interfaces.cpp
+++ b/compendium/test_bundles/TestInterfaces/src/Interfaces.cpp
@@ -4,7 +4,7 @@ namespace test {
 Interface1::~Interface1() = default;
 Interface2::~Interface2() = default;
 Interface3::~Interface3() = default;
-  
+
 TestBundleDSDependent::~TestBundleDSDependent() = default;
 TestBundleDSUpstreamDependency::~TestBundleDSUpstreamDependency() = default;
 

--- a/compendium/tools/SCRCodeGen/ManifestParserImpl.cpp
+++ b/compendium/tools/SCRCodeGen/ManifestParserImpl.cpp
@@ -68,8 +68,8 @@ std::vector<ComponentInfo> ManifestParserImplV1::ParseAndGetComponentInfos(
         { "require", "optional", "ignore" }
       };
       componentInfo.configurationPolicy =
-       JsonValueValidator(
-          jsonComponent, "configuration-policy", policyChoices).GetString();
+        JsonValueValidator(jsonComponent, "configuration-policy", policyChoices)
+          .GetString();
     }
     if (jsonComponent.isMember("configuration-pid")) {
       configPid = true;
@@ -98,12 +98,12 @@ std::vector<ComponentInfo> ManifestParserImplV1::ParseAndGetComponentInfos(
         "Admin.");
     }
     // factory
-     if (jsonComponent.isMember("factory")) {
-      auto factoryComponentID =
-        JsonValueValidator(
-          jsonComponent, "factory", Json::ValueType::stringValue)
-          .GetString();
-     }
+    if (jsonComponent.isMember("factory")) {
+      auto factoryComponentID = JsonValueValidator(jsonComponent,
+                                                   "factory",
+                                                   Json::ValueType::stringValue)
+                                  .GetString();
+    }
 
     // service
     if (jsonComponent.isMember("service")) {

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -575,7 +575,8 @@ struct CodegenValidManifestState
     : manifest(std::move(_manifest))
     , headers(std::move(_headers))
     , referenceOutput(std::move(_referenceOutput))
-  {}
+  {
+  }
 
   std::string manifest;
   std::vector<std::string> headers;
@@ -642,7 +643,8 @@ struct CodegenInvalidManifestState
     : manifest(std::move(_manifest))
     , errorOutput(std::move(_errorOutput))
     , isPartial(_isPartial)
-  {}
+  {
+  }
 
   std::string manifest;
   std::string errorOutput;
@@ -788,26 +790,26 @@ INSTANTIATE_TEST_SUITE_P(
       "Invalid value for the name 'references'. Expected non-empty array"),
     CodegenInvalidManifestState(
       manifest_illegal_configuration_policy,
-      "Invalid value 'default' for the name 'configuration-policy'. The valid choices are : [require, optional, ignore]"),  
+      "Invalid value 'default' for the name 'configuration-policy'. The valid "
+      "choices are : [require, optional, ignore]"),
     CodegenInvalidManifestState(
       manifest_duplicate_configuration_pid,
       "configuration-pid error in the manifest. Duplicate pid detected.",
-      true),  
+      true),
     CodegenInvalidManifestState(
       manifest_illegal_factory,
-      "Invalid value for the name 'factory'. Expected non-empty string"),  
+      "Invalid value for the name 'factory'. Expected non-empty string"),
     CodegenInvalidManifestState(
       manifest_configuration_policy_but_no_pid,
       "Error: Both configuration-policy and configuration-pid must be "
       "present in the manifest.json file to participate in Configuration "
       "Admin.",
-      true),  
+      true),
     CodegenInvalidManifestState(
       manifest_configuration_pid_but_no_policy,
       "Error: Both configuration-policy and configuration-pid must be "
       "present in the manifest.json file to participate in Configuration "
       "Admin.",
-      true)  
-      ));
+      true)));
 
 } // namespace codegen

--- a/doc/src/tutorial/dictionaryclient2/Activator.cpp
+++ b/doc/src/tutorial/dictionaryclient2/Activator.cpp
@@ -54,7 +54,8 @@ public:
   Activator()
     : m_context()
     , m_dictionary(nullptr)
-  {}
+  {
+  }
 
   /**
    * Implements BundleActivator::Start(). Adds itself as a listener for service

--- a/doc/src/tutorial/dictionaryclient3/Activator.cpp
+++ b/doc/src/tutorial/dictionaryclient3/Activator.cpp
@@ -53,7 +53,8 @@ public:
   Activator()
     : m_context()
     , m_tracker(nullptr)
-  {}
+  {
+  }
 
   /**
    * Implements BundleActivator::Start(). Creates a service

--- a/doc/src/tutorial/driver/main.cpp
+++ b/doc/src/tutorial/driver/main.cpp
@@ -45,8 +45,8 @@
 #endif
 
 #include <algorithm>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <map>
 #include <set>
 #include <sstream>

--- a/doc/src/tutorial/spellcheckclient/Activator.cpp
+++ b/doc/src/tutorial/spellcheckclient/Activator.cpp
@@ -52,7 +52,8 @@ public:
   Activator()
     : m_context()
     , m_tracker(nullptr)
-  {}
+  {
+  }
 
   /**
    * Implements BundleActivator::Start(). Creates a service

--- a/doc/src/tutorial/spellcheckservice/Activator.cpp
+++ b/doc/src/tutorial/spellcheckservice/Activator.cpp
@@ -193,7 +193,8 @@ private:
 public:
   Activator()
     : m_context()
-  {}
+  {
+  }
 
   /**
    * Implements BundleActivator::Start(). Registers an

--- a/framework/doc/snippets/uServices-registration/main.cpp
+++ b/framework/doc/snippets/uServices-registration/main.cpp
@@ -75,7 +75,8 @@ public:
       virtual void UngetService(const Bundle& /*bundle*/,
                                 const ServiceRegistrationBase& /*registration*/,
                                 const InterfaceMapConstPtr& /*service*/)
-      {}
+      {
+      }
     };
 
     std::shared_ptr<MyServiceFactory> myServiceFactory =
@@ -100,7 +101,8 @@ public:
       virtual void UngetService(const Bundle& /*bundle*/,
                                 const ServiceRegistrationBase& /*registration*/,
                                 const InterfaceMapConstPtr& /*service*/)
-      {}
+      {
+      }
     };
 
     std::shared_ptr<MyServiceFactory> myServiceFactory =

--- a/framework/doc/snippets/uServices-servicetracker/main.cpp
+++ b/framework/doc/snippets/uServices-servicetracker/main.cpp
@@ -29,11 +29,13 @@ struct MyTrackingCustomizer
 
   virtual void ModifiedService(const ServiceReference<IFooService>&,
                                const std::shared_ptr<MyTrackedClass>&)
-  {}
+  {
+  }
 
   virtual void RemovedService(const ServiceReference<IFooService>&,
                               const std::shared_ptr<MyTrackedClass>&)
-  {}
+  {
+  }
 };
 //! [customizer]
 
@@ -49,11 +51,13 @@ struct MyTrackingCustomizerVoid
 
   virtual void ModifiedService(const ServiceReferenceU&,
                                const std::shared_ptr<MyTrackedClass>&)
-  {}
+  {
+  }
 
   virtual void RemovedService(const ServiceReferenceU&,
                               const std::shared_ptr<MyTrackedClass>&)
-  {}
+  {
+  }
 };
 
 int main(int /*argc*/, char* /*argv*/[])

--- a/framework/doc/snippets/uServices-singleton/SingletonOne.cpp
+++ b/framework/doc/snippets/uServices-singleton/SingletonOne.cpp
@@ -20,7 +20,8 @@ SingletonOne& SingletonOne::GetInstance()
 
 SingletonOne::SingletonOne()
   : a(1)
-{}
+{
+}
 
 //![s1d]
 SingletonOne::~SingletonOne()

--- a/framework/doc/snippets/uServices-singleton/main.cpp
+++ b/framework/doc/snippets/uServices-singleton/main.cpp
@@ -15,7 +15,8 @@ public:
   MyActivator()
     : m_SingletonOne(nullptr)
     , m_SingletonTwo(nullptr)
-  {}
+  {
+  }
 
   //![0]
   void Start(BundleContext context)

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -120,18 +120,18 @@ US_Framework_EXPORT std::ostream& any_value_to_json(std::ostream& os,
                                                     const uint8_t,
                                                     const int32_t);
 
-template <typename T>
+template<typename T>
 std::ostream& any_value_to_string(std::ostream& os,
-    const std::function<bool(const T&)>&)
+                                  const std::function<bool(const T&)>&)
 {
   return os;
 }
 
 template<typename T>
 std::ostream& any_value_to_json(std::ostream& os,
-    const std::function<bool(const T&)>&,
-    const uint8_t,
-    const int32_t)
+                                const std::function<bool(const T&)>&,
+                                const uint8_t,
+                                const int32_t)
 {
   return os;
 }
@@ -297,7 +297,8 @@ public:
   template<typename ValueType>
   Any(const ValueType& value)
     : _content(new Holder<ValueType>(value))
-  {}
+  {
+  }
 
   /**
    * Copy constructor, works with empty Anys and initialized Any values.
@@ -306,7 +307,8 @@ public:
    */
   Any(const Any& other)
     : _content(other._content ? other._content->Clone() : nullptr)
-  {}
+  {
+  }
 
   /**
    * Move constructor.
@@ -315,7 +317,8 @@ public:
    */
   Any(Any&& other) noexcept
     : _content(std::move(other._content))
-  {}
+  {
+  }
 
   /**
    * Swaps the content of the two Anys.
@@ -341,7 +344,8 @@ public:
   {
     if (Type() != typeid(ValueType))
       return false;
-    return cppmicroservices::any::detail::compare(*any_cast<const ValueType>(this), val);
+    return cppmicroservices::any::detail::compare(
+      *any_cast<const ValueType>(this), val);
   }
 
   /**
@@ -495,11 +499,13 @@ private:
   public:
     Holder(const ValueType& value)
       : _held(value)
-    {}
+    {
+    }
 
     Holder(ValueType&& value)
       : _held(std::move(value))
-    {}
+    {
+    }
 
     std::string ToString() const override
     {
@@ -558,7 +564,8 @@ public:
   BadAnyCastException(std::string msg = "")
     : std::bad_cast()
     , _msg(std::move(msg))
-  {}
+  {
+  }
 
   ~BadAnyCastException() override = default;
 

--- a/framework/include/cppmicroservices/BundleActivator.h
+++ b/framework/include/cppmicroservices/BundleActivator.h
@@ -130,7 +130,7 @@ struct BundleActivator
   extern "C" US_ABI_EXPORT cppmicroservices::BundleActivator*                  \
     US_CREATE_ACTIVATOR_FUNC(US_BUNDLE_NAME)();                                \
   extern "C" US_ABI_EXPORT cppmicroservices::BundleActivator*                  \
-    US_CREATE_ACTIVATOR_FUNC(US_BUNDLE_NAME)()                                 \
+  US_CREATE_ACTIVATOR_FUNC(US_BUNDLE_NAME)()                                   \
   {                                                                            \
     return new _activator_type();                                              \
   }                                                                            \

--- a/framework/include/cppmicroservices/Constants.h
+++ b/framework/include/cppmicroservices/Constants.h
@@ -335,7 +335,8 @@ US_Framework_EXPORT extern const std::string
  * Framework bundle validation property specifying a function that control
  * whether a shared library is loaded or not into the process.
  */
-US_Framework_EXPORT extern const std::string FRAMEWORK_BUNDLE_VALIDATION_FUNC; // = "org.cppmicroservices.framework.bundle.validation.function"
+US_Framework_EXPORT extern const std::string
+  FRAMEWORK_BUNDLE_VALIDATION_FUNC; // = "org.cppmicroservices.framework.bundle.validation.function"
 
 /*
  * Service properties.

--- a/framework/include/cppmicroservices/ServiceInterface.h
+++ b/framework/include/cppmicroservices/ServiceInterface.h
@@ -137,18 +137,21 @@ struct InterfacesTuple
 
 template<class T, class... List>
 struct Contains : std::true_type
-{};
+{
+};
 
 template<class T, class Head, class... Rest>
 struct Contains<T, Head, Rest...>
   : std::conditional<std::is_same<T, Head>::value,
                      std::true_type,
                      Contains<T, Rest...>>::type
-{};
+{
+};
 
 template<class T>
 struct Contains<T> : std::false_type
-{};
+{
+};
 }
 /// \endcond
 }
@@ -257,7 +260,8 @@ public:
   MakeInterfaceMap(const std::shared_ptr<Impl>& impl)
     : m_interfaces(
         detail::InterfacesTuple<std::tuple, Interfaces...>::create(impl))
-  {}
+  {
+  }
 
   /**
    * Constructor taking a service factory.

--- a/framework/include/cppmicroservices/ServiceObjects.h
+++ b/framework/include/cppmicroservices/ServiceObjects.h
@@ -93,7 +93,8 @@ public:
 
   ServiceObjects(ServiceObjects&& other)
     : ServiceObjectsBase(std::move(other))
-  {}
+  {
+  }
   ServiceObjects& operator=(ServiceObjects&& other)
   {
     ServiceObjectsBase::operator=(std::move(other));
@@ -155,7 +156,8 @@ private:
   ServiceObjects(const std::shared_ptr<BundleContextPrivate>& context,
                  const ServiceReference<S>& reference)
     : ServiceObjectsBase(context, reference)
-  {}
+  {
+  }
 };
 
 /**

--- a/framework/include/cppmicroservices/ServiceReference.h
+++ b/framework/include/cppmicroservices/ServiceReference.h
@@ -80,7 +80,8 @@ public:
    */
   ServiceReference()
     : ServiceReferenceBase()
-  {}
+  {
+  }
 
   ServiceReference(const ServiceReference&) = default;
   ServiceReference& operator=(const ServiceReference&) = default;
@@ -124,14 +125,16 @@ public:
    */
   ServiceReference()
     : ServiceReferenceBase()
-  {}
+  {
+  }
 
   ServiceReference(const ServiceReference&) = default;
   ServiceReference& operator=(const ServiceReference&) = default;
 
   ServiceReference(const ServiceReferenceBase& base)
     : ServiceReferenceBase(base)
-  {}
+  {
+  }
 
   using ServiceReferenceBase::operator=;
 

--- a/framework/include/cppmicroservices/ServiceRegistration.h
+++ b/framework/include/cppmicroservices/ServiceRegistration.h
@@ -64,7 +64,8 @@ public:
    */
   ServiceRegistration()
     : ServiceRegistrationBase()
-  {}
+  {
+  }
 
   /**
    * Returns a <code>ServiceReference</code> object for a service being
@@ -112,7 +113,8 @@ private:
 
   ServiceRegistration(const ServiceRegistrationBase& base)
     : ServiceRegistrationBase(base)
-  {}
+  {
+  }
 };
 
 /// \cond
@@ -128,11 +130,13 @@ public:
    */
   ServiceRegistration()
     : ServiceRegistrationBase()
-  {}
+  {
+  }
 
   ServiceRegistration(const ServiceRegistrationBase& base)
     : ServiceRegistrationBase(base)
-  {}
+  {
+  }
 
   using ServiceRegistrationBase::operator=;
 };

--- a/framework/include/cppmicroservices/ServiceRegistrationBase.h
+++ b/framework/include/cppmicroservices/ServiceRegistrationBase.h
@@ -178,7 +178,8 @@ public:
 
   ServiceRegistrationBase& operator=(
     const ServiceRegistrationBase& registration);
-  ServiceRegistrationBase& operator=(ServiceRegistrationBase&& registration) noexcept;
+  ServiceRegistrationBase& operator=(
+    ServiceRegistrationBase&& registration) noexcept;
 
 private:
   friend class ServiceRegistry;

--- a/framework/include/cppmicroservices/ShrinkableMap.h
+++ b/framework/include/cppmicroservices/ShrinkableMap.h
@@ -54,7 +54,8 @@ public:
 
   ShrinkableMap()
     : container(emptyContainer)
-  {}
+  {
+  }
 
   iterator begin() { return container.begin(); }
 
@@ -128,7 +129,8 @@ private:
 
   ShrinkableMap(container_type& container)
     : container(container)
-  {}
+  {
+  }
 
   container_type& container;
 };

--- a/framework/include/cppmicroservices/ShrinkableVector.h
+++ b/framework/include/cppmicroservices/ShrinkableVector.h
@@ -52,7 +52,8 @@ public:
 
   ShrinkableVector()
     : container(emptyVector)
-  {}
+  {
+  }
 
   iterator begin() { return container.begin(); }
 
@@ -122,7 +123,8 @@ private:
 
   ShrinkableVector(container_type& container)
     : container(container)
-  {}
+  {
+  }
 
   container_type& container;
 };

--- a/framework/include/cppmicroservices/detail/BundleAbstractTracked.tpp
+++ b/framework/include/cppmicroservices/detail/BundleAbstractTracked.tpp
@@ -30,40 +30,42 @@ namespace cppmicroservices {
 namespace detail {
 
 template<class S, class TTT, class R>
-BundleAbstractTracked<S,TTT,R>::BundleAbstractTracked(BundleContext bc)
-  : closed(false), trackingCount(0), bc(bc)
+BundleAbstractTracked<S, TTT, R>::BundleAbstractTracked(BundleContext bc)
+  : closed(false)
+  , trackingCount(0)
+  , bc(bc)
 {
 }
 
 template<class S, class TTT, class R>
-BundleAbstractTracked<S,TTT,R>::~BundleAbstractTracked()
-= default;
+BundleAbstractTracked<S, TTT, R>::~BundleAbstractTracked() = default;
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::SetInitial(const std::vector<S>& initiallist)
+void BundleAbstractTracked<S, TTT, R>::SetInitial(
+  const std::vector<S>& initiallist)
 {
-  std::copy(initiallist.begin(), initiallist.end(), std::back_inserter(initial));
+  std::copy(
+    initiallist.begin(), initiallist.end(), std::back_inserter(initial));
 
-  if (bc.GetLogSink()->Enabled())
-  {
-    for(typename std::list<S>::const_iterator item = initial.begin();
-      item != initial.end(); ++item)
-    {
-      DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::setInitial: " << (*item);
+  if (bc.GetLogSink()->Enabled()) {
+    for (typename std::list<S>::const_iterator item = initial.begin();
+         item != initial.end();
+         ++item) {
+      DIAG_LOG(*bc.GetLogSink())
+        << "BundleAbstractTracked::setInitial: " << (*item);
     }
   }
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::TrackInitial()
+void BundleAbstractTracked<S, TTT, R>::TrackInitial()
 {
-  while (true)
-  {
+  while (true) {
     S item;
     {
-      auto l = this->Lock(); US_UNUSED(l);
-      if (closed || (initial.size() == 0))
-      {
+      auto l = this->Lock();
+      US_UNUSED(l);
+      if (closed || (initial.size() == 0)) {
         /*
          * if there are no more initial items
          */
@@ -75,23 +77,24 @@ void BundleAbstractTracked<S,TTT,R>::TrackInitial()
        */
       item = initial.front();
       initial.pop_front();
-      if (tracked.end() != tracked.find(item))
-      {
+      if (tracked.end() != tracked.find(item)) {
         /* if we are already tracking this item */
-        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial[already tracked]: " << item;
+        DIAG_LOG(*bc.GetLogSink())
+          << "BundleAbstractTracked::trackInitial[already tracked]: " << item;
         continue; /* skip this item */
       }
-      if (std::find(adding.begin(), adding.end(), item) != adding.end())
-      {
+      if (std::find(adding.begin(), adding.end(), item) != adding.end()) {
         /*
          * if this item is already in the process of being added.
          */
-        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial[already adding]: " << item;
+        DIAG_LOG(*bc.GetLogSink())
+          << "BundleAbstractTracked::trackInitial[already adding]: " << item;
         continue; /* skip this item */
       }
       adding.push_back(item);
     }
-    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial: " << item;
+    DIAG_LOG(*bc.GetLogSink())
+      << "BundleAbstractTracked::trackInitial: " << item;
     TrackAdding(item, R());
     /*
      * Begin tracking it. We call trackAdding
@@ -102,48 +105,43 @@ void BundleAbstractTracked<S,TTT,R>::TrackInitial()
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::Close()
+void BundleAbstractTracked<S, TTT, R>::Close()
 {
   closed = true;
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::Track(S item, R related)
+void BundleAbstractTracked<S, TTT, R>::Track(S item, R related)
 {
   std::shared_ptr<TrackedParamType> object;
   {
-    auto l = this->Lock(); US_UNUSED(l);
-    if (closed)
-    {
+    auto l = this->Lock();
+    US_UNUSED(l);
+    if (closed) {
       return;
     }
     auto trackedItemIter = tracked.find(item);
     if (trackedItemIter != tracked.end()) {
       object = trackedItemIter->second;
     }
-    if (!object)
-    { /* we are not tracking the item */
-      if (std::find(adding.begin(), adding.end(), item) != adding.end())
-      {
+    if (!object) { /* we are not tracking the item */
+      if (std::find(adding.begin(), adding.end(), item) != adding.end()) {
         /* if this item is already in the process of being added. */
-        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::track[already adding]: " << item;
+        DIAG_LOG(*bc.GetLogSink())
+          << "BundleAbstractTracked::track[already adding]: " << item;
         return;
       }
       adding.push_back(item); /* mark this item is being added */
-    }
-    else
-    { /* we are currently tracking this item */
-      DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::track[modified]: " << item;
+    } else {                  /* we are currently tracking this item */
+      DIAG_LOG(*bc.GetLogSink())
+        << "BundleAbstractTracked::track[modified]: " << item;
       Modified(); /* increment modification count */
     }
   }
 
-  if (!object)
-  { /* we are not tracking the item */
+  if (!object) { /* we are not tracking the item */
     TrackAdding(item, related);
-  }
-  else
-  {
+  } else {
     /* Call customizer outside of synchronized region */
     CustomizerModified(item, related, object);
     /*
@@ -154,18 +152,19 @@ void BundleAbstractTracked<S,TTT,R>::Track(S item, R related)
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::Untrack(S item, R related)
+void BundleAbstractTracked<S, TTT, R>::Untrack(S item, R related)
 {
   std::shared_ptr<TrackedParamType> object;
   {
-    auto l = this->Lock(); US_UNUSED(l);
+    auto l = this->Lock();
+    US_UNUSED(l);
     std::size_t initialSize = initial.size();
     initial.remove(item);
-    if (initialSize != initial.size())
-    { /* if this item is already in the list
+    if (initialSize != initial.size()) { /* if this item is already in the list
        * of initial references to process
        */
-      DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[removed from initial]: " << item;
+      DIAG_LOG(*bc.GetLogSink())
+        << "BundleAbstractTracked::untrack[removed from initial]: " << item;
       return; /* we have removed it from the list and it will not be
                * processed
                */
@@ -173,11 +172,11 @@ void BundleAbstractTracked<S,TTT,R>::Untrack(S item, R related)
 
     std::size_t addingSize = adding.size();
     adding.remove(item);
-    if (addingSize != adding.size())
-    { /* if the item is in the process of
+    if (addingSize != adding.size()) { /* if the item is in the process of
        * being added
        */
-      DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[being added]: " << item;
+      DIAG_LOG(*bc.GetLogSink())
+        << "BundleAbstractTracked::untrack[being added]: " << item;
       return; /*
            * in case the item is untracked while in the process of
            * adding
@@ -196,7 +195,8 @@ void BundleAbstractTracked<S,TTT,R>::Untrack(S item, R related)
     tracked.erase(item);
     Modified(); /* increment modification count */
   }
-  DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[removed]: " << item;
+  DIAG_LOG(*bc.GetLogSink())
+    << "BundleAbstractTracked::untrack[removed]: " << item;
   /* Call customizer outside of synchronized region */
   CustomizerRemoved(item, related, object);
   /*
@@ -206,95 +206,93 @@ void BundleAbstractTracked<S,TTT,R>::Untrack(S item, R related)
 }
 
 template<class S, class TTT, class R>
-std::size_t BundleAbstractTracked<S,TTT,R>::Size_unlocked() const
+std::size_t BundleAbstractTracked<S, TTT, R>::Size_unlocked() const
 {
   return tracked.size();
 }
 
 template<class S, class TTT, class R>
-bool BundleAbstractTracked<S,TTT,R>::IsEmpty_unlocked() const
+bool BundleAbstractTracked<S, TTT, R>::IsEmpty_unlocked() const
 {
   return tracked.empty();
 }
 
 template<class S, class TTT, class R>
-std::shared_ptr<typename BundleAbstractTracked<S,TTT,R>::TrackedParamType>
-BundleAbstractTracked<S,TTT,R>::GetCustomizedObject_unlocked(S item) const
+std::shared_ptr<typename BundleAbstractTracked<S, TTT, R>::TrackedParamType>
+BundleAbstractTracked<S, TTT, R>::GetCustomizedObject_unlocked(S item) const
 {
   typename TrackingMap::const_iterator i = tracked.find(item);
-  if (i != tracked.end()) return i->second;
+  if (i != tracked.end())
+    return i->second;
   return std::shared_ptr<TrackedParamType>();
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::GetTracked_unlocked(std::vector<S>& items) const
+void BundleAbstractTracked<S, TTT, R>::GetTracked_unlocked(
+  std::vector<S>& items) const
 {
-  for (auto& i : tracked)
-  {
+  for (auto& i : tracked) {
     items.push_back(i.first);
   }
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::Modified()
+void BundleAbstractTracked<S, TTT, R>::Modified()
 {
   // atomic
   ++trackingCount;
 }
 
 template<class S, class TTT, class R>
-int BundleAbstractTracked<S,TTT,R>::GetTrackingCount() const
+int BundleAbstractTracked<S, TTT, R>::GetTrackingCount() const
 {
   // atomic
   return trackingCount;
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::CopyEntries_unlocked(TrackingMap& map) const
+void BundleAbstractTracked<S, TTT, R>::CopyEntries_unlocked(
+  TrackingMap& map) const
 {
   map.insert(tracked.begin(), tracked.end());
 }
 
 template<class S, class TTT, class R>
-bool BundleAbstractTracked<S,TTT,R>::CustomizerAddingFinal(S item, const std::shared_ptr<TrackedParamType>& custom)
+bool BundleAbstractTracked<S, TTT, R>::CustomizerAddingFinal(
+  S item,
+  const std::shared_ptr<TrackedParamType>& custom)
 {
-  auto l = this->Lock(); US_UNUSED(l);
+  auto l = this->Lock();
+  US_UNUSED(l);
   std::size_t addingSize = adding.size();
   adding.remove(item);
-  if (addingSize != adding.size() && !closed)
-  {
+  if (addingSize != adding.size() && !closed) {
     /*
      * if the item was not untracked during the customizer
      * callback
      */
-    if (custom)
-    {
+    if (custom) {
       tracked[item] = custom;
-      Modified(); /* increment modification count */
+      Modified();        /* increment modification count */
       this->NotifyAll(); /* notify any waiters */
     }
     return false;
-  }
-  else
-  {
+  } else {
     return true;
   }
 }
 
 template<class S, class TTT, class R>
-void BundleAbstractTracked<S,TTT,R>::TrackAdding(S item, R related)
+void BundleAbstractTracked<S, TTT, R>::TrackAdding(S item, R related)
 {
   DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackAdding:" << item;
   std::shared_ptr<TrackedParamType> object;
   bool becameUntracked = false;
   /* Call customizer outside of synchronized region */
-  try
-  {
+  try {
     object = CustomizerAdding(item, related);
     becameUntracked = this->CustomizerAddingFinal(item, object);
-  }
-  catch (...)
-  {
+  } catch (...) {
     /*
      * If the customizer throws an exception, it will
      * propagate after the cleanup code.
@@ -306,9 +304,9 @@ void BundleAbstractTracked<S,TTT,R>::TrackAdding(S item, R related)
   /*
    * The item became untracked during the customizer callback.
    */
-  if (becameUntracked && object)
-  {
-    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackAdding[removed]: " << item;
+  if (becameUntracked && object) {
+    DIAG_LOG(*bc.GetLogSink())
+      << "BundleAbstractTracked::trackAdding[removed]: " << item;
     /* Call customizer outside of synchronized region */
     CustomizerRemoved(item, related, object);
     /*

--- a/framework/include/cppmicroservices/detail/CounterLatch.h
+++ b/framework/include/cppmicroservices/detail/CounterLatch.h
@@ -57,7 +57,8 @@ class CounterLatch final
 public:
   CounterLatch()
     : count(0)
-  {}
+  {
+  }
   CounterLatch(const CounterLatch&) = delete;
   CounterLatch(CounterLatch&&) = delete;
   CounterLatch& operator=(const CounterLatch&) = delete;
@@ -111,7 +112,7 @@ public:
     }
     cond.wait(lock, [&]() { return count == 0; });
     count = (std::numeric_limits<
-      long>::min)(); // makes the latch unusable for other threads
+             long>::min)(); // makes the latch unusable for other threads
   }
 
   /**

--- a/framework/include/cppmicroservices/detail/Log.h
+++ b/framework/include/cppmicroservices/detail/Log.h
@@ -87,7 +87,8 @@ struct LogMsg
     : enabled(other.enabled)
     , buffer()
     , _sink(other._sink)
-  {}
+  {
+  }
 
   ~LogMsg()
   {

--- a/framework/include/cppmicroservices/detail/ScopeGuard.h
+++ b/framework/include/cppmicroservices/detail/ScopeGuard.h
@@ -40,7 +40,8 @@ public:
   template<typename Callable>
   ScopeGuard(Callable&& func)
     : f(func)
-  {}
+  {
+  }
 
   ScopeGuard(const ScopeGuard&) = delete;
   ScopeGuard& operator=(const ScopeGuard&) = delete;

--- a/framework/include/cppmicroservices/detail/ServiceTracker.tpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.tpp
@@ -32,7 +32,6 @@
 #include <stdexcept>
 #include <string>
 
-
 namespace cppmicroservices {
 
 template<class S, class T>
@@ -54,21 +53,24 @@ ServiceTracker<S, T>::ServiceTracker(const BundleContext& context,
                                      const ServiceReference<S>& reference,
                                      _ServiceTrackerCustomizer* customizer)
   : d(new _ServiceTrackerPrivate(this, context, reference, customizer))
-{}
+{
+}
 
 template<class S, class T>
 ServiceTracker<S, T>::ServiceTracker(const BundleContext& context,
                                      const std::string& clazz,
                                      _ServiceTrackerCustomizer* customizer)
   : d(new _ServiceTrackerPrivate(this, context, clazz, customizer))
-{}
+{
+}
 
 template<class S, class T>
 ServiceTracker<S, T>::ServiceTracker(const BundleContext& context,
                                      const LDAPFilter& filter,
                                      _ServiceTrackerCustomizer* customizer)
   : d(new _ServiceTrackerPrivate(this, context, filter, customizer))
-{}
+{
+}
 
 template<class S, class T>
 ServiceTracker<S, T>::ServiceTracker(const BundleContext& context,

--- a/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.tpp
+++ b/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.tpp
@@ -20,7 +20,6 @@
 
 =============================================================================*/
 
-
 #include "cppmicroservices/detail/TrackedService.h"
 
 #include "cppmicroservices/BundleContext.h"
@@ -35,99 +34,111 @@ namespace cppmicroservices {
 namespace detail {
 
 template<class S, class TTT>
-ServiceTrackerPrivate<S,TTT>::ServiceTrackerPrivate(
-    ServiceTracker<S,T>* st,
-    BundleContext  context,
-    const ServiceReference<S>& reference,
-    ServiceTrackerCustomizer<S,T>* customizer
-    )
-  : context(std::move(context)), customizer(customizer), listenerToken(), trackReference(reference),
-    trackedService(), cachedReference(), cachedService(), q_ptr(st)
+ServiceTrackerPrivate<S, TTT>::ServiceTrackerPrivate(
+  ServiceTracker<S, T>* st,
+  BundleContext context,
+  const ServiceReference<S>& reference,
+  ServiceTrackerCustomizer<S, T>* customizer)
+  : context(std::move(context))
+  , customizer(customizer)
+  , listenerToken()
+  , trackReference(reference)
+  , trackedService()
+  , cachedReference()
+  , cachedService()
+  , q_ptr(st)
 {
   this->customizer = customizer ? customizer : q_func();
   std::stringstream ss;
   ss << "(" << Constants::SERVICE_ID << "="
      << any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)) << ")";
   this->listenerFilter = ss.str();
-  try
-  {
+  try {
     this->filter = LDAPFilter(listenerFilter);
-  }
-  catch (const std::invalid_argument& e)
-  {
+  } catch (const std::invalid_argument& e) {
     /*
      * we could only get this exception if the ServiceReference was
      * invalid
      */
-    std::invalid_argument ia(std::string("unexpected std::invalid_argument exception: ") + e.what());
+    std::invalid_argument ia(
+      std::string("unexpected std::invalid_argument exception: ") + e.what());
     throw ia;
   }
 }
 
 template<class S, class TTT>
-ServiceTrackerPrivate<S,TTT>::ServiceTrackerPrivate(
-    ServiceTracker<S,T>* st,
-    BundleContext  context,
-    const std::string& clazz,
-    ServiceTrackerCustomizer<S,T>* customizer
-    )
-  : context(std::move(context)), customizer(customizer), listenerToken(), trackClass(clazz),
-    trackReference(), trackedService(), cachedReference(),
-    cachedService(), q_ptr(st)
+ServiceTrackerPrivate<S, TTT>::ServiceTrackerPrivate(
+  ServiceTracker<S, T>* st,
+  BundleContext context,
+  const std::string& clazz,
+  ServiceTrackerCustomizer<S, T>* customizer)
+  : context(std::move(context))
+  , customizer(customizer)
+  , listenerToken()
+  , trackClass(clazz)
+  , trackReference()
+  , trackedService()
+  , cachedReference()
+  , cachedService()
+  , q_ptr(st)
 {
   this->customizer = customizer ? customizer : q_func();
-  this->listenerFilter = std::string("(") + cppmicroservices::Constants::OBJECTCLASS + "="
-                        + clazz + ")";
-  try
-  {
+  this->listenerFilter = std::string("(") +
+                         cppmicroservices::Constants::OBJECTCLASS + "=" +
+                         clazz + ")";
+  try {
     this->filter = LDAPFilter(listenerFilter);
-  }
-  catch (const std::invalid_argument& e)
-  {
+  } catch (const std::invalid_argument& e) {
     /*
      * we could only get this exception if the clazz argument was
      * malformed
      */
     std::invalid_argument ia(
-        std::string("unexpected std::invalid_argument exception: ") + e.what());
+      std::string("unexpected std::invalid_argument exception: ") + e.what());
     throw ia;
   }
 }
 
 template<class S, class TTT>
-ServiceTrackerPrivate<S,TTT>::ServiceTrackerPrivate(
-    ServiceTracker<S,T>* st,
-    const BundleContext& context,
-    const LDAPFilter& filter,
-    ServiceTrackerCustomizer<S,T>* customizer
-    )
-  : context(context), filter(filter), customizer(customizer),
-    listenerFilter(filter.ToString()), listenerToken(), trackReference(),
-    trackedService(), cachedReference(), cachedService(), q_ptr(st)
+ServiceTrackerPrivate<S, TTT>::ServiceTrackerPrivate(
+  ServiceTracker<S, T>* st,
+  const BundleContext& context,
+  const LDAPFilter& filter,
+  ServiceTrackerCustomizer<S, T>* customizer)
+  : context(context)
+  , filter(filter)
+  , customizer(customizer)
+  , listenerFilter(filter.ToString())
+  , listenerToken()
+  , trackReference()
+  , trackedService()
+  , cachedReference()
+  , cachedService()
+  , q_ptr(st)
 {
   this->customizer = customizer ? customizer : q_func();
-  if (!context)
-  {
+  if (!context) {
     throw std::invalid_argument("The bundle context cannot be null.");
   }
 }
 
 template<class S, class TTT>
-ServiceTrackerPrivate<S,TTT>::~ServiceTrackerPrivate()
-= default;
+ServiceTrackerPrivate<S, TTT>::~ServiceTrackerPrivate() = default;
 
 template<class S, class TTT>
-std::vector<ServiceReference<S> > ServiceTrackerPrivate<S,TTT>::GetInitialReferences(
-  const std::string& className, const std::string& filterString)
+std::vector<ServiceReference<S>>
+ServiceTrackerPrivate<S, TTT>::GetInitialReferences(
+  const std::string& className,
+  const std::string& filterString)
 {
-  std::vector<ServiceReference<S> > result;
-  std::vector<ServiceReferenceU> refs = context.GetServiceReferences(className, filterString);
-  for(std::vector<ServiceReferenceU>::const_iterator iter = refs.begin();
-      iter != refs.end(); ++iter)
-  {
+  std::vector<ServiceReference<S>> result;
+  std::vector<ServiceReferenceU> refs =
+    context.GetServiceReferences(className, filterString);
+  for (std::vector<ServiceReferenceU>::const_iterator iter = refs.begin();
+       iter != refs.end();
+       ++iter) {
     ServiceReference<S> ref(*iter);
-    if (ref)
-    {
+    if (ref) {
       result.push_back(ref);
     }
   }
@@ -135,26 +146,29 @@ std::vector<ServiceReference<S> > ServiceTrackerPrivate<S,TTT>::GetInitialRefere
 }
 
 template<class S, class TTT>
-void ServiceTrackerPrivate<S,TTT>::GetServiceReferences_unlocked(std::vector<ServiceReference<S> >& refs, detail::TrackedService<S,TTT>* t) const
+void ServiceTrackerPrivate<S, TTT>::GetServiceReferences_unlocked(
+  std::vector<ServiceReference<S>>& refs,
+  detail::TrackedService<S, TTT>* t) const
 {
-  if (t->Size_unlocked() == 0)
-  {
+  if (t->Size_unlocked() == 0) {
     return;
   }
   t->GetTracked_unlocked(refs);
 }
 
 template<class S, class TTT>
-std::shared_ptr<detail::TrackedService<S,TTT>> ServiceTrackerPrivate<S,TTT>::Tracked() const
+std::shared_ptr<detail::TrackedService<S, TTT>>
+ServiceTrackerPrivate<S, TTT>::Tracked() const
 {
   return trackedService.Load();
 }
 
 template<class S, class TTT>
-void ServiceTrackerPrivate<S,TTT>::Modified()
+void ServiceTrackerPrivate<S, TTT>::Modified()
 {
   cachedReference.Store(ServiceReference<S>()); /* clear cached value */
-  cachedService.Store(std::shared_ptr<TrackedParamType>()); /* clear cached value */
+  cachedService.Store(
+    std::shared_ptr<TrackedParamType>()); /* clear cached value */
   DIAG_LOG(*context.GetLogSink()) << "ServiceTracker::Modified(): " << filter;
 }
 

--- a/framework/include/cppmicroservices/detail/Threads.h
+++ b/framework/include/cppmicroservices/detail/Threads.h
@@ -48,7 +48,8 @@ public:
 #ifdef US_ENABLE_THREADING_SUPPORT
     : m_Mtx()
 #endif
-  {}
+  {
+  }
 
   friend class UniqueLock;
 
@@ -64,7 +65,8 @@ public:
 
     UniqueLock(UniqueLock&& o) noexcept
       : m_Lock(std::move(o.m_Lock))
-    {}
+    {
+    }
 
     UniqueLock& operator=(UniqueLock&& o)
     {
@@ -75,20 +77,29 @@ public:
     // Lock object
     explicit UniqueLock(const MutexLockingStrategy& host)
       : m_Lock(host.m_Mtx)
-    {}
+    {
+    }
 
     // Lock object
     explicit UniqueLock(const MutexLockingStrategy* host)
       : m_Lock(host->m_Mtx)
-    {}
+    {
+    }
 
     UniqueLock(const MutexLockingStrategy& host, std::defer_lock_t d)
       : m_Lock(host.m_Mtx, d)
-    {}
+    {
+    }
 
-    void Lock() { m_Lock.lock(); }
+    void Lock()
+    {
+      m_Lock.lock();
+    }
 
-    void UnLock() { m_Lock.unlock(); }
+    void UnLock()
+    {
+      m_Lock.unlock();
+    }
 
     template<typename Rep, typename Period>
     bool TryLockFor(const std::chrono::duration<Rep, Period>& duration)
@@ -131,9 +142,15 @@ public:
    *
    * @return A lock object.
    */
-  UniqueLock Lock() const { return UniqueLock(this); }
+  UniqueLock Lock() const
+  {
+    return UniqueLock(this);
+  }
 
-  UniqueLock DeferLock() const { return UniqueLock(this); }
+  UniqueLock DeferLock() const
+  {
+    return UniqueLock(this);
+  }
 
 protected:
 #ifdef US_ENABLE_THREADING_SUPPORT
@@ -149,7 +166,8 @@ public:
 
 template<class MutexHost>
 class NoWaitCondition
-{};
+{
+};
 
 template<class LockingStrategy = MutexLockingStrategy<>,
          template<class MutexHost> class WaitConditionStrategy =
@@ -157,7 +175,8 @@ template<class LockingStrategy = MutexLockingStrategy<>,
 class MultiThreaded
   : public LockingStrategy
   , public WaitConditionStrategy<LockingStrategy>
-{};
+{
+};
 
 template<class T>
 class Atomic : private MultiThreaded<>
@@ -168,7 +187,8 @@ public:
   template<class... Args>
   Atomic(Args&&... args)
     : m_t{ std::forward<Args>(args)... }
-  {}
+  {
+  }
 
   T Load() const { return Lock(), m_t; }
 

--- a/framework/include/cppmicroservices/detail/TrackedService.tpp
+++ b/framework/include/cppmicroservices/detail/TrackedService.tpp
@@ -25,23 +25,24 @@ namespace cppmicroservices {
 namespace detail {
 
 template<class S, class TTT>
-TrackedService<S,TTT>::TrackedService(ServiceTracker<S,T>* serviceTracker,
-                  ServiceTrackerCustomizer<S,T>* customizer)
+TrackedService<S, TTT>::TrackedService(
+  ServiceTracker<S, T>* serviceTracker,
+  ServiceTrackerCustomizer<S, T>* customizer)
   : Superclass(serviceTracker->d->context)
   , serviceTracker(serviceTracker)
   , customizer(customizer)
   , latch{}
 {
-
 }
 
 template<class S, class TTT>
-void TrackedService<S,TTT>::WaitOnCustomizersToFinish() {
+void TrackedService<S, TTT>::WaitOnCustomizersToFinish()
+{
   latch.Wait();
 }
 
 template<class S, class TTT>
-void TrackedService<S,TTT>::ServiceChanged(const ServiceEvent& event)
+void TrackedService<S, TTT>::ServiceChanged(const ServiceEvent& event)
 {
   (void)latch.CountUp();
   ScopeGuard sg([this]() {
@@ -75,31 +76,24 @@ void TrackedService<S,TTT>::ServiceChanged(const ServiceEvent& event)
     }
   }
 
-  switch (event.GetType())
-  {
-  case ServiceEvent::SERVICE_REGISTERED :
-  case ServiceEvent::SERVICE_MODIFIED :
-    {
-      if (!serviceTracker->d->listenerFilter.empty())
-      { // service listener added with filter
+  switch (event.GetType()) {
+    case ServiceEvent::SERVICE_REGISTERED:
+    case ServiceEvent::SERVICE_MODIFIED: {
+      if (!serviceTracker->d->listenerFilter
+             .empty()) { // service listener added with filter
         this->Track(reference, event);
         /*
        * If the customizer throws an unchecked exception, it
        * is safe to let it propagate
        */
-      }
-      else
-      { // service listener added without filter
-        if (serviceTracker->d->filter.Match(reference))
-        {
+      } else { // service listener added without filter
+        if (serviceTracker->d->filter.Match(reference)) {
           this->Track(reference, event);
           /*
          * If the customizer throws an unchecked exception,
          * it is safe to let it propagate
          */
-        }
-        else
-        {
+        } else {
           this->Untrack(reference, event);
           /*
          * If the customizer throws an unchecked exception,
@@ -109,44 +103,46 @@ void TrackedService<S,TTT>::ServiceChanged(const ServiceEvent& event)
       }
       break;
     }
-  case ServiceEvent::SERVICE_MODIFIED_ENDMATCH :
-  case ServiceEvent::SERVICE_UNREGISTERING :
-    this->Untrack(reference, event);
-    /*
+    case ServiceEvent::SERVICE_MODIFIED_ENDMATCH:
+    case ServiceEvent::SERVICE_UNREGISTERING:
+      this->Untrack(reference, event);
+      /*
      * If the customizer throws an unchecked exception, it is
      * safe to let it propagate
      */
-    break;
+      break;
   }
 }
 
 template<class S, class TTT>
-void TrackedService<S,TTT>::Modified()
+void TrackedService<S, TTT>::Modified()
 {
   Superclass::Modified(); /* increment the modification count */
   serviceTracker->d->Modified();
 }
 
 template<class S, class TTT>
-std::shared_ptr<typename TrackedService<S,TTT>::TrackedParamType>
-TrackedService<S,TTT>::CustomizerAdding(ServiceReference<S> item,
-                                        const ServiceEvent& /*related*/)
+std::shared_ptr<typename TrackedService<S, TTT>::TrackedParamType>
+TrackedService<S, TTT>::CustomizerAdding(ServiceReference<S> item,
+                                         const ServiceEvent& /*related*/)
 {
   return customizer->AddingService(item);
 }
 
 template<class S, class TTT>
-void TrackedService<S,TTT>::CustomizerModified(ServiceReference<S> item,
-                                               const ServiceEvent& /*related*/,
-                                               const std::shared_ptr<TrackedParamType>& object)
+void TrackedService<S, TTT>::CustomizerModified(
+  ServiceReference<S> item,
+  const ServiceEvent& /*related*/,
+  const std::shared_ptr<TrackedParamType>& object)
 {
   customizer->ModifiedService(item, object);
 }
 
 template<class S, class TTT>
-void TrackedService<S,TTT>::CustomizerRemoved(ServiceReference<S> item,
-                                              const ServiceEvent& /*related*/,
-                                              const std::shared_ptr<TrackedParamType>& object)
+void TrackedService<S, TTT>::CustomizerRemoved(
+  ServiceReference<S> item,
+  const ServiceEvent& /*related*/,
+  const std::shared_ptr<TrackedParamType>& object)
 {
   customizer->RemovedService(item, object);
 }

--- a/framework/src/bundle/Bundle.cpp
+++ b/framework/src/bundle/Bundle.cpp
@@ -47,7 +47,8 @@ Bundle::Bundle(const Bundle&) = default;
 Bundle::Bundle(Bundle&& b) noexcept
   : d(std::move(b.d))
   , c(std::move(b.c))
-{}
+{
+}
 
 Bundle& Bundle::operator=(const Bundle&) = default;
 
@@ -97,7 +98,8 @@ Bundle& Bundle::operator=(std::nullptr_t)
 Bundle::Bundle(const std::shared_ptr<BundlePrivate>& d)
   : d(d)
   , c(d ? d->coreCtx->shared_from_this() : nullptr)
-{}
+{
+}
 
 Bundle::~Bundle() = default;
 

--- a/framework/src/bundle/BundleArchive.cpp
+++ b/framework/src/bundle/BundleArchive.cpp
@@ -57,7 +57,8 @@ BundleArchive::BundleArchive()
   : storage(nullptr)
   , bundleId(0)
   , manifest(any_map::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
-{}
+{
+}
 
 BundleArchive::BundleArchive(
   BundleStorage* storage,
@@ -74,7 +75,8 @@ BundleArchive::BundleArchive(
   , lastModified(now())
   , autostartSetting(-1)
   , manifest(std::move(bundleManifest))
-{}
+{
+}
 
 bool BundleArchive::IsValid() const
 {

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -55,7 +55,8 @@ std::shared_ptr<BundlePrivate> GetAndCheckBundlePrivate(
 
 BundleContext::BundleContext(std::shared_ptr<BundleContextPrivate> ctx)
   : d(std::move(ctx))
-{}
+{
+}
 
 BundleContext::BundleContext() = default;
 
@@ -247,7 +248,8 @@ struct ServiceHolder
     : b(b)
     , sref(sr)
     , service(std::move(s))
-  {}
+  {
+  }
 
   ~ServiceHolder()
   {

--- a/framework/src/bundle/BundleContextPrivate.cpp
+++ b/framework/src/bundle/BundleContextPrivate.cpp
@@ -57,7 +57,8 @@ std::shared_ptr<BundleContextPrivate> GetPrivate(const BundleContext& c)
 BundleContextPrivate::BundleContextPrivate(BundlePrivate* bundle_)
   : bundle(bundle_->shared_from_this())
   , valid(true)
-{}
+{
+}
 
 bool BundleContextPrivate::IsValid() const
 {

--- a/framework/src/bundle/BundleEvent.cpp
+++ b/framework/src/bundle/BundleEvent.cpp
@@ -57,7 +57,8 @@ public:
 
 BundleEvent::BundleEvent()
   : d(nullptr)
-{}
+{
+}
 
 BundleEvent::operator bool() const
 {
@@ -66,11 +67,13 @@ BundleEvent::operator bool() const
 
 BundleEvent::BundleEvent(Type type, const Bundle& bundle)
   : d(new BundleEventData(type, bundle, bundle))
-{}
+{
+}
 
 BundleEvent::BundleEvent(Type type, const Bundle& bundle, const Bundle& origin)
   : d(new BundleEventData(type, bundle, origin))
-{}
+{
+}
 
 Bundle BundleEvent::GetBundle() const
 {

--- a/framework/src/bundle/BundleEventInternal.h
+++ b/framework/src/bundle/BundleEventInternal.h
@@ -39,7 +39,8 @@ struct BundleEventInternal
                       std::shared_ptr<BundlePrivate> const& b)
     : type(t)
     , bundle(b)
-  {}
+  {
+  }
 
   BundleEvent::Type type;
   std::shared_ptr<BundlePrivate> bundle;

--- a/framework/src/bundle/BundleHooks.cpp
+++ b/framework/src/bundle/BundleHooks.cpp
@@ -37,7 +37,8 @@ namespace cppmicroservices {
 
 BundleHooks::BundleHooks(CoreBundleContext* ctx)
   : coreCtx(ctx)
-{}
+{
+}
 
 Bundle BundleHooks::FilterBundle(const BundleContext& context,
                                  const Bundle& bundle) const

--- a/framework/src/bundle/BundleManifest.cpp
+++ b/framework/src/bundle/BundleManifest.cpp
@@ -139,11 +139,13 @@ void ParseJsonArray(const rapidjson::Value& jsonArray,
 
 BundleManifest::BundleManifest()
   : m_Headers(AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
-{}
+{
+}
 
 BundleManifest::BundleManifest(const AnyMap& m)
   : m_Headers(m)
-{}
+{
+}
 
 void BundleManifest::Parse(std::istream& is)
 {

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -218,7 +218,7 @@ void BundlePrivate::FinalizeActivation()
 {
   switch (GetUpdatedState()) {
     case Bundle::STATE_INSTALLED: {
-      if(resolveFailException) {
+      if (resolveFailException) {
         std::rethrow_exception(resolveFailException);
       }
       break;
@@ -573,7 +573,8 @@ void BundlePrivate::StartFailed()
   coreCtx->listeners.BundleChanged(BundleEvent(
     BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
   RemoveBundleResources();
-  auto oldBundleContext = bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
+  auto oldBundleContext =
+    bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
   if (oldBundleContext) {
     oldBundleContext->Invalidate();
   }
@@ -604,7 +605,8 @@ BundlePrivate::BundlePrivate(CoreBundleContext* coreCtx)
   , bundleManifest()
   , lib()
   , SetBundleContext(nullptr)
-{}
+{
+}
 
 BundlePrivate::BundlePrivate(CoreBundleContext* coreCtx,
                              const std::shared_ptr<BundleArchive>& ba)

--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -51,7 +51,8 @@ class InitialBundleMapCleanup
 public:
   InitialBundleMapCleanup(std::function<void()> cleanupFcn)
     : _cleanupFcn(std::move(cleanupFcn))
-  {}
+  {
+  }
   ~InitialBundleMapCleanup() { _cleanupFcn(); }
 
 private:
@@ -64,7 +65,8 @@ namespace cppmicroservices {
 
 BundleRegistry::BundleRegistry(CoreBundleContext* coreCtx)
   : coreCtx(coreCtx)
-{}
+{
+}
 
 BundleRegistry::~BundleRegistry() = default;
 

--- a/framework/src/bundle/BundleRegistry.h
+++ b/framework/src/bundle/BundleRegistry.h
@@ -183,7 +183,8 @@ private:
       : m(std::make_unique<std::mutex>())
       , cv(std::make_unique<std::condition_variable>())
       , waitFlag(true)
-    {}
+    {
+    }
   };
 
   std::unordered_map<std::string, std::pair<unsigned int, WaitCondition>>

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -40,7 +40,8 @@ class BundleResourcePrivate
 public:
   BundleResourcePrivate(std::shared_ptr<const BundleArchive> archive)
     : archive(std::move(archive))
-  {}
+  {
+  }
 
   void InitFilePath(const std::string& file);
 
@@ -89,11 +90,13 @@ void BundleResourcePrivate::InitFilePath(const std::string& file)
 
 BundleResource::BundleResource()
   : d(std::make_shared<BundleResourcePrivate>(nullptr))
-{}
+{
+}
 
 BundleResource::BundleResource(const BundleResource& resource)
   : d(resource.d)
-{}
+{
+}
 
 BundleResource::BundleResource(
   const std::string& file,

--- a/framework/src/bundle/BundleResourceBuffer.cpp
+++ b/framework/src/bundle/BundleResourceBuffer.cpp
@@ -56,7 +56,8 @@ public:
 #ifdef DATA_NEEDS_NEWLINE_CONVERSION
     , pos(0)
 #endif
-  {}
+  {
+  }
 
   const char* const begin;
   const char* const end;

--- a/framework/src/bundle/BundleResourceContainer.h
+++ b/framework/src/bundle/BundleResourceContainer.h
@@ -58,7 +58,8 @@ public:
       , modifiedTime(0)
       , crc32(0)
       , isDir(false)
-    {}
+    {
+    }
 
     std::string filePath;
     int index;

--- a/framework/src/bundle/BundleResourceStream.cpp
+++ b/framework/src/bundle/BundleResourceStream.cpp
@@ -35,7 +35,8 @@ BundleResourceStream::BundleResourceStream(const BundleResource& resource,
                          resource.GetSize(),
                          mode | std::ios_base::in)
   , std::istream(this)
-{}
+{
+}
 }
 
 US_MSVC_POP_WARNING

--- a/framework/src/bundle/BundleStorageMemory.cpp
+++ b/framework/src/bundle/BundleStorageMemory.cpp
@@ -35,7 +35,8 @@ namespace sc = std::chrono;
 BundleStorageMemory::BundleStorageMemory()
   : BundleStorage()
   , nextFreeId(1)
-{}
+{
+}
 
 std::shared_ptr<BundleArchive> BundleStorageMemory::CreateAndInsertArchive(
   const std::shared_ptr<BundleResourceContainer>& resCont,

--- a/framework/src/bundle/BundleVersion.cpp
+++ b/framework/src/bundle/BundleVersion.cpp
@@ -55,7 +55,8 @@ BundleVersion& BundleVersion::operator=(const BundleVersion&) = default;
 BundleVersion::BundleVersion(bool undefined)
   : qualifier("")
   , undefined(undefined)
-{}
+{
+}
 
 void BundleVersion::Validate()
 {
@@ -74,7 +75,8 @@ BundleVersion::BundleVersion(unsigned int majorVersion,
   , microVersion(microVersion)
   , qualifier("")
   , undefined(false)
-{}
+{
+}
 
 BundleVersion::BundleVersion(unsigned int majorVersion,
                              unsigned int minorVersion,

--- a/framework/src/bundle/Constants.cpp
+++ b/framework/src/bundle/Constants.cpp
@@ -56,8 +56,8 @@ const std::string FRAMEWORK_LOG = "org.cppmicroservices.framework.log";
 const std::string FRAMEWORK_UUID = "org.cppmicroservices.framework.uuid";
 const std::string FRAMEWORK_WORKING_DIR =
   "org.cppmicroservices.framework.working.dir";
-const std::string FRAMEWORK_BUNDLE_VALIDATION_FUNC = 
-    "org.cppmicroservices.framework.bundle.validation.function";
+const std::string FRAMEWORK_BUNDLE_VALIDATION_FUNC =
+  "org.cppmicroservices.framework.bundle.validation.function";
 const std::string OBJECTCLASS = "objectclass";
 const std::string SERVICE_ID = "service.id";
 const std::string SERVICE_PID = "service.pid";

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -164,7 +164,9 @@ void CoreBundleContext::Init()
   auto bundleValidationFunc =
     frameworkProperties.find(Constants::FRAMEWORK_BUNDLE_VALIDATION_FUNC);
   if (bundleValidationFunc != frameworkProperties.end()) {
-    validationFunc = any_cast<std::function<bool(const cppmicroservices::Bundle&)>>(bundleValidationFunc->second);
+    validationFunc =
+      any_cast<std::function<bool(const cppmicroservices::Bundle&)>>(
+        bundleValidationFunc->second);
   }
 
   systemBundle->InitSystemBundle();

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -110,7 +110,7 @@ public:
   */
   std::shared_ptr<detail::LogSink> sink;
 
-   /**
+  /**
    * Bundle Storage
    */
   std::unique_ptr<BundleStorage> storage;

--- a/framework/src/service/ListenerToken.cpp
+++ b/framework/src/service/ListenerToken.cpp
@@ -28,11 +28,13 @@ namespace cppmicroservices {
 
 ListenerToken::ListenerToken()
   : tokenId(ListenerTokenId(0))
-{}
+{
+}
 
 ListenerToken::ListenerToken(ListenerTokenId _tokenId)
   : tokenId(_tokenId)
-{}
+{
+}
 
 ListenerToken::ListenerToken(ListenerToken&& other) noexcept
   : tokenId(std::move(other.tokenId))

--- a/framework/src/service/ServiceEvent.cpp
+++ b/framework/src/service/ServiceEvent.cpp
@@ -33,7 +33,8 @@ public:
                    const ServiceReferenceBase& reference)
     : type(type)
     , reference(reference)
-  {}
+  {
+  }
 
   const ServiceEvent::Type type;
   const ServiceReferenceBase reference;
@@ -41,7 +42,8 @@ public:
 
 ServiceEvent::ServiceEvent()
   : d(nullptr)
-{}
+{
+}
 
 ServiceEvent::operator bool() const
 {
@@ -50,7 +52,8 @@ ServiceEvent::operator bool() const
 
 ServiceEvent::ServiceEvent(Type type, const ServiceReferenceBase& reference)
   : d(new ServiceEventData(type, reference))
-{}
+{
+}
 
 ServiceEvent::ServiceEvent(const ServiceEvent&) = default;
 

--- a/framework/src/service/ServiceException.cpp
+++ b/framework/src/service/ServiceException.cpp
@@ -31,7 +31,8 @@ ServiceException::~ServiceException() = default;
 ServiceException::ServiceException(const std::string& msg, const Type& type)
   : std::runtime_error(msg)
   , type(type)
-{}
+{
+}
 
 ServiceException::ServiceException(const ServiceException&) = default;
 

--- a/framework/src/service/ServiceHooks.cpp
+++ b/framework/src/service/ServiceHooks.cpp
@@ -42,7 +42,8 @@ ServiceHooks::ServiceHooks(CoreBundleContext* coreCtx)
   : coreCtx(coreCtx)
   , listenerHookTracker()
   , bOpen(false)
-{}
+{
+}
 
 ServiceHooks::~ServiceHooks()
 {
@@ -86,7 +87,8 @@ void ServiceHooks::Open()
 {
   auto l = this->Lock();
   US_UNUSED(l);
-  listenerHookTracker = std::make_unique<ServiceTracker<ServiceListenerHook>>(GetBundleContext(), this);
+  listenerHookTracker = std::make_unique<ServiceTracker<ServiceListenerHook>>(
+    GetBundleContext(), this);
   listenerHookTracker->Open();
 
   bOpen = true;

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -125,7 +125,8 @@ ServiceListenerEntry::ServiceListenerEntry(
   const std::string& filter)
   : ServiceListenerHook::ListenerInfo(
       new ServiceListenerEntryData(context, l, data, tokenId, filter))
-{}
+{
+}
 
 const LDAPExpr& ServiceListenerEntry::GetLDAPExpr() const
 {

--- a/framework/src/service/ServiceListenerHook.cpp
+++ b/framework/src/service/ServiceListenerHook.cpp
@@ -45,17 +45,20 @@ ServiceListenerHook::ListenerInfoData::ListenerInfoData(
   , tokenId(tokenId)
   , filter(std::move(filter))
   , bRemoved(false)
-{}
+{
+}
 
 ServiceListenerHook::ListenerInfoData::~ListenerInfoData() = default;
 
 ServiceListenerHook::ListenerInfo::ListenerInfo(ListenerInfoData* data)
   : d(data)
-{}
+{
+}
 
 ServiceListenerHook::ListenerInfo::ListenerInfo()
   : d(nullptr)
-{}
+{
+}
 
 ServiceListenerHook::ListenerInfo::ListenerInfo(const ListenerInfo&) = default;
 

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -47,7 +47,8 @@ public:
                             const ServiceReferenceBase& reference)
     : m_context(std::move(context))
     , m_reference(reference)
-  {}
+  {
+  }
 
   InterfaceMapConstPtr GetServiceInterfaceMap()
   {
@@ -100,7 +101,8 @@ struct UngetHelper
     : interfaceMap(std::move(im))
     , sref(sr)
     , b(b)
-  {}
+  {
+  }
   ~UngetHelper()
   {
     try {
@@ -187,11 +189,13 @@ ServiceReferenceBase ServiceObjectsBase::GetReference() const
 
 ServiceObjectsBase::ServiceObjectsBase(ServiceObjectsBase&& other) noexcept
   : d(std::move(other.d))
-{}
+{
+}
 
 ServiceObjectsBase::~ServiceObjectsBase() = default;
 
-ServiceObjectsBase& ServiceObjectsBase::operator=(ServiceObjectsBase&& other) noexcept
+ServiceObjectsBase& ServiceObjectsBase::operator=(
+  ServiceObjectsBase&& other) noexcept
 {
   d = std::move(other.d);
   return *this;
@@ -199,9 +203,11 @@ ServiceObjectsBase& ServiceObjectsBase::operator=(ServiceObjectsBase&& other) no
 
 ServiceObjects<void>::ServiceObjects(ServiceObjects&& other) noexcept
   : ServiceObjectsBase(std::move(other))
-{}
+{
+}
 
-ServiceObjects<void>& ServiceObjects<void>::operator=(ServiceObjects&& other) noexcept
+ServiceObjects<void>& ServiceObjects<void>::operator=(
+  ServiceObjects&& other) noexcept
 {
   ServiceObjectsBase::operator=(std::move(other));
   return *this;
@@ -221,5 +227,6 @@ ServiceObjects<void>::ServiceObjects(
   const std::shared_ptr<BundleContextPrivate>& context,
   const ServiceReferenceU& reference)
   : ServiceObjectsBase(context, reference)
-{}
+{
+}
 }

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -35,7 +35,8 @@ namespace cppmicroservices {
 
 ServiceReferenceBase::ServiceReferenceBase()
   : d(new ServiceReferenceBasePrivate(nullptr))
-{}
+{
+}
 
 ServiceReferenceBase::ServiceReferenceBase(const ServiceReferenceBase& ref)
   : d(ref.d.load())
@@ -45,7 +46,8 @@ ServiceReferenceBase::ServiceReferenceBase(const ServiceReferenceBase& ref)
 
 ServiceReferenceBase::ServiceReferenceBase(ServiceRegistrationBasePrivate* reg)
   : d(new ServiceReferenceBasePrivate(reg))
-{}
+{
+}
 
 void ServiceReferenceBase::SetInterfaceId(const std::string& interfaceId)
 {

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -69,7 +69,8 @@ ServiceRegistrationBase::ServiceRegistrationBase(
   const InterfaceMapConstPtr& service,
   Properties&& props)
   : d(new ServiceRegistrationBasePrivate(bundle, service, std::move(props)))
-{}
+{
+}
 
 ServiceRegistrationBase::operator bool() const
 {

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -77,7 +77,8 @@ Properties ServiceRegistry::CreateServiceProperties(
 
 ServiceRegistry::ServiceRegistry(CoreBundleContext* coreCtx)
   : core(coreCtx)
-{}
+{
+}
 
 ServiceRegistrationBase ServiceRegistry::RegisterService(
   BundlePrivate* bundle,

--- a/framework/src/util/Any.cpp
+++ b/framework/src/util/Any.cpp
@@ -108,8 +108,8 @@ std::ostream& any_value_to_json(std::ostream& o,
       default:
 // suppress type-limits warning on linux arm 64 build
 #if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
         if ('\x00' <= *c && *c <= '\x1f') {
           o << "\\u" << std::hex << std::setw(4) << std::setfill('0')
@@ -118,7 +118,7 @@ std::ostream& any_value_to_json(std::ostream& o,
           o << *c;
         }
 #if defined(__GNUC__)
-#pragma GCC diagnostic pop
+#  pragma GCC diagnostic pop
 #endif
     }
   }

--- a/framework/src/util/CFRLogger.cpp
+++ b/framework/src/util/CFRLogger.cpp
@@ -122,11 +122,13 @@ void CFRLogger::Open()
   if (!cfrContext) {
     return;
   }
-  serviceTracker = std::make_unique<cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>> (cfrContext, this);
+  serviceTracker = std::make_unique<
+    cppmicroservices::ServiceTracker<cppmicroservices::logservice::LogService>>(
+    cfrContext, this);
   serviceTracker->Open();
 }
 
-void CFRLogger::Close() 
+void CFRLogger::Close()
 {
   auto l = this->Lock();
   US_UNUSED(l);

--- a/framework/src/util/CFRLogger.h
+++ b/framework/src/util/CFRLogger.h
@@ -84,7 +84,7 @@ public:
     const ServiceReference<cppmicroservices::logservice::LogService>& reference,
     const std::shared_ptr<cppmicroservices::logservice::LogService>& service)
     override;
-  
+
   // methods for the CFRLogger class
   void Open();
   void Close();

--- a/framework/src/util/Framework.cpp
+++ b/framework/src/util/Framework.cpp
@@ -40,7 +40,8 @@ Framework::Framework(const Framework&) = default;
 
 Framework::Framework(Framework&& fw) noexcept
   : Bundle(std::move(fw))
-{}
+{
+}
 
 Framework& Framework::operator=(const Framework&) = default;
 
@@ -60,7 +61,8 @@ Framework::Framework(Bundle b)
 
 Framework::Framework(const std::shared_ptr<FrameworkPrivate>& d)
   : Bundle(d)
-{}
+{
+}
 
 void Framework::Init()
 {

--- a/framework/src/util/FrameworkEvent.cpp
+++ b/framework/src/util/FrameworkEvent.cpp
@@ -41,7 +41,8 @@ public:
     , bundle(std::move(bundle))
     , message(std::move(message))
     , exception(exception)
-  {}
+  {
+  }
 
   FrameworkEventData(const FrameworkEventData& other)
 
@@ -55,14 +56,16 @@ public:
 
 FrameworkEvent::FrameworkEvent()
   : d(nullptr)
-{}
+{
+}
 
 FrameworkEvent::FrameworkEvent(Type type,
                                const Bundle& bundle,
                                const std::string& message,
                                const std::exception_ptr exception)
   : d(new FrameworkEventData(type, bundle, message, exception))
-{}
+{
+}
 
 Bundle FrameworkEvent::GetBundle() const
 {

--- a/framework/src/util/FrameworkFactory.cpp
+++ b/framework/src/util/FrameworkFactory.cpp
@@ -35,7 +35,8 @@ struct CoreBundleContextHolder
 {
   CoreBundleContextHolder(std::unique_ptr<CoreBundleContext> ctx)
     : ctx(std::move(ctx))
-  {}
+  {
+  }
 
   ~CoreBundleContextHolder()
   {

--- a/framework/src/util/LDAPProp.cpp
+++ b/framework/src/util/LDAPProp.cpp
@@ -29,11 +29,13 @@ namespace cppmicroservices {
 
 LDAPPropExpr::LDAPPropExpr()
   : m_ldapExpr()
-{}
+{
+}
 
 LDAPPropExpr::LDAPPropExpr(std::string expr)
   : m_ldapExpr(std::move(expr))
-{}
+{
+}
 
 LDAPPropExpr& LDAPPropExpr::operator!()
 {

--- a/framework/src/util/SecurityException.cpp
+++ b/framework/src/util/SecurityException.cpp
@@ -25,9 +25,10 @@
 namespace cppmicroservices {
 SecurityException::SecurityException(std::string what,
                                      cppmicroservices::Bundle origin)
-  : std::runtime_error(std::move(what)),
-    origin(std::move(origin))
-{}
+  : std::runtime_error(std::move(what))
+  , origin(std::move(origin))
+{
+}
 
 Bundle SecurityException::GetBundle() const
 {

--- a/framework/src/util/SharedLibrary.cpp
+++ b/framework/src/util/SharedLibrary.cpp
@@ -54,7 +54,8 @@ public:
   SharedLibraryPrivate()
     : m_Suffix(US_LIB_EXT)
     , m_Prefix(US_LIB_PREFIX)
-  {}
+  {
+  }
 
   void* m_Handle{ nullptr };
 
@@ -67,7 +68,8 @@ public:
 
 SharedLibrary::SharedLibrary()
   : d(new SharedLibraryPrivate)
-{}
+{
+}
 
 SharedLibrary::SharedLibrary(const SharedLibrary&) = default;
 

--- a/framework/src/util/SharedLibraryException.cpp
+++ b/framework/src/util/SharedLibraryException.cpp
@@ -31,7 +31,8 @@ SharedLibraryException::SharedLibraryException(std::error_code ec,
                                                Bundle origin)
   : std::system_error(std::move(ec), std::move(msg))
   , origin(std::move(origin))
-{}
+{
+}
 
 Bundle SharedLibraryException::GetBundle() const
 {

--- a/framework/test/bench/ServiceRegistryTest.cpp
+++ b/framework/test/bench/ServiceRegistryTest.cpp
@@ -191,40 +191,38 @@ BENCHMARK_REGISTER_F(ServiceRegistryFixture, UnregisterServices)
 BENCHMARK_DEFINE_F(ServiceRegistryFixture, ModifyServices)
 (benchmark::State& state)
 {
-    using namespace std::chrono;
+  using namespace std::chrono;
 
-    auto fc = framework->GetBundleContext();
-    auto regCount = state.range(0);
-    auto interfaceCount = state.range(1);
-    auto interfaceMap = MakeInterfaceMapWithNInterfaces(interfaceCount);
+  auto fc = framework->GetBundleContext();
+  auto regCount = state.range(0);
+  auto interfaceCount = state.range(1);
+  auto interfaceMap = MakeInterfaceMapWithNInterfaces(interfaceCount);
 
-    std::vector<ServiceRegistrationBase> regs;
-    for (auto i = regCount; i > 0; --i) {
-        InterfaceMapPtr iMapCopy(std::make_shared<InterfaceMap>(*interfaceMap));
-        auto reg =
-            fc.RegisterService(iMapCopy); 
-        regs.push_back(reg);
+  std::vector<ServiceRegistrationBase> regs;
+  for (auto i = regCount; i > 0; --i) {
+    InterfaceMapPtr iMapCopy(std::make_shared<InterfaceMap>(*interfaceMap));
+    auto reg = fc.RegisterService(iMapCopy);
+    regs.push_back(reg);
+  }
+
+  for (auto _ : state) {
+
+    ServiceProperties props;
+    props["perf.service.value"] = rand() % 100;
+
+    auto start = high_resolution_clock::now();
+
+    for (std::size_t i = 0; i < regs.size(); i++) {
+      regs[i].SetProperties(props);
     }
 
-    for (auto _ : state) {
-
-        ServiceProperties props;
-        props["perf.service.value"] = rand() % 100;
-
-        auto start = high_resolution_clock::now();
-
-        for (std::size_t i = 0; i < regs.size(); i++) {
-            regs[i].SetProperties(props);
-        }
-
-        auto end = high_resolution_clock::now();
-        auto elapsed_seconds = duration_cast<duration<double>>(end - start);
-        state.SetIterationTime(elapsed_seconds.count());
-
-    }
+    auto end = high_resolution_clock::now();
+    auto elapsed_seconds = duration_cast<duration<double>>(end - start);
+    state.SetIterationTime(elapsed_seconds.count());
+  }
 }
 
 BENCHMARK_REGISTER_F(ServiceRegistryFixture, ModifyServices)
-->RangeMultiplier(4)
-->Ranges({ { 1, 1000 }, { 1, 1000 } })
-->UseManualTime();
+  ->RangeMultiplier(4)
+  ->Ranges({ { 1, 1000 }, { 1, 1000 } })
+  ->UseManualTime();

--- a/framework/test/bench/ServiceTrackerTest.cpp
+++ b/framework/test/bench/ServiceTrackerTest.cpp
@@ -228,9 +228,7 @@ BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithBundleContext)
   ->UseManualTime();
 BENCHMARK_REGISTER_F(ServiceTrackerFixture, OpenServiceTrackerWithInterfaceName)
   ->UseManualTime();
-BENCHMARK(CloseServiceTracker)
-  ->RangeMultiplier(2)
-  ->Range(1000, 1000000);
+BENCHMARK(CloseServiceTracker)->RangeMultiplier(2)->Range(1000, 1000000);
 
 // Run this benchmark for each Arg(...) call, passing in the parameter value to the benchmark.
 BENCHMARK_REGISTER_F(ServiceTrackerFixture, ServiceTrackerScalability)

--- a/framework/test/bundles/libC1/TestBundleC1.cpp
+++ b/framework/test/bundles/libC1/TestBundleC1.cpp
@@ -44,7 +44,8 @@ public:
     : context()
     , stop(false)
     , count(0)
-  {}
+  {
+  }
 
   ~TestBundleC1Activator() {}
 

--- a/framework/test/bundles/libH/TestBundleH.cpp
+++ b/framework/test/bundles/libH/TestBundleH.cpp
@@ -55,7 +55,8 @@ class TestProduct : public TestBundleH
 public:
   TestProduct(const Bundle& /*caller*/)
   //: caller(caller)
-  {}
+  {
+  }
 };
 
 class TestProduct2
@@ -65,7 +66,8 @@ class TestProduct2
 public:
   TestProduct2(const Bundle& caller)
     : TestProduct(caller)
-  {}
+  {
+  }
 };
 
 class FakeTestProduct : public TestBundleH3
@@ -87,7 +89,8 @@ public:
   void UngetService(const Bundle& /*caller*/,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /*service*/)
-  {}
+  {
+  }
 };
 
 class TestBundleHServiceFactory : public ServiceFactory
@@ -102,7 +105,8 @@ public:
   void UngetService(const Bundle& /*caller*/,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /*service*/)
-  {}
+  {
+  }
 };
 
 // Simulate the ServiceFactory throwing an exception
@@ -119,7 +123,8 @@ public:
   void UngetService(const Bundle& /*caller*/,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /*service*/)
-  {}
+  {
+  }
 };
 
 // Simulate the ServiceFactory throwing an exception
@@ -159,7 +164,8 @@ public:
   void UngetService(const Bundle& /*caller*/,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /*service*/)
-  {}
+  {
+  }
 };
 
 // Simulates an error condition of a ServiceFactory returning a nullptr
@@ -175,7 +181,8 @@ public:
   void UngetService(const Bundle& /* caller */,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /* service */)
-  {}
+  {
+  }
 };
 
 // Simulate an error condition whereby the service factory recursively tries
@@ -221,7 +228,8 @@ public:
   void UngetService(const Bundle& /*caller*/,
                     const ServiceRegistrationBase& /*sReg*/,
                     const InterfaceMapConstPtr& /*service*/)
-  {}
+  {
+  }
 };
 
 class TestBundleHActivator : public BundleActivator
@@ -243,7 +251,8 @@ class TestBundleHActivator : public BundleActivator
 public:
   TestBundleHActivator()
     : thisServiceName(us_service_interface_iid<TestBundleH>())
-  {}
+  {
+  }
 
   void Start(BundleContext context)
   {

--- a/framework/test/bundles/libSL1/ActivatorSL1.cpp
+++ b/framework/test/bundles/libSL1/ActivatorSL1.cpp
@@ -56,7 +56,8 @@ public:
                               const BundleContext& bc)
     : bundlePropsService(propService)
     , context(bc)
-  {}
+  {
+  }
 
   virtual ~SL1ServiceTrackerCustomizer() { context = nullptr; }
 
@@ -73,7 +74,8 @@ public:
 
   void ModifiedService(const ServiceReference<FooService>& /*reference*/,
                        const std::shared_ptr<FooService>& /*service*/)
-  {}
+  {
+  }
 
   void RemovedService(const ServiceReference<FooService>& /*reference*/,
                       const std::shared_ptr<FooService>& /*service*/)
@@ -91,7 +93,8 @@ public:
     , trackerCustomizer(nullptr)
     , tracker(nullptr)
     , context()
-  {}
+  {
+  }
 
   ~ActivatorSL1() {}
 

--- a/framework/test/bundles/libSL3/ActivatorSL3.cpp
+++ b/framework/test/bundles/libSL3/ActivatorSL3.cpp
@@ -54,7 +54,8 @@ public:
     const BundleContext& bc)
     : bundlePropsService(propService)
     , context(bc)
-  {}
+  {
+  }
 
   virtual ~SL3ServiceTrackerCustomizer() { context = nullptr; }
 
@@ -71,7 +72,8 @@ public:
 
   void ModifiedService(const ServiceReference<FooService>& /*reference*/,
                        const std::shared_ptr<FooService>& /*service*/)
-  {}
+  {
+  }
 
   void RemovedService(const ServiceReference<FooService>& /*reference*/,
                       const std::shared_ptr<FooService>& /*service*/)
@@ -92,7 +94,8 @@ public:
     : trackerCustomizer(nullptr)
     , tracker(nullptr)
     , context()
-  {}
+  {
+  }
 
   ~ActivatorSL3() {}
 

--- a/framework/test/bundles/libTestModuleWithEmbeddedZip/foo.cpp
+++ b/framework/test/bundles/libTestModuleWithEmbeddedZip/foo.cpp
@@ -1,4 +1,5 @@
 
-class foo final {
-    ~foo() = default;
+class foo final
+{
+  ~foo() = default;
 };

--- a/framework/test/gtest/BundleGetSymbolTest.cpp
+++ b/framework/test/gtest/BundleGetSymbolTest.cpp
@@ -48,7 +48,8 @@ protected:
 public:
   BundleGetSymbolTest()
     : f(FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~BundleGetSymbolTest() override = default;
 
   void SetUp() override

--- a/framework/test/gtest/BundleManifestTest.cpp
+++ b/framework/test/gtest/BundleManifestTest.cpp
@@ -110,7 +110,8 @@ class BundleManifestTest : public ::testing::Test
 protected:
   BundleManifestTest()
     : framework(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   virtual ~BundleManifestTest() = default;
 
   virtual void SetUp() { framework.Start(); }

--- a/framework/test/gtest/BundleResourceTest.cpp
+++ b/framework/test/gtest/BundleResourceTest.cpp
@@ -52,7 +52,8 @@ protected:
 public:
   BundleResourceTest()
     : framework(FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~BundleResourceTest() override = default;
 
   void SetUp() override
@@ -522,7 +523,8 @@ protected:
 public:
   BundleResourceDataOnlyTest()
     : framework(FrameworkFactory().NewFramework())
-  {}
+  {
+  }
   ~BundleResourceDataOnlyTest() override = default;
 
   void SetUp() override

--- a/framework/test/gtest/BundleValidationTest.cpp
+++ b/framework/test/gtest/BundleValidationTest.cpp
@@ -24,8 +24,8 @@ limitations under the License.
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/Constants.h"
 #include "cppmicroservices/Framework.h"
-#include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/SecurityException.h"
 
 #include "TestUtils.h"
@@ -36,11 +36,11 @@ limitations under the License.
 
 TEST(BundleValidationTest, BundleValidationFailure)
 {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle&) -> bool {
-    return false;
-  };
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle&) -> bool { return false; };
   cppmicroservices::FrameworkConfiguration configuration{
     { cppmicroservices::Constants::FRAMEWORK_BUNDLE_VALIDATION_FUNC,
       validationFunc }
@@ -65,12 +65,13 @@ TEST(BundleValidationTest, BundleValidationFailure)
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 
-TEST(BundleValidationTest, BundleValidationSuccess) {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+TEST(BundleValidationTest, BundleValidationSuccess)
+{
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle&) -> bool {
-    return true;
-  };
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle&) -> bool { return true; };
   cppmicroservices::FrameworkConfiguration configuration{
     { cppmicroservices::Constants::FRAMEWORK_BUNDLE_VALIDATION_FUNC,
       validationFunc }
@@ -88,17 +89,19 @@ TEST(BundleValidationTest, BundleValidationSuccess) {
   // a bundle validation function which returns true must cause the
   // Framework to start the bundle and it should be loaded
   // into the process.
-  ASSERT_EQ(bundleA.GetState(),
-            cppmicroservices::Bundle::State::STATE_ACTIVE);
+  ASSERT_EQ(bundleA.GetState(), cppmicroservices::Bundle::State::STATE_ACTIVE);
 
   f.Stop();
   f.WaitForStop(std::chrono::milliseconds::zero());
 }
 
-TEST(BundleValidationTest, BundleValidationFunctionException) {
-  using validationFuncType = std::function<bool(const cppmicroservices::Bundle&)>;
+TEST(BundleValidationTest, BundleValidationFunctionException)
+{
+  using validationFuncType =
+    std::function<bool(const cppmicroservices::Bundle&)>;
 
-  validationFuncType validationFunc = [](const cppmicroservices::Bundle&) -> bool {
+  validationFuncType validationFunc =
+    [](const cppmicroservices::Bundle&) -> bool {
     throw std::runtime_error("foobar");
   };
   cppmicroservices::FrameworkConfiguration configuration{
@@ -115,7 +118,7 @@ TEST(BundleValidationTest, BundleValidationFunctionException) {
     [&receivedBundleValidationErrorEvent](
       const cppmicroservices::FrameworkEvent& evt) {
       if (evt.GetType() ==
-          cppmicroservices::FrameworkEvent::Type::FRAMEWORK_WARNING &&
+            cppmicroservices::FrameworkEvent::Type::FRAMEWORK_WARNING &&
           evt.GetBundle().GetSymbolicName() == "TestBundleA") {
         receivedBundleValidationErrorEvent = true;
       }

--- a/framework/test/gtest/FrameworkTestActivator.cpp
+++ b/framework/test/gtest/FrameworkTestActivator.cpp
@@ -30,7 +30,8 @@ FrameworkTestActivator* FrameworkTestActivator::m_Instance = nullptr;
 
 FrameworkTestActivator::FrameworkTestActivator()
   : m_StartCalled(false)
-{}
+{
+}
 
 bool FrameworkTestActivator::StartCalled()
 {

--- a/framework/test/gtest/MultipleListenersTest.cpp
+++ b/framework/test/gtest/MultipleListenersTest.cpp
@@ -230,7 +230,8 @@ class MultipleListenersTest : public ::testing::Test
 public:
   MultipleListenersTest()
     : framework(FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   ~MultipleListenersTest() override = default;
 
@@ -414,7 +415,8 @@ TEST_F(MultipleListenersTest, testListenerTypes)
       : service_count(0)
       , bundle_count(0)
       , framework_count(0)
-    {}
+    {
+    }
 
     void serviceChanged(const ServiceEvent& /*evt*/) { ++service_count; }
     void bundleChanged(const BundleEvent& /*evt*/) { ++bundle_count; }

--- a/framework/test/gtest/OpenFileHandleTest.cpp
+++ b/framework/test/gtest/OpenFileHandleTest.cpp
@@ -102,7 +102,7 @@ TEST(OpenFileHandleTest, InstallBundle)
     << "The handle counts before and after installing a bundle should not "
        "differ.";
 
-  f.Stop(); 
+  f.Stop();
   f.WaitForStop(std::chrono::seconds::zero());
 }
 
@@ -140,18 +140,15 @@ TEST(OpenFileHandleTest, InstallBundleFailure)
   std::string testModulePath =
     cppmicroservices::testing::LIB_PATH + util::DIR_SEP + US_LIB_PREFIX +
     "TestModuleWithEmbeddedZip" + US_LIB_POSTFIX + US_LIB_EXT;
-  EXPECT_TRUE(
-    mz_zip_reader_init_file(&zipArchive, testModulePath.c_str(), 0));
+  EXPECT_TRUE(mz_zip_reader_init_file(&zipArchive, testModulePath.c_str(), 0));
 
   mz_uint numFiles =
     mz_zip_reader_get_num_files(const_cast<mz_zip_archive*>(&zipArchive));
   EXPECT_EQ(numFiles, 1) << "Wrong # of files in the zip found.";
   for (mz_uint fileIndex = 0; fileIndex < numFiles; ++fileIndex) {
     char fileName[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
-    if (mz_zip_reader_get_filename(&zipArchive,
-                                   fileIndex,
-                                   fileName,
-                                   MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE)) {
+    if (mz_zip_reader_get_filename(
+          &zipArchive, fileIndex, fileName, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE)) {
       std::string strFileName{ fileName };
       std::size_t pos = strFileName.find_first_of('/');
       EXPECT_EQ(pos, std::string::npos)
@@ -175,4 +172,3 @@ TEST(OpenFileHandleTest, InstallBundleFailure)
   f.Stop();
   f.WaitForStop(std::chrono::seconds::zero());
 }
-

--- a/framework/test/gtest/SecurityExceptionTest.cpp
+++ b/framework/test/gtest/SecurityExceptionTest.cpp
@@ -20,19 +20,19 @@ limitations under the License.
 
 =============================================================================*/
 
-#include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/SecurityException.h"
+#include "cppmicroservices/Bundle.h"
 
 #include "TestUtils.h"
 
 #include "gtest/gtest.h"
 
-TEST(SecurityExceptionTest, ctor) {
+TEST(SecurityExceptionTest, ctor)
+{
 
   cppmicroservices::Bundle b;
   std::string excMessage{ "foo" };
-  cppmicroservices::SecurityException secException(excMessage,
-                                                   b);
+  cppmicroservices::SecurityException secException(excMessage, b);
 
   cppmicroservices::SecurityException copyOfException = secException;
 

--- a/framework/test/gtest/ServiceFactoryTest.cpp
+++ b/framework/test/gtest/ServiceFactoryTest.cpp
@@ -621,7 +621,7 @@ TEST_F(ServiceFactoryTest, TestServiceFactoryBundleScopeErrorConditions)
 
   //Test that the service object returned is not a nullptr
   ASSERT_NE(nullptr,
-      GetBundleContext().GetService(svcRecursiveGetServiceRefs[0]));
+            GetBundleContext().GetService(svcRecursiveGetServiceRefs[0]));
   //Test that no FrameworkEvent was sent
   ASSERT_TRUE(fwEvents.empty());
 }

--- a/framework/test/gtest/ServiceHooksTest.cpp
+++ b/framework/test/gtest/ServiceHooksTest.cpp
@@ -81,7 +81,8 @@ public:
   TestServiceEventListenerHook(int id, const BundleContext& context)
     : id(id)
     , bundleCtx(context)
-  {}
+  {
+  }
 
   using MapType =
     ShrinkableMap<BundleContext,
@@ -177,7 +178,8 @@ public:
   TestServiceFindHook(int id, const BundleContext& context)
     : id(id)
     , bundleCtx(context)
-  {}
+  {
+  }
 
   void Find(const BundleContext& context,
             const std::string& /*name*/,
@@ -218,7 +220,8 @@ public:
   TestServiceListenerHook(int id, const BundleContext& context)
     : id(id)
     , bundleCtx(context)
-  {}
+  {
+  }
 
   void Added(const std::vector<ListenerInfo>& listeners)
   {

--- a/framework/test/gtest/ServiceListenerTest.cpp
+++ b/framework/test/gtest/ServiceListenerTest.cpp
@@ -85,7 +85,8 @@ public:
     , events()
     , teststatus(true)
     , context(context)
-  {}
+  {
+  }
 
   bool getTestStatus() const { return teststatus; }
 

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -82,7 +82,8 @@ class MyCustomizer
 public:
   MyCustomizer(const BundleContext& context)
     : m_context(context)
-  {}
+  {
+  }
 
   virtual std::shared_ptr<MyInterfaceOne> AddingService(
     const ServiceReference<MyInterfaceOne>& reference)
@@ -477,14 +478,16 @@ class CustomFooTracker final
      */
   void ModifiedService(::cppmicroservices::ServiceReference<FooService> const&,
                        std::shared_ptr<FooService> const&) override
-  {}
+  {
+  }
 
   /**
      * Called when a service is removed.
      */
   void RemovedService(::cppmicroservices::ServiceReference<FooService> const&,
                       std::shared_ptr<FooService> const&) override
-  {}
+  {
+  }
 };
 }
 
@@ -591,7 +594,8 @@ class MyNullPtrCustomizer final
 public:
   MyNullPtrCustomizer(const BundleContext& context)
     : m_context(context)
-  {}
+  {
+  }
 
   virtual std::shared_ptr<MyInterfaceOne> AddingService(
     const ServiceReference<MyInterfaceOne>&)
@@ -601,11 +605,13 @@ public:
 
   virtual void ModifiedService(const ServiceReference<MyInterfaceOne>&,
                                const std::shared_ptr<MyInterfaceOne>&)
-  {}
+  {
+  }
 
   virtual void RemovedService(const ServiceReference<MyInterfaceOne>&,
                               const std::shared_ptr<MyInterfaceOne>&)
-  {}
+  {
+  }
 
 private:
   BundleContext m_context;
@@ -630,7 +636,8 @@ TEST_F(ServiceTrackerTestFixture, TestNullPtrServiceTrackerCustomizer)
 
   context.RegisterService<MyInterfaceOne>(serviceOne);
 
-  ASSERT_EQ(tracker.GetServiceReferences().size(), 0) << "tracking count should be 0";
+  ASSERT_EQ(tracker.GetServiceReferences().size(), 0)
+    << "tracking count should be 0";
 
   auto trackedObj = tracker.WaitForService(std::chrono::seconds(1));
   ASSERT_EQ(nullptr, trackedObj) << "tracked object should be nullptr";
@@ -669,5 +676,4 @@ TEST_F(ServiceTrackerTestFixture, TestReOpenServiceTrackerWithCustomizer)
     context.RegisterService<MyInterfaceOne>(std::make_shared<MyServiceOne>());
   svcReg2.SetProperties({ { "test", Any(std::string("foo")) } });
   tracker->Close();
-  
 }

--- a/framework/test/gtest/SharedLibraryExceptionTest.cpp
+++ b/framework/test/gtest/SharedLibraryExceptionTest.cpp
@@ -38,7 +38,8 @@ class SharedLibraryExceptionTest : public ::testing::Test
 protected:
   SharedLibraryExceptionTest()
     : f(cppmicroservices::FrameworkFactory().NewFramework())
-  {}
+  {
+  }
 
   virtual ~SharedLibraryExceptionTest() = default;
 

--- a/framework/test/gtest/ShrinkableMapTest.cpp
+++ b/framework/test/gtest/ShrinkableMapTest.cpp
@@ -62,7 +62,7 @@ TEST(ShrinkableMapTest, testShrinkableMapOperations)
   shrinkable.erase(shrinkable.find(1));
   //New size
   ASSERT_EQ(m.size(), 2);
-  EXPECT_THROW(shrinkable.at(1),std::out_of_range);
+  EXPECT_THROW(shrinkable.at(1), std::out_of_range);
   //back() access
   ASSERT_EQ(shrinkable.at(2), "two");
 }

--- a/framework/test/gtest/UtilsTest.cpp
+++ b/framework/test/gtest/UtilsTest.cpp
@@ -59,9 +59,15 @@ protected:
     return TempDir.Path + DIR_SEP + longName.data();
   }
 
-  static std::string GetExistingDir() { return GetCurrentWorkingDirectory(); }
+  static std::string GetExistingDir()
+  {
+    return GetCurrentWorkingDirectory();
+  }
 
-  static std::string GetExistingFile() { return GetExecutablePath(); }
+  static std::string GetExistingFile()
+  {
+    return GetExecutablePath();
+  }
 
   static cppmicroservices::testing::TempDir TempDir;
 };

--- a/framework/test/gtest/ZipFile.h
+++ b/framework/test/gtest/ZipFile.h
@@ -22,8 +22,8 @@ limitations under the License.
 
 #include "miniz.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
 /*
 * @brief Struct which represents an entry in the zip archive.

--- a/framework/test/util/TestUtilBundleListener.cpp
+++ b/framework/test/util/TestUtilBundleListener.cpp
@@ -29,7 +29,8 @@ namespace cppmicroservices {
 TestBundleListener::TestBundleListener()
   : serviceEvents()
   , bundleEvents()
-{}
+{
+}
 
 void TestBundleListener::BundleChanged(const BundleEvent& event)
 {

--- a/framework/test/util/TestUtilFrameworkListener.cpp
+++ b/framework/test/util/TestUtilFrameworkListener.cpp
@@ -31,7 +31,8 @@ namespace cppmicroservices {
 
 TestFrameworkListener::TestFrameworkListener()
   : _events()
-{}
+{
+}
 TestFrameworkListener::~TestFrameworkListener(){};
 
 std::size_t TestFrameworkListener::events_received() const
@@ -45,9 +46,9 @@ bool TestFrameworkListener::CheckEvents(
   bool listenState = true; // assume success
   if (events.size() != _events.size()) {
     listenState = false;
-    ADD_FAILURE()<< "*** Framework event mismatch ***\n expected "
-                   << events.size() << " event(s)\n found " << _events.size()
-                   << " event(s).";
+    ADD_FAILURE() << "*** Framework event mismatch ***\n expected "
+                  << events.size() << " event(s)\n found " << _events.size()
+                  << " event(s).";
 
     const std::size_t max =
       events.size() > _events.size() ? events.size() : _events.size();
@@ -56,7 +57,7 @@ bool TestFrameworkListener::CheckEvents(
         i < events.size() ? events[i] : FrameworkEvent();
       const FrameworkEvent& pR =
         i < _events.size() ? _events[i] : FrameworkEvent();
-      std::cout<< " - " << pE << " - " << pR;
+      std::cout << " - " << pE << " - " << pR;
     }
   } else {
     for (std::size_t i = 0; i < events.size(); ++i) {
@@ -64,8 +65,8 @@ bool TestFrameworkListener::CheckEvents(
       const FrameworkEvent& pR = _events[i];
       if (pE.GetType() != pR.GetType() || pE.GetBundle() != pR.GetBundle()) {
         listenState = false;
-        ADD_FAILURE()<< "*** Wrong framework event ***\n found " << pR
-                       << "\n expected " << pE;
+        ADD_FAILURE() << "*** Wrong framework event ***\n found " << pR
+                      << "\n expected " << pE;
       }
     }
   }

--- a/framework/test/util/TestUtils.cpp
+++ b/framework/test/util/TestUtils.cpp
@@ -388,12 +388,14 @@ char* mkdtemps_compat(char* tmpl, int suffixlen)
 File::File()
   : FileDescr(-1)
   , Path()
-{}
+{
+}
 
 File::File(int fd, const std::string& path)
   : FileDescr(fd)
   , Path(path)
-{}
+{
+}
 
 File::File(File&& o)
   : FileDescr(o.FileDescr)
@@ -419,11 +421,13 @@ TempDir::TempDir() {}
 
 TempDir::TempDir(const std::string& path)
   : Path(path)
-{}
+{
+}
 
 TempDir::TempDir(TempDir&& o)
   : Path(std::move(o.Path))
-{}
+{
+}
 
 TempDir& TempDir::operator=(TempDir&& o)
 {

--- a/httpservice/src/HttpServlet.cpp
+++ b/httpservice/src/HttpServlet.cpp
@@ -39,7 +39,8 @@ public:
   explicit NoBodyOutputStreamBuffer(HttpServletResponsePrivate* response)
     : HttpOutputStreamBuffer(response)
     , m_ContentLength(0)
-  {}
+  {
+  }
 
   std::size_t GetContentLength() const { return m_ContentLength; }
 
@@ -129,7 +130,8 @@ const std::string HttpServlet::PROP_CONTEXT_ROOT =
 
 HttpServlet::HttpServlet()
   : d(new HttpServletPrivate)
-{}
+{
+}
 
 void HttpServlet::Init(const ServletConfig& config)
 {

--- a/httpservice/src/HttpServletRequest.cpp
+++ b/httpservice/src/HttpServletRequest.cpp
@@ -329,7 +329,8 @@ void HttpServletRequest::SetAttribute(const std::string& name, const Any& value)
 
 HttpServletRequest::HttpServletRequest(HttpServletRequestPrivate* d)
   : d(d)
-{}
+{
+}
 }
 
 US_MSVC_POP_WARNING

--- a/httpservice/src/HttpServletResponse.cpp
+++ b/httpservice/src/HttpServletResponse.cpp
@@ -51,7 +51,8 @@ HttpServletResponsePrivate::HttpServletResponsePrivate(
   , m_HttpOutputStream(nullptr)
   , m_IsCommited(false)
   , m_BufferSize(1024)
-{}
+{
+}
 
 HttpServletResponsePrivate::~HttpServletResponsePrivate()
 {
@@ -421,7 +422,8 @@ void HttpServletResponse::SetOutputStreamBuffer(std::streambuf* sb)
 
 HttpServletResponse::HttpServletResponse(HttpServletResponsePrivate* d)
   : d(d)
-{}
+{
+}
 }
 
 US_MSVC_POP_WARNING

--- a/httpservice/src/ServletConfig.cpp
+++ b/httpservice/src/ServletConfig.cpp
@@ -50,7 +50,8 @@ void ServletConfig::SetServletContext(
 
 ServletConfig::ServletConfig()
   : d(new ServletConfigPrivate)
-{}
+{
+}
 
 ServletConfig::ServletConfig(const ServletConfig&) = default;
 ServletConfig& ServletConfig::operator=(const ServletConfig&) = default;

--- a/httpservice/src/ServletContainer.cpp
+++ b/httpservice/src/ServletContainer.cpp
@@ -53,7 +53,8 @@ public:
   ServletHandler(std::shared_ptr<HttpServlet> servlet, std::string servletPath)
     : m_Servlet(std::move(servlet))
     , m_ServletPath(std::move(servletPath))
-  {}
+  {
+  }
 
   std::shared_ptr<ServletContext> GetServletContext() const
   {
@@ -129,7 +130,8 @@ ServletContainerPrivate::ServletContainerPrivate(BundleContext bundleCtx,
   , m_Server(nullptr)
   , m_ServletTracker(m_Context, this)
   , q(q)
-{}
+{
+}
 
 void ServletContainerPrivate::Start()
 {

--- a/httpservice/src/ServletContext.cpp
+++ b/httpservice/src/ServletContext.cpp
@@ -28,7 +28,8 @@ namespace cppmicroservices {
 
 ServletContext::ServletContext(ServletContainer* container)
   : m_Container(container)
-{}
+{
+}
 
 std::string ServletContext::GetContextPath() const
 {

--- a/shellservice/src/ShellService.cpp
+++ b/shellservice/src/ShellService.cpp
@@ -279,7 +279,8 @@ struct ShellService::Impl
 {
   Impl()
     : m_Scheme(scheme_init_new())
-  {}
+  {
+  }
   ~Impl() { free(m_Scheme); }
 
   void InitSymbols();

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -122,10 +122,12 @@ class InvalidManifest : public std::runtime_error
 public:
   InvalidManifest(const std::string& msg)
     : std::runtime_error(msg)
-  {}
+  {
+  }
   InvalidManifest(const char* msg)
     : std::runtime_error(msg)
-  {}
+  {
+  }
 };
 
 /*

--- a/util/include/cppmicroservices/util/BundleElfFile.h
+++ b/util/include/cppmicroservices/util/BundleElfFile.h
@@ -41,7 +41,8 @@ struct InvalidElfException : public InvalidObjFileException
 {
   InvalidElfException(std::string what, int errorNumber = 0)
     : InvalidObjFileException(std::move(what), errorNumber)
-  {}
+  {
+  }
 };
 
 template<int>

--- a/util/include/cppmicroservices/util/BundleMachOFile.h
+++ b/util/include/cppmicroservices/util/BundleMachOFile.h
@@ -42,7 +42,8 @@ struct InvalidMachOException : public InvalidObjFileException
 {
   InvalidMachOException(const std::string& what, int errorNumber = 0)
     : InvalidObjFileException(what, errorNumber)
-  {}
+  {
+  }
 };
 
 template<uint32_t>

--- a/util/include/cppmicroservices/util/BundleObjFile.h
+++ b/util/include/cppmicroservices/util/BundleObjFile.h
@@ -53,7 +53,8 @@ class RawBundleResources
 public:
   RawBundleResources(std::unique_ptr<DataContainer> data)
     : m_Data(std::move(data))
-  {}
+  {
+  }
 
   operator bool() const
   {

--- a/util/include/cppmicroservices/util/BundlePEFile.h
+++ b/util/include/cppmicroservices/util/BundlePEFile.h
@@ -64,7 +64,8 @@ public:
     : m_ModuleHandle(std::move(moduleHandle))
     , m_Data(data)
     , m_DataSize(dataSize)
-  {}
+  {
+  }
   ~ResDataContainer() = default;
 
   void* GetData() const override { return m_Data; }
@@ -80,7 +81,8 @@ struct InvalidPEException : public InvalidObjFileException
 {
   InvalidPEException(std::string what, int errorNumber = 0)
     : InvalidObjFileException(std::move(what), errorNumber)
-  {}
+  {
+  }
 };
 
 class BundlePEFile : public BundleObjFile

--- a/util/include/cppmicroservices/util/DataContainer.h
+++ b/util/include/cppmicroservices/util/DataContainer.h
@@ -54,7 +54,8 @@ public:
                    std::size_t dataSize)
     : m_Data(std::move(data))
     , m_DataSize(dataSize)
-  {}
+  {
+  }
   ~RawDataContainer() = default;
 
   void* GetData() const override { return m_Data.get(); }

--- a/util/include/cppmicroservices/util/MappedFile.h
+++ b/util/include/cppmicroservices/util/MappedFile.h
@@ -41,7 +41,8 @@ public:
     : fileDesc(-1)
     , mappedAddress(nullptr)
     , mapSize(0)
-  {}
+  {
+  }
   MappedFile(const std::string& fileLocation, size_t mapLength, off_t offset)
     : fileDesc(-1)
     , mappedAddress(nullptr)

--- a/webconsole/include/cppmicroservices/webconsole/SimpleWebConsolePlugin.h
+++ b/webconsole/include/cppmicroservices/webconsole/SimpleWebConsolePlugin.h
@@ -57,8 +57,8 @@ public:
   SimpleWebConsolePlugin(
     const std::string& label,
     const std::string& title,
-    std::string  category = std::string(),
-    std::vector<std::string>  css = std::vector<std::string>());
+    std::string category = std::string(),
+    std::vector<std::string> css = std::vector<std::string>());
 
   /**
    * @see AbstractWebConsolePlugin#GetLabel()

--- a/webconsole/src/BundlesPlugin.cpp
+++ b/webconsole/src/BundlesPlugin.cpp
@@ -94,7 +94,8 @@ std::string SizeTag(const std::pair<std::size_t, std::size_t>& p)
 
 BundlesPlugin::BundlesPlugin()
   : SimpleWebConsolePlugin("bundles", "Bundles", "")
-{}
+{
+}
 
 void BundlesPlugin::RenderContent(HttpServletRequest& request,
                                   HttpServletResponse& response)
@@ -300,7 +301,7 @@ std::pair<std::size_t, std::size_t> BundlesPlugin::GetResourceJsonTree(
         totalSize.second += size.second;
         json += indent + ",\n";
       }
-      for (auto & childFile : childFiles) {
+      for (auto& childFile : childFiles) {
         auto size = GetResourceJsonTree(bundle,
                                         currResource.GetResourcePath(),
                                         childFile,

--- a/webconsole/src/ServicesPlugin.cpp
+++ b/webconsole/src/ServicesPlugin.cpp
@@ -42,7 +42,8 @@ std::string NumToString(int64_t val);
 
 ServicesPlugin::ServicesPlugin()
   : SimpleWebConsolePlugin("services", "Services", "")
-{}
+{
+}
 
 void ServicesPlugin::RenderContent(HttpServletRequest& request,
                                    HttpServletResponse& response)

--- a/webconsole/src/SettingsPlugin.cpp
+++ b/webconsole/src/SettingsPlugin.cpp
@@ -38,7 +38,8 @@ namespace cppmicroservices {
 
 SettingsPlugin::SettingsPlugin()
   : SimpleWebConsolePlugin("settings", "Settings", "")
-{}
+{
+}
 
 void SettingsPlugin::RenderContent(HttpServletRequest& request,
                                    HttpServletResponse& response)

--- a/webconsole/src/SimpleWebConsolePlugin.cpp
+++ b/webconsole/src/SimpleWebConsolePlugin.cpp
@@ -33,11 +33,10 @@
 
 namespace cppmicroservices {
 
-SimpleWebConsolePlugin::SimpleWebConsolePlugin(
-  const std::string& label,
-  const std::string& title,
-  std::string  category,
-  std::vector<std::string>  css)
+SimpleWebConsolePlugin::SimpleWebConsolePlugin(const std::string& label,
+                                               const std::string& title,
+                                               std::string category,
+                                               std::vector<std::string> css)
   : m_Label(label)
   , m_Title(title)
   , m_Category(std::move(category))

--- a/webconsole/src/VariableResolverStreamBuffer.cpp
+++ b/webconsole/src/VariableResolverStreamBuffer.cpp
@@ -32,7 +32,7 @@ namespace cppmicroservices {
 
 VariableResolverStreamBuffer::VariableResolverStreamBuffer(
   std::unique_ptr<std::ostream> out,
-  std::shared_ptr<WebConsoleVariableResolver>  variables)
+  std::shared_ptr<WebConsoleVariableResolver> variables)
   : m_State(State::NIL)
   , m_Out(std::move(out))
   , m_Variables(std::move(variables))

--- a/webconsole/src/VariableResolverStreamBuffer.h
+++ b/webconsole/src/VariableResolverStreamBuffer.h
@@ -37,7 +37,7 @@ class VariableResolverStreamBuffer : public std::streambuf
 public:
   explicit VariableResolverStreamBuffer(
     std::unique_ptr<std::ostream> out,
-    std::shared_ptr<WebConsoleVariableResolver>  resolver);
+    std::shared_ptr<WebConsoleVariableResolver> resolver);
 
   ~VariableResolverStreamBuffer();
 

--- a/webconsole/src/WebConsoleServlet.cpp
+++ b/webconsole/src/WebConsoleServlet.cpp
@@ -48,7 +48,8 @@ public:
     , m_StreamBuf(nullptr)
     , m_Plugin(plugin)
     , m_Request(request)
-  {}
+  {
+  }
 
   ~FilteringResponseWrapper() override = default;
 
@@ -98,7 +99,8 @@ void WebConsolePluginTracker::AddPlugin(const std::string& label,
 WebConsolePluginTracker::WebConsolePluginTracker()
   : ServiceTracker<HttpServlet>(GetBundleContext())
   , m_ServletContext(nullptr)
-{}
+{
+}
 
 void WebConsolePluginTracker::Open(
   const std::shared_ptr<ServletContext>& context)


### PR DESCRIPTION
equivalent of PR #759.

Ran `find . -iname '*.h' -o -iname '*.cpp' -o -iname '*.tpp' | xargs clang-format -i --verbose` with clang-format from clang-14. Reverted changes in third-party folder and committed the rest.

In addition to the 205 changed files from #759, this PR also changes `framework/include/cppmicroservices/detail/BundleAbstractTracked.tpp`