### PR TITLE
Add condition on development branch

### DIFF
--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -10,6 +10,7 @@ permissions:
   deployments: write
   # contents permission to update benchmark contents in gh-pages branch
   contents: write
+  if: github.ref == 'refs/heads/development'
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -55,9 +56,11 @@ jobs:
       run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
     - name: Deploy results
+      # Condition the step on the 'development' branch only
+      if: github.ref == 'refs/heads/development'
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
-        name: CppMicroServices Benchmark
+        name: C++ Benchmark
         tool: 'googlecpp'
         output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- This makes sure that results are only deployed with development branch

Signed-off-by: The MathWorks, Inc. aadityap@mathworks.com