### PR TITLE
701- ComponentManagermemory reallocation bug fix (#834)

### DIFF
--- a/compendium/DeclarativeServices/src/CMakeLists.txt
+++ b/compendium/DeclarativeServices/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(_srcs
   ComponentRegistry.cpp
   SCRAsyncWorkService.cpp
   SCRBundleExtension.cpp
+  SCRExtensionRegistry.cpp
   SCRLogger.cpp
   ServiceComponentRuntimeImpl.cpp
   ComponentContextImpl.cpp
@@ -42,6 +43,7 @@ set(_private_headers
   SCRActivator.hpp
   SCRAsyncWorkService.hpp
   SCRBundleExtension.hpp
+  SCRExtensionRegistry.hpp
   SCRLogger.hpp
   ServiceComponentRuntimeImpl.hpp
   ServiceReferenceComparator.hpp

--- a/compendium/DeclarativeServices/src/SCRActivator.hpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.hpp
@@ -25,6 +25,7 @@
 #include "ComponentRegistry.hpp"
 #include "SCRAsyncWorkService.hpp"
 #include "SCRBundleExtension.hpp"
+#include "SCRExtensionRegistry.hpp"
 #include "SCRLogger.hpp"
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
@@ -76,9 +77,8 @@ namespace cppmicroservices
             cppmicroservices::BundleContext runtimeContext;
             cppmicroservices::ServiceRegistration<ServiceComponentRuntime> scrServiceReg;
             std::shared_ptr<ComponentRegistry> componentRegistry;
-            std::mutex bundleRegMutex;
-            std::unordered_map<long, std::unique_ptr<SCRBundleExtension>> bundleRegistry;
             std::shared_ptr<SCRLogger> logger;
+            std::shared_ptr<SCRExtensionRegistry> bundleRegistry;
             ListenerToken bundleListenerToken;
             std::shared_ptr<SCRAsyncWorkService> asyncWorkService;
             cppmicroservices::ServiceRegistration<cppmicroservices::service::cm::ConfigurationListener>

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -52,12 +52,19 @@ namespace cppmicroservices
         class SCRBundleExtension
         {
           public:
+            /* SCRBundleExtension constructor
+             * @param bundle { @link Bundle }
+             * @param shared_ptr to {@link ComponentRegistry} registry 
+             * @param shared_ptr to {@link LogService} logger
+             * @param shared_ptr to {@link ConfigurationNotifier} object
+             * @throws std::illegal_argument if any input parameters fail validation.
+             */
+
             SCRBundleExtension(cppmicroservices::Bundle const& bundle,
-                               cppmicroservices::AnyMap const& scrMetadata,
-                               std::shared_ptr<ComponentRegistry> const& registry,
-                               std::shared_ptr<LogService> const& logger,
-                               std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWorkService,
-                               std::shared_ptr<ConfigurationNotifier> const& configNotifier);
+                                                   std::shared_ptr<ComponentRegistry> const& registry,
+                                                   std::shared_ptr<LogService> const& logger,
+                                                   std::shared_ptr<ConfigurationNotifier> const& configNotifier);
+   
 
             SCRBundleExtension(SCRBundleExtension const&) = delete;
             SCRBundleExtension(SCRBundleExtension&&) = delete;
@@ -65,6 +72,25 @@ namespace cppmicroservices
             SCRBundleExtension& operator=(SCRBundleExtension&&) = delete;
             ~SCRBundleExtension();
 
+             /*
+             *@throws std::bad_alloc exception if a storage failure occurs on 
+             * reallocation. Has the same exception guarantees as std::vector::push_back
+             */
+            void AddComponentManager(std::shared_ptr<ComponentManager>);
+
+            /* SCRBundleExtension::Initialize - Creates the ComponentManagerImpl
+             * object to manage the creation of the component configurations.
+             * @param AnyMap containing the bundle metadata 
+             * @param shared_ptr to {@link AsyncWorkService} object
+             * @throws std::illegal_argument if any input parameters fail validation.
+             * @throws {@link SharedLibraryException} if library cannot be loaded.
+             * @throws {@link SecurityException} if bundle validation fails.
+             * @throws std::exception for all other exceptions
+             */
+
+            void Initialize(cppmicroservices::AnyMap const& scrMetadata,
+                            std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWorkService);
+ 
           private:
             FRIEND_TEST(SCRBundleExtensionTest, CtorWithValidArgs);
 

--- a/compendium/DeclarativeServices/src/SCRExtensionRegistry.cpp
+++ b/compendium/DeclarativeServices/src/SCRExtensionRegistry.cpp
@@ -1,0 +1,76 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  =============================================================================*/
+#include "SCRExtensionRegistry.hpp"
+
+namespace cppmicroservices
+{
+    namespace scrimpl
+    {
+        SCRExtensionRegistry::SCRExtensionRegistry(std::shared_ptr<SCRLogger> logger)
+            : logger(std::move(logger))
+        {
+            if (!(this->logger))
+            {
+                throw std::invalid_argument(" SCRExtensionRegistry Constructor "
+                "provided with invalid arguments");
+            }
+        }
+
+        std::shared_ptr<SCRBundleExtension>
+        SCRExtensionRegistry::Find(long bundleId) noexcept
+        {
+            std::lock_guard<std::mutex> l(extensionRegMutex);
+            auto const& it = extensionRegistry.find(bundleId);
+            if (it != extensionRegistry.end())
+            {
+                return it->second;
+            }
+            return nullptr;
+        }
+
+        void
+        SCRExtensionRegistry::Add(long bundleId, std::shared_ptr<SCRBundleExtension> extension)
+        {
+            if (!extension) {
+                throw std::invalid_argument("SCRExtensionRegistry::Add invalid extension");	
+            }
+            if (extensionRegistry.find(bundleId) == extensionRegistry.end()){
+                std::lock_guard<std::mutex> l(extensionRegMutex);
+                extensionRegistry.insert(std::make_pair(bundleId, std::move(extension)));
+            }
+        }
+
+        void
+        SCRExtensionRegistry::Remove(long bundleId)
+        {
+            std::lock_guard<std::mutex> l(extensionRegMutex);
+            extensionRegistry.erase(bundleId);
+        }
+
+        void
+        SCRExtensionRegistry::Clear()
+        {
+            std::lock_guard<std::mutex> l(extensionRegMutex);
+            extensionRegistry.clear();
+         }
+    } // namespace scrimpl
+} // namespace cppmicroservices

--- a/compendium/DeclarativeServices/src/SCRExtensionRegistry.hpp
+++ b/compendium/DeclarativeServices/src/SCRExtensionRegistry.hpp
@@ -1,0 +1,103 @@
+/*=============================================================================
+
+ Library: CppMicroServices
+
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ =============================================================================*/
+
+#ifndef __CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__
+#define __CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__
+
+#include "SCRBundleExtension.hpp"
+#include "SCRLogger.hpp"
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace cppmicroservices
+{
+    namespace scrimpl
+    {
+        /* The SCRBundleExtension is a helper class to load and unload Components of
+         * a single bundle. It is responsible for creating a component manager for each
+         * valid component description found in the bundle. The SCRExtensionRegistry 
+         * maintains a map of SCRBundleExtension objects that is accesed by BundleId.
+         */
+        class SCRExtensionRegistry 
+        {
+
+          public:
+            /**
+             * @throws std::invalid_argument exception if any of the params is a nullptr
+             */
+            SCRExtensionRegistry(std::shared_ptr<SCRLogger> logger);
+ 
+            SCRExtensionRegistry(SCRExtensionRegistry const&) = delete;
+            SCRExtensionRegistry(SCRExtensionRegistry&&) = delete;
+            SCRExtensionRegistry& operator=(SCRExtensionRegistry const&) = delete;
+            SCRExtensionRegistry& operator=(SCRExtensionRegistry&&) = delete;
+            ~SCRExtensionRegistry() = default;
+
+            /* SCRExtensionRegistry::Find 
+             * Searches the extensionRegistry for the bundleId matching the input 
+             * parameter. 
+             * @param bundleId The bundleId {@link Bundle} associated with the 
+             * {@link SCRBundleExtension} responsible for creating the components.
+             * @returns shared_ptr to a {@link SCRBundleExtension} object or nullptr 
+             * if the no matching bundleId is found. 
+             */
+            std::shared_ptr<SCRBundleExtension> Find(long bundleId) noexcept;
+           
+            /* SCRExtensionRegistry::Add
+             * Inserts a SCRBundleExtension object into the extensionRegistry using
+             * the bundleId as the key.
+             * @param bundleId The bundleId {@link Bundle} associated with the
+             * {@link SCRBundleExtension} object to be inserted.
+             * @param shared_ptr to the {@link SCRBundleExtension} object to be inserted. 
+             * @throws std::invalid_argument if the extension input parameter if invalid.
+             * @throws std::bad_alloc exception if a storage failure occurs. 
+             */
+            void Add(long bundleId, std::shared_ptr<SCRBundleExtension> extension);
+
+            /* SCRExtensionRegistry::Remove
+             * Removes a SCRBundleExtension object from the extensionRegistry using
+             * the bundleId as the key.
+             * @param bundleId The bundleId {@link Bundle} associated with the
+             * {@link SCRBundleExtension} object to be removed.
+             * @throws std::current_exception if an exception is thrown by the 
+             * {@link SCRBundleExtension} destructor
+             */
+            void Remove(long bundleId);
+
+            /* SCRExtensionRegistry::Clears
+             * Removes all  SCRBundleExtension objects from the extensionRegistry.
+             * @throws std::current_exception if an exception is thrown by a
+             * {@link SCRBundleExtension} destructor
+             */
+            void Clear();
+
+          private:
+            std::shared_ptr<SCRLogger> logger;
+            std::mutex extensionRegMutex;  //protects the extensionRegistry
+            std::unordered_map<long,std::shared_ptr<SCRBundleExtension>> extensionRegistry;
+        };
+
+    } // namespace scrimpl
+} // namespace cppmicroservices
+#endif //__CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.cpp
@@ -37,9 +37,8 @@ namespace cppmicroservices
             cppmicroservices::Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier, managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier)
         {
         }
 

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
@@ -46,8 +46,7 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
             BundleOrPrototypeComponentConfigurationImpl(BundleOrPrototypeComponentConfigurationImpl const&) = delete;
             BundleOrPrototypeComponentConfigurationImpl(BundleOrPrototypeComponentConfigurationImpl&&) = delete;
             BundleOrPrototypeComponentConfigurationImpl& operator=(BundleOrPrototypeComponentConfigurationImpl const&)

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.cpp
@@ -36,9 +36,8 @@ namespace cppmicroservices
             cppmicroservices::Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-        {
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+         {
             std::shared_ptr<ComponentConfigurationImpl> retVal;
             std::string scope = compDesc->serviceMetadata.scope;
             if (scope == cppmicroservices::Constants::SCOPE_SINGLETON)
@@ -47,8 +46,7 @@ namespace cppmicroservices
                                                                                bundle,
                                                                                registry,
                                                                                logger,
-                                                                               configNotifier,
-                                                                               managers);
+                                                                               configNotifier);
             }
             else if (scope == cppmicroservices::Constants::SCOPE_BUNDLE
                      || scope == cppmicroservices::Constants::SCOPE_PROTOTYPE)
@@ -57,8 +55,7 @@ namespace cppmicroservices
                                                                                        bundle,
                                                                                        registry,
                                                                                        logger,
-                                                                                       configNotifier,
-                                                                                       managers);
+                                                                                       configNotifier);
             }
             if (retVal)
             {

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
@@ -44,9 +44,8 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
-        };
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
+       };
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -58,8 +58,7 @@ namespace cppmicroservices
             Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
             : configID(++idCounter)
             , metadata(std::move(metadata))
             , bundle(bundle)
@@ -67,14 +66,12 @@ namespace cppmicroservices
             , logger(std::move(logger))
             , configManager()
             , configNotifier(std::move(configNotifier))
-            , managers(std::move(managers))
             , state(std::make_shared<CCUnsatisfiedReferenceState>())
             , newCompInstanceFunc(nullptr)
             , deleteCompInstanceFunc(nullptr)
         {
-            if (!this->metadata || !this->bundle || !this->registry || !this->logger || !this->configNotifier
-                || !this->managers)
-            {
+            if (!this->metadata || !this->bundle || !this->registry || !this->logger || !this->configNotifier)
+           {
                 throw std::invalid_argument("ComponentConfigurationImpl - Invalid arguments passed to constructor");
             }
 

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -77,13 +77,11 @@ namespace cppmicroservices
             /**
              * \throws std::invalid_argument exception if any of the params is a nullptr
              */
-            explicit ComponentConfigurationImpl(
-                std::shared_ptr<const metadata::ComponentMetadata> metadata,
-                Bundle const& bundle,
-                std::shared_ptr<ComponentRegistry> registry,
-                std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+            explicit ComponentConfigurationImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
+                                                Bundle const& bundle,
+                                                std::shared_ptr<ComponentRegistry> registry,
+                                                std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+                                                std::shared_ptr<ConfigurationNotifier> configNotifier);
             ComponentConfigurationImpl(ComponentConfigurationImpl const&) = delete;
             ComponentConfigurationImpl(ComponentConfigurationImpl&&) = delete;
             ComponentConfigurationImpl& operator=(ComponentConfigurationImpl const&) = delete;
@@ -166,16 +164,7 @@ namespace cppmicroservices
                 return metadata;
             };
 
-            /**
-             * This method returns the {@link ComponentManager} vector which holds
-             * the ComponentManagerImpl objects.
-             */
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>>
-            GetManagers() const
-            {
-                return managers;
-            };
-
+            
             /**
              * Method to check if this component provides a service
              *
@@ -439,7 +428,6 @@ namespace cppmicroservices
             std::shared_ptr<ConfigurationNotifier> configNotifier; // to get updates for configuration objects
             std::vector<std::shared_ptr<ListenerToken>>
                 configListenerTokens; ///< vector of the listener tokens received from the config manager
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
             std::shared_ptr<ComponentConfigurationState> state; ///< only modified using std::atomic operations
             std::function<ComponentInstance*(void)>
                 newCompInstanceFunc; ///< extern C function to create a new instance {@link ComponentInstance} class

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.cpp
@@ -42,8 +42,7 @@ namespace cppmicroservices
             BundleContext bundleContext,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
             std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
             : registry(std::move(registry))
             , compDesc(std::move(metadata))
             , bundleContext(std::move(bundleContext))
@@ -51,10 +50,9 @@ namespace cppmicroservices
             , state(std::make_shared<CMDisabledState>())
             , asyncWorkService(std::move(asyncWorkService))
             , configNotifier(std::move(configNotifier))
-            , managers(std::move(managers))
         {
             if (!compDesc || !this->registry || !this->bundleContext || !this->logger || !this->asyncWorkService
-                || !this->configNotifier || !this->managers)
+                || !this->configNotifier)
             {
                 throw std::invalid_argument("Invalid arguments to ComponentManagerImpl constructor");
             }
@@ -167,14 +165,13 @@ namespace cppmicroservices
             auto reg = GetRegistry();
             auto logger = GetLogger();
             auto configNotifier = GetConfigNotifier();
-            auto managers = GetManagers();
 
             using ActualTask = std::packaged_task<void(std::shared_ptr<CMEnabledState>)>;
             using PostTask = std::packaged_task<void()>;
 
-            ActualTask task([metadata, bundle, reg, logger, configNotifier, managers](
+            ActualTask task([metadata, bundle, reg, logger, configNotifier](
                                 std::shared_ptr<CMEnabledState> eState) mutable
-                            { eState->CreateConfigurations(metadata, bundle, reg, logger, configNotifier, managers); });
+                            { eState->CreateConfigurations(metadata, bundle, reg, logger, configNotifier); });
 
             std::shared_ptr<CMEnabledState> enabledState = std::make_shared<CMEnabledState>(task.get_future().share());
 

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -55,9 +55,8 @@ namespace cppmicroservices
                                  cppmicroservices::BundleContext bundleContext,
                                  std::shared_ptr<cppmicroservices::logservice::LogService> logger,
                                  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-                                 std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                 std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
-            ComponentManagerImpl(ComponentManagerImpl const&) = delete;
+                                 std::shared_ptr<ConfigurationNotifier> configNotifier);
+             ComponentManagerImpl(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl(ComponentManagerImpl&&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl&&) = delete;
@@ -151,14 +150,6 @@ namespace cppmicroservices
             }
 
             /**
-             * Returns the managers object associated with this ComponentManager
-             */
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>>
-            GetManagers() const
-            {
-                return managers;
-            }
-            /**
              * This method modifies the vector of futures stored in this object. If
              * any of the futures in the vector are ready, the ready future is replaced
              * by the given future. If none of the futures are ready, the given future
@@ -230,8 +221,7 @@ namespace cppmicroservices
             std::mutex
                 transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic
             std::shared_ptr<ConfigurationNotifier> configNotifier;
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
-        };
+       };
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.cpp
@@ -29,6 +29,7 @@
 #include "cppmicroservices/SharedLibraryException.h"
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
 #include "cppmicroservices/cm/ConfigurationAdmin.hpp"
+#include "../SCRExtensionRegistry.hpp"
 
 namespace cppmicroservices
 {
@@ -39,13 +40,15 @@ namespace cppmicroservices
         ConfigurationNotifier::ConfigurationNotifier(
             cppmicroservices::BundleContext const& context,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService_)
+            std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkSvc,
+            std::shared_ptr<SCRExtensionRegistry> extensionReg)
             : tokenCounter(0)
             , bundleContext(context)
             , logger(std::move(logger))
-            , asyncWorkService(asyncWorkService_)
+            , asyncWorkService(asyncWorkSvc)
+            , extensionRegistry(extensionReg)
         {
-            if (!bundleContext || !(this->logger) || (!this->asyncWorkService))
+            if (!bundleContext || !(this->logger) || (!this->asyncWorkService) || (!this->extensionRegistry))
             {
                 throw std::invalid_argument("ConfigurationNotifier Constructor "
                                             "provided with invalid arguments");
@@ -183,8 +186,6 @@ namespace cppmicroservices
             auto registry = mgr->GetRegistry();
             auto logger = mgr->GetLogger();
             auto configNotifier = mgr->GetConfigNotifier();
-            auto managers = mgr->GetManagers();
-
             try
             {
                 auto compManager = std::make_shared<ComponentManagerImpl>(newMetadata,
@@ -192,12 +193,22 @@ namespace cppmicroservices
                                                                           bundle.GetBundleContext(),
                                                                           logger,
                                                                           asyncWorkService,
-                                                                          configNotifier,
-                                                                          managers);
+                                                                          configNotifier);
                 if (registry->AddComponentManager(compManager))
                 {
-                    managers->push_back(compManager);
-                    compManager->Initialize();
+                    auto const& extension = extensionRegistry->Find(bundle.GetBundleId());
+                    if (extension)
+                    {
+                        extension->AddComponentManager(compManager);
+                        compManager->Initialize();
+                    }
+                    else
+                    {
+                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                                    "Failed to find ComponentManager with name " + newMetadata->name
+                                        + " from bundle with Id "
+                                        + std::to_string(bundleContext.GetBundle().GetBundleId()));
+                    }
                 }
             }
             catch (cppmicroservices::SharedLibraryException const&)

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
@@ -33,6 +33,7 @@ namespace cppmicroservices
     namespace scrimpl
     {
         class ComponentConfigurationImpl;
+        class SCRExtensionRegistry;
 
         /** ConfigChangeNotification
          * This class is used by ConfigurationListener to notify ComponentConfigurationImpl
@@ -76,7 +77,8 @@ namespace cppmicroservices
              */
             ConfigurationNotifier(cppmicroservices::BundleContext const& context,
                                   std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                                  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService_);
+                                  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkSvc,
+                                  std::shared_ptr<SCRExtensionRegistry> extensionReg);
 
             ConfigurationNotifier(ConfigurationNotifier const&) = delete;
             ConfigurationNotifier(ConfigurationNotifier&&) = delete;
@@ -115,6 +117,7 @@ namespace cppmicroservices
             cppmicroservices::BundleContext bundleContext;
             std::shared_ptr<cppmicroservices::logservice::LogService> logger;
             std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService;
+            std::shared_ptr<SCRExtensionRegistry> extensionRegistry;
         };
 
     } // namespace scrimpl

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.cpp
@@ -47,9 +47,8 @@ namespace cppmicroservices
             Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<ConfigurationNotifier> configNotifier,
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier, managers)
+            std::shared_ptr<ConfigurationNotifier> configNotifier)
+            : ComponentConfigurationImpl(metadata, bundle, registry, logger, configNotifier)
         {
         }
 

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -47,8 +47,7 @@ namespace cppmicroservices
                 cppmicroservices::Bundle const& bundle,
                 std::shared_ptr<ComponentRegistry> registry,
                 std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                std::shared_ptr<ConfigurationNotifier> configNotifier,
-                std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                std::shared_ptr<ConfigurationNotifier> configNotifier);
             SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl const&) = delete;
             SingletonComponentConfigurationImpl(SingletonComponentConfigurationImpl&&) = delete;
             SingletonComponentConfigurationImpl& operator=(SingletonComponentConfigurationImpl const&) = delete;

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
@@ -51,8 +51,7 @@ namespace cppmicroservices
                                              cppmicroservices::Bundle const& bundle,
                                              std::shared_ptr<ComponentRegistry> registry,
                                              std::shared_ptr<logservice::LogService> logger,
-                                             std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                             std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
+                                             std::shared_ptr<ConfigurationNotifier> configNotifier)
         {
             try
             {
@@ -60,9 +59,8 @@ namespace cppmicroservices
                                                                                     bundle,
                                                                                     registry,
                                                                                     logger,
-                                                                                    configNotifier,
-                                                                                    managers);
-                configurations.push_back(cc);
+                                                                                    configNotifier);
+               configurations.push_back(cc);
             }
             catch (cppmicroservices::SharedLibraryException const&)
             {

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.hpp
@@ -118,8 +118,7 @@ namespace cppmicroservices
                                       cppmicroservices::Bundle const& bundle,
                                       std::shared_ptr<ComponentRegistry> registry,
                                       std::shared_ptr<logservice::LogService> logger,
-                                      std::shared_ptr<ConfigurationNotifier> configNotifier,
-                                      std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers);
+                                      std::shared_ptr<ConfigurationNotifier> configNotifier);
 
             /**
              * Helper function used to remove all the configuration objects created by this state.

--- a/compendium/DeclarativeServices/test/gtest/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/gtest/Mocks.hpp
@@ -335,9 +335,8 @@ namespace cppmicroservices
                                      BundleContext bundleContext,
                                      std::shared_ptr<cppmicroservices::logservice::LogService> logger,
                                      std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
-                                     std::shared_ptr<ConfigurationNotifier> notifier,
-                                     std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-                : ComponentManagerImpl(metadata, registry, bundleContext, logger, asyncWorkService, notifier, managers)
+                                     std::shared_ptr<ConfigurationNotifier> notifier)
+               : ComponentManagerImpl(metadata, registry, bundleContext, logger, asyncWorkService, notifier)
                 , statechangecount(0)
             {
             }
@@ -376,9 +375,8 @@ namespace cppmicroservices
                                            Bundle const& bundle,
                                            std::shared_ptr<ComponentRegistry> registry,
                                            std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-                                           std::shared_ptr<ConfigurationNotifier> notifier,
-                                           std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers)
-                : ComponentConfigurationImpl(metadata, bundle, registry, logger, notifier, managers)
+                                           std::shared_ptr<ConfigurationNotifier> notifier)
+                : ComponentConfigurationImpl(metadata, bundle, registry, logger, notifier)
                 , statechangecount(0)
             {
             }

--- a/compendium/DeclarativeServices/test/gtest/TestCCActiveState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCActiveState.cpp
@@ -26,6 +26,7 @@
 #include <random>
 
 #include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "../../src/manager/states/CCActiveState.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
@@ -57,18 +58,18 @@ namespace cppmicroservices
                 auto asyncWorkService
                     = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
                                                                                        logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
+ 
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
-            }
+                                                                                  notifier);
+             }
 
             virtual void
             TearDown()

--- a/compendium/DeclarativeServices/test/gtest/TestCCRegisteredState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCRegisteredState.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "../../src/manager/states/CCRegisteredState.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
@@ -54,17 +55,17 @@ namespace cppmicroservices
                 auto asyncWorkService
                     = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
                                                                                        logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
+ 
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
+                                                                                  notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestCCUnsatisfiedReferenceState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestCCUnsatisfiedReferenceState.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "../../src/manager/states/CCUnsatisfiedReferenceState.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
@@ -55,16 +56,16 @@ namespace cppmicroservices
                 auto asyncWorkService
                     = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
                                                                                        logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
+                                                                        asyncWorkService,
+                                                                        extRegistry);
                 mockCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                   framework,
                                                                                   mockRegistry,
                                                                                   fakeLogger,
-                                                                                  notifier,
-                                                                                  managers);
+                                                                                  notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -23,6 +23,7 @@
 #include <random>
 
 #include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "../../src/SCRLogger.hpp"
 #include "../../src/manager/BundleLoader.hpp"
 #include "../../src/manager/BundleOrPrototypeComponentConfiguration.hpp"
@@ -88,19 +89,18 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             EXPECT_THROW(
                 {
                     auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(nullptr,
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
             EXPECT_THROW(
@@ -109,8 +109,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            nullptr,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
             EXPECT_THROW(
@@ -119,8 +118,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            nullptr,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                 },
                 std::invalid_argument);
 
@@ -129,9 +127,8 @@ namespace cppmicroservices
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
-                EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+                                                                                       notifier);
+                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_EQ(fakeCompConfig->regManager, nullptr);
                 EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
             });
@@ -146,11 +143,11 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry); 
             std::set<unsigned long> idSet;
             const size_t iterCount = 10;
             for (size_t i = 0; i < iterCount; ++i)
@@ -160,8 +157,7 @@ namespace cppmicroservices
                                                                                            GetFramework(),
                                                                                            mockRegistry,
                                                                                            fakeLogger,
-                                                                                           notifier,
-                                                                                           managers);
+                                                                                           notifier);
                     idSet.insert(fakeCompConfig->GetId());
                 });
             }
@@ -178,7 +174,6 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
 
             mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             auto refMgr1 = std::make_shared<MockReferenceManager>();
@@ -199,14 +194,14 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
-            auto notifier = std::make_shared<ConfigurationNotifier>(bc, fakeLogger, asyncWorkService);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
+            auto notifier = std::make_shared<ConfigurationNotifier>(bc, fakeLogger, asyncWorkService, extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
-            EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
+                                                                                   notifier);
+           EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
             // add the mock reference managers to the config object
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref1", refMgr1));
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref2", refMgr2));
@@ -230,21 +225,21 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             auto logger = std::make_shared<SCRLogger>(GetFramework().GetBundleContext());
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             auto mockStatisfiedState = std::make_shared<MockComponentConfigurationState>();
             auto mockUnsatisfiedState = std::make_shared<MockComponentConfigurationState>();
             EXPECT_CALL(*mockStatisfiedState, GetValue())
@@ -275,8 +270,7 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+ 
             // Test that a call to Register with a component containing both a service
             // and a reference to the same service interface will not cause a state change.
             scrimpl::metadata::ReferenceMetadata refMetadata {};
@@ -287,16 +281,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
 
             auto reg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
                 std::make_shared<dummy::ServiceImpl>());
@@ -315,11 +309,11 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             // Test if a call to Register will change the state when the component
             // does not provide a service.
             {
@@ -327,8 +321,7 @@ namespace cppmicroservices
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_EQ(fakeCompConfig->regManager, nullptr);
                 EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
@@ -345,17 +338,16 @@ namespace cppmicroservices
                 auto asyncWorkService = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
                     GetFramework().GetBundleContext(),
                     logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillRepeatedly(testing::Return(mockFactory));
                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_NE(fakeCompConfig->regManager, nullptr);
@@ -379,17 +371,16 @@ namespace cppmicroservices
                 auto asyncWorkService = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
                     GetFramework().GetBundleContext(),
                     logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillRepeatedly(testing::Return(mockFactory));
                 EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                     .Times(1)
@@ -416,17 +407,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
             fakeCompConfig->state = mockState;
             ComponentConfigurationImpl& fakeCompConfigBase
@@ -450,17 +440,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             fakeCompConfig->state = std::make_shared<CCRegisteredState>();
             auto mockCompInstance = std::make_shared<MockComponentInstance>();
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -480,18 +469,17 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry); 
             // Test for exception from user code
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             fakeCompConfig->state = std::make_shared<CCRegisteredState>();
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::SATISFIED);
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
@@ -510,17 +498,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             auto activeState = std::make_shared<CCActiveState>();
             fakeCompConfig->state = activeState;
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::ACTIVE);
@@ -574,17 +561,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_CALL(*fakeCompConfig, GetFactory()).WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
             EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
             EXPECT_NE(fakeCompConfig->regManager, nullptr);
@@ -634,17 +620,16 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                 .WillRepeatedly(testing::Return(mockCompInstance));
             EXPECT_CALL(*fakeCompConfig, GetFactory()).WillRepeatedly(testing::Return(std::make_shared<MockFactory>()));
@@ -684,18 +669,17 @@ namespace cppmicroservices
                 auto asyncWorkService = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
                     GetFramework().GetBundleContext(),
                     logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
                 auto mockCompInstance = std::make_shared<MockComponentInstance>();
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
+                                                                                       notifier);
                 EXPECT_CALL(*fakeCompConfig, CreateAndActivateComponentInstance(testing::_))
                     .Times(2)
                     .WillRepeatedly(testing::Return(mockCompInstance));
@@ -722,20 +706,19 @@ namespace cppmicroservices
                 auto asyncWorkService = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
                     GetFramework().GetBundleContext(),
                     logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry); 
                 mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
                 mockMetadata->immediate = false;
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                        GetFramework(),
                                                                                        mockRegistry,
                                                                                        fakeLogger,
-                                                                                       notifier,
-                                                                                       managers);
-                EXPECT_CALL(*fakeCompConfig, GetFactory())
+                                                                                       notifier);
+                 EXPECT_CALL(*fakeCompConfig, GetFactory())
                     .Times(testing::AtLeast(1)) // 2
                     .WillRepeatedly(testing::Return(mockFactory));
                 fakeCompConfig->Initialize();
@@ -782,11 +765,11 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    logger);
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-            auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
             mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             mockMetadata->immediate = false;
             metadata::ReferenceMetadata rm1;
@@ -801,8 +784,7 @@ namespace cppmicroservices
                                                                                    GetFramework(),
                                                                                    mockRegistry,
                                                                                    fakeLogger,
-                                                                                   notifier,
-                                                                                   managers);
+                                                                                   notifier);
             EXPECT_EQ(fakeCompConfig->GetAllDependencyManagers().size(), mockMetadata->refsMetadata.size());
             EXPECT_NE(fakeCompConfig->GetDependencyManager("Foo"), nullptr);
             EXPECT_NE(fakeCompConfig->GetDependencyManager("Bar"), nullptr);
@@ -849,26 +831,26 @@ namespace cppmicroservices
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
                                                                                    fakeLogger);
+            auto logger = std::make_shared<cppmicroservices::scrimpl::SCRLogger>(GetFramework().GetBundleContext());
+            auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
-                                                                    asyncWorkService);
-
-            auto fakeCompConfig = std::make_shared<SingletonComponentConfigurationImpl>(
-                mockMetadata,
-                GetFramework(),
-                std::make_shared<MockComponentRegistry>(),
-                fakeLogger,
-                notifier,
-                std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>());
-
+                                                                    asyncWorkService,
+                                                                    extRegistry);
+            auto fakeCompConfig
+                = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
+                                                                        GetFramework(),
+                                                                        std::make_shared<MockComponentRegistry>(),
+                                                                        fakeLogger,
+                                                                        notifier);
+ 
             auto fakeBundleProtoCompConfig = std::make_shared<BundleOrPrototypeComponentConfigurationImpl>(
                 mockMetadata,
                 GetFramework(),
                 std::make_shared<MockComponentRegistry>(),
                 fakeLogger,
-                notifier,
-                std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>());
-
+                notifier);
+ 
             auto svcReg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
                 std::make_shared<dummy::ServiceImpl>());
 

--- a/compendium/DeclarativeServices/test/gtest/TestComponentManagerDisabledState.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentManagerDisabledState.cpp
@@ -22,6 +22,7 @@
 
 #include "../../src/SCRAsyncWorkService.hpp"
 #include "../../src/manager/states/CMDisabledState.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
 #include "cppmicroservices/Framework.h"
@@ -50,18 +51,17 @@ namespace cppmicroservices
                 auto asyncWorkService
                     = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
                                                                                        logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         fakeLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry);
                 compMgr = std::make_shared<MockComponentManagerImpl>(compDesc,
                                                                      mockRegistry,
                                                                      framework.GetBundleContext(),
                                                                      fakeLogger,
                                                                      asyncWorkService,
-                                                                     notifier,
-                                                                     managers);
+                                                                     notifier);
             }
 
             virtual void

--- a/compendium/DeclarativeServices/test/gtest/TestSCRExtensionRegistry.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestSCRExtensionRegistry.cpp
@@ -1,0 +1,262 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  =============================================================================*/
+
+#include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRBundleExtension.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
+#include "../../src/manager/SingletonComponentConfiguration.hpp"
+#include "../TestUtils.hpp"
+#include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
+#include <cppmicroservices/BundleContext.h>
+#include <cppmicroservices/Framework.h>
+#include <cppmicroservices/FrameworkEvent.h>
+#include <cppmicroservices/FrameworkFactory.h>
+#include "gmock/gmock.h"
+#include "Mocks.hpp"
+
+namespace cppmicroservices
+{
+    namespace scrimpl
+    {
+        // The fixture for testing class SCRExtensionRegistry.
+        class SCRExtensionRegistryTest : public ::testing::Test
+        {
+          protected:
+            SCRExtensionRegistryTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {}
+            ~SCRExtensionRegistryTest() = default;
+
+            void
+            SetUp() override
+            {
+                framework.Start();
+                fakeRegistry = std::make_shared<ComponentRegistry>();
+                logger = std::make_shared<cppmicroservices::scrimpl::SCRLogger>(framework.GetBundleContext());
+                asyncWorkService
+                    = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
+                                                                                       logger);
+                extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
+                notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
+                                                                   logger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+            }
+
+            void
+            TearDown() override
+            {
+                framework.Stop();
+                framework.WaitForStop(std::chrono::milliseconds::zero());
+            }
+
+            cppmicroservices::Framework&
+            GetFramework()
+            {
+                return framework;
+            }
+
+            void
+            ConcurrentInvoke(std::vector<cppmicroservices::Bundle> allBundles, bool addOperation)
+            {
+                std::promise<void> go;
+                std::shared_future<void> ready(go.get_future());
+                int numCalls = allBundles.size();
+                std::vector<std::promise<void>> readies(numCalls);
+                std::vector<std::future<void>> bundle_result(numCalls);
+                try
+                {
+                    if (addOperation)
+                    {
+                        for (int i = 0; i < numCalls; i++)
+                        {
+
+                            bundle_result[i]
+                                = std::async(std::launch::async,
+                                             [&readies, &ready, &allBundles, this, i]()
+                                             {
+                                                 readies[i].set_value();
+                                                 ready.wait();
+                                                 auto ba = std::make_shared<SCRBundleExtension>(allBundles[i],
+                                                                                                this->fakeRegistry,
+                                                                                                this->logger,
+                                                                                                this->notifier);
+                                                 extRegistry->Add(allBundles[i].GetBundleId(), ba);
+                                             });
+                        }
+                    }
+                    else // remove operation
+                    {
+                        for (int i = 0; i < numCalls; i++)
+                        {
+                            bundle_result[i] = std::async(std::launch::async,
+                                                          [&readies, &ready, &allBundles, this, i]()
+                                                          {
+                                                              readies[i].set_value();
+                                                              ready.wait();
+                                                              this->extRegistry->Remove(allBundles[i].GetBundleId());
+                                                          });
+                        }
+                    }
+
+                    for (int i = 0; i < numCalls; i++)
+                    {
+                        readies[i].get_future().wait();
+                    }
+                    go.set_value();
+                    for (int i = 0; i < numCalls; i++)
+                    {
+                        bundle_result[i].wait();
+                    }
+                }
+                catch (std::exception const& e)
+                {
+                    EXPECT_TRUE(false) << "Error: exception received ... " << e.what() << std::endl;
+                    go.set_value();
+                    throw std::current_exception();
+                }
+            }
+          protected:
+            cppmicroservices::Framework framework;
+            std::shared_ptr<ComponentRegistry> fakeRegistry;
+            std::shared_ptr<cppmicroservices::scrimpl::SCRLogger> logger;
+            std::shared_ptr<cppmicroservices::scrimpl::SCRAsyncWorkService> asyncWorkService;
+            std::shared_ptr<SCRExtensionRegistry> extRegistry;
+            std::shared_ptr<ConfigurationNotifier> notifier;
+        };
+
+        // Test constructor with invalid arguments
+        TEST_F(SCRExtensionRegistryTest, CtorInvalidArgs)
+        {
+            EXPECT_THROW({ SCRExtensionRegistry bundleExt(nullptr); }, std::invalid_argument);
+        }
+
+        //Test constructor with valid arguments
+        TEST_F(SCRExtensionRegistryTest, CtorWithValidArgs)
+        {
+            EXPECT_NO_THROW({ SCRExtensionRegistry bundleExt = SCRExtensionRegistry(logger); });
+        }
+
+        // Test Add, Find, Remove and Clear methods
+        TEST_F(SCRExtensionRegistryTest, AddFindRemoveClear)
+        {
+            auto bundle = test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI1");
+            ASSERT_TRUE(static_cast<bool>(bundle)) << "TestBundleDSTOI1 not installed.";
+ 
+            // Test invalid arguments for Add method.
+            EXPECT_THROW({ extRegistry->Add(bundle.GetBundleId(),nullptr); }, std::invalid_argument); 
+
+            // Add a bundle extension to the SCRExtensionRegistry
+            auto ba = std::make_shared<SCRBundleExtension>(bundle, fakeRegistry, logger, notifier);
+            extRegistry->Add(bundle.GetBundleId(), ba);
+
+            // Try to find the bundle extension just added.
+            auto bundleExt = extRegistry->Find(bundle.GetBundleId());
+            ASSERT_TRUE(bundleExt) << "SCRBundleExtension not found in Extension Registry";
+ 
+            // Remove the bundle extension and make sure it's no longer there.
+            extRegistry->Remove(bundle.GetBundleId());
+            bundleExt = extRegistry->Find(bundle.GetBundleId());
+            ASSERT_TRUE(!bundleExt) << "SCRBundleExtension found in Extension Registry. It should have been removed";
+            
+            // Add a bundle extension, clear the SCRExtensionRegistry and make sure the bundle extension is no longer there. 
+            extRegistry->Add(bundle.GetBundleId(), ba);
+            extRegistry->Clear();
+            bundleExt = extRegistry->Find(bundle.GetBundleId());
+            ASSERT_TRUE(!bundleExt) << "SCRBundleExtension found in Extension Registry. It should have been cleared";
+ 
+            asyncWorkService->StopTracking();
+            fakeRegistry->Clear();
+        }
+        // Test to test concurrent additions of bundle extensions to the SCRExtensionRegistry and
+        // concurrent removals.
+        TEST_F(SCRExtensionRegistryTest, VerifyConcurrentAddRemove)
+        {
+            int count = 4;
+            test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI1");
+            test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI2");
+            test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI3");
+            test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI5");
+ 
+            auto bundleContext = GetFramework().GetBundleContext();
+            auto allBundles = bundleContext.GetBundles();
+            ASSERT_TRUE(allBundles.size() > count) << "All bundles not installed.";
+
+            // Add a bundle extension object for each bundle in the allBundles vector to the 
+            // extension registry
+            ConcurrentInvoke(allBundles, true);           
+            for (auto const& item : allBundles) {
+                ASSERT_TRUE(extRegistry->Find(item.GetBundleId()))
+                    << "bundle " << item.GetSymbolicName() << " not found.";
+            }
+ 
+            // Remove the bundle extension for all bundles in the allBundles vector from 
+            // the extension registry.
+            ConcurrentInvoke(allBundles, false);
+            for (auto const& item : allBundles)
+            {
+                ASSERT_TRUE(!extRegistry->Find(item.GetBundleId()))
+                    << "bundle " << item.GetSymbolicName() << " should have been removed.";
+            }
+            asyncWorkService->StopTracking();
+            fakeRegistry->Clear();
+  
+        }
+
+        //Mock SCRExtensionRegistry class used by the testException class
+        class MockSCRExtensionRegistry : public cppmicroservices::scrimpl::SCRExtensionRegistry
+        {
+          public:
+            MockSCRExtensionRegistry(std::shared_ptr<SCRLogger> const& logger)
+                : cppmicroservices::scrimpl::SCRExtensionRegistry (logger)
+            {
+            }
+            virtual ~MockSCRExtensionRegistry() = default;    
+            MOCK_METHOD1(Find, std::shared_ptr<SCRBundleExtension>(long bundleId));
+        }; 
+
+        // Tests the CreateFactoryComponent method of the ConfigurationNotifier class. If the bundle extension 
+        // cannot be found in the SCRExtensionRegistry when creating a factory component then an
+        // exception will be logged.
+        TEST_F(SCRExtensionRegistryTest, testException)
+        {
+            auto bundle = test::InstallAndStartBundle(GetFramework().GetBundleContext(), "TestBundleDSTOI1");
+            ASSERT_TRUE(static_cast<bool>(bundle));
+            auto mockExtRegistry = std::make_shared<MockSCRExtensionRegistry>(logger);
+            auto mockLogger = std::make_shared<MockLogger>();
+            auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
+                                                                    mockLogger,
+                                                                    asyncWorkService,
+                                                                    mockExtRegistry);
+  
+            EXPECT_CALL(*mockExtRegistry, Find (bundle.GetBundleId())).Times(1).WillOnce(::testing::Return(nullptr));
+            EXPECT_CALL(*(mockLogger.get()),
+                        Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, testing::_, testing::_))
+                .Times(1);
+            auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
+ 
+ 
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl
+                = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata, bundle, fakeRegistry, logger, notifier);
+            std::string pid { 123 };
+            EXPECT_NO_THROW({ notifier->CreateFactoryComponent(pid, compConfigImpl); }); 
+         }
+    } // namespace scrimpl
+} // namespace cppmicroservices

--- a/compendium/DeclarativeServices/test/gtest/TestSingletonComponentConfiguration.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestSingletonComponentConfiguration.cpp
@@ -21,6 +21,7 @@
   =============================================================================*/
 
 #include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
 #include "../../src/manager/SingletonComponentConfiguration.hpp"
 #include "../../src/manager/states/CCActiveState.hpp"
 #include "../../src/manager/states/CCRegisteredState.hpp"
@@ -54,17 +55,16 @@ namespace cppmicroservices
                 auto asyncWorkService
                     = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(framework.GetBundleContext(),
                                                                                        logger);
+                auto extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
                 auto notifier = std::make_shared<ConfigurationNotifier>(framework.GetBundleContext(),
                                                                         mockLogger,
-                                                                        asyncWorkService);
-                auto managers = std::make_shared<std::vector<std::shared_ptr<ComponentManager>>>();
-
+                                                                        asyncWorkService,
+                                                                        extRegistry); 
                 obj = std::make_shared<SingletonComponentConfigurationImpl>(mockMetadata,
                                                                             framework,
                                                                             mockRegistry,
                                                                             mockLogger,
-                                                                            notifier,
-                                                                            managers);
+                                                                            notifier);
             }
 
             virtual void


### PR DESCRIPTION
Cherry-picked 6133ab9a57c7414e825442ed33820f5d4703ce9f / #834 with C++14 adaptations:
* move initialization statements out of if clauses
* adapt assignment construction in test code (TestSCRBundleExtension.cpp) calling deleted move constructor (SCRBundleExtension) to in-place construction

Signed-off-by: Ingmar Sittl <ingmar.sittl@elektrobit.com>