### PR TITLE
Bundle Start after Framework Stop race fix

### DIFF
--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -146,7 +146,6 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -295,6 +294,7 @@ namespace cppmicroservices
             {
                 auto l = Lock();
                 US_UNUSED(l);
+                auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
                 coreCtx->Uninit1();
                 ShutdownDone_unlocked(restart);
             }

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -286,21 +286,17 @@ namespace cppmicroservices
                 state = Bundle::STATE_STOPPING;
             }
 
-            {
-                // after BundleChanged notifications are sent out, we want to mark the framework as stopped, even if
-                // there is a security exception thrown by the user callback
-                detail::ScopeGuard sg([this]()
-                                      { auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true); });
-
-                coreCtx->listeners.BundleChanged(
-                    BundleEvent(BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
-            }
+            coreCtx->listeners.BundleChanged(
+                BundleEvent(BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
 
             if (wasActive)
             {
                 StopAllBundles();
             }
-            coreCtx->Uninit0();
+            {
+                auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
+                coreCtx->Uninit0();
+            }
             {
                 auto l = Lock();
                 US_UNUSED(l);

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -25,7 +25,6 @@ limitations under the License.
 #include "cppmicroservices/BundleEvent.h"
 #include "cppmicroservices/Framework.h"
 #include "cppmicroservices/FrameworkEvent.h"
-#include "cppmicroservices/detail/ScopeGuard.h"
 
 #include "BundleContextPrivate.h"
 #include "BundleStorage.h"
@@ -285,10 +284,8 @@ namespace cppmicroservices
                 operation = OP_DEACTIVATING;
                 state = Bundle::STATE_STOPPING;
             }
-
             coreCtx->listeners.BundleChanged(
                 BundleEvent(BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
-
             if (wasActive)
             {
                 StopAllBundles();


### PR DESCRIPTION
We were setting the bundle stopping value prior to the async call to notify the listeners for a config event. So the framework was being marked as stopped before a listener was alerted. Now, that is done after the call to notify listeners. 