### PR TITLE
701 - Code scanning alert fix: Use of a moved from object #864 (#866)

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/src/CMAsyncWorkService.cpp
@@ -88,7 +88,6 @@ namespace cppmicroservices
                     using Handler = typename Result::completion_handler_type;
 
                     Handler handler(std::forward<decltype(task)>(task));
-                    Result result(handler);
 
                     boost::asio::post(threadpool->get_executor(),
                                       [handler = std::move(handler)]() mutable { handler(); });

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
@@ -88,7 +88,6 @@ namespace cppmicroservices
                     using Handler = typename Result::completion_handler_type;
 
                     Handler handler(std::forward<decltype(task)>(task));
-                    Result result(handler);
 
                     boost::asio::post(threadpool->get_executor(),
                                       [handler = std::move(handler)]() mutable { handler(); });


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/f244220f7a40a7c02d40b36aabf5dbb4140e9eac / #866 without changes.