### PR TITLE
701 - include cstdint in FileSystem.cpp (#850)

### DIFF
--- a/util/src/FileSystem.cpp
+++ b/util/src/FileSystem.cpp
@@ -25,6 +25,7 @@
 #include "cppmicroservices/util/String.h"
 #include <cppmicroservices/GlobalConfig.h>
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Cherry-picked d43df283388e986574311dabaa9360bd190af639 / #850 without changes.