### PR TITLE
701 - Clang-format git hook pre-commit enforcement (#760)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Run clang-format pre-commit hook
+sh .githooks/pre-commit-clang-format-hook

--- a/.githooks/pre-commit-clang-format-hook
+++ b/.githooks/pre-commit-clang-format-hook
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+printf "Running clang-format pre-commit hook... ";
+
+CLANG_FORMAT=$(which clang-format)
+
+if [ ! -x "$CLANG_FORMAT" ]; then
+  printf "Error.\n";
+  printf "The clang-format cannot be found in your PATH. Please ensure clang-format is installed and on the PATH."
+  exit 1
+fi
+
+# Get clang-format output and store it for later checking
+clangformatoutput=$(git clang-format --style=file --diff --staged -q)
+
+# Redirect output to stderr
+exec 1>&2
+
+if [ "$clangformatoutput" != "" ];
+then
+  printf "Error.\n";
+  printf "clang-format detected that changes have been made and are not properly formatted!\n"
+  printf "Please run \`git clang-format --style=file --staged\`, re-stage modified files, and commit.\n"
+  exit 1
+else
+  printf "Success.\n";
+fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,19 @@ foreach(policy ${policies_new})
 endforeach()
 
 #-----------------------------------------------------------------------------
+# Setup git hooks
+#-----------------------------------------------------------------------------
+find_package(Git)
+if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  execute_process(COMMAND ${GIT_EXECUTABLE} config core.hooksPath "${PROJECT_SOURCE_DIR}/.githooks"
+                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                          RESULT_VARIABLE GIT_CONFIGMOD_RESULT)
+  if (NOT GIT_CONFIGMOD_RESULT EQUAL "0")
+    message(WARNING "Command `git config core.hooksPath ${PROJECT_SOURCE_DIR}/.githooks` failed with ${GIT_CONFIGMOD_RESULT}")
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------
 # Check minimum required compiler versions
 #------------------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -224,3 +224,22 @@ file for details about the contribution process.
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/master
 .. |Code Coverage Status (development)| image:: https://img.shields.io/codecov/c/github/CppMicroServices/CppMicroServices/development.svg?style=flat-square
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/development
+
+Git Hooks General Information
+-----------------------------
+
+The CppMicroServices repository defines its git hooks in the `.githooks` directory. This directory is
+set as the directory for git hooks via executing `git config core.hooksPath <path>` in our `CMakeLists.txt` file.
+
+Git Hooks Failure Help
+----------------------
+
+If the clang-format pre-commit hook fails because `clang-format` is not installed, please install it and
+put it on the path. Similarly, if `git-clang-format` is not installed, do the same. `git-clang-format` comes
+with the LLVM distribution of `clang-format`.
+
+If this is not feasible for you, you can specify `--no-verify` when committing your changes. This is heavily discouraged
+and you must provide a justification as to why you are unable to format your commit.
+
+We reserve the right to reject any pull requests that are not properly formatted and do not have a
+valid justification specified.

--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -1,0 +1,4 @@
+{
+    "DisableFormat": true,
+    "SortIncludes": false,
+}


### PR DESCRIPTION
Cherry-picked #760 / 196dec7a552cd5410f84ef263e38298e2ae3a61b without changes.