### PR TITLE
CMake Updates for Boost Versioning Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ include(usFunctionGenerateBundleInit)
 include(usMacroCreateBundle)
 include(usFunctionCreateTestBundle)
 include(usFunctionCreateDSTestBundle)
+include(usFunctionBoostPath)
 
 if (US_COMPILER_CLANG OR US_COMPILER_APPLE_CLANG)
   check_cxx_compiler_flag(-Wno-missing-braces HAS_MISSING_BRACES_FLAG)
@@ -879,6 +880,7 @@ install(EXPORT ${PROJECT_NAME}Targets
     ${US_CMAKE_DIR}/usFunctionGetResourceSource.cmake
     ${US_CMAKE_DIR}/usFunctionCheckResourceLinking.cmake
     ${US_CMAKE_DIR}/usFunctionCheckCompilerFlags.cmake
+    ${US_CMAKE_DIR}/usFunctionBoostPath.cmake
     )
 
   install(FILES ${_install_cmake_scripts}

--- a/CppMicroServicesConfig.cmake.in
+++ b/CppMicroServicesConfig.cmake.in
@@ -69,6 +69,7 @@ include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionGenerateBundleInit.cmake")
 include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionAddResources.cmake")
 include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionCheckCompilerFlags.cmake")
 include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionEmbedResources.cmake")
+include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionBoostPath.cmake")
 include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionCheckResourceLinking.cmake")
 include("@PACKAGE_CONFIG_CMAKE_DIR@/usFunctionGetResourceSource.cmake")
 

--- a/cmake/usFunctionBoostPath.cmake
+++ b/cmake/usFunctionBoostPath.cmake
@@ -1,0 +1,17 @@
+#
+# Helper macro allowing to return path to boost library
+#
+# Usage:
+#    usFunctionBoostPath(USE_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR}
+#      BOOST_DIR ${BOOST_INCLUDEDIR})
+
+
+function(usFunctionBoostPath)
+  cmake_parse_arguments(Boost_Path "BOOST_SYSTEM" "CPPMS_SOURCE_DIR;BOOST_DIR" "" ${ARGN})
+
+  if (Boost_Path_BOOST_SYSTEM)
+      set(_boost_library ${Boost_Path_BOOST_DIR} PARENT_SCOPE)
+  else()
+      set(_boost_library ${Boost_Path_CPPMS_SOURCE_DIR}/third_party/boost/include PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/usFunctionBoostPath.cmake
+++ b/cmake/usFunctionBoostPath.cmake
@@ -7,7 +7,7 @@
 
 
 function(usFunctionBoostPath)
-  cmake_parse_arguments(Boost_Path "BOOST_SYSTEM" "CPPMS_SOURCE_DIR;BOOST_DIR" "" ${ARGN})
+  cmake_parse_arguments(Boost_Path "" "BOOST_SYSTEM;CPPMS_SOURCE_DIR;BOOST_DIR" "" ${ARGN})
 
   if (Boost_Path_BOOST_SYSTEM)
       set(_boost_library ${Boost_Path_BOOST_DIR} PARENT_SCOPE)

--- a/compendium/ConfigurationAdmin/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/CMakeLists.txt
@@ -65,6 +65,13 @@ target_include_directories(ConfigurationAdmin PRIVATE
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
+set(_boost_library)
+if (US_USE_SYSTEM_BOOST)
+    set(_boost_library ${BOOST_INCLUDEDIR})
+else()
+    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+endif()
+
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+include_directories(SYSTEM ${_boost_library})

--- a/compendium/ConfigurationAdmin/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/CMakeLists.txt
@@ -65,12 +65,7 @@ target_include_directories(ConfigurationAdmin PRIVATE
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
-set(_boost_library)
-if (US_USE_SYSTEM_BOOST)
-    set(_boost_library ${BOOST_INCLUDEDIR})
-else()
-    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
 
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/ConfigurationAdmin/src/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/src/CMakeLists.txt
@@ -46,12 +46,7 @@ target_include_directories(ConfigurationAdminObjs PRIVATE
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
-  set(_boost_library)
-  if (US_USE_SYSTEM_BOOST)
-      set(_boost_library ${BOOST_INCLUDEDIR})
-  else()
-      set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-  endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
   
   # There are warnings in the boost asio headers which are flagged as errors. Include the boost
   # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/ConfigurationAdmin/src/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/src/CMakeLists.txt
@@ -46,6 +46,13 @@ target_include_directories(ConfigurationAdminObjs PRIVATE
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
-# There are warnings in the boost asio headers which are flagged as errors. Include the boost
-# asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+  set(_boost_library)
+  if (US_USE_SYSTEM_BOOST)
+      set(_boost_library ${BOOST_INCLUDEDIR})
+  else()
+      set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+  endif()
+  
+  # There are warnings in the boost asio headers which are flagged as errors. Include the boost
+  # asio headers as system headers to ignore these warnings and not treat them as errors.
+  include_directories(SYSTEM ${_boost_library})

--- a/compendium/ConfigurationAdmin/src/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/src/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(ConfigurationAdminObjs PRIVATE
   )
 
 usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
-  
-  # There are warnings in the boost asio headers which are flagged as errors. Include the boost
-  # asio headers as system headers to ignore these warnings and not treat them as errors.
-  include_directories(SYSTEM ${_boost_library})
+
+# There are warnings in the boost asio headers which are flagged as errors. Include the boost
+# asio headers as system headers to ignore these warnings and not treat them as errors.
+include_directories(SYSTEM ${_boost_library})

--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -22,12 +22,7 @@ include_directories(
   ${GMOCK_INCLUDE_DIRS}
   )
 
-set(_boost_library)
-if (US_USE_SYSTEM_BOOST)
-    set(_boost_library ${BOOST_INCLUDEDIR})
-else()
-    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
 
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -22,9 +22,16 @@ include_directories(
   ${GMOCK_INCLUDE_DIRS}
   )
 
+set(_boost_library)
+if (US_USE_SYSTEM_BOOST)
+    set(_boost_library ${BOOST_INCLUDEDIR})
+else()
+    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+endif()
+
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+include_directories(SYSTEM ${_boost_library})
 
 if (US_COMPILER_CLANG OR US_COMPILER_APPLE_CLANG)
   check_cxx_compiler_flag(-Wno-inconsistent-missing-override HAS_MISSING_OVERRIDE_FLAG)

--- a/compendium/DeclarativeServices/CMakeLists.txt
+++ b/compendium/DeclarativeServices/CMakeLists.txt
@@ -67,12 +67,7 @@ include_directories(${CppMicroServices_SOURCE_DIR}/framework/include
   ${CppMicroServices_SOURCE_DIR}/cppmicroservices/cm/include
   )
 
-set(_boost_library)
-if (US_USE_SYSTEM_BOOST)
-    set(_boost_library ${BOOST_INCLUDEDIR})
-else()
-    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
 
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/DeclarativeServices/CMakeLists.txt
+++ b/compendium/DeclarativeServices/CMakeLists.txt
@@ -67,6 +67,13 @@ include_directories(${CppMicroServices_SOURCE_DIR}/framework/include
   ${CppMicroServices_SOURCE_DIR}/cppmicroservices/cm/include
   )
 
+set(_boost_library)
+if (US_USE_SYSTEM_BOOST)
+    set(_boost_library ${BOOST_INCLUDEDIR})
+else()
+    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+endif()
+
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+include_directories(SYSTEM ${_boost_library})

--- a/compendium/DeclarativeServices/src/CMakeLists.txt
+++ b/compendium/DeclarativeServices/src/CMakeLists.txt
@@ -103,6 +103,13 @@ include_directories(${CppMicroServices_SOURCE_DIR}/framework/include
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
-# There are warnings in the boost asio headers which are flagged as errors. Include the boost
-# asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+  set(_boost_library)
+  if (US_USE_SYSTEM_BOOST)
+      set(_boost_library ${BOOST_INCLUDEDIR})
+  else()
+      set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+  endif()
+  
+  # There are warnings in the boost asio headers which are flagged as errors. Include the boost
+  # asio headers as system headers to ignore these warnings and not treat them as errors.
+  include_directories(SYSTEM ${_boost_library})

--- a/compendium/DeclarativeServices/src/CMakeLists.txt
+++ b/compendium/DeclarativeServices/src/CMakeLists.txt
@@ -103,12 +103,7 @@ include_directories(${CppMicroServices_SOURCE_DIR}/framework/include
   ${CppMicroServices_SOURCE_DIR}/third_party/googletest/googlemock/include
   )
 
-  set(_boost_library)
-  if (US_USE_SYSTEM_BOOST)
-      set(_boost_library ${BOOST_INCLUDEDIR})
-  else()
-      set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-  endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
   
   # There are warnings in the boost asio headers which are flagged as errors. Include the boost
   # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/DeclarativeServices/src/CMakeLists.txt
+++ b/compendium/DeclarativeServices/src/CMakeLists.txt
@@ -104,7 +104,7 @@ include_directories(${CppMicroServices_SOURCE_DIR}/framework/include
   )
 
 usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
-  
-  # There are warnings in the boost asio headers which are flagged as errors. Include the boost
-  # asio headers as system headers to ignore these warnings and not treat them as errors.
-  include_directories(SYSTEM ${_boost_library})
+
+# There are warnings in the boost asio headers which are flagged as errors. Include the boost
+# asio headers as system headers to ignore these warnings and not treat them as errors.
+include_directories(SYSTEM ${_boost_library})

--- a/compendium/DeclarativeServices/test/bench/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/bench/CMakeLists.txt
@@ -23,12 +23,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/third_party/benchmark/include
   )
 
-set(_boost_library)
-if (US_USE_SYSTEM_BOOST)
-    set(_boost_library ${BOOST_INCLUDEDIR})
-else()
-    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
 
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.

--- a/compendium/DeclarativeServices/test/bench/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/bench/CMakeLists.txt
@@ -23,9 +23,16 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/third_party/benchmark/include
   )
 
+set(_boost_library)
+if (US_USE_SYSTEM_BOOST)
+    set(_boost_library ${BOOST_INCLUDEDIR})
+else()
+    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+endif()
+
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+include_directories(SYSTEM ${_boost_library})
 
 
 if (US_COMPILER_CLANG OR US_COMPILER_APPLE_CLANG)

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -22,9 +22,16 @@ include_directories(
   ${GMOCK_INCLUDE_DIRS}
   )
 
+set(_boost_library)
+if (US_USE_SYSTEM_BOOST)
+    set(_boost_library ${BOOST_INCLUDEDIR})
+else()
+    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+endif()
+
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.
-include_directories(SYSTEM ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
+include_directories(SYSTEM ${_boost_library})
 
 
 if (US_COMPILER_CLANG OR US_COMPILER_APPLE_CLANG)

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -22,12 +22,7 @@ include_directories(
   ${GMOCK_INCLUDE_DIRS}
   )
 
-set(_boost_library)
-if (US_USE_SYSTEM_BOOST)
-    set(_boost_library ${BOOST_INCLUDEDIR})
-else()
-    set(_boost_library ${CppMicroServices_SOURCE_DIR}/third_party/boost/include)
-endif()
+usFunctionBoostPath(BOOST_SYSTEM ${US_USE_SYSTEM_BOOST} CPPMS_SOURCE_DIR ${CppMicroServices_SOURCE_DIR} BOOST_DIR ${BOOST_INCLUDEDIR})
 
 # There are warnings in the boost asio headers which are flagged as errors. Include the boost
 # asio headers as system headers to ignore these warnings and not treat them as errors.


### PR DESCRIPTION
This creates updates for the Boost Versioning fix that was merged recently in PR #939 
That PR did not include changes to CMake files in the subfolders (ConfigurationAdmin and DeclarativeServices) that were necessary to support the feature change