### PR TITLE
Fix undefined behavior in LDAPExpr::Trim

### DIFF
--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -375,7 +375,11 @@ namespace cppmicroservices
     LDAPExpr::Trim(std::string str)
     {
         str.erase(0, str.find_first_not_of(' '));
-        str.erase(str.find_last_not_of(' ') + 1);
+        auto const last_not_space = str.find_last_not_of(' ');
+        if(last_not_space != std::string::npos)
+        {
+            str.erase(last_not_space + 1);
+        }
         return str;
     }
 


### PR DESCRIPTION
If there is no "space" left in the string after the first erase (or if there never was a space in it), calling str.find_last_not_of() returns `std::string::npos`.
Trying to add 1 to `npos` leads to undefined behavior reported by UBSAN:

`src/framework/src/util/LDAPExpr.cpp:200:39: runtime error: unsigned integer overflow: 18446744073709551615 + 1 cannot be represented in type 'unsigned long'`

Signed-off-by: Ingmar Sittl <ingmar.sittl@elektrobit.com>