### PR TITLE
Automate Performance Testing and Deploy Results

### DIFF
--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -68,7 +68,7 @@ jobs:
         name: C++ Benchmark
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
-        github-token: ${{ secrets.MY_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         gh-repository: 'github.com/aadityap-mathworks/UPT'
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -3,8 +3,6 @@ name: PerformanceWindows
 on:
   push:
     branches: [ development, performance, c\+\+14-compliant, master ]
-  pull_request:
-    branches: [ development, c\+\+14-compliant ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -20,7 +20,7 @@ env:
 jobs:
 
   benchmark:
-    name: UPT [${{matrix.os}},Configuration=${{matrix.buildconfiguration}}]
+    name: CppMicroServices Benchmarks [${{matrix.os}},Configuration=${{matrix.buildconfiguration}}]
     runs-on: ${{matrix.os}}
     env:
       BUILD_DIR: Z:\build\config_${{matrix.buildconfiguration}}

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -69,7 +69,7 @@ jobs:
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-repository: 'https://github.com/aadityap-mathworks/CppMicroServices_UPT'
+        gh-repository: 'github.com/aadityap-mathworks/CppMicroServices_UPT'
         gh-pages-branch: performance-results
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -1,0 +1,79 @@
+name: PerformanceWindows
+
+on:
+  push:
+    branches: [ development, performance, c\+\+14-compliant, master ]
+  pull_request:
+    branches: [ development, c\+\+14-compliant ]
+  workflow_dispatch:
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  BUILD_CONFIGURATION: 0
+  WITH_COVERAGE: 0
+
+jobs:
+
+  benchmark:
+    name: UPT [${{matrix.os}},Configuration=${{matrix.buildconfiguration}}]
+    runs-on: ${{matrix.os}}
+    env:
+      BUILD_DIR: Z:\build\config_${{matrix.buildconfiguration}}
+      BUILD_CONFIGURATION: ${{matrix.buildconfiguration}}
+      BUILD_OS: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022]
+        # build configurations:
+        # 0 = threading ON / shared lib ON
+        # 1 = threading ON / shared lib OFF
+        # 2 = threading OFF / shared lib ON
+        # 3 = threading OFF/ shared lib OFF
+        buildconfiguration: [0]
+
+    steps:
+    - name: Initialization
+      run: |
+        git config --global core.autocrlf true
+        subst Z: ${{github.workspace}}
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Build And Test
+      working-directory: Z:\
+      run: ctest -VV -S cmake\usCTestScript_github.cmake
+
+    - name: Download previous benchmark data
+      uses: actions/cache@v1
+      with:
+        path: ./cache
+        key: ${{matrix.os}}-benchmark
+
+    - name: Run benchmark and store result in json format
+      run: Z:\build\config_0\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee Z:\build\config_0\bin\Release\benchmark_result.json
+
+    - name: Continuous Benchmark
+      uses: benchmark-action/github-action-benchmark@v1.16.1
+      with:
+        name: C++ Benchmark
+        tool: 'googlecpp'
+        output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        gh-repository: 'github.com/aadityap-mathworks/UPT'
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '15%'
+        comment-on-alert: true
+        fail-on-alert: false
+        
+        

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -69,7 +69,8 @@ jobs:
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-repository: 'github.com/aadityap-mathworks/UPT'
+        gh-repository: 'https://github.com/aadityap-mathworks/CppMicroServices_UPT'
+        gh-pages-branch: performance-results
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '15%'

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -58,18 +58,18 @@ jobs:
         key: ${{matrix.os}}-benchmark
 
     - name: Run benchmark and store result in json format
-      run: Z:\build\config_0\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee Z:\build\config_0\bin\Release\benchmark_result.json
+      run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
     - name: Benchmark and Deploy
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
         name: C++ Benchmark
         tool: 'googlecpp'
-        output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
+        output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '15%'
+        alert-threshold: '20%'
         comment-on-alert: true
         fail-on-alert: false
         

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -68,7 +68,7 @@ jobs:
         name: C++ Benchmark
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.MY_TOKEN }}
         gh-repository: 'github.com/aadityap-mathworks/UPT'
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -62,14 +62,13 @@ jobs:
     - name: Run benchmark and store result in json format
       run: Z:\build\config_0\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee Z:\build\config_0\bin\Release\benchmark_result.json
 
-    - name: Continuous Benchmark
+    - name: Benchmark and Deploy
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
         name: C++ Benchmark
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-pages-branch: performance-results
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '15%'

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -2,7 +2,7 @@ name: PerformanceWindows
 
 on:
   push:
-    branches: [ development, performance, c\+\+14-compliant, master ]
+    branches: [ development, c\+\+14-compliant, master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -69,8 +69,7 @@ jobs:
         tool: 'googlecpp'
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-repository: 'github.com/aadityap-mathworks/CppMicroServices_UPT'
-        gh-pages-branch: perf
+        gh-pages-branch: performance-results
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '15%'

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -51,16 +51,10 @@ jobs:
       working-directory: Z:\
       run: ctest -VV -S cmake\usCTestScript_github.cmake
 
-    - name: Download previous benchmark data
-      uses: actions/cache@v1
-      with:
-        path: ./cache
-        key: ${{matrix.os}}-benchmark
-
     - name: Run benchmark and store result in json format
       run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
-    - name: Benchmark and Deploy
+    - name: Deploy results
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
         name: C++ Benchmark

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -70,7 +70,7 @@ jobs:
         output-file-path: Z:\build\config_0\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
         gh-repository: 'github.com/aadityap-mathworks/CppMicroServices_UPT'
-        gh-pages-branch: performance-results
+        gh-pages-branch: perf
         auto-push: true
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '15%'

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@
 
 |Coverity Scan Build Status|
 
+|Performance Status|
+ 
 
 C++ Micro Services
 ==================
@@ -223,6 +225,8 @@ file for details about the contribution process.
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/master
 .. |Code Coverage Status (development)| image:: https://img.shields.io/codecov/c/github/CppMicroServices/CppMicroServices/development.svg?style=flat-square
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/development
+.. |Performance Status| image:: https://github.com/CppMicroServices/CppMicroServices/actions/workflows/performance_windows.yml/badge.svg
+   :target: http://cppmicroservices.org/
 
 Git Hooks General Information
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ file for details about the contribution process.
 .. |Code Coverage Status (development)| image:: https://img.shields.io/codecov/c/github/CppMicroServices/CppMicroServices/development.svg?style=flat-square
    :target: https://codecov.io/gh/cppmicroservices/CppMicroServices/branch/development
 .. |Performance Status| image:: https://github.com/CppMicroServices/CppMicroServices/actions/workflows/performance_windows.yml/badge.svg
-   :target: http://cppmicroservices.org/
+   :target: https://cppmicroservices.org/dev/bench/
 
 Git Hooks General Information
 -----------------------------


### PR DESCRIPTION
Changes:
- Added GitHub actions workflow for windows that runs performance tests and deploys the results on GitHub Pages.
- Added a badge in Readme to show performance results

Notes:
- This is configured for windows 2022 build config 0
- Workflow will not run for pull requests
- Performance threshold is at 20% for now.
- Deploys results to http://cppmicroservices.org/dev/bench/

Signed-off-by: The MathWorks, Inc. <aadityap@mathworks.com>