### PR TITLE
701 - Fix warning "Use of BITWISE AND to check if a flag is set" (#849)

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMActivator.cpp
+++ b/compendium/ConfigurationAdmin/src/CMActivator.cpp
@@ -50,7 +50,7 @@ namespace cppmicroservices
             // manually
             for (auto const& bundle : context.GetBundles())
             {
-                if (cppmicroservices::Bundle::State::STATE_ACTIVE == bundle.GetState())
+                if (cppmicroservices::Bundle::State::STATE_ACTIVE & bundle.GetState())
                 {
                     cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
                     BundleChanged(evt);
@@ -178,11 +178,11 @@ namespace cppmicroservices
             }
 
             // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
-            if (cppmicroservices::BundleEvent::BUNDLE_STARTED == eventType)
+            if (cppmicroservices::BundleEvent::BUNDLE_STARTED & eventType)
             {
                 CreateExtension(bundle);
             }
-            else if (cppmicroservices::BundleEvent::BUNDLE_STOPPING == eventType)
+            else if (cppmicroservices::BundleEvent::BUNDLE_STOPPING & eventType)
             {
                 RemoveExtension(bundle);
             }

--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -77,7 +77,7 @@ namespace cppmicroservices
             // manually
             for (auto const& bundle : context.GetBundles())
             {
-                if (bundle.GetState() == cppmicroservices::Bundle::State::STATE_ACTIVE)
+                if (bundle.GetState() & cppmicroservices::Bundle::State::STATE_ACTIVE)
                 {
                     cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
                     BundleChanged(evt);
@@ -215,11 +215,11 @@ namespace cppmicroservices
             }
 
             // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
-            if (eventType == cppmicroservices::BundleEvent::BUNDLE_STARTED)
+            if (eventType & cppmicroservices::BundleEvent::BUNDLE_STARTED)
             {
                 CreateExtension(bundle);
             }
-            else if (eventType == cppmicroservices::BundleEvent::BUNDLE_STOPPING)
+            else if (eventType & cppmicroservices::BundleEvent::BUNDLE_STOPPING)
             {
                 DisposeExtension(bundle);
             }


### PR DESCRIPTION
Cherry-picked 8f4432a5b4bdeb0068302e47a3b1306305c3dbc7 / #849 without changes.