### PR TITLE
701 - Fix #872 (#875) Remove Statics in MultipleListenersTest.cpp and ServiceHooksTest.cpp

### DIFF
--- a/framework/test/gtest/MultipleListenersTest.cpp
+++ b/framework/test/gtest/MultipleListenersTest.cpp
@@ -246,7 +246,12 @@ namespace
       public:
         MultipleListenersTest() : framework(FrameworkFactory().NewFramework()) {}
 
-        ~MultipleListenersTest() override = default;
+        ~MultipleListenersTest() override
+        {
+            // when using gtest_repeat flag, this clears count within the
+            // namespace to avoid failures on repetition.
+            count = 0;
+        }
 
         void
         SetUp() override


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/f9fd6587f73ea270014e482d6560c3c70c02d4e7 / #875 without changes.