### PR TITLE
701 - fix clang 16 warning

### DIFF
--- a/framework/src/service/ServiceListeners.cpp
+++ b/framework/src/service/ServiceListeners.cpp
@@ -417,8 +417,6 @@ namespace cppmicroservices
                                      ServiceEvent const& evt,
                                      ServiceListenerEntries& matchBefore)
     {
-        int n = 0;
-
         if (!matchBefore.empty())
         {
             for (auto& l : receivers)
@@ -433,7 +431,6 @@ namespace cppmicroservices
             {
                 try
                 {
-                    ++n;
                     l.CallDelegate(evt);
                 }
                 catch (...)


### PR DESCRIPTION
Fix compiler warning about unused variable reported by Clang 16 (only written to but never read).

Signed-off-by: Ingmar Sittl <Ingmar.Sittl@elektrobit.com>