### PR TITLE
701 - Adding support for multiple cardinality for service references. (#871)

### DIFF
--- a/compendium/DeclarativeServices/src/manager/BindingPolicy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicy.cpp
@@ -104,7 +104,9 @@ namespace cppmicroservices
                     ServiceReference<void> svcRefToBind;
                     {
                         auto boundRefsHandle = mgr.boundRefs.lock(); // acquires lock on boundRefs
-                        if (!boundRefsHandle->empty())
+                        // we only need to rebind if maxCardinality is unary, in case of multiple
+                        // bound references remain as is after removing current reference
+                        if (!boundRefsHandle->empty() && mgr.IsUnary())
                         {
                             svcRefToBind = *(boundRefsHandle->begin());
                             Log("Notify BIND for reference " + mgr.metadata_.name);

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicGreedy.cpp
@@ -26,6 +26,7 @@ namespace cppmicroservices
 {
     namespace scrimpl
     {
+        using namespace cppmicroservices::logservice;
 
         /**
          * If no service is bound, bind to better target service.
@@ -67,10 +68,22 @@ namespace cppmicroservices
                     {
                         notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
                     }
-                    else
-                    { // there are bound refs, determine whether to rebind
+                    // there are bound refs, determine whether to rebind based on multiplicity of reference
+                    else if (mgr.IsUnary()) {
+                        //rebind new and unbind older reference if maxCardinality is unary
                         svcRefToUnBind = *(boundRefsHandle->begin());
                         needRebind = svcRefToUnBind < reference;
+                    }
+                    else if (mgr.IsMultiple()) {
+                        //bind to new reference if maxCardinality is multiple
+                        if (boundRefsHandle->size() < mgr.metadata_.maxCardinality) {
+                            //number of bound references are within maxCardinality limit
+                            notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
+                        }
+                        else {
+                            //Maximum limit of multiple references has reached, no new references will be bound
+                            Log("Number of multiple references has reached its maximum limit. New reference(s) will not be bound.", SeverityLevel::LOG_WARNING);
+                        }
                     }
                 }
 

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicReluctant.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyDynamicReluctant.cpp
@@ -61,6 +61,23 @@ namespace cppmicroservices
 
                     notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
                 }
+
+                // for multiple cardinality rebind to new reference if number of
+                // bound references is within limit of maxCardinality value
+                // otherwise log to the user that further bind is not possible
+                if (mgr.IsMultiple()) {
+                    if (mgr.GetBoundReferences().size() < mgr.metadata_.maxCardinality) {
+                        Log("Notify BIND for reference " + mgr.metadata_.name);
+
+                        ClearBoundRefs();
+                        mgr.UpdateBoundRefs();
+
+                        notifications.emplace_back(mgr.metadata_.name, RefEvent::REBIND, reference);
+                    }
+                    else {
+                        Log("Number of multiple references has reached its maximum limit. New reference(s) will not be bound.", SeverityLevel::LOG_WARNING);
+                    }
+                }
             }
 
             if (notifySatisfied)

--- a/compendium/DeclarativeServices/src/manager/BindingPolicyStaticGreedy.cpp
+++ b/compendium/DeclarativeServices/src/manager/BindingPolicyStaticGreedy.cpp
@@ -58,15 +58,25 @@ namespace cppmicroservices
                     // old service and then bind to the new service.
                     if (!boundRefsHandle->empty())
                     {
-                        // We only need to unbind if there's actually a bound ref.
                         ServiceReferenceBase const& minBound = *(boundRefsHandle->begin());
-                        if (minBound < reference)
+                        if (mgr.IsUnary() && minBound < reference)
                         {
+                            // We only need to unbind if there's actually a bound ref.
                             // And we only need to unbind if the new reference is a better match than the
                             // current best match (i.e. boundRefs are stored in reverse order with the best
                             // match in the first position).
                             replacementNeeded = true;
                             serviceToUnbind = minBound; // remember which service to unbind.
+                        }
+                        else {
+                            // in case of multiple cardinality, always bind if number of bound references
+                            // is within limit of maxCardinality value
+                            if (boundRefsHandle->size() < mgr.metadata_.maxCardinality) {
+                                replacementNeeded = true;
+                            }
+                            else {
+                                Log("Number of multiple references has reached its maximum limit. New reference(s) will not be bound.", SeverityLevel::LOG_WARNING);
+                            }
                         }
                     }
                     else

--- a/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
@@ -141,6 +141,16 @@ namespace cppmicroservices
              */
             virtual void StopTracking() = 0;
 
+            /**
+             * Method returns true if maxCardinality is unary (1)
+             */
+            virtual bool IsUnary() const = 0;
+
+            /**
+             * Method returns true if maxCardinality is multiple (n)
+             */
+            virtual bool IsMultiple() const = 0;
+
           protected:
             ReferenceManager() = default;
         };

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
@@ -146,6 +146,16 @@ namespace cppmicroservices
             return (boundRefs.lock()->size() >= metadata_.minCardinality);
         }
 
+        bool ReferenceManagerBaseImpl::IsUnary() const
+        {
+            return (metadata_.maxCardinality == 1);
+        }
+
+        bool ReferenceManagerBaseImpl::IsMultiple() const
+        {
+            return (metadata_.maxCardinality > 1);
+        }
+
         ReferenceManagerBaseImpl::~ReferenceManagerBaseImpl() { StopTracking(); }
 
         struct dummyRefObj

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -176,6 +176,16 @@ namespace cppmicroservices
              */
             void StopTracking() override;
 
+            /**
+             * Method returns true if maxCardinality is unary (1)
+             */
+            bool IsUnary() const override;
+
+            /**
+             * Method returns true if maxCardinality is multiple (n)
+             */
+            bool IsMultiple() const override;
+
             class BindingPolicy
             {
               public:

--- a/compendium/DeclarativeServices/test/gtest/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/gtest/Mocks.hpp
@@ -227,6 +227,8 @@ namespace cppmicroservices
                          cppmicroservices::ListenerTokenId(std::function<void(RefChangeNotification const&)>));
             MOCK_METHOD1(UnregisterListener, void(cppmicroservices::ListenerTokenId));
             MOCK_METHOD0(StopTracking, void(void));
+            MOCK_CONST_METHOD0(IsUnary, bool(void));
+            MOCK_CONST_METHOD0(IsMultiple, bool(void));
         };
 
         class MockReferenceManagerBaseImpl : public ReferenceManagerBaseImpl

--- a/compendium/ServiceComponent/test/CMakeLists.txt
+++ b/compendium/ServiceComponent/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 #-----------------------------------------------------------------------------
 # Build and run the GTest Suite of tests
 #-----------------------------------------------------------------------------
-
 set(us_servicecomponent_test_exe_name usServiceComponentTests)
 
 include_directories(
@@ -20,11 +19,6 @@ endif()
 # Add test source files
 #-----------------------------------------------------------------------------
 set(_servicecomponent_tests
-  TestCompInst_InvalidInheritance.cpp
-  TestCompInst_NoDepsNoDefaultCtor.cpp
-  TestCompInst_NoInjectNoDefaultCtor.cpp
-  TestCompInst_RefCount.cpp
-  TestCompInst_RefOrder.cpp
   TestComponentInstance.cpp             
   suite_registration.cpp
 )
@@ -112,3 +106,47 @@ if (WIN32 AND US_USE_SYSTEM_GTEST)
         $<TARGET_FILE_DIR:${us_servicecomponent_test_exe_name}>)
   endforeach(lib_fullpath)
 endif()
+
+#Compile-only tests addition
+#Adding executables for compile-only test files
+add_executable(usServiceComponentRefOrderTest TestCompInst_RefOrder.cpp)
+add_executable(usServiceComponentRefOrderMultipleCardinalityTest TestCompInst_RefOrderMultipleCardinality.cpp)
+add_executable(usServiceComponentInvalidInheritanceTest TestCompInst_InvalidInheritance.cpp)
+add_executable(usServiceComponentNoDepsNoDefaultCtorTest TestCompInst_NoDepsNoDefaultCtor.cpp)
+add_executable(usServiceComponentNoDefaultCtorTest TestCompInst_NoInjectNoDefaultCtor.cpp)
+add_executable(usServiceComponentRefCountTest TestCompInst_RefCount.cpp)
+
+set(compile_only_exe_names usServiceComponentRefOrderTest usServiceComponentRefOrderMultipleCardinalityTest usServiceComponentInvalidInheritanceTest usServiceComponentNoDepsNoDefaultCtorTest usServiceComponentNoDefaultCtorTest usServiceComponentRefCountTest)
+
+foreach(exe_name ${compile_only_exe_names})
+    
+    if (US_COMPILER_MSVC AND BUILD_SHARED_LIBS)
+        target_compile_options(${exe_name} PRIVATE -DGTEST_LINKED_AS_SHARED_LIBRARY)
+    endif()
+
+    target_link_libraries(${exe_name} 
+	PRIVATE
+		${GTEST_BOTH_LIBRARIES}
+		${GMOCK_BOTH_LIBRARIES}
+        CppMicroServices
+        usServiceComponent
+    )
+
+    #Excluding compile-only tests from default build to avoid build failure
+    set_target_properties(${exe_name} PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+    #For compile-only tests we add a test with Cmake command to build the target only as we expect a build failure
+    add_test(NAME ${exe_name}
+    COMMAND ${CMAKE_COMMAND} --build . --target ${exe_name}
+    WORKING_DIRECTORY ${CppMicroServices_BINARY_DIR}
+    )
+
+endforeach()
+
+#Set test properties for compile-only tests to check if compilation fails and corresponding errors are generated in the log
+set_tests_properties(usServiceComponentRefOrderTest PROPERTIES PASS_REGULAR_EXPRESSION ".*An appropriate constructor was not found and/or the service implementation does not implement all of the service interface's methods. A constructor with service reference input parameters or a constructor with an AnyMap input parameter for configuration properties and service reference input parameters is required when inject-references is true.*")
+set_tests_properties(usServiceComponentRefOrderMultipleCardinalityTest PROPERTIES PASS_REGULAR_EXPRESSION ".*An appropriate constructor was not found and/or the service implementation does not implement all of the service interface's methods. A constructor with service reference input parameters or a constructor with an AnyMap input parameter for configuration properties and service reference input parameters is required when inject-references is true.*")
+set_tests_properties(usServiceComponentInvalidInheritanceTest PROPERTIES PASS_REGULAR_EXPRESSION ".*['static_cast' cannot convert].* [Types pointed to are unrelated] .* [conversion requires reinterpret_cast, C-style cast or function-style cast] .*")
+set_tests_properties(usServiceComponentNoDepsNoDefaultCtorTest PROPERTIES PASS_REGULAR_EXPRESSION ".*An appropriate constructor was not found and/or the service implementation does not implement all of the service interface's methods. A default constructor or a constructor with an AnyMap input parameter for the configuration properties is required when inject-references is false..*")
+set_tests_properties(usServiceComponentNoDefaultCtorTest PROPERTIES PASS_REGULAR_EXPRESSION ".*An appropriate constructor was not found and/or the service implementation does not implement all of the service interface's methods. A constructor with service reference input parameters or a constructor with an AnyMap input parameter for configuration properties and service reference input parameters is required when inject-references is true.*")
+set_tests_properties(usServiceComponentRefCountTest PROPERTIES PASS_REGULAR_EXPRESSION ".*An appropriate constructor was not found and/or the service implementation does not implement all of the service interface's methods. A constructor with service reference input parameters or a constructor with an AnyMap input parameter for configuration properties and service reference input parameters is required when inject-references is true.*")

--- a/compendium/ServiceComponent/test/TestCompInst_InvalidInheritance.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_InvalidInheritance.cpp
@@ -19,7 +19,7 @@
   limitations under the License.
 
   =============================================================================*/
-#if NEVER
+
 #    include <algorithm>
 #    include <chrono>
 #    include <cstdio>
@@ -53,7 +53,7 @@ namespace
      * This test point is used to verify a compile error is generated when a service component
      * description specifies an interface that is not implemented by the implementation class
      *
-     * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
+     * CMake tests will build this file to catch the expected compile time error
      */
     TEST(ComponentInstance, ValidateInheritance)
     {
@@ -67,5 +67,3 @@ main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-
-#endif

--- a/compendium/ServiceComponent/test/TestCompInst_NoDepsNoDefaultCtor.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_NoDepsNoDefaultCtor.cpp
@@ -19,7 +19,7 @@
   limitations under the License.
 
   =============================================================================*/
-#if NEVER
+
 #    include <algorithm>
 #    include <chrono>
 #    include <cstdio>
@@ -48,7 +48,7 @@ namespace
      * This test point is used to verify a compile error is generated when a service component
      * does not have any dependencies and it does not provide a default constructor.
      *
-     * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
+     * CMake tests will build this file to catch the expected compile time error
      */
     TEST(ComponentInstance, CheckNoDefaultCtor)
     {
@@ -62,4 +62,3 @@ main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-#endif

--- a/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_NoInjectNoDefaultCtor.cpp
@@ -19,7 +19,7 @@
   limitations under the License.
 
   =============================================================================*/
-#if NEVER
+
 #    include <algorithm>
 #    include <chrono>
 #    include <cstdio>
@@ -52,14 +52,14 @@ namespace
      * This test point is used to verify a compile error is generated when a service component
      * has dependencies, opted out of constructor injection and it does not provide a default constructor.
      *
-     * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
+     * CMake tests will build this file to catch the expected compile time error
      */
     TEST(ComponentInstance, CheckNoDefaultCtorNoInjection)
     {
         ComponentInstanceImpl<TestServiceImpl,
                               std::tuple<>,
                               std::false_type,
-                              ServiceDependency>
+                              std::shared_ptr<ServiceDependency>>
             compInstance; // compile error
     }
 } // namespace
@@ -70,4 +70,3 @@ main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-#endif

--- a/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
+++ b/compendium/ServiceComponent/test/TestCompInst_RefCount.cpp
@@ -19,7 +19,7 @@
  limitations under the License.
 
  =============================================================================*/
-#if NEVER
+
 #    include <algorithm>
 #    include <chrono>
 #    include <cstdio>
@@ -97,7 +97,7 @@ namespace
      * the service component description does not match the dependencies in the service component implementation
      * class constructor.
      *
-     * @todo Automate this test point. Currently interactive is the only way to verify compilation failures.
+     * CMake tests will build this file to catch the expected compile time error
      */
     TEST(ComponentInstance, VerifyDependencyCount)
     {
@@ -111,10 +111,10 @@ namespace
         ComponentInstanceImpl<TestServiceImpl1,
                               std::tuple<>,
                               std::true_type,
-                              ServiceDependency1,
-                              ServiceDependency2,
-                              ServiceDependency2>
-            compInstance(binders); // compile error
+                              std::shared_ptr<ServiceDependency1>,
+                              std::shared_ptr<ServiceDependency2>,
+                              std::shared_ptr<ServiceDependency2>>
+            compInstance({ "foo", "bar", "bar2" }, binders); // compile error
     }
 } // namespace
 
@@ -124,4 +124,3 @@ main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-#endif

--- a/compendium/test_bundles/CMakeLists.txt
+++ b/compendium/test_bundles/CMakeLists.txt
@@ -75,3 +75,4 @@ add_subdirectory(TestBundleManagedServiceFactory)
 add_subdirectory(TestBundleNestedStartManagedSvc)
 add_subdirectory(TestBundleMultipleManagedService)
 add_subdirectory(TestBundleMultipleManagedServiceFactory)
+

--- a/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
@@ -129,9 +129,10 @@ namespace codegen
                 }
                 else
                 {
-                    mStrStream << datamodel::GetCtorInjectedRefTypes(componentInfo) << ">("
-                               << datamodel::GetCtorInjectedRefNames(componentInfo) << ", binders"
-                               << ");";
+
+                    mStrStream << datamodel::GetCtorInjectedRefParameters(componentInfo) << ">("
+                        << datamodel::GetCtorInjectedRefNames(componentInfo) << ", binders"
+                        << ");";
                 }
 
                 mStrStream << std::endl << std::endl << "  return componentInstance;" << std::endl << "}" << std::endl;

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -58,7 +58,7 @@ namespace codegen
         }
 
         std::string
-        GetCtorInjectedRefTypes(ComponentInfo const& compInfo)
+        GetCtorInjectedRefParameters(ComponentInfo const& compInfo)
         {
             std::string result;
             auto sep = ", ";
@@ -66,7 +66,12 @@ namespace codegen
             {
                 if ((true == compInfo.injectReferences) && (reference.policy == "static"))
                 {
-                    result += (sep + reference.interface);
+                    if (reference.cardinality == "0..n" || reference.cardinality == "1..n") {
+                        result += (sep + std::string("std::vector<std::shared_ptr<") + reference.interface + ">>");
+                    }
+                    else {
+                        result += (sep + std::string("std::shared_ptr<") + reference.interface + ">");
+                    }
                 }
             }
             return result;

--- a/compendium/tools/SCRCodeGen/ComponentInfo.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.hpp
@@ -67,6 +67,7 @@ namespace codegen
         std::string GetCtorInjectedRefTypes(ComponentInfo const& compInfo);
         std::string GetCtorInjectedRefNames(ComponentInfo const& compInfo);
         std::string GetReferenceBinderStr(ReferenceInfo const& ref, bool injectReferences);
+        std::string GetCtorInjectedRefParameters(ComponentInfo const& compInfo);
 
     } // namespace datamodel
 } // namespace codegen

--- a/compendium/tools/SCRCodeGen/test/ReferenceAutogenFiles.hpp
+++ b/compendium/tools/SCRCodeGen/test/ReferenceAutogenFiles.hpp
@@ -41,7 +41,7 @@ using scd::DynamicBinder;
 extern "C" US_ABI_EXPORT scd::ComponentInstance* NewInstance_DSSpellCheck_SpellCheckImpl()
 {
   std::vector<std::shared_ptr<scd::Binder<DSSpellCheck::SpellCheckImpl>>> binders;
-  scd::ComponentInstance* componentInstance = new (std::nothrow) scd::ComponentInstanceImpl<DSSpellCheck::SpellCheckImpl, std::tuple<test::ISpellCheckService>, test::IDictionaryService>({{"dictionary"}}, binders);
+  scd::ComponentInstance* componentInstance = new (std::nothrow) scd::ComponentInstanceImpl<DSSpellCheck::SpellCheckImpl, std::tuple<test::ISpellCheckService>, std::shared_ptr<test::IDictionaryService>>({{"dictionary"}}, binders);
 
   return componentInstance;
 }
@@ -65,7 +65,7 @@ namespace scd = cppmicroservices::service::component::detail;
 extern "C" US_ABI_EXPORT scd::ComponentInstance* NewInstance_DSSpellCheck_SpellCheckImpl()
 {
   std::vector<std::shared_ptr<scd::Binder<DSSpellCheck::SpellCheckImpl>>> binders;
-  scd::ComponentInstance* componentInstance = new (std::nothrow) scd::ComponentInstanceImpl<DSSpellCheck::SpellCheckImpl, std::tuple<SpellCheck::ISpellCheckService>, DictionaryService::IDictionaryService>({{"dictionary"}}, binders);
+  scd::ComponentInstance* componentInstance = new (std::nothrow) scd::ComponentInstanceImpl<DSSpellCheck::SpellCheckImpl, std::tuple<SpellCheck::ISpellCheckService>, std::shared_ptr<DictionaryService::IDictionaryService>>({{"dictionary"}}, binders);
 
   return componentInstance;
 }
@@ -173,6 +173,30 @@ extern "C" US_ABI_EXPORT scd::ComponentInstance* NewInstance_FooImpl2()
 }
 
 extern "C" US_ABI_EXPORT void DeleteInstance_FooImpl2(scd::ComponentInstance* componentInstance)
+{
+  delete componentInstance;
+}
+
+)manifestsrc";
+
+    const std::string REF_MULT_CARD = R"manifestsrc(
+#include <vector>
+#include <cppmicroservices/ServiceInterface.h>
+#include "cppmicroservices/servicecomponent/detail/ComponentInstanceImpl.hpp"
+#include "SpellCheckerImpl.hpp"
+
+namespace sc = cppmicroservices::service::component;
+namespace scd = cppmicroservices::service::component::detail;
+
+extern "C" US_ABI_EXPORT scd::ComponentInstance* NewInstance_DSSpellCheck_SpellCheckImpl()
+{
+  std::vector<std::shared_ptr<scd::Binder<DSSpellCheck::SpellCheckImpl>>> binders;
+  scd::ComponentInstance* componentInstance = new (std::nothrow) scd::ComponentInstanceImpl<DSSpellCheck::SpellCheckImpl, std::tuple<SpellCheck::ISpellCheckService>, std::vector<std::shared_ptr<DictionaryService::IDictionaryService>>, std::shared_ptr<Foo::Interface>>({{"dictionary", "foo"}}, binders);
+
+  return componentInstance;
+}
+
+extern "C" US_ABI_EXPORT void DeleteInstance_DSSpellCheck_SpellCheckImpl(scd::ComponentInstance* componentInstance)
 {
   delete componentInstance;
 }

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -119,6 +119,30 @@ namespace codegen
   }
   )manifest";
 
+    const std::string manifest_multiple_cardinality_ref = R"manifest(
+ {
+    "scr" : { "version" : 1,
+              "components": [{
+                       "implementation-class": "DSSpellCheck::SpellCheckImpl",
+                       "inject-references" : true,
+                       "service": {
+                       "interfaces": ["SpellCheck::ISpellCheckService"]
+                       },
+                       "references": [{
+                         "name": "dictionary",
+                         "interface": "DictionaryService::IDictionaryService",
+                         "cardinality": "1..n"
+                       },
+                       {
+                         "name": "foo",
+                         "interface": "Foo::Interface",
+                         "cardinality": "1..1"
+                       }]
+                       }]
+            }
+  }
+  )manifest";
+
     const std::string manifest_no_scr = R"manifest(
   {
   }
@@ -623,8 +647,9 @@ namespace codegen
             CodegenValidManifestState(manifest_mult_comp, { "A.hpp", "B.hpp", "C.hpp" }, REF_MULT_COMPS),
             // valid manifest with multiple components of the same implementation class
             CodegenValidManifestState(manifest_mult_comp_same_impl,
-                                      { "A.hpp", "B.hpp", "C.hpp" },
-                                      REF_MULT_COMPS_SAME_IMPL)));
+                { "A.hpp", "B.hpp", "C.hpp" },
+                REF_MULT_COMPS_SAME_IMPL),
+            CodegenValidManifestState(manifest_multiple_cardinality_ref, { "SpellCheckerImpl.hpp" }, REF_MULT_CARD)));
 
     // For the manifest specified in the member manifest, we expect the exception message
     // output by the code-generator to be exactly errorOutput.


### PR DESCRIPTION
Cherry-picked https://github.com/CppMicroServices/CppMicroServices/commit/fc006a89cc4c2b210baa71be47adc4676d2a441c / #871 without changes.