### PR TITLE
701 - Fix #710 ServiceTracker TSAN warnings (#883)

### DIFF
--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -151,9 +151,21 @@ namespace cppmicroservices
     void
     ServiceTracker<S, T>::Close()
     {
+
+        /*
+        The call to RemoveListener() below must be done while the ServiceTracker object is unlocked because of a
+        possibility for reentry from customer code. Therefore, we have to swap d->listenerToken to a local variable and
+        replace it with a default constructed ListenerToken object.
+        */
+        ListenerToken swappedToken;
+        {
+            auto l = d->Lock();
+            US_UNUSED(l);
+            std::swap(d->listenerToken, swappedToken);
+        }
         try
         {
-            d->context.RemoveListener(std::move(d->listenerToken));
+            d->context.RemoveListener(std::move(swappedToken));
         }
         catch (std::runtime_error const& /*e*/)
         {

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,6 +1,9 @@
 # ServiceTracker/ServiceListener races
-race:cppmicroservices::ServiceListeners::RemoveServiceListener
-race:cppmicroservices::ServiceTracker*
+# Call to WaitFor() in WaitForService() leads to TSAN false-positive
+mutex:ServiceTrackerTestFixture_TestServiceTracker_Test::TestBody
+
+# expected race condition that IsRemoved() checks for
+race:ServiceTrackerTestFixture_DefaultCustomizerServiceTrackerCloseRace_Test::TestBody
 
 # BundleRegistry races and double lock false-positives
 # https://github.com/google/sanitizers/issues/1259


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/dc9142aeb8dec1d36478658bc28be1c217134a6c / #883 without changes.