### PR TITLE
Fix 489 - Char Const* property

### DIFF
--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -376,7 +376,7 @@ namespace cppmicroservices
     {
         str.erase(0, str.find_first_not_of(' '));
         auto const last_not_space = str.find_last_not_of(' ');
-        if(last_not_space != std::string::npos)
+        if (last_not_space != std::string::npos)
         {
             str.erase(last_not_space + 1);
         }
@@ -493,7 +493,9 @@ namespace cppmicroservices
             for (auto const& m_arg : d->m_args)
             {
                 if (!m_arg.IsSimple(keywords, cache, matchCase))
+                {
                     return false;
+                }
             }
             return true;
         }
@@ -621,14 +623,18 @@ namespace cppmicroservices
                     for (auto const& m_arg : d->m_args)
                     {
                         if (!m_arg.Evaluate(p, matchCase))
+                        {
                             return false;
+                        }
                     }
                     return true;
                 case OR:
                     for (auto const& m_arg : d->m_args)
                     {
                         if (m_arg.Evaluate(p, matchCase))
+                        {
                             return true;
+                        }
                     }
                     return false;
                 case NOT:
@@ -643,9 +649,13 @@ namespace cppmicroservices
     LDAPExpr::Compare(Any const& obj, int op, std::string const& s) const
     {
         if (obj.Empty())
+        {
             return false;
+        }
         if (op == EQ && s == LDAPExprConstants::WILDCARD_STRING())
+        {
             return true;
+        }
 
         try
         {
@@ -654,13 +664,19 @@ namespace cppmicroservices
             {
                 return CompareString(ref_any_cast<std::string>(obj), op, s);
             }
+            else if (objType == typeid(char const*))
+            {
+                return CompareString(std::string(ref_any_cast<char const*>(obj)), op, s);
+            }
             else if (objType == typeid(std::vector<std::string>))
             {
                 auto const& list = ref_any_cast<std::vector<std::string>>(obj);
                 for (std::size_t it = 0; it != list.size(); it++)
                 {
                     if (CompareString(list[it], op, s))
+                    {
                         return true;
+                    }
                 }
             }
             else if (objType == typeid(std::list<std::string>))
@@ -669,7 +685,9 @@ namespace cppmicroservices
                 for (auto const& it : list)
                 {
                     if (CompareString(it, op, s))
+                    {
                         return true;
+                    }
                 }
             }
             else if (objType == typeid(char))
@@ -679,7 +697,9 @@ namespace cppmicroservices
             else if (objType == typeid(bool))
             {
                 if (op == LE || op == GE)
+                {
                     return false;
+                }
 
                 std::string boolVal = any_cast<bool>(obj) ? "true" : "false";
                 return std::equal(s.begin(), s.end(), boolVal.begin(), stricomp);
@@ -776,7 +796,9 @@ namespace cppmicroservices
                 for (std::size_t it = 0; it != list.size(); it++)
                 {
                     if (Compare(list[it], op, s))
+                    {
                         return true;
+                    }
                 }
             }
         }
@@ -846,7 +868,9 @@ namespace cppmicroservices
             if (!std::isspace(c))
             {
                 if (std::isupper(c))
+                {
                     c = std::tolower(c);
+                }
                 sb.append(1, c);
             }
         }
@@ -857,16 +881,22 @@ namespace cppmicroservices
     LDAPExpr::PatSubstr(const std::string_view s, int si, const std::string_view pat, int pi)
     {
         if (pat.size() - pi == 0)
+        {
             return s.size() - si == 0;
+        }
         if (pat[pi] == LDAPExprConstants::WILDCARD())
         {
             pi++;
             for (;;)
             {
                 if (PatSubstr(s, si, pat, pi))
+                {
                     return true;
+                }
                 if (s.size() - si == 0)
+                {
                     return false;
+                }
                 si++;
             }
         }
@@ -895,7 +925,9 @@ namespace cppmicroservices
     {
         ps.skipWhite();
         if (!ps.prefix("("))
+        {
             ps.error(LDAPExprConstants::MALFORMED());
+        }
 
         int op;
         ps.skipWhite();
@@ -927,7 +959,9 @@ namespace cppmicroservices
 
         std::size_t n = v.size();
         if (!ps.prefix(")") || n == 0 || (op == NOT && n > 1))
+        {
             ps.error(LDAPExprConstants::MALFORMED());
+        }
 
         return LDAPExpr(op, v);
     }
@@ -937,16 +971,26 @@ namespace cppmicroservices
     {
         std::string attrName = ps.getAttributeName();
         if (attrName.empty())
+        {
             ps.error(LDAPExprConstants::MALFORMED());
+        }
         int op = 0;
         if (ps.prefix("="))
+        {
             op = EQ;
+        }
         else if (ps.prefix("<="))
+        {
             op = LE;
+        }
         else if (ps.prefix(">="))
+        {
             op = GE;
+        }
         else if (ps.prefix("~="))
+        {
             op = APPROX;
+        }
         else
         {
             //      System.out.println("undef op='" + ps.peek() + "'");
@@ -954,7 +998,9 @@ namespace cppmicroservices
         }
         std::string attrValue = ps.getAttributeValue();
         if (!ps.prefix(")"))
+        {
             ps.error(LDAPExprConstants::MALFORMED());
+        }
         return LDAPExpr(op, attrName, attrValue);
     }
 
@@ -1033,7 +1079,9 @@ namespace cppmicroservices
     {
         std::string::iterator startIter = m_str.begin() + m_pos;
         if (!std::equal(pre.begin(), pre.end(), startIter))
+        {
             return false;
+        }
         m_pos += pre.size();
         return true;
     }

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -678,10 +678,9 @@ TEST_F(ServiceTrackerTestFixture, TestFilterPropertiesTypes)
     tracker.Open();
 
     auto fooService = std::make_shared<MockFooBar>();
-    cppmicroservices::ServiceProperties props = std::initializer_list<cppmicroservices::ServiceProperties::value_type> {
-        std::make_pair("tag",
-                       ("foo::bar::Baz"))
-    };
+    cppmicroservices::ServiceProperties props
+        = std::initializer_list<cppmicroservices::ServiceProperties::value_type> { std::make_pair("tag",
+                                                                                                  ("foo::bar::Baz")) };
 
     auto svc = framework.GetBundleContext().RegisterService<foo::Bar>(fooService, std::move(props));
 

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -651,3 +651,43 @@ TEST_F(ServiceTrackerTestFixture, TestReOpenServiceTrackerWithCustomizer)
     });
     tracker->Close();
 }
+
+namespace
+{
+    namespace foo
+    {
+        class Bar
+        {
+          public:
+            virtual ~Bar() {}
+        };
+    } // namespace foo
+
+    class MockFooBar : public foo::Bar
+    {
+    };
+} // namespace
+
+TEST_F(ServiceTrackerTestFixture, TestFilterPropertiesTypes)
+{
+    auto framework = cppmicroservices::FrameworkFactory().NewFramework();
+    framework.Start();
+
+    LDAPFilter filter("(tag=foo::bar::Baz)");
+    ServiceTracker<foo::Bar> tracker(framework.GetBundleContext(), filter);
+    tracker.Open();
+
+    auto fooService = std::make_shared<MockFooBar>();
+    cppmicroservices::ServiceProperties props = std::initializer_list<cppmicroservices::ServiceProperties::value_type> {
+        std::make_pair("tag",
+                       ("foo::bar::Baz"))
+    };
+
+    auto svc = framework.GetBundleContext().RegisterService<foo::Bar>(fooService, std::move(props));
+
+    ASSERT_EQ(tracker.GetTrackingCount(), 1);
+
+    tracker.Close();
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
+}


### PR DESCRIPTION
This fixes a problem where `char const*` properties were not being matched to `LDAPFilter`s. This was an issue with `LDAPExpr::Compare`. This function uses `typeid` to compare an object of type `Any` to the filter's attribute value. There were many cases, but not one for an `Any` value of type `Char Const*`. This option was added. 

Signed-off-by: Toby Cormack <tcormack@mathworks.com>