### PR TITLE
701 - Removing std::move use with const object (#848)

### DIFF
--- a/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
+++ b/compendium/CM/include/cppmicroservices/cm/ConfigurationListener.hpp
@@ -58,10 +58,10 @@ namespace cppmicroservices
             class ConfigurationEvent
             {
               public:
-                ConfigurationEvent(ServiceReference<ConfigurationAdmin> const configAdmin,
+                ConfigurationEvent(ServiceReference<ConfigurationAdmin> configAdmin,
                                    const ConfigurationEventType type,
-                                   const std::string factoryPid,
-                                   const std::string pid)
+                                   std::string factoryPid,
+                                   std::string pid)
                     : configAdmin(std::move(configAdmin))
                     , type(type)
                     , factoryPid(std::move(factoryPid))

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -56,7 +56,7 @@ namespace cppmicroservices
         {
             ListenerToken(std::string pid, const ListenerTokenId tokenId)
                 : pid(std::move(pid))
-                , tokenId(std::move(tokenId))
+                , tokenId(tokenId)
             {
             }
             std::string pid;


### PR DESCRIPTION
Cherry-picked 3f2a46157b8d9ec6172784fbe346b6310463d0ca without changes.