### PR TITLE
Fix race condition when concurrently adding to SCRExtensionRegistry

### DIFF
--- a/compendium/DeclarativeServices/src/SCRExtensionRegistry.cpp
+++ b/compendium/DeclarativeServices/src/SCRExtensionRegistry.cpp
@@ -49,11 +49,13 @@ namespace cppmicroservices
         void
         SCRExtensionRegistry::Add(long bundleId, std::shared_ptr<SCRBundleExtension> extension)
         {
-            if (!extension) {
+            if (!extension)
+            {
                 throw std::invalid_argument("SCRExtensionRegistry::Add invalid extension");	
             }
-            if (extensionRegistry.find(bundleId) == extensionRegistry.end()){
-                std::lock_guard<std::mutex> l(extensionRegMutex);
+            std::lock_guard<std::mutex> l(extensionRegMutex);
+            if (extensionRegistry.find(bundleId) == extensionRegistry.end())
+            {
                 extensionRegistry.insert(std::make_pair(bundleId, std::move(extension)));
             }
         }

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -77,6 +77,7 @@ set(_declarativeservices_tests
   TestReferenceSelfSatisfyDeadLock.cpp
   TestRegistrationManager.cpp
   TestSCRBundleExtension.cpp
+  TestSCRExtensionRegistry.cpp
   TestServiceComponentRuntimeImpl.cpp
   TestServiceMetadataParserV1.cpp
   TestSetConfiguration.cpp


### PR DESCRIPTION
Fixed a race that can happen when multiple threads are trying to add to the extension registry container.

Fixed a bug with the tests for SCRExtensionRegsitry class never being compiled and run.