### PR TITLE
Removing std::move use with const object [ci skip]

### DIFF
--- a/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
@@ -62,10 +62,10 @@ namespace cppmicroservices
                                    const ConfigurationEventType type,
                                    const std::string factoryPid,
                                    const std::string pid)
-                    : configAdmin(std::move(configAdmin))
+                    : configAdmin(configAdmin)
                     , type(type)
-                    , factoryPid(std::move(factoryPid))
-                    , pid(std::move(pid))
+                    , factoryPid(factoryPid)
+                    , pid(pid)
                 {
                 }
 

--- a/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
@@ -58,14 +58,14 @@ namespace cppmicroservices
             class ConfigurationEvent
             {
               public:
-                ConfigurationEvent(ServiceReference<ConfigurationAdmin> const configAdmin,
+                ConfigurationEvent(ServiceReference<ConfigurationAdmin> configAdmin,
                                    const ConfigurationEventType type,
-                                   const std::string factoryPid,
-                                   const std::string pid)
-                    : configAdmin(configAdmin)
+                                   std::string factoryPid,
+                                   std::string pid)
+                    : configAdmin(std::move(configAdmin))
                     , type(type)
-                    , factoryPid(factoryPid)
-                    , pid(pid)
+                    , factoryPid(std::move(factoryPid))
+                    , pid(std::move(pid))
                 {
                 }
 

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -56,7 +56,7 @@ namespace cppmicroservices
         {
             ListenerToken(std::string pid, const ListenerTokenId tokenId)
                 : pid(std::move(pid))
-                , tokenId(std::move(tokenId))
+                , tokenId(tokenId)
             {
             }
             std::string pid;


### PR DESCRIPTION
#771 
This warning indicates that the use of std::move is not consistent with how it is intended to be used. When called on a const object, std::move does not perform a move operation but instead returns a copy of the object, which is likely not the developer's intent.

To fix this, I simply removed its use from the two files where the warning appeared:
- ConfigurationListener.hpp
- ComponentConfigurationImpl.hpp
I run tests locally (in the usDeclarativeServicesTest module) that use this part of the code, and the tests seem to be working as before. 

I also used [ci skip] since the changes are minor