### PR TITLE
Fixes #718

### DIFF
--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -320,6 +320,8 @@ namespace cppmicroservices
     {
         if (!reference)
         {
+            auto tmp = !reference;
+            US_UNUSED(tmp);
             throw std::invalid_argument("Default constructed ServiceReference is not a "
                                         "valid input to GetService()");
         }

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -320,8 +320,6 @@ namespace cppmicroservices
     {
         if (!reference)
         {
-            auto tmp = !reference;
-            US_UNUSED(tmp);
             throw std::invalid_argument("Default constructed ServiceReference is not a "
                                         "valid input to GetService()");
         }

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -183,6 +183,8 @@ TEST(BundleContextTest, NoSegfaultWithServiceFactory)
     // .join() and when the spawned thread is destructed, it will call terminate because it was not joined.
     try
     {
+        // Framework may throw as the registration is no longer valid (depending on thread ordering) but we care that no
+        // thread segfaults
         context.GetService(svcGetServiceThrowsRefs[0]);
     }
     catch (...)


### PR DESCRIPTION
Removed assertion because, depending on interleaving, the framework may or may not throw. Either is fine and expected. 

Issue with segfaults occurred because if the framework threw, the `.join()` was not reached and on destruction of the spawned thread, it called terminate as a result of no `.join()` or `.detach()` being called. 

Solution: try catch around `GetService()` with no assertion as to behavior.