### PR TITLE
701 - Fix #881

### DIFF
--- a/framework/include/cppmicroservices/detail/BundleAbstractTracked.hpp
+++ b/framework/include/cppmicroservices/detail/BundleAbstractTracked.hpp
@@ -237,7 +237,9 @@ namespace cppmicroservices
         {
             typename TrackingMap::const_iterator i = tracked.find(item);
             if (i != tracked.end())
+            {
                 return i->second;
+            }
             return std::shared_ptr<TrackedParamType>();
         }
 


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/fcc802227089ca248ab5956b7307af8d53e04079 / #882.

Cherry-picking lead to a conflict, after resolving the conflict the diff showed that all the other headers were already clang-formatted before in one of the previous PRs (via pre-commit hook?). Manually re-running clang-format on the `.hpp` files changed in the original commit also did not show any further changes.