### PR TITLE
701 - prepare v3.6.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,7 @@ Deprecated
 Fixed
 -----
 
-`v3.6.2 <https://github.com/cppmicroservices/cppmicroservices/tree/v3.6.2>`_ (2023-03-10)
+`v3.6.2 <https://github.com/cppmicroservices/cppmicroservices/tree/v3.6.2>`_ (2023-03-16)
 ---------------------------------------------------------------------------------------------------------
 
 `Full Changelog <https://github.com/CppMicroServices/CppMicroServices/compare/v3.6.1...v3.6.2>`_
@@ -40,7 +40,7 @@ General Note
 ------------
 
 This entry in the change log captures the relevant changes that were made between v3.6.1 and v3.6.2.
-This version contains all changes between v3.7.2 and v3.7.4 except setting CXX_STANDARD to 17 for the documentation.
+This version contains all changes between v3.7.2 and v3.7.5 except setting CXX_STANDARD to 17 for the documentation.
 Additionally there have been 3rd-party dependency updates and some compiler warning fixes not in v3.7.4.
 
 Added
@@ -48,10 +48,21 @@ Added
 
 Changed
 -------
+- Code formatting, no functional changes:
+    - `updated formatting - clang-fromat ran on all files <https://github.com/CppMicroServices/CppMicroServices/pull/759>`_
+    - `Clang-format git hook pre-commit enforcement <https://github.com/CppMicroServices/CppMicroServices/pull/760>`_
+    - `clang-format ran on all files <https://github.com/CppMicroServices/CppMicroServices/pull/766>`_
 - `Update spdlog to v1.11.0 and its bundled fmt to latest master <https://github.com/CppMicroServices/CppMicroServices/pull/789>`_
 - `Update miniz to v3.0.2 <https://github.com/CppMicroServices/CppMicroServices/pull/788>`_
 - `Update gtest to v1.13.0 to fix compiler warnings with gcc-12 <https://github.com/CppMicroServices/CppMicroServices/pull/803>`_
 - `[Core Framework] Improve performance of LDAP matching - C++14 variant <https://github.com/CppMicroServices/CppMicroServices/pull/793>`_
+- `[Declarative Services] Improve error message that is generated when an appropriate constructor isn't found for the Service Instance. <https://github.com/CppMicroServices/CppMicroServices/pull/724>`_
+- `[Configuration Admin] Remove automatic config object creation <https://github.com/CppMicroServices/CppMicroServices/pull/717>`_
+- `Updated CI to use macos-12 <https://github.com/CppMicroServices/CppMicroServices/pull/711>`_
+- `[Core Framework] Remove manual ref counting for BundleResource <https://github.com/CppMicroServices/CppMicroServices/pull/695>`_
+- `Add ignore for 3rdparty code for MSVC code analysis <https://github.com/CppMicroServices/CppMicroServices/pull/692>`_
+- `[Core Framework/Declarative Services] Add log messages when shared library loading throws an exception <https://github.com/CppMicroServices/CppMicroServices/pull/690>`_
+- `Only run certain BundleContextTests if threading support is enabled <https://github.com/CppMicroServices/CppMicroServices/pull/669>`_
 
 Removed
 -------
@@ -61,16 +72,31 @@ Deprecated
 
 Fixed
 -----
+- `[Configuration Admin] Fix deadlock in ConfigurationAdminImpl::RemoveConfigurations <https://github.com/CppMicroServices/CppMicroServices/pull/748>`_
+- `[Configuration Admin] configurations using the same pid are not updated properly <https://github.com/CppMicroServices/CppMicroServices/pull/754>`_
+- `[Declarative Services] Ensure ~SCRBundleExtension does not throw <https://github.com/CppMicroServices/CppMicroServices/pull/761>`_
+- `Fix broken static build configurations on macOS <https://github.com/CppMicroServices/CppMicroServices/pull/774>`_
+- `[Core Framework] Performance improvements <https://github.com/CppMicroServices/CppMicroServices/pull/728>`_
+- `[Core Framework] Fix undefined behavior <https://github.com/CppMicroServices/CppMicroServices/pull/777>`_
+- `[Declarative Services] Fix race with Declarative Services service object construction <https://github.com/CppMicroServices/CppMicroServices/pull/801>`_
+- `[Core Framework] RegisterService performance improvement <https://github.com/CppMicroServices/CppMicroServices/pull/808>`_
+- `[Core Framework] Ensure that the ServiceTracker::GetTrackingCount() method returns -1 if the tracker has been opened and then closed. <https://github.com/CppMicroServices/CppMicroServices/pull/714>`_
+- `[Declarative Services] BugFix when creating instance name for factory components <https://github.com/CppMicroServices/CppMicroServices/pull/720>`_
+- `[Configuration Admin] Fix race in ConfigurationNotifier::NotifyAllListeners() <https://github.com/CppMicroServices/CppMicroServices/pull/715>`_
+- `[Core Framework] Improve performance of LDAP matching <https://github.com/CppMicroServices/CppMicroServices/pull/704>`_
+- `[Core Framework] Fix CFRlogger accessviolation <https://github.com/CppMicroServices/CppMicroServices/pull/706>`_
+- `Cleaned up some security warnings regarding 'noexcept' <https://github.com/CppMicroServices/CppMicroServices/pull/700>`_
+- `[Configuration Admin] Multiple services and factory services in bundle dependent on same configuration pid <https://github.com/CppMicroServices/CppMicroServices/pull/698>`_
+- `Disable code signing for bundle with no c++ code <https://github.com/CppMicroServices/CppMicroServices/pull/697>`_
+- `Fix compilation issue for arm macOS native compilation <https://github.com/CppMicroServices/CppMicroServices/pull/696>`_
+- `[Core Framework] Add file handle leak test <https://github.com/CppMicroServices/CppMicroServices/pull/693>`_
 - `[ConfigurationAdmin] Factory Configuration Bug Fix <https://github.com/CppMicroServices/CppMicroServices/pull/731>`_
-- `[Declarative Services] Improve error messages for ComponentInstance constructor <https://github.com/CppMicroServices/CppMicroServices/pull/724>`_
 - `[Configuration Admin] Fix race that results in missed config updated event <https://github.com/CppMicroServices/CppMicroServices/pull/727>`_
 - `[Core Framework] Fix sporadic race conditions during framework shutdown <https://github.com/CppMicroServices/CppMicroServices/pull/725>`_
-- `[Declarative Services] Factory instance name should use component name <https://github.com/CppMicroServices/CppMicroServices/pull/720>`_
 - `[Configuration Admin] ListConfigurations fix for empty configuration objects. <https://github.com/CppMicroServices/CppMicroServices/pull/682>`_
 - `[Configuration Admin] Fix deadlock and double update. <https://github.com/CppMicroServices/CppMicroServices/pull/651>`_
-- `[Configuration Admin] Remove automatic configuration object creation <https://github.com/CppMicroServices/CppMicroServices/pull/717>`_
-- `[Core Framework] ServiceTracker GetTrackingCount() when opened and then closed <https://github.com/CppMicroServices/CppMicroServices/pull/714>`_
 - `[SCRCodeGen] Fixed compiler warning for gcc-12 <https://github.com/CppMicroServices/CppMicroServices/pull/803>`_
+
 
 `v3.6.1 <https://github.com/cppmicroservices/cppmicroservices/tree/v3.6.1>`_ (2022-12-06)
 ---------------------------------------------------------------------------------------------------------

--- a/compendium/DeclarativeServices/CMakeLists.txt
+++ b/compendium/DeclarativeServices/CMakeLists.txt
@@ -39,7 +39,7 @@ add_compile_definitions(BOOST_REGEX_NO_LIB)
 
 
 usMacroCreateBundle(DeclarativeServices
-  VERSION "1.5.1"
+  VERSION "1.5.2"
   DEPENDS Framework
   TARGET DeclarativeServices
   SYMBOLIC_NAME declarative_services

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -71,38 +71,37 @@ namespace cppmicroservices
                 auto const& refName = refManager->GetReferenceName();
                 auto const& refScope = refManager->GetReferenceScope();
                 bool foundAtLeastOneValidBoundService = false;
-                std::for_each(
-                    sRefs.rbegin(),
-                    sRefs.rend(),
-                    [&](cppmicroservices::ServiceReferenceBase const& sRef)
-                    {
-                        if (sRef)
-                        {
-                            ServiceReferenceU sRefU(sRef);
-                            auto bc = GetBundleContext();
-                            auto boundServicesCacheHandle = boundServicesCache.lock();
-                            auto& serviceMap = (*boundServicesCacheHandle)[refName];
-                            if (refScope == cppmicroservices::Constants::SCOPE_BUNDLE)
-                            {
-                                auto svc = bc.GetService(sRefU);
-                                if (svc)
-                                {
-                                    foundAtLeastOneValidBoundService = true;
-                                }
-                                serviceMap.push_back(svc);
-                            }
-                            else
-                            {
-                                cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(sRefU);
-                                auto interfaceMap = sObjs.GetService();
-                                if (interfaceMap)
-                                {
-                                    foundAtLeastOneValidBoundService = true;
-                                    serviceMap.push_back(interfaceMap);
-                                }
-                            }
-                        }
-                    });
+                std::for_each(sRefs.rbegin(),
+                              sRefs.rend(),
+                              [&](cppmicroservices::ServiceReferenceBase const& sRef)
+                              {
+                                  if (sRef)
+                                  {
+                                      ServiceReferenceU sRefU(sRef);
+                                      auto bc = GetBundleContext();
+                                      auto boundServicesCacheHandle = boundServicesCache.lock();
+                                      auto& serviceMap = (*boundServicesCacheHandle)[refName];
+                                      if (refScope == cppmicroservices::Constants::SCOPE_BUNDLE)
+                                      {
+                                          auto svc = bc.GetService(sRefU);
+                                          if (svc)
+                                          {
+                                              foundAtLeastOneValidBoundService = true;
+                                          }
+                                          serviceMap.push_back(svc);
+                                      }
+                                      else
+                                      {
+                                          cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(sRefU);
+                                          auto interfaceMap = sObjs.GetService();
+                                          if (interfaceMap)
+                                          {
+                                              foundAtLeastOneValidBoundService = true;
+                                              serviceMap.push_back(interfaceMap);
+                                          }
+                                      }
+                                  }
+                              });
 
                 // Check that all the refernece managers have a valid bound service reference if one
                 // is manodatory.
@@ -110,9 +109,11 @@ namespace cppmicroservices
                 // while the service object was being retrieved to add to the container of bound services.
                 if (!refManager->IsOptional() && !foundAtLeastOneValidBoundService)
                 {
-                    throw ComponentException("Failed to construct a component context for " + configManagerPtr->GetMetadata()->implClassName + 
-                        ". No services were found which satisfy the mandatory service dependency " + refName + 
-                        ". This typically occurs because the dependent service was unregistered before it could be used.");
+                    throw ComponentException(
+                        "Failed to construct a component context for " + configManagerPtr->GetMetadata()->implClassName
+                        + ". No services were found which satisfy the mandatory service dependency " + refName
+                        + ". This typically occurs because the dependent service was unregistered before it could be "
+                          "used.");
                 }
             }
         }
@@ -128,7 +129,9 @@ namespace cppmicroservices
             return configManagerPtr->GetProperties();
         }
 
-        bool ServiceReferenceTargetIsMandatory(std::shared_ptr<ComponentConfiguration> const& configManagerPtr, std::string const& svcRefTargetName)
+        bool
+        ServiceReferenceTargetIsMandatory(std::shared_ptr<ComponentConfiguration> const& configManagerPtr,
+                                          std::string const& svcRefTargetName)
         {
             auto metadata = configManagerPtr->GetMetadata();
             for (auto const& _data : metadata->refsMetadata)
@@ -136,7 +139,7 @@ namespace cppmicroservices
                 if (_data.name == svcRefTargetName)
                 {
                     auto const cardinality = _data.cardinality;
-                    return (cardinality.empty())?true:(cardinality.find("1..") != std::string::npos);
+                    return (cardinality.empty()) ? true : (cardinality.find("1..") != std::string::npos);
                 }
             }
 
@@ -277,7 +280,7 @@ namespace cppmicroservices
                     return service;
                 }
             }
-            
+
             return nullptr;
         }
 

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -238,7 +238,8 @@ namespace cppmicroservices
                 {
                     GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
                                      "Exception received from user code while binding "
-                                     "service reference" + refName + ".",
+                                     "service reference"
+                                         + refName + ".",
                                      std::current_exception());
                 }
             }
@@ -261,7 +262,8 @@ namespace cppmicroservices
                 {
                     GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
                                      "Exception received from user code while unbinding "
-                                     "service reference" + refName + ".",
+                                     "service reference"
+                                         + refName + ".",
                                      std::current_exception());
                 }
 

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -227,7 +227,8 @@ namespace cppmicroservices
             {
                 GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
                                  "Exception received from user code while binding "
-                                 "service reference" + refName + ".",
+                                 "service reference"
+                                     + refName + ".",
                                  std::current_exception());
             }
         }
@@ -244,7 +245,8 @@ namespace cppmicroservices
             {
                 GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
                                  "Exception received from user code while unbinding "
-                                 "service reference" + refName + ".",
+                                 "service reference"
+                                     + refName + ".",
                                  std::current_exception());
             }
             auto context = GetComponentContext();

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp
@@ -521,7 +521,7 @@ namespace cppmicroservices
 
                     template <std::size_t... Is>
                     std::shared_ptr<T>
-                    call_make_shared_with_tuple(std::tuple<const std::shared_ptr<CtorInjectedRefs>&...> const& tuple,
+                    call_make_shared_with_tuple(std::tuple<std::shared_ptr<CtorInjectedRefs> const&...> const& tuple,
                                                 std::index_sequence<Is...>)
                     {
                         return std::make_shared<T>(std::get<Is>(tuple)...);
@@ -531,7 +531,7 @@ namespace cppmicroservices
                     std::shared_ptr<T>
                     call_make_shared_with_tuple_and_props(
                         std::shared_ptr<cppmicroservices::AnyMap> const& props,
-                        std::tuple<const std::shared_ptr<CtorInjectedRefs>&...> const& tuple,
+                        std::tuple<std::shared_ptr<CtorInjectedRefs> const&...> const& tuple,
                         std::index_sequence<Is...>)
                     {
                         return std::make_shared<T>(props, std::get<Is>(tuple)...);

--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -124,14 +124,14 @@ namespace cppmicroservices
 
     template <typename T>
     std::ostream&
-    any_value_to_string(std::ostream& os, std::function<bool(const T&)> const&)
+    any_value_to_string(std::ostream& os, std::function<bool(T const&)> const&)
     {
         return os;
     }
 
     template <typename T>
     std::ostream&
-    any_value_to_json(std::ostream& os, std::function<bool(const T&)> const&, const uint8_t, const int32_t)
+    any_value_to_json(std::ostream& os, std::function<bool(T const&)> const&, const uint8_t, const int32_t)
     {
         return os;
     }

--- a/framework/include/cppmicroservices/BundleResource.h
+++ b/framework/include/cppmicroservices/BundleResource.h
@@ -299,9 +299,9 @@ namespace cppmicroservices
         uint32_t GetCrc32() const;
 
       private:
-        BundleResource(std::string const& file, std::shared_ptr<const BundleArchive> const& archive);
+        BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive);
 
-        BundleResource(int index, std::shared_ptr<const BundleArchive> const& archive);
+        BundleResource(int index, std::shared_ptr<BundleArchive const> const& archive);
 
         /// Helper function which initializes the childNodes member in BundleResourcePrivate;
         /// this is called during BundleResource construction.

--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -57,7 +57,6 @@ set(_srcs
   bundle/BundleVersion.cpp
   bundle/Constants.cpp
   bundle/CoreBundleContext.cpp
-  ../../third_party/jsoncpp.cpp
   ../../third_party/miniz.c
 )
 

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -100,7 +100,7 @@ namespace cppmicroservices
 
     BundleResource::BundleResource(BundleResource const& resource) : d(resource.d) {}
 
-    BundleResource::BundleResource(std::string const& file, std::shared_ptr<const BundleArchive> const& archive)
+    BundleResource::BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive)
         : d(std::make_shared<BundleResourcePrivate>(archive))
     {
         d->InitFilePath(file);
@@ -112,7 +112,7 @@ namespace cppmicroservices
         InitializeChildren();
     }
 
-    BundleResource::BundleResource(int index, std::shared_ptr<const BundleArchive> const& archive)
+    BundleResource::BundleResource(int index, std::shared_ptr<BundleArchive const> const& archive)
         : d(std::make_shared<BundleResourcePrivate>(archive))
     {
         d->archive->GetResourceContainer()->GetStat(index, d->stat);

--- a/framework/src/bundle/BundleResourceContainer.cpp
+++ b/framework/src/bundle/BundleResourceContainer.cpp
@@ -183,7 +183,7 @@ namespace cppmicroservices
     }
 
     void
-    BundleResourceContainer::FindNodes(std::shared_ptr<const BundleArchive> const& archive,
+    BundleResourceContainer::FindNodes(std::shared_ptr<BundleArchive const> const& archive,
                                        std::string const& path,
                                        std::string const& filePattern,
                                        bool recurse,

--- a/framework/src/bundle/BundleResourceContainer.h
+++ b/framework/src/bundle/BundleResourceContainer.h
@@ -76,7 +76,7 @@ namespace cppmicroservices
                          std::vector<std::string>& names,
                          std::vector<uint32_t>& indices) const;
 
-        void FindNodes(std::shared_ptr<const BundleArchive> const& archive,
+        void FindNodes(std::shared_ptr<BundleArchive const> const& archive,
                        std::string const& path,
                        std::string const& filePattern,
                        bool recurse,

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -127,6 +127,7 @@ TEST(BundleContextTest, BundleContextThrowWhenInvalid)
         << "InstallBundles() on invalid BundleContext did not throw.";
 }
 
+#if defined(US_ENABLE_THREADING_SUPPORT)
 TEST(BundleContextTest, NoSegfaultWithRegisterServiceShutdownRace)
 {
     cppmicroservices::Framework framework = cppmicroservices::FrameworkFactory().NewFramework();
@@ -182,3 +183,4 @@ TEST(BundleContextTest, NoSegfaultWithServiceFactory)
 
     thread.join();
 }
+#endif


### PR DESCRIPTION
[Compared](https://github.com/CppMicroServices/CppMicroServices/compare/c++14-compliant..v3.7.5) `v3.7.5` tag with `c++14-compliant` branch and updated with relevant changes:
* Cherry-picked #669 / 590616b24eaae2a6ad08ce3cf93ae2f872bf0532 as that one seems to have been missing
* Reran v15 clang-format on .h/.hpp/.cpp files (interestingly this produces formatting parity of .h[pp] files, but produces more formatting diffs on .cpp files)
* Removed jsoncpp from framework/src/CMakeLists.txt (the additional warning from jsoncpp was not suppressed as on `development`, but instead fixed by changing the code in the corresponding `v3.6.1` PR)

Updated changelog to show all PRs picked since `v3.7.2`.

Signed-off-by: Ingmar Sittl <ingmar.sittl@elektrobit.com>

The resulting diff between the changes proposed for v3.6.2 (including this PR) and v3.7.5 can be seen [here](https://github.com/CppMicroServices/CppMicroServices/compare/v3.7.5..insi-eb:CppMicroServices-cpp14:c++14-compliant-develop).

After this PR is merged, from my point of view a `v3.6.2` could be released.