### PR TITLE
Fix #913 ServiceTracker deadlock

### DIFF
--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -3,8 +3,6 @@ name: PerformanceWindows
 on:
   push:
     branches: [ development ]
-  pull_request:
-    branches: [ development ]
   workflow_dispatch:
 
 permissions:
@@ -56,17 +54,17 @@ jobs:
     - name: Run benchmark and store result in json format
       run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
-    # - name: Deploy results
-    #   uses: benchmark-action/github-action-benchmark@v1.16.1
-    #   with:
-    #     name: CppMicroServices Benchmark
-    #     tool: 'googlecpp'
-    #     output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-    #     github-token: ${{ secrets.GITHUB_TOKEN }}
-    #     auto-push: true
-    #     # Show alert with commit comment on detecting possible performance regression
-    #     alert-threshold: '20%'
-    #     comment-on-alert: true
-    #     fail-on-alert: false
+    - name: Deploy results
+      uses: benchmark-action/github-action-benchmark@v1.16.1
+      with:
+        name: CppMicroServices Benchmark
+        tool: 'googlecpp'
+        output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '20%'
+        comment-on-alert: true
+        fail-on-alert: false
         
         

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -3,6 +3,8 @@ name: PerformanceWindows
 on:
   push:
     branches: [ development ]
+  pull_request:
+    branches: [ development ]
   workflow_dispatch:
 
 permissions:
@@ -54,17 +56,17 @@ jobs:
     - name: Run benchmark and store result in json format
       run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
-    - name: Deploy results
-      uses: benchmark-action/github-action-benchmark@v1.16.1
-      with:
-        name: CppMicroServices Benchmark
-        tool: 'googlecpp'
-        output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
-        # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '20%'
-        comment-on-alert: true
-        fail-on-alert: false
+    # - name: Deploy results
+    #   uses: benchmark-action/github-action-benchmark@v1.16.1
+    #   with:
+    #     name: CppMicroServices Benchmark
+    #     tool: 'googlecpp'
+    #     output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
+    #     github-token: ${{ secrets.GITHUB_TOKEN }}
+    #     auto-push: true
+    #     # Show alert with commit comment on detecting possible performance regression
+    #     alert-threshold: '20%'
+    #     comment-on-alert: true
+    #     fail-on-alert: false
         
         

--- a/framework/include/cppmicroservices/ServiceTracker.h
+++ b/framework/include/cppmicroservices/ServiceTracker.h
@@ -242,6 +242,10 @@ namespace cppmicroservices
          * <p>
          * This implementation calls GetService() to determine if a service
          * is being tracked.
+         * 
+         * @throws std::logic_error If the <code>BundleContext</code>
+         *         with which this <code>ServiceTracker</code> was created is no
+         *         longer valid or became invalid while waiting on Service.
          *
          * @return The result of GetService().
          */
@@ -265,6 +269,9 @@ namespace cppmicroservices
          * @param rel_time The relative time duration to wait for a service. If
          *        zero, the method will wait indefinitely.
          * @throws std::invalid_argument exception if \c rel_time is negative.
+         * @throws std::logic_error If the <code>BundleContext</code>
+         *         with which this <code>ServiceTracker</code> was created is no
+         *         longer valid or became invalid while waiting on Service.
          * @return The result of GetService().
          */
         template <class Rep, class Period>

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -278,17 +278,19 @@ namespace cppmicroservices
                                             std::chrono::milliseconds(500),
                                             [&t, &a] { return (t->Size_unlocked() > 0 || t->closed || !a); }))
                             {
-                                // if timeout finished and (size ==0 AND t->closed == false AND a != false)
+                                // if timeout finished and (size ==0 AND t->closed == false AND a == true)
                                 continue;
                             }
                             else
                             {
-                                // (t->Size_unlocked() > 0 OR t->closed == true OR a == true)
+                                // predicate evaluates to true
+                                // (t->Size_unlocked() > 0 OR t->closed == true OR a != true)
                                 if (!a)
                                 {
-                                    // bundle is invalid, break
+                                    // bundle is invalid, throw
                                     throw std::invalid_argument("The bundle context became null.");
                                 }
+                                // bundle is valid, other condition met, break
                                 break;
                             }
                         }

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -270,7 +270,6 @@ namespace cppmicroservices
                         }
 
                         // predicate evaluates to true
-                        // (t->Size_unlocked() > 0 OR t->closed == true OR a != true)
                         if (!a)
                         {
                             // bundle is invalid, throw

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -260,11 +260,13 @@ namespace cppmicroservices
 
                     if (rel_time == std::chrono::milliseconds::zero())
                     {
-                        // need to cycle on definite end time to check for invalid bundle
                         while (!t->WaitFor(l,
                                            std::chrono::milliseconds(500),
                                            [&t, &a] { return (t->Size_unlocked() > 0 || t->closed || !a); }))
                         {
+                            // if bundle becomes invalid while waiting for service, an indefinite time WaitFor will
+                            // never be woken and will thus deadlock. So, we wait on definite time and check for invalid
+                            // bundle periodically.
                         }
 
                         // predicate evaluates to true

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -670,9 +670,6 @@ namespace
 
 TEST_F(ServiceTrackerTestFixture, TestFilterPropertiesTypes)
 {
-    auto framework = cppmicroservices::FrameworkFactory().NewFramework();
-    framework.Start();
-
     LDAPFilter filter("(tag=foo::bar::Baz)");
     ServiceTracker<foo::Bar> tracker(framework.GetBundleContext(), filter);
     tracker.Open();
@@ -687,6 +684,32 @@ TEST_F(ServiceTrackerTestFixture, TestFilterPropertiesTypes)
     ASSERT_EQ(tracker.GetTrackingCount(), 1);
 
     tracker.Close();
-    framework.Stop();
-    framework.WaitForStop(std::chrono::milliseconds::zero());
 }
+
+#ifdef US_ENABLE_THREADING_SUPPORT
+
+TEST(ServiceTrackerTests, TestServiceTrackerDeadlock)
+{
+    Framework framework = FrameworkFactory().NewFramework();
+    framework.Start();
+
+    ServiceTracker<MyInterfaceOne> tracker(framework.GetBundleContext());
+    tracker.Open();
+    auto f = std::async(
+        [&framework]
+        {
+            // technically there's a race here, so the async should ensure WaitForService is started prior to
+            // terminating the framework.
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            auto fooService = std::make_shared<MyInterfaceOne>();
+
+            // auto svc = framework.GetBundleContext().RegisterService<MyInterfaceOne>(fooService);
+
+            framework.Stop();
+            framework.WaitForStop(std::chrono::milliseconds::zero());
+        });
+
+    ASSERT_THROW(tracker.WaitForService(), std::invalid_argument);
+}
+
+#endif

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -745,3 +745,5 @@ TEST(ServiceTrackerTests, FrameworkTrackerCloseRace)
                           });
     tracker.Close();
 }
+
+#endif

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -706,7 +706,21 @@ TEST(ServiceTrackerTests, TestServiceTrackerDeadlock)
             framework.WaitForStop(std::chrono::milliseconds::zero());
         });
 
-    ASSERT_THROW(tracker.WaitForService(), std::invalid_argument);
+    ASSERT_THROW(tracker.WaitForService(), std::logic_error);
+}
+
+TEST(ServiceTrackerTests, TestServiceTrackerInvalidBundle)
+{
+    Framework framework = FrameworkFactory().NewFramework();
+    framework.Start();
+
+    ServiceTracker<MyInterfaceOne> tracker(framework.GetBundleContext());
+    tracker.Open();
+
+    framework.Stop();
+    framework.WaitForStop(std::chrono::milliseconds::zero());
+
+    ASSERT_THROW(tracker.WaitForService(), std::runtime_error);
 }
 
 #endif

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -720,7 +720,7 @@ TEST(ServiceTrackerTests, TestServiceTrackerInvalidBundle)
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
 
-    ASSERT_THROW(tracker.WaitForService(), std::runtime_error);
+    ASSERT_THROW(tracker.WaitForService(), std::logic_error);
 }
 
 // If the test doesn't throw, it is successful.

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -701,9 +701,6 @@ TEST(ServiceTrackerTests, TestServiceTrackerDeadlock)
             // technically there's a race here, so the async should ensure WaitForService is started prior to
             // terminating the framework.
             std::this_thread::sleep_for(std::chrono::seconds(1));
-            auto fooService = std::make_shared<MyInterfaceOne>();
-
-            // auto svc = framework.GetBundleContext().RegisterService<MyInterfaceOne>(fooService);
 
             framework.Stop();
             framework.WaitForStop(std::chrono::milliseconds::zero());


### PR DESCRIPTION
This fixes the deadlock in #913 caused by a waitForService call deadlocking as a result of the bundle being deleted while the tracker is waiting.

As bundles do not have a way to access the tracker on destruction to wake it up, this implementation utilizes a time limit for the wait condition to ensure that the bundle is periodically checked. 