### PR TITLE
701 - Support arm64 on macOS (#778)

### DIFF
--- a/util/include/cppmicroservices/util/BundleMachOFile.h
+++ b/util/include/cppmicroservices/util/BundleMachOFile.h
@@ -249,6 +249,8 @@ namespace cppmicroservices
         ident[1] = CPU_TYPE_X86;
 #    elif defined(__arm__) || defined(_M_ARM)
         ident[1] = CPU_TYPE_ARM;
+#    elif defined(__arm64__)
+        ident[1] = CPU_TYPE_ARM64;
 #    endif
 
         return ident;


### PR DESCRIPTION
Cherry-picked #778 / 749fb520182f29742d203abccfba91a373e55ad9 without changes.