### PR TITLE
ComponentManagermemory reallocation bug fix

### DIFF
--- a/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
@@ -73,8 +73,7 @@ namespace cppmicroservices
                                                                               bundle_.GetBundleContext(),
                                                                               logger,
                                                                               asyncWorkService,
-                                                                              configNotifier,
-                                                                              managers);
+                                                                              configNotifier);
                     if (registry->AddComponentManager(compManager))
                     {
                         managers->push_back(compManager);

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -37,9 +37,8 @@ namespace cppmicroservices
             cppmicroservices::Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier, managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier)
         {
         }
 

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
@@ -46,8 +46,7 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
             BundleOrPrototypeComponentConfigurationImpl(BundleOrPrototypeComponentConfigurationImpl const&) = delete;
             BundleOrPrototypeComponentConfigurationImpl(BundleOrPrototypeComponentConfigurationImpl&&) = delete;
             BundleOrPrototypeComponentConfigurationImpl& operator=(BundleOrPrototypeComponentConfigurationImpl const&)

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
@@ -36,9 +36,8 @@ namespace cppmicroservices
             cppmicroservices::Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-        {
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+         {
             std::shared_ptr<ComponentConfigurationImpl> retVal;
             std::string scope = compDesc->serviceMetadata.scope;
             if (scope == cppmicroservices::Constants::SCOPE_SINGLETON)
@@ -47,8 +46,7 @@ namespace cppmicroservices
                                                                                bundle,
                                                                                registry,
                                                                                logger,
-                                                                               configNotifier,
-                                                                               managers);
+                                                                               configNotifier);
             }
             else if (scope == cppmicroservices::Constants::SCOPE_BUNDLE
                      || scope == cppmicroservices::Constants::SCOPE_PROTOTYPE)
@@ -57,8 +55,7 @@ namespace cppmicroservices
                                                                                        bundle,
                                                                                        registry,
                                                                                        logger,
-                                                                                       configNotifier,
-                                                                                       managers);
+                                                                                       configNotifier);
             }
             if (retVal)
             {

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
@@ -44,9 +44,8 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
-        };
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
+       };
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -58,8 +58,7 @@ namespace cppmicroservices
             Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
             : configID(++idCounter)
             , metadata(std::move(metadata))
             , bundle(bundle)
@@ -67,14 +66,12 @@ namespace cppmicroservices
             , logger(std::move(logger))
             , configManager()
             , configNotifier(std::move(configNotifier))
-            , managers(std::move(managers))
             , state(std::make_shared<CCUnsatisfiedReferenceState>())
             , newCompInstanceFunc(nullptr)
             , deleteCompInstanceFunc(nullptr)
         {
-            if (!this->metadata || !this->bundle || !this->registry || !this->logger || !this->configNotifier
-                || !this->managers)
-            {
+            if (!this->metadata || !this->bundle || !this->registry || !this->logger || !this->configNotifier)
+           {
                 throw std::invalid_argument("ComponentConfigurationImpl - Invalid arguments passed to constructor");
             }
 

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -77,13 +77,11 @@ namespace cppmicroservices
             /**
              * \throws std::invalid_argument exception if any of the params is a nullptr
              */
-            explicit ComponentConfigurationImpl(
-                std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                Bundle const& bundle,
-                std::shared_ptr<ComponentRegistry> registry,
-                std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+            explicit ComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
+                                                Bundle const& bundle,
+                                                std::shared_ptr<ComponentRegistry> registry,
+                                                std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+                                                std::shared_ptr<ConfigurationNotifier> configNotifier);
             ComponentConfigurationImpl(ComponentConfigurationImpl const&) = delete;
             ComponentConfigurationImpl(ComponentConfigurationImpl&&) = delete;
             ComponentConfigurationImpl& operator=(ComponentConfigurationImpl const&) = delete;
@@ -166,16 +164,7 @@ namespace cppmicroservices
                 return metadata;
             };
 
-            /**
-             * This method returns the {@link ComponentManager} vector which holds
-             * the ComponentManagerImpl objects.
-             */
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>>
-            GetManagers() const
-            {
-                return managers;
-            };
-
+            
             /**
              * Method to check if this component provides a service
              *
@@ -439,7 +428,6 @@ namespace cppmicroservices
             std::shared_ptr<ConfigurationNotifier> configNotifier; // to get updates for configuration objects
             std::vector<std::shared_ptr<ListenerToken>>
                 configListenerTokens; ///< vector of the listener tokens received from the config manager
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
             std::shared_ptr<ComponentConfigurationState> state; ///< only modified using std::atomic operations
             std::function<ComponentInstance*(void)>
                 newCompInstanceFunc; ///< extern C function to create a new instance {@link ComponentInstance} class

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
@@ -42,8 +42,7 @@ namespace cppmicroservices
             BundleContext bundleContext,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
             std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
             : registry(std::move(registry))
             , compDesc(std::move(metadata))
             , bundleContext(std::move(bundleContext))
@@ -51,10 +50,9 @@ namespace cppmicroservices
             , state(std::make_shared<CMDisabledState>())
             , asyncWorkService(std::move(asyncWorkService))
             , configNotifier(std::move(configNotifier))
-            , managers(std::move(managers))
         {
             if (!compDesc || !this->registry || !this->bundleContext || !this->logger || !this->asyncWorkService
-                || !this->configNotifier || !this->managers)
+                || !this->configNotifier)
             {
                 throw std::invalid_argument("Invalid arguments to ComponentManagerImpl constructor");
             }
@@ -167,14 +165,13 @@ namespace cppmicroservices
             auto reg = GetRegistry();
             auto logger = GetLogger();
             auto configNotifier = GetConfigNotifier();
-            auto managers = GetManagers();
 
             using ActualTask = std::packaged_task<void(std::shared_ptr<CMEnabledState>)>;
             using PostTask = std::packaged_task<void()>;
 
-            ActualTask task([metadata, bundle, reg, logger, configNotifier, managers](
+            ActualTask task([metadata, bundle, reg, logger, configNotifier](
                                 std::shared_ptr<CMEnabledState> eState) mutable
-                            { eState->CreateConfigurations(metadata, bundle, reg, logger, configNotifier, managers); });
+                            { eState->CreateConfigurations(metadata, bundle, reg, logger, configNotifier); });
 
             std::shared_ptr<CMEnabledState> enabledState = std::make_shared<CMEnabledState>(task.get_future().share());
 

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -55,9 +55,8 @@ namespace cppmicroservices
                                  cppmicroservices::BundleContext bundleContext,
                                  std::shared_ptr<cppmicroservices::logservice::LogService> logger,
                                  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-                                 std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                 std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
-            ComponentManagerImpl(ComponentManagerImpl const&) = delete;
+                                 std::shared_ptr<ConfigurationNotifier> configNotifier);
+             ComponentManagerImpl(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl(ComponentManagerImpl&&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl&&) = delete;
@@ -151,14 +150,6 @@ namespace cppmicroservices
             }
 
             /**
-             * Returns the managers object associated with this ComponentManager
-             */
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>>
-            GetManagers() const
-            {
-                return managers;
-            }
-            /**
              * This method modifies the vector of futures stored in this object. If
              * any of the futures in the vector are ready, the ready future is replaced
              * by the given future. If none of the futures are ready, the given future
@@ -230,8 +221,7 @@ namespace cppmicroservices
             std::mutex
                 transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic
             std::shared_ptr<ConfigurationNotifier> configNotifier;
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
-        };
+       };
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
@@ -183,8 +183,8 @@ namespace cppmicroservices
             auto registry = mgr->GetRegistry();
             auto logger = mgr->GetLogger();
             auto configNotifier = mgr->GetConfigNotifier();
-            auto managers = mgr->GetManagers();
-
+            auto managers = std::make_shared<std::vector<std::shared_ptr<cppmicroservices::scrimpl::ComponentManager>>>(
+                mgr->GetRegistry()->GetComponentManagers());
             try
             {
                 auto compManager = std::make_shared<ComponentManagerImpl>(newMetadata,
@@ -192,8 +192,7 @@ namespace cppmicroservices
                                                                           bundle.GetBundleContext(),
                                                                           logger,
                                                                           asyncWorkService,
-                                                                          configNotifier,
-                                                                          managers);
+                                                                          configNotifier);
                 if (registry->AddComponentManager(compManager))
                 {
                     managers->push_back(compManager);

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -47,9 +47,8 @@ namespace cppmicroservices
             Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier, managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier)
         {
         }
 

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -47,8 +47,7 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
             SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl const&) = delete;
             SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl&&) = delete;
             SingletonComponentConfigurationImpl& operator=(SingletonComponentConfigurationImpl const&) = delete;

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
@@ -51,8 +51,7 @@ namespace cppmicroservices
                                              cppmicroservices::Bundle const& bundle,
                                              std::shared_ptr<ComponentRegistry> registry,
                                              std::shared_ptr<logservice::LogService> logger,
-                                             std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                             std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+                                             std::shared_ptr<ConfigurationNotifier> configNotifier)
         {
             try
             {
@@ -60,9 +59,8 @@ namespace cppmicroservices
                                                                                     bundle,
                                                                                     registry,
                                                                                     logger,
-                                                                                    configNotifier,
-                                                                                    managers);
-                configurations.push_back(cc);
+                                                                                    configNotifier);
+               configurations.push_back(cc);
             }
             catch (cppmicroservices::SharedLibraryException const&)
             {

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
@@ -118,8 +118,7 @@ namespace cppmicroservices
                                       cppmicroservices::Bundle const& bundle,
                                       std::shared_ptr<ComponentRegistry> registry,
                                       std::shared_ptr<logservice::LogService> logger,
-                                      std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                      std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                                      std::shared_ptr<ConfigurationNotifier> configNotifier);
 
             /**
              * Helper function used to remove all the configuration objects created by this state.

--- a/compendium/DeclarativeServices/test/gtest/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/gtest/Mocks.hpp
@@ -335,9 +335,8 @@ namespace cppmicroservices
                                      BundleContext bundleContext,
                                      std::shared_ptr<cppmicroservices::logservice::LogService> logger,
                                      std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-                                     std::shared_ptr<ConfigurationNotifier> notifier,
-                                     std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-                : ComponentManagerImpl(metadata, registry, bundleContext, logger, asyncWorkService, notifier, managers)
+                                     std::shared_ptr<ConfigurationNotifier> notifier)
+               : ComponentManagerImpl(metadata, registry, bundleContext, logger, asyncWorkService, notifier)
                 , statechangecount(0)
             {
             }
@@ -376,9 +375,8 @@ namespace cppmicroservices
                                            Bundle const& bundle,
                                            std::shared_ptr<ComponentRegistry> registry,
                                            std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                                           std::shared_ptr<ConfigurationNotifier> notifier,
-                                           std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-                : ComponentConfigurationImpl(metadata, bundle, registry, logger, notifier, managers)
+                                           std::shared_ptr<ConfigurationNotifier> notifier)
+                : ComponentConfigurationImpl(metadata, bundle, registry, logger, notifier)
                 , statechangecount(0)
             {
             }

--- a/compendium/DeclarativeServices/test/gtest/TestCCActiveState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCActiveState.cpp
@@ -60,15 +60,13 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
-            }
+                                                                                  notifier);
+             }
 
             virtual void
             TearDown()

--- a/compendium/DeclarativeServices/test/gtest/TestCCRegisteredState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCRegisteredState.cpp
@@ -57,14 +57,12 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
+                                                                                  notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestCCUnsatisfiedReferenceState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCUnsatisfiedReferenceState.cpp
@@ -58,13 +58,11 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
+                                                                                  notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -91,7 +91,6 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             EXPECT_THROW(
                 {
@@ -99,8 +98,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
             EXPECT_THROW(
@@ -109,8 +107,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            nullptr,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
             EXPECT_THROW(
@@ -119,8 +116,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            nullptr,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
 
@@ -129,9 +125,8 @@ namespace cppmicroservices
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
-                EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+                                                                                       notifier);
+                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_EQ(fakeCompConfig->regManager, nullptr);
                 EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
             });
@@ -149,8 +144,7 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             std::set<unsigned long> idSet;
             const size_t iterCount = 10;
             for (size_t i = 0; i < iterCount; ++i)
@@ -160,8 +154,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                     idSet.insert(fakeCompConfig->GetId());
                 });
             }
@@ -178,7 +171,6 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             auto refMgr1 = std::make_shared<MockReferenceManager>();
@@ -204,9 +196,8 @@ namespace cppmicroservices
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
-            EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
+                                                                                   notifier);
+           EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
             // add the mock reference managers to the config object
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref1", refMgr1));
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref2", refMgr2));
@@ -230,8 +221,7 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             auto logger = std::make_shared<SCRLogger>(GetFramework().GetBundleContext());
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
@@ -243,8 +233,7 @@ namespace cppmicroservices
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             auto mockStatisfiedState = std::make_shared<MockComponentConfigurationState>();
             auto mockUnsatisfiedState = std::make_shared<MockComponentConfigurationState>();
             EXPECT_CALL(*mockStatisfiedState, GetValue())
@@ -275,8 +264,7 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             // Test that a call to Register with a component containing both a service
             // and a reference to the same service interface will not cause a state change.
             scrimpl::metadata::ReferenceMetadata refMetadata {};
@@ -295,8 +283,7 @@ namespace cppmicroservices
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
 
             auto reg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
                 std::make_shared<dummy::ServiceImpl>());
@@ -318,8 +305,7 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             // Test if a call to Register will change the state when the component
             // does not provide a service.
             {
@@ -327,8 +313,7 @@ namespace cppmicroservices
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_EQ(fakeCompConfig->regManager, nullptr);
                 EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
@@ -348,14 +333,12 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillRepeatedly(testing::Return(mockFactory));
                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_NE(fakeCompConfig->regManager, nullptr);
@@ -382,14 +365,12 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillRepeatedly(testing::Return(mockFactory));
                 EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                     .Times(1)
@@ -419,14 +400,12 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
             fakeCompConfig->state = mockState;
             ComponentConfigurationImpl& fakeCompConfigBase
@@ -453,14 +432,12 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             fakeCompConfig->state = std::make_shared<CCRegisteredState>();
             auto mockCompInstance = std::make_shared<MockComponentInstance>();
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -483,15 +460,13 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             // Test for exception from user code
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             fakeCompConfig->state = std::make_shared<CCRegisteredState>();
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -513,14 +488,12 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             auto activeState = std::make_shared<CCActiveState>();
             fakeCompConfig->state = activeState;
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
@@ -577,14 +550,12 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_CALL(*fakeCompConfig, GetFactory()).WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
             EXPECT_NE(fakeCompConfig->regManager, nullptr);
@@ -637,14 +608,12 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                 .WillRepeatedly(testing::Return(mockCompInstance));
             EXPECT_CALL(*fakeCompConfig, GetFactory()).WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
@@ -687,15 +656,13 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
                 auto mockCompInstance = std::make_shared<MockComponentInstance>();
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                     .Times(2)
                     .WillRepeatedly(testing::Return(mockCompInstance));
@@ -725,17 +692,15 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
                 mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
                 mockMetadata->immediate = false;
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
-                EXPECT_CALL(*fakeCompConfig, GetFactory())
+                                                                                       notifier);
+                 EXPECT_CALL(*fakeCompConfig, GetFactory())
                     .Times(testing::AtLeast(1)) // 2
                     .WillRepeatedly(testing::Return(mockFactory));
                 fakeCompConfig->Initialize();
@@ -785,7 +750,6 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             mockMetadata->immediate = false;
@@ -801,8 +765,7 @@ namespace cppmicroservices
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_EQ(fakeCompConfig->GetAllDependencyManagers().size(), mockMetadata->refsMetadata.size());
             EXPECT_NE(fakeCompConfig->GetDependencyManager("Foo"), nullptr);
             EXPECT_NE(fakeCompConfig->GetDependencyManager("Bar"), nullptr);
@@ -853,22 +816,20 @@ namespace cppmicroservices
                                                                     fakeLogger,
                                                                     asyncWorkService);
 
-            auto fakeCompConfig = std::make_shared<SingletonComponentConfigurationImpl>(
-                mockMetadata,
-                GetFramework(),
-                std::make_shared<MockComponentRegistry>(),
-                fakeLogger,
-                notifier,
-                std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>());
-
+            auto fakeCompConfig
+                = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
+                                                                        GetFramework(),
+                                                                        std::make_shared<MockComponentRegistry>(),
+                                                                        fakeLogger,
+                                                                        notifier);
+ 
             auto fakeBundleProtoCompConfig = std::make_shared<BundleOrPrototypeComponentConfigurationImpl>(
                 mockMetadata,
                 GetFramework(),
                 std::make_shared<MockComponentRegistry>(),
                 fakeLogger,
-                notifier,
-                std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>());
-
+                notifier);
+ 
             auto svcReg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
                 std::make_shared<dummy::ServiceImpl>());
 

--- a/compendium/DeclarativeServices/test/gtest/TestComponentManagerDisabledState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentManagerDisabledState.cpp
@@ -53,15 +53,13 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
                 compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
                                                                      mockRegistry,
                                                                      framework.GetBundleContext(),
                                                                      fakeLogger,
                                                                      asyncWorkService,
-                                                                     notifier,
-                                                                     managers);
+                                                                     notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestComponentManagerEnabledState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentManagerEnabledState.cpp
@@ -57,15 +57,13 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
                 compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
                                                                      mockRegistry,
                                                                      framework.GetBundleContext(),
                                                                      fakeLogger,
                                                                      asyncWorkService,
-                                                                     notifier,
-                                                                     managers);
+                                                                     notifier);
             }
 
             virtual void
@@ -110,8 +108,7 @@ namespace cppmicroservices
                                                                      framework,
                                                                      compMgr->GetRegistry(),
                                                                      compMgr->GetLogger(),
-                                                                     compMgr->GetConfigNotifier(),
-                                                                     compMgr->GetManagers()) };
+                                                                     compMgr->GetConfigNotifier()) };
             auto fut = std::async(std::launch::async, [&]() { return enabledState->GetConfigurations(*compMgr); });
             EXPECT_NE(fut.wait_for(std::chrono::milliseconds::zero()), std::future_status::ready)
                 << "The call to GetConfigurations must not return until the promise is set";
@@ -205,8 +202,7 @@ namespace cppmicroservices
                                                    compMgr->GetBundle(),
                                                    compMgr->GetRegistry(),
                                                    compMgr->GetLogger(),
-                                                   compMgr->GetConfigNotifier(),
-                                                   compMgr->GetManagers());
+                                                   compMgr->GetConfigNotifier());
             });
             EXPECT_EQ(enabledState->configurations.size(), 1ul)
                 << "Must have a configuration created after call to CreateConfigurations";

--- a/compendium/DeclarativeServices/test/gtest/TestComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentManagerImpl.cpp
@@ -53,7 +53,6 @@ namespace cppmicroservices
             framework.Start();
             auto bc = framework.GetBundleContext();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto logger = std::make_shared<SCRLogger>(bc);
@@ -68,8 +67,7 @@ namespace cppmicroservices
                                                                          bc,
                                                                          fakeLogger,
                                                                          asyncWorkService,
-                                                                         notifier,
-                                                                         managers));
+                                                                         notifier));
                     },
                     std::invalid_argument);
             }
@@ -81,9 +79,8 @@ namespace cppmicroservices
                                                                          bc,
                                                                          fakeLogger,
                                                                          asyncWorkService,
-                                                                         notifier,
-                                                                         managers));
-                    },
+                                                                         notifier));
+                   },
                     std::invalid_argument);
             }
             {
@@ -94,8 +91,7 @@ namespace cppmicroservices
                                                                          BundleContext(),
                                                                          fakeLogger,
                                                                          asyncWorkService,
-                                                                         notifier,
-                                                                         managers));
+                                                                         notifier));
                     },
                     std::invalid_argument);
             }
@@ -107,9 +103,8 @@ namespace cppmicroservices
                                                                          bc,
                                                                          nullptr,
                                                                          asyncWorkService,
-                                                                         notifier,
-                                                                         managers));
-                    },
+                                                                         notifier));
+                   },
                     std::invalid_argument);
             }
             {
@@ -119,8 +114,7 @@ namespace cppmicroservices
                                                                      bc,
                                                                      fakeLogger,
                                                                      asyncWorkService,
-                                                                     notifier,
-                                                                     managers));
+                                                                     notifier));
                 });
             }
         }
@@ -147,7 +141,6 @@ namespace cppmicroservices
                 notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                    fakeLogger,
                                                                    asyncWorkService);
-                managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
             }
 
             virtual void
@@ -163,7 +156,6 @@ namespace cppmicroservices
             std::shared_ptr<logservice::LogService> fakeLogger;
             std::shared_ptr<MockComponentRegistry> mockRegistry;
             std::shared_ptr<ConfigurationNotifier> notifier;
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
             std::shared_ptr<cppmicroservices::scrimpl::SCRAsyncWorkService> asyncWorkService;
         };
 
@@ -175,9 +167,8 @@ namespace cppmicroservices
                                                                   framework.GetBundleContext(),
                                                                   fakeLogger,
                                                                   asyncWorkService,
-                                                                  notifier,
-                                                                  managers);
-            EXPECT_EQ(compMgr->IsEnabled(), false) << "Illegal state before Initialization";
+                                                                  notifier);
+           EXPECT_EQ(compMgr->IsEnabled(), false) << "Illegal state before Initialization";
             compMgr->Initialize();
             EXPECT_EQ(compMgr->IsEnabled(), compMgr->GetMetadata()->enabled) << "Illegal state after Initialization";
         }
@@ -190,8 +181,7 @@ namespace cppmicroservices
                                                                   framework.GetBundleContext(),
                                                                   fakeLogger,
                                                                   asyncWorkService,
-                                                                  notifier,
-                                                                  managers);
+                                                                  notifier);
             EXPECT_NO_THROW({
                 compMgr->Initialize();
                 compMgr->Enable();
@@ -209,8 +199,7 @@ namespace cppmicroservices
                                                                   framework.GetBundleContext(),
                                                                   fakeLogger,
                                                                   asyncWorkService,
-                                                                  notifier,
-                                                                  managers);
+                                                                  notifier);
             EXPECT_NO_THROW({
                 compMgr->Initialize();
                 compMgr->Disable();
@@ -228,8 +217,7 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
+                                                                      notifier);
             EXPECT_NO_THROW({
                 compMgr->Initialize();
                 compMgr->ResetCounter();
@@ -251,8 +239,7 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
+                                                                      notifier);
             EXPECT_NO_THROW({
                 auto prevState = compMgr->IsEnabled();
                 compMgr->Initialize();
@@ -289,8 +276,7 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
+                                                                      notifier);
 
             compMgr->Initialize();
             compMgr->Disable(); // ensure the component is in DISABLED state
@@ -322,8 +308,7 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
+                                                                      notifier);
 
             compMgr->Initialize();
             compMgr->Enable(); // ensure the component is in ENABLED state
@@ -356,9 +341,8 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
-            compMgr->Initialize();
+                                                                      notifier);
+           compMgr->Initialize();
             // test concurrent calls to enable and disable from multiple threads
             std::function<std::shared_future<void>()> func = [compMgr]() mutable
             {
@@ -390,8 +374,7 @@ namespace cppmicroservices
                                                                       framework.GetBundleContext(),
                                                                       fakeLogger,
                                                                       asyncWorkService,
-                                                                      notifier,
-                                                                      managers);
+                                                                      notifier);
 
             EXPECT_EQ(compMgr->disableFutures.size(), 0ul) << "Disabled futures list must be empty before any calls to "
                                                               "AccumulateFuture method";

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
@@ -165,4 +165,47 @@ namespace test
         auto instances = GetInstances<test::CAInterface>();
         EXPECT_EQ(instances.size(), count);
     }
+    /* test MultipleFactoryConfig. 
+     * This test creates 10 factory objects without waiting for the previous one to complete. 
+     */
+    TEST_F(tServiceComponent, testMultipleFactoryConfig)
+    {
+        std::string configurationPid = "ServiceComponentPid";
+
+        // Start the test bundle containing the factory component. 
+        cppmicroservices::Bundle testBundle = StartTestBundle(
+            "TestBundleDSCA21"); 
+        
+        // Get a service reference to ConfigAdmin to create the factory component instances.
+        auto configAdminService = GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
+        ASSERT_TRUE(configAdminService) << "GetService failed for ConfigurationAdmin";
+
+        // Create some factory configuration objects. Don't wait for one to complete before 
+        // creating the next one.
+        constexpr auto count = 10;
+        std::vector<std::shared_future<void>> futures;
+
+        for (int i = 0; i < count; i++)
+        {
+            // Create the factory configuration object
+            auto factoryConfig = configAdminService->CreateFactoryConfiguration(configurationPid);
+
+            // Update the properties for the factory configuration object
+            cppmicroservices::AnyMap props(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            const std::string instanceId { "instance" + std::to_string(i) };
+            props["uniqueProp"] = instanceId;
+            auto fut = factoryConfig->Update(props);
+            futures.push_back(fut);
+        }
+
+        // Wait for all factory objects to finish updating.
+        for (auto& item : futures) {
+            item.get();
+         } 
+
+        // Request service references to the new component instances. This will
+        // cause DS to construct the factory instances.
+        auto instances = GetInstances<test::CAInterface>();
+        EXPECT_EQ(instances.size(), count);
+    }
 } // namespace test

--- a/compendium/DeclarativeServices/test/gtest/TestSingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestSingletonComponentConfiguration.cpp
@@ -57,14 +57,12 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         mockLogger,
                                                                         asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
                 obj = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
                                                                             framework,
                                                                             mockRegistry,
                                                                             mockLogger,
-                                                                            notifier,
-                                                                            managers);
+                                                                            notifier);
             }
 
             virtual void


### PR DESCRIPTION
The ComponentManagerImpl object contained a shared_ptr to the vector of all ComponentManagerImpl objects. When adding an item to this vector, the resizing of the vector caused a memory allocation error. Fixed by removing the vector from the ComponentManagerImpl object. Signed-off-by: The MathWorks, Inc. <pelliott@mathworks.com>

