### PR TITLE
701 - Remove CoreBundleContext.dataStorage clear (#845)

### DIFF
--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -239,7 +239,6 @@ namespace cppmicroservices
         listeners.Clear();
         resolver.Clear();
 
-        dataStorage.clear();
         storage->Close();
     }
 


### PR DESCRIPTION
Cherry-picked 6df481092c1beca864cb64c0db0e9e9e341bdb94 / #845 without changes.