### PR TITLE
Ensure that bundle.Start() after the framework has stopped throws

### DIFF
--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -420,8 +420,8 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
-        auto frameworkStopped = coreCtx->GetFrameworkStopped();
-        if (frameworkStopped->stopped)
+        auto frameworkBlock = coreCtx->GetFrameworkStopped();
+        if (frameworkBlock->frameworkHasStopped)
         {
             throw std::runtime_error("Bundle " + symbolicName + " (location=" + location
                                      + ") belongs to a stopped framework");

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -420,7 +420,7 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
-        auto frameworkBlock = coreCtx->BlockFrameworkShutdown();
+        auto frameworkBlock = coreCtx->GetFrameworkStateAndBlock();
         if (frameworkBlock->frameworkHasStopped)
         {
             throw std::runtime_error("Bundle " + symbolicName + " (location=" + location

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -420,7 +420,7 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
-        auto frameworkBlock = coreCtx->GetFrameworkStopped();
+        auto frameworkBlock = coreCtx->StopFrameworkFromShuttingDown();
         if (frameworkBlock->frameworkHasStopped)
         {
             throw std::runtime_error("Bundle " + symbolicName + " (location=" + location

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -421,8 +421,8 @@ namespace cppmicroservices
         auto l = this->Lock();
         US_UNUSED(l);
         if(coreCtx->FrameworkStopped()){
-            throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
-                                               + ") is part of a stopped Framework");
+            throw std::runtime_error("Bundle #" + util::ToString(id) + " (location=" + location
+                                               + ") belongs to a stopped framework");
         }
         if (state == Bundle::STATE_UNINSTALLED)
         {

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -420,7 +420,7 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
-        auto frameworkBlock = coreCtx->StopFrameworkFromShuttingDown();
+        auto frameworkBlock = coreCtx->BlockFrameworkShutdown();
         if (frameworkBlock->frameworkHasStopped)
         {
             throw std::runtime_error("Bundle " + symbolicName + " (location=" + location

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -420,6 +420,10 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
+        if(coreCtx->FrameworkStopped()){
+            throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
+                                               + ") is part of a stopped Framework");
+        }
         if (state == Bundle::STATE_UNINSTALLED)
         {
             throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location + ") is uninstalled");

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -268,10 +268,10 @@ namespace cppmicroservices
         return lock;
     }
 
-    std::unique_ptr<stoppedStruct>
+    std::unique_ptr<BlockFrameworkShutdown>
     CoreBundleContext::GetFrameworkStopped() const
     {
         ReadLock lock(stoppedLock);
-        return std::make_unique<stoppedStruct>(stopped, std::move(lock));
+        return std::make_unique<BlockFrameworkShutdown>(stopped, std::move(lock));
     }
 } // namespace cppmicroservices

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -253,7 +253,7 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::SetFrameworkStopped()
+    CoreBundleContext::BlockForFrameworkShutdown()
     {
         WriteLock lock(stoppedLock);
         stopped = true;
@@ -261,7 +261,7 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::SetFrameworkStarted()
+    CoreBundleContext::BlockForFrameworkStartup()
     {
         WriteLock lock(stoppedLock);
         stopped = false;
@@ -269,7 +269,7 @@ namespace cppmicroservices
     }
 
     std::unique_ptr<BlockFrameworkShutdown>
-    CoreBundleContext::GetFrameworkStopped() const
+    CoreBundleContext::StopFrameworkFromShuttingDown() const
     {
         ReadLock lock(stoppedLock);
         return std::make_unique<BlockFrameworkShutdown>(stopped, std::move(lock));

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -261,7 +261,7 @@ namespace cppmicroservices
     }
 
     std::unique_ptr<FrameworkShutdownBlocker>
-    CoreBundleContext::BlockFrameworkShutdown() const
+    CoreBundleContext::GetFrameworkStateAndBlock() const
     {
         ReadLock lock(stoppedLock);
         return std::make_unique<FrameworkShutdownBlocker>(stopped, std::move(lock));

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -94,6 +94,7 @@ namespace cppmicroservices
         , firstInit(true)
         , initCount(0)
         , libraryLoadOptions(0)
+        , stopped(false)
     {
         auto enableDiagLog = any_cast<bool>(frameworkProperties.at(Constants::FRAMEWORK_LOG));
         std::ostream* diagnosticLogger = (diagLogger) ? diagLogger : &std::clog;
@@ -249,5 +250,17 @@ namespace cppmicroservices
             return dataStorage + util::DIR_SEP + util::ToString(id);
         }
         return std::string();
+    }
+
+    void CoreBundleContext::StopFramework() {
+        this->self.Lock(), stopped = true;
+    }
+
+    void CoreBundleContext::StartFramework() {
+        this->self.Lock(), stopped = false;
+    }
+
+    bool CoreBundleContext::FrameworkStopped() const {
+        return this->self.Lock(), stopped;
     }
 } // namespace cppmicroservices

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -253,7 +253,7 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::BlockForFrameworkShutdown()
+    CoreBundleContext::BlockWhileFrameworkShutdown()
     {
         WriteLock lock(stoppedLock);
         stopped = true;
@@ -261,17 +261,17 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::BlockForFrameworkStartup()
+    CoreBundleContext::BlockWhileFrameworkStartup()
     {
         WriteLock lock(stoppedLock);
         stopped = false;
         return lock;
     }
 
-    std::unique_ptr<BlockFrameworkShutdown>
-    CoreBundleContext::StopFrameworkFromShuttingDown() const
+    std::unique_ptr<FrameworkShutdownBlocker>
+    CoreBundleContext::BlockFrameworkShutdown() const
     {
         ReadLock lock(stoppedLock);
-        return std::make_unique<BlockFrameworkShutdown>(stopped, std::move(lock));
+        return std::make_unique<FrameworkShutdownBlocker>(stopped, std::move(lock));
     }
 } // namespace cppmicroservices

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -253,18 +253,10 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::BlockDuringFrameworkShutdown()
+    CoreBundleContext::SetFrameworkStateAndBlockUntilComplete(bool desiredState)
     {
         WriteLock lock(stoppedLock);
-        stopped = true;
-        return lock;
-    }
-
-    WriteLock
-    CoreBundleContext::BlockDuringFrameworkStartup()
-    {
-        WriteLock lock(stoppedLock);
-        stopped = false;
+        stopped = desiredState;
         return lock;
     }
 

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -253,7 +253,7 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::BlockWhileFrameworkShutdown()
+    CoreBundleContext::BlockDuringFrameworkShutdown()
     {
         WriteLock lock(stoppedLock);
         stopped = true;
@@ -261,7 +261,7 @@ namespace cppmicroservices
     }
 
     WriteLock
-    CoreBundleContext::BlockWhileFrameworkStartup()
+    CoreBundleContext::BlockDuringFrameworkStartup()
     {
         WriteLock lock(stoppedLock);
         stopped = false;

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -65,12 +65,12 @@ namespace cppmicroservices
     using WriteLock = std::unique_lock<shared_lock>;
     using ReadLock = std::shared_lock<shared_lock>;
 
-    struct stoppedStruct
+    struct BlockFrameworkShutdown
     {
-        bool stopped;
+        bool frameworkHasStopped;
         ReadLock lock;
 
-        stoppedStruct(bool s, ReadLock l) : stopped(s), lock(std::move(l)) {}
+        BlockFrameworkShutdown(bool s, ReadLock l) : frameworkHasStopped(s), lock(std::move(l)) {}
     };
 
     struct BundleStorage;
@@ -203,7 +203,7 @@ namespace cppmicroservices
 
         WriteLock SetFrameworkStarted();
 
-        std::unique_ptr<stoppedStruct> GetFrameworkStopped() const;
+        std::unique_ptr<BlockFrameworkShutdown> GetFrameworkStopped() const;
         /**
          * Get private bundle data storage file handle.
          *

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -187,6 +187,11 @@ namespace cppmicroservices
 
         void Uninit1();
 
+        void StopFramework();
+
+        void StartFramework();
+
+        bool FrameworkStopped() const;
         /**
          * Get private bundle data storage file handle.
          *
@@ -197,6 +202,7 @@ namespace cppmicroservices
         // The core context is exclusively constructed by the FrameworkFactory class
         friend class FrameworkFactory;
 
+        bool stopped;
         /**
          * Construct a core context
          *

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -199,20 +199,12 @@ namespace cppmicroservices
         void Uninit1();
 
         /**
-         * Called when framework shutdown has begun.
+         * Called when framework shutdown/startup has begun.
          * This blocks (while returned object is held):
          *     - other calls to start or stop the framework
          *     - calls to start bundles
          */
-        WriteLock BlockDuringFrameworkShutdown();
-
-        /**
-         * Called when framework startup has begun.
-         * This blocks (while returned object is held):
-         *     - other calls to start or stop the framework
-         *     - calls to start bundles
-         */
-        WriteLock BlockDuringFrameworkStartup();
+        WriteLock SetFrameworkStateAndBlockUntilComplete(bool desiredState);
 
         /**
          * Called when bundle startup is occuring

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -213,7 +213,7 @@ namespace cppmicroservices
          * And allows:
          *    - concurrent calls for bundle startup on other bundles
          */
-        std::unique_ptr<FrameworkShutdownBlocker> BlockFrameworkShutdown() const;
+        std::unique_ptr<FrameworkShutdownBlocker> GetFrameworkStateAndBlock() const;
 
         /**
          * Get private bundle data storage file handle.

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -199,22 +199,27 @@ namespace cppmicroservices
         void Uninit1();
 
         /**
-         * Called when framework shutdown has started.
-         * This blocks other calls to start or stop the framework as well as
-         * calls to start bundles as long as returned object is held.
+         * Called when framework shutdown has begun.
+         * This blocks (while returned object is held):
+         *     - other calls to start or stop the framework
+         *     - calls to start bundles
          */
-        WriteLock BlockWhileFrameworkShutdown();
+        WriteLock BlockDuringFrameworkShutdown();
 
         /**
-         * Called when framework is started.
-         * This blocks other calls to start or stop the framework as well as
-         * calls to start bundles as long as returned object is held.
+         * Called when framework startup has begun.
+         * This blocks (while returned object is held):
+         *     - other calls to start or stop the framework
+         *     - calls to start bundles
          */
-        WriteLock BlockWhileFrameworkStartup();
+        WriteLock BlockDuringFrameworkStartup();
 
         /**
-         * Blocks the framework from starting or shutting down while
-         * the returned object is held
+         * Called when bundle startup is occuring
+         * This blocks (while returned object is held):
+         *    - calls to start or stop the framework
+         * And allows:
+         *    - concurrent calls for bundle startup on other bundles
          */
         std::unique_ptr<FrameworkShutdownBlocker> BlockFrameworkShutdown() const;
 
@@ -228,12 +233,13 @@ namespace cppmicroservices
         // The core context is exclusively constructed by the FrameworkFactory class
         friend class FrameworkFactory;
 
-        // Mutex required to be held when changing stopped. 
+        // Mutex required to be held when changing stopped.
         // ReadLock or WriteLock construction is done using this mutex.
         mutable std::shared_mutex stoppedLock;
 
-        // Flag for whether the Framework has been stopped. Seee mutex stoppedLock
+        // Flag for whether the Framework has been stopped. See mutex stoppedLock
         bool stopped;
+
         /**
          * Construct a core context
          *

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,7 +146,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->SetFrameworkStopped();
+        auto writerLock = coreCtx->BlockForFrameworkShutdown();
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -184,7 +184,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
-            auto writerLock = coreCtx->SetFrameworkStarted();
+            auto writerLock = coreCtx->BlockForFrameworkStartup();
 
             switch (state.load())
             {

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,7 +146,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->BlockDuringFrameworkShutdown();
+        auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -184,7 +184,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
-            auto writerLock = coreCtx->BlockDuringFrameworkStartup();
+            auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(false);
 
             switch (state.load())
             {

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,6 +146,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
+        auto writerLock = coreCtx->SetFrameworkStopped();
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -167,7 +168,6 @@ namespace cppmicroservices
 #else
                 Shutdown0(restart, wa);
 #endif
-                coreCtx->StopFramework();
                 break;
             }
             case Bundle::STATE_UNINSTALLED:
@@ -184,6 +184,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
+            auto writerLock = coreCtx->SetFrameworkStarted();
 
             switch (state.load())
             {
@@ -199,10 +200,10 @@ namespace cppmicroservices
                 default:
                     std::stringstream ss;
                     ss << state;
+
                     throw std::runtime_error("INTERNAL ERROR, Illegal state, " + ss.str());
             }
             bundlesToStart = coreCtx->storage->GetStartOnLaunchBundles();
-            coreCtx->StartFramework();
         }
 
         // Start bundles according to their autostart setting.

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -93,7 +93,9 @@ namespace cppmicroservices
     {
         auto bc = bundleContext.Exchange(std::shared_ptr<BundleContextPrivate>());
         if (bc)
+        {
             bc->Invalidate();
+        }
     }
 
     FrameworkEvent
@@ -165,6 +167,7 @@ namespace cppmicroservices
 #else
                 Shutdown0(restart, wa);
 #endif
+                coreCtx->StopFramework();
                 break;
             }
             case Bundle::STATE_UNINSTALLED:
@@ -199,6 +202,7 @@ namespace cppmicroservices
                     throw std::runtime_error("INTERNAL ERROR, Illegal state, " + ss.str());
             }
             bundlesToStart = coreCtx->storage->GetStartOnLaunchBundles();
+            coreCtx->StartFramework();
         }
 
         // Start bundles according to their autostart setting.
@@ -207,7 +211,7 @@ namespace cppmicroservices
             auto b = coreCtx->bundleRegistry.GetBundle(i);
             try
             {
-                const int32_t autostartSetting = b->barchive->GetAutostartSetting();
+                int32_t const autostartSetting = b->barchive->GetAutostartSetting();
                 // Launch must not change the autostart setting of a bundle
                 int option = Bundle::START_TRANSIENT;
                 if (Bundle::START_ACTIVATION_POLICY == autostartSetting)

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,7 +146,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->BlockForFrameworkShutdown();
+        auto writerLock = coreCtx->BlockWhileFrameworkShutdown();
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -184,7 +184,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
-            auto writerLock = coreCtx->BlockForFrameworkStartup();
+            auto writerLock = coreCtx->BlockWhileFrameworkStartup();
 
             switch (state.load())
             {

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,7 +146,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->BlockWhileFrameworkShutdown();
+        auto writerLock = coreCtx->BlockDuringFrameworkShutdown();
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -184,7 +184,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
-            auto writerLock = coreCtx->BlockWhileFrameworkStartup();
+            auto writerLock = coreCtx->BlockDuringFrameworkStartup();
 
             switch (state.load())
             {

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -77,7 +77,7 @@ namespace
       public:
         MOCK_METHOD2(Log, void(cppmicroservices::logservice::SeverityLevel, std::string const&));
         MOCK_METHOD3(Log,
-                     void(cppmicroservices::logservice::SeverityLevel, std::string const&, const std::exception_ptr));
+                     void(cppmicroservices::logservice::SeverityLevel, std::string const&, std::exception_ptr const));
         MOCK_METHOD3(Log,
                      void(cppmicroservices::ServiceReferenceBase const&,
                           cppmicroservices::logservice::SeverityLevel,
@@ -86,7 +86,7 @@ namespace
                      void(cppmicroservices::ServiceReferenceBase const&,
                           cppmicroservices::logservice::SeverityLevel,
                           std::string const&,
-                          const std::exception_ptr));
+                          std::exception_ptr const));
     };
 } // namespace
 
@@ -290,7 +290,7 @@ TEST(FrameworkTest, FrameworkStartsWhenFileNamedDataExistsInTempDir)
             file << "test";
             file.close();
         }
-        const std::string filePath;
+        std::string const filePath;
     };
 
     auto frameworkStorage = MakeUniqueTempDirectory();
@@ -460,7 +460,9 @@ TEST(Framework, LifeCycle)
             auto ev = f.WaitForStop(std::chrono::seconds(10));
             ASSERT_TRUE(ev); // "Test for valid framework event returned by Framework::WaitForStop()"
             if (!ev && ev.GetType() == FrameworkEvent::Type::FRAMEWORK_ERROR)
+            {
                 std::rethrow_exception(ev.GetThrowable());
+            }
             ASSERT_EQ(ev.GetType(),
                       FrameworkEvent::Type::FRAMEWORK_STOPPED); // "Check that framework event is stopped"
         });
@@ -477,6 +479,21 @@ TEST(Framework, LifeCycle)
               Bundle::STATE_ACTIVE); // "Check framework is not active"
 }
 
+TEST(Framework, BundleStartAfterFrameworkStop)
+{
+    auto f = FrameworkFactory().NewFramework();
+    f.Start();
+    f.Stop();
+#if defined(US_BUILD_SHARED_LIBS)
+    auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA");
+#else
+    auto bundle = cppmicroservices::testing::GetBundle("TestBundleA", f.GetBundleContext());
+#endif
+    ASSERT_TRUE(bundle); // "Non-null bundle"
+    ASSERT_THROW(bundle.Start(), std::runtime_error);
+
+}
+
 #ifdef US_ENABLE_THREADING_SUPPORT
 
 TEST(FrameworkTest, ConcurrentFrameworkStart)
@@ -489,7 +506,9 @@ TEST(FrameworkTest, ConcurrentFrameworkStart)
         [&start_count](FrameworkEvent const& ev)
         {
             if (FrameworkEvent::Type::FRAMEWORK_STARTED == ev.GetType())
+            {
                 ++start_count;
+            }
         });
     size_t num_threads { 100 };
     std::vector<std::thread> threads;
@@ -499,7 +518,9 @@ TEST(FrameworkTest, ConcurrentFrameworkStart)
     }
 
     for (auto& t : threads)
+    {
         t.join();
+    }
 
     // To test that the correct FrameworkEvent is returned, we must guarantee that the Framework
     // is in a STARTING, ACTIVE, or STOPPING state.
@@ -553,7 +574,9 @@ TEST(FrameworkTest, ConcurrentFrameworkStop)
     }
 
     for (auto& t : threads)
+    {
         t.join();
+    }
     waitForStopThread.join();
 }
 
@@ -758,7 +781,6 @@ TEST(FrameworkTest, ShutdownAndStart)
 
 TEST(FrameworkTest, ConfigurationWithBundleValidation)
 {
-
     using validationFuncType = std::function<bool(cppmicroservices::Bundle const&)>;
 
     validationFuncType validationFunc = [](cppmicroservices::Bundle const&) -> bool { return false; };
@@ -785,8 +807,8 @@ TEST(FrameworkTest, ConfigurationWithBundleValidation)
     ASSERT_TRUE(!isBundleValid);
 
     // exercise cppmicroservices::Any partial template specializations for std::function<bool(const
-    // cppmicroservices::Bundle&)> There is no string/json representation of a std::function, so these should be empty
-    // strings.
+    // cppmicroservices::Bundle&)> There is no string/json representation of a std::function, so these should be
+    // empty strings.
     ASSERT_TRUE(func.ToStringNoExcept().empty());
     ASSERT_TRUE(func.ToJSON().empty());
 

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -483,15 +483,17 @@ TEST(Framework, BundleStartAfterFrameworkStop)
 {
     auto f = FrameworkFactory().NewFramework();
     f.Start();
-    f.Stop();
+
 #if defined(US_BUILD_SHARED_LIBS)
     auto bundle = cppmicroservices::testing::InstallLib(f.GetBundleContext(), "TestBundleA");
 #else
     auto bundle = cppmicroservices::testing::GetBundle("TestBundleA", f.GetBundleContext());
 #endif
     ASSERT_TRUE(bundle); // "Non-null bundle"
-    ASSERT_THROW(bundle.Start(), std::runtime_error);
 
+    f.Stop();
+    f.WaitForStop(std::chrono::milliseconds::zero());
+    ASSERT_THROW(bundle.Start(), std::runtime_error);
 }
 
 #ifdef US_ENABLE_THREADING_SUPPORT


### PR DESCRIPTION
According to the OSGi [spec](https://docs.osgi.org/specification/osgi.core/8.0.0/framework.api.html#org.osgi.framework.Bundle.start-int-), we must throw if the framework has been stopped when bundle.Start() is called. 