### PR TITLE
#Issue873: Redundant calls to .Load()

### DIFF
--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -68,9 +68,10 @@ namespace cppmicroservices
     Any
     ServiceReferenceBase::GetProperty(std::string const& key) const
     {
-        auto l = d.Load()->coreInfo->properties.Lock();
+        auto temp = d.Load();
+        auto l = temp->coreInfo->properties.Lock();
         US_UNUSED(l);
-        return d.Load()->coreInfo->properties.Value_unlocked(key).first;
+        return temp->coreInfo->properties.Value_unlocked(key).first;
     }
 
     void
@@ -82,9 +83,10 @@ namespace cppmicroservices
     std::vector<std::string>
     ServiceReferenceBase::GetPropertyKeys() const
     {
-        auto l = d.Load()->coreInfo->properties.Lock();
+        auto temp = d.Load();
+        auto l = temp->coreInfo->properties.Lock();
         US_UNUSED(l);
-        return d.Load()->coreInfo->properties.Keys_unlocked();
+        return temp->coreInfo->properties.Keys_unlocked();
     }
 
     Bundle
@@ -110,9 +112,10 @@ namespace cppmicroservices
     ServiceReferenceBase::GetUsingBundles() const
     {
         std::vector<Bundle> bundles;
-        auto l = d.Load()->LockServiceRegistration();
+        auto tmp = d.Load();
+        auto l = tmp->LockServiceRegistration();
         US_UNUSED(l);
-        for (auto const& iter : d.Load()->coreInfo->dependents)
+        for (auto const& iter : tmp->coreInfo->dependents)
         {
             bundles.push_back(MakeBundle(iter.first->shared_from_this()));
         }
@@ -136,8 +139,9 @@ namespace cppmicroservices
         {
             return false;
         }
-
-        if (d.Load()->registration.lock() == reference.d.Load()->registration.lock())
+        auto self = d.Load();
+        auto ref = reference.d.Load();
+        if (self->registration.lock() == ref->registration.lock())
         {
             return false;
         }
@@ -150,22 +154,22 @@ namespace cppmicroservices
         Any anyR1;
         Any anyId1;
         {
-            auto l1 = d.Load()->coreInfo->properties.Lock();
+            auto l1 = self->coreInfo->properties.Lock();
             US_UNUSED(l1);
-            anyR1 = d.Load()->coreInfo->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
+            anyR1 = self->coreInfo->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
             assert(anyR1.Empty() || anyR1.Type() == typeid(int));
-            anyId1 = d.Load()->coreInfo->properties.Value_unlocked(Constants::SERVICE_ID).first;
+            anyId1 = self->coreInfo->properties.Value_unlocked(Constants::SERVICE_ID).first;
             assert(anyId1.Empty() || anyId1.Type() == typeid(long int));
         }
 
         Any anyR2;
         Any anyId2;
         {
-            auto l2 = reference.d.Load()->coreInfo->properties.Lock();
+            auto l2 = ref->coreInfo->properties.Lock();
             US_UNUSED(l2);
-            anyR2 = reference.d.Load()->coreInfo->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
+            anyR2 = ref->coreInfo->properties.Value_unlocked(Constants::SERVICE_RANKING).first;
             assert(anyR2.Empty() || anyR2.Type() == typeid(int));
-            anyId2 = reference.d.Load()->coreInfo->properties.Value_unlocked(Constants::SERVICE_ID).first;
+            anyId2 = ref->coreInfo->properties.Value_unlocked(Constants::SERVICE_ID).first;
             assert(anyId2.Empty() || anyId2.Type() == typeid(long int));
         }
 

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -68,10 +68,10 @@ namespace cppmicroservices
     Any
     ServiceReferenceBase::GetProperty(std::string const& key) const
     {
-        auto temp = d.Load();
-        auto l = temp->coreInfo->properties.Lock();
+        auto refP = d.Load();
+        auto l = refP->coreInfo->properties.Lock();
         US_UNUSED(l);
-        return temp->coreInfo->properties.Value_unlocked(key).first;
+        return refP->coreInfo->properties.Value_unlocked(key).first;
     }
 
     void
@@ -83,39 +83,39 @@ namespace cppmicroservices
     std::vector<std::string>
     ServiceReferenceBase::GetPropertyKeys() const
     {
-        auto temp = d.Load();
-        auto l = temp->coreInfo->properties.Lock();
+        auto refP = d.Load();
+        auto l = refP->coreInfo->properties.Lock();
         US_UNUSED(l);
-        return temp->coreInfo->properties.Keys_unlocked();
+        return refP->coreInfo->properties.Keys_unlocked();
     }
 
     Bundle
     ServiceReferenceBase::GetBundle() const
     {
-        auto p = d.Load();
-        auto reg = p->registration.lock();
+        auto refP = d.Load();
+        auto reg = refP->registration.lock();
         if (!reg)
         {
             return Bundle();
         }
 
-        auto l = p->LockServiceRegistration();
+        auto l = refP->LockServiceRegistration();
         US_UNUSED(l);
-        if (p->coreInfo->bundle_.lock() == nullptr)
+        if (refP->coreInfo->bundle_.lock() == nullptr)
         {
             return Bundle();
         }
-        return MakeBundle(p->coreInfo->bundle_.lock()->shared_from_this());
+        return MakeBundle(refP->coreInfo->bundle_.lock()->shared_from_this());
     }
 
     std::vector<Bundle>
     ServiceReferenceBase::GetUsingBundles() const
     {
         std::vector<Bundle> bundles;
-        auto tmp = d.Load();
-        auto l = tmp->LockServiceRegistration();
+        auto refP = d.Load();
+        auto l = refP->LockServiceRegistration();
         US_UNUSED(l);
-        for (auto const& iter : tmp->coreInfo->dependents)
+        for (auto const& iter : refP->coreInfo->dependents)
         {
             bundles.push_back(MakeBundle(iter.first->shared_from_this()));
         }

--- a/framework/test/gtest/ServiceReferenceTest.cpp
+++ b/framework/test/gtest/ServiceReferenceTest.cpp
@@ -249,32 +249,3 @@ TEST_F(ServiceReferenceTest, TestGetServiceReferenceWithModifiedProperties)
     });
     ASSERT_EQ(context.GetServiceReference<ServiceNS::ITestServiceA>(), regArr[1].GetReference());
 }
-
-TEST_F(ServiceReferenceTest, TestParallelAccessOfService)
-{
-    auto context = framework.GetBundleContext();
-
-    std::array<cppmicroservices::ServiceRegistration<ServiceNS::ITestServiceA>, 2> regArr;
-    regArr[0] = context.RegisterService<ServiceNS::ITestServiceA>(std::make_shared<TestServiceA>());
-    regArr[1] = context.RegisterService<ServiceNS::ITestServiceA>(std::make_shared<TestServiceA>());
-
-    std::vector<std::thread> worker_threads;
-    for (size_t i = 0; i < 2; ++i)
-    {
-        worker_threads.push_back(std::thread(
-            [tmp = regArr[i]]()
-            {
-                for (int i = 0; i < 1; ++i)
-                {
-                    auto ref = tmp.GetReference();
-                    auto keys = ref.GetPropertyKeys();
-                    US_UNUSED(keys);
-                }
-            }));
-    }
-
-    for (auto& t : worker_threads)
-    {
-        t.join();
-    }
-}

--- a/framework/test/gtest/ServiceReferenceTest.cpp
+++ b/framework/test/gtest/ServiceReferenceTest.cpp
@@ -30,9 +30,6 @@ limitations under the License.
 #include "gtest/gtest.h"
 #include <array>
 
-#include <future>
-#include <thread>
-
 using namespace cppmicroservices;
 
 namespace ServiceNS


### PR DESCRIPTION
Within ServiceReferenceBase, there are redundant calls to `.Load()` which are not required given that the class is not guarantied to be thread safe except for copying and assignment. These calls are causing significant performance losses. 