### PR TITLE
Fix #937 `GetServiceReferences` ordering guarantee

### DIFF
--- a/framework/include/cppmicroservices/BundleContext.h
+++ b/framework/include/cppmicroservices/BundleContext.h
@@ -380,9 +380,9 @@ namespace cppmicroservices
         }
 
         /**
-         * Returns a list of <code>ServiceReference</code> objects. The returned
-         * list contains services that were registered under the specified class
-         * and match the specified filter expression.
+         * Returns a list of <code>ServiceReference</code> objects ordered
+         * by rank. The returned list contains services that were registered under
+         * the specified class and match the specified filter expression.
          *
          * <p>
          * The list is valid at the time of the call to this method. However, since
@@ -418,7 +418,7 @@ namespace cppmicroservices
          *        services.
          * @return A list of <code>ServiceReference</code> objects or
          *         an empty list if no services are registered that satisfy the
-         *         search.
+         *         search. These objects will be in decreasing order of their rank.
          * @throws std::invalid_argument If the specified <code>filter</code>
          *         contains an invalid filter expression that cannot be parsed.
          * @throws std::runtime_error If this BundleContext is no longer valid.
@@ -430,9 +430,8 @@ namespace cppmicroservices
 
         /**
          * Returns a list of <code>ServiceReference</code> objects ordered by rank. The returned
-         * list contains services that
-         * were registered under the interface id of the template argument <code>S</code>
-         * and match the specified filter expression.
+         * list contains services that were registered under the interface id of
+         * the template argument <code>S</code> and match the specified filter expression.
          *
          * <p>
          * This method is identical to GetServiceReferences(const std::string&, const std::string&) except that

--- a/framework/include/cppmicroservices/BundleContext.h
+++ b/framework/include/cppmicroservices/BundleContext.h
@@ -429,7 +429,7 @@ namespace cppmicroservices
                                                             std::string const& filter = std::string());
 
         /**
-         * Returns a list of <code>ServiceReference</code> objects. The returned
+         * Returns a list of <code>ServiceReference</code> objects ordered by rank. The returned
          * list contains services that
          * were registered under the interface id of the template argument <code>S</code>
          * and match the specified filter expression.
@@ -443,7 +443,7 @@ namespace cppmicroservices
          *        services.
          * @return A list of <code>ServiceReference</code> objects or
          *         an empty list if no services are registered which satisfy the
-         *         search.
+         *         search. These objects will be in decreasing order of their rank.
          * @throws std::invalid_argument If the specified <code>filter</code>
          *         contains an invalid filter expression that cannot be parsed.
          * @throws std::runtime_error If this BundleContext is no longer valid.

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -80,9 +80,8 @@ class BundleContextTest : public ::testing::Test
     cppmicroservices::BundleContext context;
 };
 
-class BundleContextTestParam
-    : public ::testing::TestWithParam<
-          std::pair<std::vector<std::pair<std::string, size_t>>, std::vector<ServiceProperties>>>
+using BundleContParamType = std::pair<std::vector<std::pair<std::string, size_t>>, std::vector<ServiceProperties>>;
+class BundleContextTestParam : public ::testing::TestWithParam<BundleContParamType>
 {
   public:
     BundleContextTestParam() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {}
@@ -243,7 +242,6 @@ verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>> const& 
     return true;
 }
 
-using BundleContParamType = std::pair<std::vector<std::pair<std::string, size_t>>, std::vector<ServiceProperties>>;
 INSTANTIATE_TEST_SUITE_P(BundleContextTestParameterized,
                          BundleContextTestParam,
                          ::testing::Values(

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -221,6 +221,8 @@ TEST_F(BundleContextTest, NoSegfaultWithServiceFactory)
     thread.join();
 }
 
+#endif
+
 template <typename ServiceT>
 bool
 verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>> const& refs)
@@ -230,7 +232,7 @@ verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>> const& 
         for (size_t i = 1; i < refs.size(); ++i)
         {
             if ((any_cast<int>(refs[i].GetProperty(Constants::SERVICE_RANKING))
-                  >= any_cast<int>(refs[i - 1].GetProperty(Constants::SERVICE_RANKING))))
+                 >= any_cast<int>(refs[i - 1].GetProperty(Constants::SERVICE_RANKING))))
             {
                 return false;
             }
@@ -277,5 +279,3 @@ TEST_P(BundleContextTestParam, TestGetServiceReferenceOrdering)
         ASSERT_TRUE(refs.size() == pair.second);
     }
 }
-
-#endif

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -200,7 +200,7 @@ verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>>& refs)
     if (refs.size() > 0)
     {
         auto last = refs[0];
-        for (auto ref : refs)
+        for (auto const& ref : refs)
         {
             if (!(any_cast<int>(ref.GetProperty(Constants::SERVICE_RANKING))
                   <= any_cast<int>(last.GetProperty(Constants::SERVICE_RANKING))))

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -242,36 +242,26 @@ verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>> const& 
     }
     return true;
 }
-std::vector<ServiceProperties> props1 { { { "service.ranking", 2 } },
-                                        { { "service.ranking", 0 } },
-                                        { { "service.ranking", 4 } },
-                                        { { "service.ranking", 1 } },
-                                        { { "service.ranking", 3 } } };
-std::vector<std::pair<std::string, size_t>> vec1 {
-    {"", 5}
-};
 
-std::vector<ServiceProperties> props2 {
-    {{ "service.ranking", 2000 }, { "Key1", std::string("Val1") }},
-    {  { "service.ranking", 15 }, { "Key1", std::string("Val2") }},
-    {   { "service.ranking", 0 }, { "Key1", std::string("Val2") }},
-    {{ "service.ranking", 1506 }, { "Key2", std::string("Val1") }},
-    { { "service.ranking", 905 }, { "Key2", std::string("Val1") }}
-};
-std::vector<std::pair<std::string, size_t>> vec2 {
-    {           "", 5},
-    {"(Key1=Val*)", 3},
-    {"(Key2=Val*)", 2}
-};
-
-std::vector<std::pair<std::vector<std::pair<std::string, size_t>>, std::vector<ServiceProperties>>> parameterizedInputs {
-    {vec1, props1},
-    {vec2, props2}
-};
-
+using BundleContParamType = std::pair<std::vector<std::pair<std::string, size_t>>, std::vector<ServiceProperties>>;
 INSTANTIATE_TEST_SUITE_P(BundleContextTestParameterized,
                          BundleContextTestParam,
-                         ::testing::ValuesIn(parameterizedInputs.begin(), parameterizedInputs.end()));
+                         ::testing::Values(
+                             BundleContParamType {
+                                 { { "", 5 } },
+                                 { { { "service.ranking", 2 } },
+                                  { { "service.ranking", 0 } },
+                                  { { "service.ranking", 4 } },
+                                  { { "service.ranking", 1 } },
+                                  { { "service.ranking", 3 } } }
+},
+                             BundleContParamType {
+                                 { { "", 5 }, { "(Key1=Val*)", 3 }, { "(Key2=Val*)", 2 } },
+                                 { { { "service.ranking", 2000 }, { "Key1", std::string("Val1") } },
+                                   { { "service.ranking", 15 }, { "Key1", std::string("Val2") } },
+                                   { { "service.ranking", 0 }, { "Key1", std::string("Val2") } },
+                                   { { "service.ranking", 1506 }, { "Key2", std::string("Val1") } },
+                                   { { "service.ranking", 905 }, { "Key2", std::string("Val1") } } } }));
 
 TEST_P(BundleContextTestParam, TestGetServiceReferenceOrdering)
 {

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -225,18 +225,15 @@ template <typename ServiceT>
 bool
 verifyOrdering(std::vector<cppmicroservices::ServiceReference<ServiceT>> const& refs)
 {
-    if (refs.size() > 0)
+    if (refs.size() > 1)
     {
-        auto last = refs[0];
-        for (auto const& ref : refs)
+        for (size_t i = 1; i < refs.size(); ++i)
         {
-            if (!(any_cast<int>(ref.GetProperty(Constants::SERVICE_RANKING))
-                  <= any_cast<int>(last.GetProperty(Constants::SERVICE_RANKING))))
+            if ((any_cast<int>(refs[i].GetProperty(Constants::SERVICE_RANKING))
+                  >= any_cast<int>(refs[i - 1].GetProperty(Constants::SERVICE_RANKING))))
             {
                 return false;
             }
-
-            last = ref;
         }
     }
     return true;


### PR DESCRIPTION
This PR introduces two tests to guarantee that the ordering of services returned by `GetServiceReferences()` is ordered by rank. This was already the way the code was written, but now it can be guaranteed