### PR TITLE
701 - Fix #920 serviceTracker segfault on concurrent `tracker.Close()` and `framework.Stop()`

### DIFF
--- a/framework/include/cppmicroservices/BundleContext.h
+++ b/framework/include/cppmicroservices/BundleContext.h
@@ -1143,11 +1143,6 @@ namespace cppmicroservices
         friend class BundleResource;
         friend class BundleResourceContainer;
 
-        // Not for use by clients of the Framework.
-        // Provides access to the Framework's log sink to allow templated code
-        // to log diagnostic information.
-        std::shared_ptr<detail::LogSink> GetLogSink() const;
-
         ListenerToken AddServiceListener(ServiceListener const& delegate, void* data, std::string const& filter);
         void RemoveServiceListener(ServiceListener const& delegate, void* data);
 

--- a/framework/include/cppmicroservices/detail/BundleAbstractTracked.hpp
+++ b/framework/include/cppmicroservices/detail/BundleAbstractTracked.hpp
@@ -47,14 +47,6 @@ namespace cppmicroservices
         BundleAbstractTracked<S, TTT, R>::SetInitial(std::vector<S> const& initiallist)
         {
             std::copy(initiallist.begin(), initiallist.end(), std::back_inserter(initial));
-
-            if (bc.GetLogSink()->Enabled())
-            {
-                for (typename std::list<S>::const_iterator item = initial.begin(); item != initial.end(); ++item)
-                {
-                    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::setInitial: " << (*item);
-                }
-            }
         }
 
         template <class S, class TTT, class R>
@@ -83,7 +75,6 @@ namespace cppmicroservices
                     if (tracked.end() != tracked.find(item))
                     {
                         /* if we are already tracking this item */
-                        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial[already tracked]: " << item;
                         continue; /* skip this item */
                     }
                     if (std::find(adding.begin(), adding.end(), item) != adding.end())
@@ -91,12 +82,10 @@ namespace cppmicroservices
                         /*
                          * if this item is already in the process of being added.
                          */
-                        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial[already adding]: " << item;
                         continue; /* skip this item */
                     }
                     adding.push_back(item);
                 }
-                DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackInitial: " << item;
                 TrackAdding(item, R());
                 /*
                  * Begin tracking it. We call trackAdding
@@ -135,14 +124,12 @@ namespace cppmicroservices
                     if (std::find(adding.begin(), adding.end(), item) != adding.end())
                     {
                         /* if this item is already in the process of being added. */
-                        DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::track[already adding]: " << item;
                         return;
                     }
                     adding.push_back(item); /* mark this item is being added */
                 }
                 else
                 { /* we are currently tracking this item */
-                    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::track[modified]: " << item;
                     Modified(); /* increment modification count */
                 }
             }
@@ -176,7 +163,6 @@ namespace cppmicroservices
                 { /* if this item is already in the list
                    * of initial references to process
                    */
-                    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[removed from initial]: " << item;
                     return; /* we have removed it from the list and it will not be
                              * processed
                              */
@@ -188,7 +174,6 @@ namespace cppmicroservices
                 { /* if the item is in the process of
                    * being added
                    */
-                    DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[being added]: " << item;
                     return; /*
                              * in case the item is untracked while in the process of
                              * adding
@@ -208,7 +193,6 @@ namespace cppmicroservices
                 tracked.erase(item);
                 Modified(); /* increment modification count */
             }
-            DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::untrack[removed]: " << item;
             /* Call customizer outside of synchronized region */
             CustomizerRemoved(item, related, object);
             /*
@@ -308,7 +292,6 @@ namespace cppmicroservices
         void
         BundleAbstractTracked<S, TTT, R>::TrackAdding(S item, R related)
         {
-            DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackAdding:" << item;
             std::shared_ptr<TrackedParamType> object;
             bool becameUntracked = false;
             /* Call customizer outside of synchronized region */
@@ -332,7 +315,6 @@ namespace cppmicroservices
              */
             if (becameUntracked && object)
             {
-                DIAG_LOG(*bc.GetLogSink()) << "BundleAbstractTracked::trackAdding[removed]: " << item;
                 /* Call customizer outside of synchronized region */
                 CustomizerRemoved(item, related, object);
                 /*

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -105,8 +105,6 @@ namespace cppmicroservices
                 return;
             }
 
-            DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::Open: " << d->filter;
-
             t.reset(new _TrackedService(this, d->customizer));
             try
             {
@@ -187,7 +185,6 @@ namespace cppmicroservices
                 return;
             }
 
-            DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::close:" << d->filter;
             outgoing->Close();
 
             d->Modified();         /* clear the cache */
@@ -212,14 +209,6 @@ namespace cppmicroservices
         for (auto& ref : references)
         {
             outgoing->Untrack(ref, ServiceEvent());
-        }
-
-        if (d->context.GetLogSink()->Enabled())
-        {
-            if (!d->cachedReference.Load().GetBundle() && d->cachedService.Load() == nullptr)
-            {
-                DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::close[cached cleared]:" << d->filter;
-            }
         }
     }
 
@@ -307,10 +296,8 @@ namespace cppmicroservices
         ServiceReference<S> reference = d->cachedReference.Load();
         if (reference.GetBundle())
         {
-            DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::getServiceReference[cached]:" << d->filter;
             return reference;
         }
-        DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::getServiceReference:" << d->filter;
         auto references = GetServiceReferences();
         std::size_t length = references.size();
         if (length == 0)
@@ -420,10 +407,8 @@ namespace cppmicroservices
         auto service = d->cachedService.Load();
         if (service)
         {
-            DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::getService[cached]:" << d->filter;
             return service;
         }
-        DIAG_LOG(*d->context.GetLogSink()) << "ServiceTracker<S,TTT>::getService:" << d->filter;
 
         try
         {

--- a/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTrackerPrivate.hpp
@@ -170,7 +170,6 @@ namespace cppmicroservices
         {
             cachedReference.Store(ServiceReference<S>());             /* clear cached value */
             cachedService.Store(std::shared_ptr<TrackedParamType>()); /* clear cached value */
-            DIAG_LOG(*context.GetLogSink()) << "ServiceTracker::Modified(): " << filter;
         }
 
     } // namespace detail

--- a/framework/include/cppmicroservices/detail/TrackedService.hpp
+++ b/framework/include/cppmicroservices/detail/TrackedService.hpp
@@ -77,8 +77,6 @@ namespace cppmicroservices
 
                 reference = event.GetServiceReference<S>();
 
-                DIAG_LOG(*serviceTracker->d->context.GetLogSink())
-                    << "TrackedService::ServiceChanged[" << event.GetType() << "]: " << reference;
                 if (!reference)
                 {
                     return;

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -87,26 +87,6 @@ namespace cppmicroservices
         return *this;
     }
 
-    std::shared_ptr<detail::LogSink>
-    BundleContext::GetLogSink() const
-    {
-        if (!d)
-        {
-            throw std::runtime_error("The bundle context is no longer valid");
-        }
-
-        d->CheckValid();
-
-        if (auto bundle_ = d->bundle.lock())
-        {
-            return bundle_->coreCtx->sink->shared_from_this();
-        }
-        else
-        {
-            throw std::runtime_error("The bundle context is no longer valid");
-        }
-    }
-
     Any
     BundleContext::GetProperty(std::string const& key) const
     {
@@ -259,9 +239,9 @@ namespace cppmicroservices
     template <class S>
     struct ServiceHolder
     {
-        const std::weak_ptr<BundlePrivate> b;
-        const ServiceReferenceBase sref;
-        const std::shared_ptr<S> service;
+        std::weak_ptr<BundlePrivate> const b;
+        ServiceReferenceBase const sref;
+        std::shared_ptr<S> const service;
 
         ServiceHolder(std::shared_ptr<BundlePrivate> const& b, ServiceReferenceBase const& sr, std::shared_ptr<S> s)
             : b(b)

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -288,15 +288,7 @@ namespace cppmicroservices
             return { nullptr, ::free };
         }
 
-        auto data = d->archive->GetResourceContainer()->GetData(d->stat.index);
-        if (!data)
-        {
-            auto sink = GetBundleContext().GetLogSink();
-            DIAG_LOG(*sink) << "Error uncompressing resource data for " << this->GetResourcePath() << " from "
-                            << d->archive->GetBundleLocation();
-        }
-
-        return data;
+        return d->archive->GetResourceContainer()->GetData(d->stat.index);
     }
 
     std::ostream&

--- a/framework/src/bundle/BundleResourceContainer.cpp
+++ b/framework/src/bundle/BundleResourceContainer.cpp
@@ -162,7 +162,9 @@ namespace cppmicroservices
         for (++iter; iter != m_SortedEntries.end(); ++iter)
         {
             if (resourcePath.size() > iter->first.size())
+            {
                 break;
+            }
             if (iter->first.compare(0, resourcePath.size(), resourcePath) == 0)
             {
                 std::size_t pos = iter->first.find_first_of('/', resourcePath.size());
@@ -221,10 +223,8 @@ namespace cppmicroservices
             m_ObjFile = BundleObjFactory().CreateBundleFileObj(m_Location);
             rawBundleResourceData = m_ObjFile->GetRawBundleResourceContainer();
         }
-        catch (std::exception const& ex)
+        catch (std::exception const&)
         {
-            auto sink = GetBundleContext().GetLogSink();
-            DIAG_LOG(*sink) << "Exception thrown creating BundleFileObj : " << ex.what();
         }
 
         if (!rawBundleResourceData || !rawBundleResourceData->GetData()

--- a/framework/test/gtest/ServiceTrackerTest.cpp
+++ b/framework/test/gtest/ServiceTrackerTest.cpp
@@ -690,3 +690,26 @@ TEST_F(ServiceTrackerTestFixture, TestFilterPropertiesTypes)
     framework.Stop();
     framework.WaitForStop(std::chrono::milliseconds::zero());
 }
+
+// If the test doesn't throw, it is successful.
+// Intended to be run with many repititions to test for sporadic failures.
+TEST(ServiceTrackerTests, FrameworkTrackerCloseRace)
+{
+    auto framework = cppmicroservices::FrameworkFactory().NewFramework();
+    framework.Start();
+
+    ServiceTracker<MyInterfaceOne> tracker(framework.GetBundleContext());
+    tracker.Open();
+
+    auto interfaceOneService = std::make_shared<MyInterfaceOne>();
+
+    auto svc = framework.GetBundleContext().RegisterService<MyInterfaceOne>(interfaceOneService);
+
+    auto fut = std::async(std::launch::async,
+                          [&framework]()
+                          {
+                              framework.Stop();
+                              framework.WaitForStop(std::chrono::milliseconds::zero());
+                          });
+    tracker.Close();
+}


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/792c0b81698d8d539019482541089409721b29f9 / #922 without changes.