### PR TITLE
701 - Fix code scanning alerts (#861)

### DIFF
--- a/compendium/DeclarativeServices/src/manager/BindingPolicy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicy.cpp
@@ -32,7 +32,7 @@ namespace cppmicroservices
         ReferenceManagerBaseImpl::BindingPolicy::Log(std::string const& logStr,
                                                      cppmicroservices::logservice::SeverityLevel logLevel)
         {
-            mgr.logger->Log(logLevel, logStr);
+            mgr.logger_->Log(logLevel, logStr);
         }
 
         bool
@@ -62,14 +62,14 @@ namespace cppmicroservices
             std::vector<RefChangeNotification> notifications;
             if (ShouldClearBoundRefs(reference))
             {
-                Log("Notify UNSATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_UNSATISFIED);
+                Log("Notify UNSATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_UNSATISFIED);
 
                 ClearBoundRefs();
                 if (mgr.UpdateBoundRefs())
                 {
-                    Log("Notify SATISFIED for reference " + mgr.metadata.name);
-                    notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_SATISFIED);
+                    Log("Notify SATISFIED for reference " + mgr.metadata_.name);
+                    notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_SATISFIED);
                 }
 
                 mgr.BatchNotifyAllListeners(notifications);
@@ -107,18 +107,18 @@ namespace cppmicroservices
                         if (!boundRefsHandle->empty())
                         {
                             svcRefToBind = *(boundRefsHandle->begin());
-                            Log("Notify BIND for reference " + mgr.metadata.name);
+                            Log("Notify BIND for reference " + mgr.metadata_.name);
                         }
                     }
 
-                    Log("Notify UNBIND for reference " + mgr.metadata.name);
-                    notifications.emplace_back(mgr.metadata.name, RefEvent::REBIND, svcRefToBind, reference);
+                    Log("Notify UNBIND for reference " + mgr.metadata_.name);
+                    notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, svcRefToBind, reference);
                 }
 
                 if (!mgr.IsSatisfied())
                 {
-                    Log("Notify UNSATISFIED for reference " + mgr.metadata.name);
-                    notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_UNSATISFIED);
+                    Log("Notify UNSATISFIED for reference " + mgr.metadata_.name);
+                    notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_UNSATISFIED);
                 }
 
                 mgr.BatchNotifyAllListeners(notifications);

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
@@ -65,7 +65,7 @@ namespace cppmicroservices
                     auto boundRefsHandle = mgr.boundRefs.lock(); // acquires lock on boundRefs
                     if (boundRefsHandle->empty())
                     {
-                        notifications.emplace_back(mgr.metadata.name, RefEvent::REBIND, reference);
+                        notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
                     }
                     else
                     { // there are bound refs, determine whether to rebind
@@ -83,14 +83,14 @@ namespace cppmicroservices
                     // to eliminate any gaps between unbinding the current bound target service
                     // and binding to the new bound target service.
                     notifications.push_back(
-                        RefChangeNotification { mgr.metadata.name, RefEvent::REBIND, reference, svcRefToUnBind });
+                        RefChangeNotification { mgr.metadata_.name, RefEvent::REBIND, reference, svcRefToUnBind });
                 }
             }
 
             if (notifySatisfied)
             {
-                Log("Notify SATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_SATISFIED);
+                Log("Notify SATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_SATISFIED);
             }
             mgr.BatchNotifyAllListeners(notifications);
         }

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicReluctant.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicReluctant.cpp
@@ -54,19 +54,19 @@ namespace cppmicroservices
                 // is optional and there are no bound refs.
                 if (0 == mgr.GetBoundReferences().size())
                 {
-                    Log("Notify BIND for reference " + mgr.metadata.name);
+                    Log("Notify BIND for reference " + mgr.metadata_.name);
 
                     ClearBoundRefs();
                     mgr.UpdateBoundRefs();
 
-                    notifications.emplace_back(mgr.metadata.name, RefEvent::REBIND, reference);
+                    notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
                 }
             }
 
             if (notifySatisfied)
             {
-                Log("Notify SATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_SATISFIED);
+                Log("Notify SATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_SATISFIED);
             }
             mgr.BatchNotifyAllListeners(notifications);
         }

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyStaticGreedy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyStaticGreedy.cpp
@@ -82,8 +82,8 @@ namespace cppmicroservices
             std::vector<RefChangeNotification> notifications;
             if (replacementNeeded)
             {
-                Log("Notify UNSATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_UNSATISFIED, reference);
+                Log("Notify UNSATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_UNSATISFIED, reference);
                 // The following "clear and copy" strategy is sufficient for
                 // updating the boundRefs for static binding policy
                 if (serviceToUnbind)
@@ -94,8 +94,8 @@ namespace cppmicroservices
             }
             if (notifySatisfied)
             {
-                Log("Notify SATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_SATISFIED, reference);
+                Log("Notify SATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_SATISFIED, reference);
             }
             mgr.BatchNotifyAllListeners(notifications);
         }

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyStaticReluctant.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyStaticReluctant.cpp
@@ -45,8 +45,8 @@ namespace cppmicroservices
             auto notifySatisfied = ShouldNotifySatisfied();
             if (notifySatisfied)
             {
-                Log("Notify SATISFIED for reference " + mgr.metadata.name);
-                notifications.emplace_back(mgr.metadata.name, RefEvent::BECAME_SATISFIED, reference);
+                Log("Notify SATISFIED for reference " + mgr.metadata_.name);
+                notifications.emplace_back(mgr.metadata_.name, RefEvent::BECAME_SATISFIED, reference);
             }
 
             mgr.BatchNotifyAllListeners(notifications);

--- a/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
+++ b/compendium/DeclarativeServices/src/manager/BundleLoader.cpp
@@ -78,7 +78,7 @@ namespace cppmicroservices
             wchar_count = MultiByteToWideChar(CP_UTF8, 0, inStr.c_str(), -1, wBuf.get(), wchar_count);
             if (wchar_count == 0)
             {
-                std::invalid_argument("Failed to convert " + inStr + " to UTF16.");
+                throw std::invalid_argument("Failed to convert " + inStr + " to UTF16.");
             }
             return wBuf.get();
         }

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -82,7 +82,7 @@ namespace cppmicroservices
             std::string
             GetReferenceName() const override
             {
-                return metadata.name;
+                return metadata_.name;
             }
 
             /**
@@ -91,7 +91,7 @@ namespace cppmicroservices
             std::string
             GetReferenceScope() const override
             {
-                return metadata.scope;
+                return metadata_.scope;
             }
 
             /**
@@ -100,7 +100,7 @@ namespace cppmicroservices
             std::string
             GetLDAPString() const override
             {
-                return metadata.target;
+                return metadata_.target;
             }
 
             /**
@@ -131,7 +131,7 @@ namespace cppmicroservices
             metadata::ReferenceMetadata const&
             GetMetadata() const
             {
-                return metadata;
+                return metadata_;
             }
 
             /**
@@ -269,11 +269,11 @@ namespace cppmicroservices
              */
             void BatchNotifyAllListeners(std::vector<RefChangeNotification> const& notification) noexcept;
 
-            const metadata::ReferenceMetadata metadata;    ///< reference information from the component description
+            const metadata::ReferenceMetadata metadata_;    ///< reference information from the component description
             std::unique_ptr<ServiceTracker<void>> tracker; ///< used to track service availability
-            std::shared_ptr<cppmicroservices::logservice::LogService> logger; ///< logger for this runtime
+            std::shared_ptr<cppmicroservices::logservice::LogService> logger_; ///< logger for this runtime
             const std::string
-                configName; ///< Keep track of which component configuration object this reference manager belongs to.
+                configName_; ///< Keep track of which component configuration object this reference manager belongs to.
 
             mutable Guarded<std::set<cppmicroservices::ServiceReferenceBase>>
                 boundRefs; ///< guarded set of bound references

--- a/framework/include/cppmicroservices/detail/Threads.h
+++ b/framework/include/cppmicroservices/detail/Threads.h
@@ -68,7 +68,7 @@ namespace cppmicroservices
                 UniqueLock(UniqueLock&& o) noexcept : m_Lock(std::move(o.m_Lock)) {}
 
                 UniqueLock&
-                operator=(UniqueLock&& o)
+                operator=(UniqueLock&& o) noexcept
                 {
                     m_Lock = std::move(o.m_Lock);
                     return *this;

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -54,6 +54,8 @@
 #include <cstring>
 #include <iterator>
 
+#include <absl/base/attributes.h>
+
 namespace cppmicroservices
 {
 
@@ -263,7 +265,7 @@ namespace cppmicroservices
                     return;
                 }
             }
-            // INTENTIONALLY FALLS THROUGH - in case of lazy activation.
+                ABSL_FALLTHROUGH_INTENDED;
             case Bundle::STATE_RESOLVED:
             {
                 state = Bundle::STATE_STARTING;
@@ -337,7 +339,7 @@ namespace cppmicroservices
                         }
                     }
                 }
-                // INTENTIONALLY FALLS THROUGH
+                    ABSL_FALLTHROUGH_INTENDED;
                 case Bundle::STATE_RESOLVED:
                 case Bundle::STATE_INSTALLED:
                 {

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -31,6 +31,8 @@ limitations under the License.
 
 #include <chrono>
 
+#include <absl/base/attributes.h>
+
 namespace cppmicroservices
 {
 
@@ -93,7 +95,9 @@ namespace cppmicroservices
     {
         auto bc = bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
         if (bc)
+        {
             bc->Invalidate();
+        }
     }
 
     FrameworkEvent
@@ -153,7 +157,7 @@ namespace cppmicroservices
                 break;
             case Bundle::STATE_ACTIVE:
                 wasActive = true;
-                // Fall through
+                ABSL_FALLTHROUGH_INTENDED;
             case Bundle::STATE_STARTING:
             {
                 bool const wa = wasActive;
@@ -187,7 +191,7 @@ namespace cppmicroservices
                 case Bundle::STATE_INSTALLED:
                 case Bundle::STATE_RESOLVED:
                     DoInit();
-                    // Fall through
+                    ABSL_FALLTHROUGH_INTENDED;
                 case Bundle::STATE_STARTING:
                     operation = BundlePrivate::OP_ACTIVATING;
                     break;


### PR DESCRIPTION
Cherry-picked 6185cb4d8ccbd047526935c446dad1fe1cdf8d74 / #861 with adaptations to C++14:

* use ABSL_FALLTHROUGH_INTENDED instead of the (C++17) [[fallthrough]] being used in the original PR. I also checked ABSL_MUST_USE_RESULT as alternative for the [[nodiscard]] use-case, but that doesn't seem to provide a fallback for older compilers

Signed-off-by: Ingmar Sittl <Ingmar.Sittl@elektrobit.com>