### PR TITLE
Remove CoreBundleContext.dataStorage clear

### DIFF
--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -239,7 +239,6 @@ namespace cppmicroservices
         listeners.Clear();
         resolver.Clear();
 
-        dataStorage.clear();
         storage->Close();
     }
 


### PR DESCRIPTION
As per issue #733 this commit removes the code for 'clear()' `dataStorage` to solve the data-race warning generated by ThreadSanitizer.

Analysis:
The Thread Sanitizer data-race warning is caused when two threads simultaneously try to access the `dataStorage` variable. Thread T71 (in the issue log) tries to perform a READ operation on the variable while thread T74 performs a write.

Solution:
As the `dataStorage` string variable is only set at the time of initialization of the framework and will not be changed during the lifecycle. There is no need to perform a `clear()` operation during `Shutdown`. Thus, this line is removed solving the possible race-condition.