### PR TITLE
Remove unwanted branches from performance workflow.

### DIFF
--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -2,7 +2,7 @@ name: PerformanceWindows
 
 on:
   push:
-    branches: [ development, c\+\+14-compliant, master ]
+    branches: [ development ]
   workflow_dispatch:
 
 permissions:
@@ -57,7 +57,7 @@ jobs:
     - name: Deploy results
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
-        name: C++ Benchmark
+        name: CppMicroServices Benchmark
         tool: 'googlecpp'
         output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed 'c\+\+14-compliant' and 'master' branches from the performance workflow
This workflow will only be running on *development* branch going forward

Signed-off-by: The MathWorks, Inc. <aadityap@mathworks.com>