### PR TITLE
701 - Performance improvement from `brian-performance` branch (#728) - C++14 variant

### DIFF
--- a/compendium/DeclarativeServices/test/TestReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/test/TestReferenceManagerImpl.cpp
@@ -611,7 +611,7 @@ namespace cppmicroservices
 
             auto registeredServiceRefs = bc.GetServiceReferences<dummy::Reference1>();
             auto registeredServiceCount = registeredServiceRefs.size();
-            // statuc-reluctant, mandatory-unary - depends on which thread's service was bound
+            // static-reluctant, mandatory-unary - depends on which thread's service was bound
             // static-reluctant, optional-unary - none of the services are bound
             if (refManager.IsOptional() && fakeMetadata.policyOption == ReferencePolicyOption_Reluctant
                 && !(ReferencePolicy_Dynamic == fakeMetadata.policy))
@@ -631,7 +631,6 @@ namespace cppmicroservices
             if (refManager.IsOptional())
             {
                 EXPECT_TRUE(refManager.IsSatisfied()) << "Ref should only be satisfied if it is optional";
-                ;
             }
             EXPECT_EQ(refManager.GetTargetReferences().size(), registeredServiceCount)
                 << "TargetReferences must be the same as any available services in the "

--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -478,7 +478,7 @@ namespace cppmicroservices
             }
 
             // Check the cache
-            auto const c = any_cast<std::vector<std::string>>(props->Value_unlocked(Constants::OBJECTCLASS).first);
+            auto const& c = ref_any_cast<std::vector<std::string>>(props->ValueByRef_unlocked(Constants::OBJECTCLASS));
             for (auto& objClass : c)
             {
                 AddToSet_unlocked(set, receivers, OBJECTCLASS_IX, objClass);

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -263,11 +263,9 @@ namespace cppmicroservices
 
         for (; s != send; ++s)
         {
-            ServiceReferenceBase sri = s->GetReference(clazz);
-
             if (filter.empty() || ldap.Evaluate(PropertiesHandle(s->d->properties, true), false))
             {
-                res.push_back(sri);
+                res.emplace_back(s->GetReference(clazz));
             }
         }
 

--- a/framework/src/util/Properties.cpp
+++ b/framework/src/util/Properties.cpp
@@ -103,6 +103,84 @@ namespace cppmicroservices
         return *this;
     }
 
+    Any const&
+    Properties::ValueByRef_unlocked(std::string const& key, bool matchCase) const
+    {
+        if (props.GetType() == AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
+        {
+            auto itr = props.findUOCI_TypeChecked(key);
+            if (itr != props.endUOCI_TypeChecked())
+            {
+                if (!matchCase)
+                {
+                    return itr->second;
+                }
+                else if (matchCase && itr->first == key)
+                {
+                    return itr->second;
+                }
+                else
+                {
+                    return emptyAny;
+                }
+            }
+            else
+            {
+                return emptyAny;
+            }
+        }
+        else if (props.GetType() == AnyMap::UNORDERED_MAP)
+        {
+            auto itr = props.findUO_TypeChecked(key);
+            if (itr != props.endUO_TypeChecked())
+            {
+                return itr->second;
+            }
+
+            if (!matchCase)
+            {
+                auto ciItr = caseInsensitiveLookup.find(key);
+                if (ciItr != caseInsensitiveLookup.end())
+                {
+                    return props.findUO_TypeChecked(ciItr->second.data())->second;
+                }
+                else
+                {
+                    return emptyAny;
+                }
+            }
+
+            return emptyAny;
+        }
+        else if (props.GetType() == AnyMap::ORDERED_MAP)
+        {
+            auto itr = props.findOM_TypeChecked(key);
+            if (itr != props.endOM_TypeChecked())
+            {
+                return itr->second;
+            }
+
+            if (!matchCase)
+            {
+                auto ciItr = caseInsensitiveLookup.find(key);
+                if (ciItr != caseInsensitiveLookup.end())
+                {
+                    return props.findOM_TypeChecked(ciItr->second.data())->second;
+                }
+                else
+                {
+                    return emptyAny;
+                }
+            }
+
+            return emptyAny;
+        }
+        else
+        {
+            throw std::runtime_error("Unknown AnyMap type.");
+        }
+    }
+
     // This function has been modified to perform both the "find" and "lookup" operations rather than
     // just the "lookup" as originally written.
     //

--- a/framework/src/util/Properties.h
+++ b/framework/src/util/Properties.h
@@ -44,6 +44,8 @@ namespace cppmicroservices
         Properties(Properties&& o) noexcept;
         Properties& operator=(Properties&& o) noexcept;
 
+        Any const& ValueByRef_unlocked(std::string const& key, bool matchCase = false) const;
+
         std::pair<Any, bool> Value_unlocked(std::string const& key, bool matchCase = false) const;
 
         std::vector<std::string> Keys_unlocked() const;


### PR DESCRIPTION
Cherry-picked #728 / a209f1dd0d03495ea0aba5b3dc6874d23c67de28.

Adapted to C++14 (moved one init-statement out of a selection statement in Properties::ValueByRef_unlocked: first `if` contained a `auto itr = ...` in the if-statement, while the others didn't).

Signed-off-by Ingmar Sittl <ingmar.sittl@elektrobit.com>