### PR TITLE
Add CMake option and associated miniz changes to facilitate deterministic bundle builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,7 @@ if(MSVC)
   # Allow forcing of bundle builds to be deterministic
   if (US_USE_DETERMINISTIC_BUNDLE_BUILDS)
     set(US_CXX_FLAGS "${US_CXX_FLAGS} -DUS_DETERMINISTIC_MINIZ_ZIP_FILES")
+    set(US_C_FLAGS "${US_C_FLAGS} -DUS_DETERMINISTIC_MINIZ_ZIP_FILES")
   endif()
 
   # Since we are compiling with boost, there exists some code which looks
@@ -547,6 +548,11 @@ else()
 
   if(US_COMPILER_APPLE_CLANG AND US_USE_DETERMINISTIC_BUNDLE_BUILDS)
     set(ENV{ZERO_AR_DATE} 1)
+  endif()
+
+  if(NOT MSVC)
+    set(US_CXX_FLAGS "${US_CXX_FLAGS} -DUS_DETERMINISTIC_MINIZ_ZIP_FILES")
+    set(US_C_FLAGS "${US_C_FLAGS} -DUS_DETERMINISTIC_MINIZ_ZIP_FILES")
   endif()
 
   if(US_COMPILER_GNU_ARM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ us_cache_var(US_BUILD_TESTING OFF BOOL "Build tests")
 us_cache_var(US_BUILD_EXAMPLES OFF BOOL "Build example projects")
 us_cache_var(US_USE_SYSTEM_GTEST OFF BOOL "Build using an external GTest installation" ADVANCED)
 us_cache_var(US_USE_SYSTEM_BOOST OFF BOOL "Build using an external Boost installation" ADVANCED)
-us_cache_var(US_USE_DETERMINISTIC_BUNDLE_BUILDS ON BOOL "Build bundles deterministically" ADVANCED)
+us_cache_var(US_USE_DETERMINISTIC_BUNDLE_BUILDS OFF BOOL "Build bundles deterministically" ADVANCED)
 
 set(_us_build_shared ${BUILD_SHARED_LIBS})
 
@@ -546,6 +546,8 @@ else()
     usFunctionCheckCompilerFlags(${_cxxflag} US_CXX_FLAGS)
   endforeach()
 
+  # Force clang compiler to use deterministic timestamp when linking
+  # shared libraries.
   if(US_COMPILER_APPLE_CLANG AND US_USE_DETERMINISTIC_BUNDLE_BUILDS)
     set(ENV{ZERO_AR_DATE} 1)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,9 @@ else()
     usFunctionCheckCompilerFlags(${_cxxflag} US_CXX_FLAGS)
   endforeach()
 
+  if(US_COMPILER_APPLE_CLANG AND US_USE_DETERMINISTIC_BUNDLE_BUILDS)
+    set(ENV{ZERO_AR_DATE} 1)
+  endif()
 
   if(US_COMPILER_GNU_ARM)
     # arm gcc warns that several reinterpret_cast need increased alignemnt in reinterpret_cast<>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ us_cache_var(US_BUILD_TESTING OFF BOOL "Build tests")
 us_cache_var(US_BUILD_EXAMPLES OFF BOOL "Build example projects")
 us_cache_var(US_USE_SYSTEM_GTEST OFF BOOL "Build using an external GTest installation" ADVANCED)
 us_cache_var(US_USE_SYSTEM_BOOST OFF BOOL "Build using an external Boost installation" ADVANCED)
-us_cache_var(US_USE_DETERMINISTIC_BUNDLE_BUILDS OFF BOOL "Build bundles deterministically" ADVANCED)
+us_cache_var(US_USE_DETERMINISTIC_BUNDLE_BUILDS ON BOOL "Build bundles deterministically" ADVANCED)
 
 set(_us_build_shared ${BUILD_SHARED_LIBS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ us_cache_var(US_BUILD_TESTING OFF BOOL "Build tests")
 us_cache_var(US_BUILD_EXAMPLES OFF BOOL "Build example projects")
 us_cache_var(US_USE_SYSTEM_GTEST OFF BOOL "Build using an external GTest installation" ADVANCED)
 us_cache_var(US_USE_SYSTEM_BOOST OFF BOOL "Build using an external Boost installation" ADVANCED)
+us_cache_var(US_USE_DETERMINISTIC_BUNDLE_BUILDS OFF BOOL "Build bundles deterministically" ADVANCED)
 
 set(_us_build_shared ${BUILD_SHARED_LIBS})
 
@@ -483,6 +484,11 @@ set(US_CXX_UBSAN_FLAGS "")
 set(US_UBSAN_LINK_FLAGS "")
 
 if(MSVC)
+  # Allow forcing of bundle builds to be deterministic
+  if (US_USE_DETERMINISTIC_BUNDLE_BUILDS)
+    set(US_CXX_FLAGS "${US_CXX_FLAGS} -DUS_DETERMINISTIC_MINIZ_ZIP_FILES")
+  endif()
+
   # Since we are compiling with boost, there exists some code which looks
   # at the value of this define. Since we previously did not specify the
   # define, boost assumed a value (0x0601, meaning Windows 7). We will
@@ -709,6 +715,12 @@ if(NOT MSVC)
 
   if (US_ENABLE_UBSAN AND US_CXX_UBSAN_FLAGS)
     set(US_UBSAN_LINK_FLAGS "-fsanitize=undefined")
+  endif()
+else()
+  # Force MSVC compiler to use deterministic timestamp when linking
+  # shared libraries.
+  if (US_USE_DETERMINISTIC_BUNDLE_BUILDS)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /Brepro" CACHE STRING "Forced shared linker flags" FORCE)
   endif()
 endif()
 

--- a/third_party/miniz.c
+++ b/third_party/miniz.c
@@ -3440,7 +3440,6 @@ static void mz_zip_time_t_to_dos_time(MZ_TIME_T time, mz_uint16 *pDOS_time, mz_u
 #else
     struct tm *tm = localtime(&time);
 #endif /* #ifdef _MSC_VER */
-
     *pDOS_time = (mz_uint16)(((tm->tm_hour) << 11) + ((tm->tm_min) << 5) + ((tm->tm_sec) >> 1));
     *pDOS_date = (mz_uint16)(((tm->tm_year + 1900 - 1980) << 9) + ((tm->tm_mon + 1) << 5) + tm->tm_mday);
 }

--- a/third_party/miniz.c
+++ b/third_party/miniz.c
@@ -6090,6 +6090,9 @@ static mz_bool mz_zip_writer_create_local_dir_header(mz_zip_archive *pZip, mz_ui
     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_VERSION_NEEDED_OFS, method ? 20 : 0);
     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_BIT_FLAG_OFS, bit_flags);
     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_METHOD_OFS, method);
+
+    // If US_DETERMINISTIC_MINIZ_ZIP_FILES is defined, set the time and date fields of the local
+    // directory header to a consistent value.
 #ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, 0);
     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, 0);
@@ -6117,6 +6120,9 @@ static mz_bool mz_zip_writer_create_central_dir_header(mz_zip_archive *pZip, mz_
     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);
+
+    // If US_DETERMINISTIC_MINIZ_ZIP_FILES is defined, set the time and date fields of the central
+    // directory header to a consistent value.
 #ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, 0);
     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, 0);

--- a/third_party/miniz.c
+++ b/third_party/miniz.c
@@ -3464,14 +3464,6 @@ static mz_bool mz_zip_get_file_modified_time(const char *pFilename, MZ_TIME_T *p
 
 static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_time, MZ_TIME_T modified_time)
 {
-#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
-    struct utimbuf t;
-    memset(&t, 0, sizeof(t));
-    t.actime = 0;
-    t.modtime = 0;
-
-    return !utime(pFilename, &t);
-#else
     struct utimbuf t;
 
     memset(&t, 0, sizeof(t));
@@ -3479,7 +3471,6 @@ static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_tim
     t.modtime = modified_time;
 
     return !utime(pFilename, &t);
-#endif
 }
 #endif /* #ifndef MINIZ_NO_STDIO */
 #endif /* #ifndef MINIZ_NO_TIME */
@@ -6502,17 +6493,10 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
                                                            (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
     }
 
-#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
-    if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
-                                          comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, 0, 0, local_dir_header_ofs, ext_attributes,
-                                          user_extra_data_central, user_extra_data_central_len))
-        return MZ_FALSE;
-#else
     if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
                                           comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
                                           user_extra_data_central, user_extra_data_central_len))
         return MZ_FALSE;
-#endif
 
     pZip->m_total_files++;
     pZip->m_archive_size = cur_archive_file_ofs;

--- a/third_party/patches/miniz_3.0.2.patch
+++ b/third_party/patches/miniz_3.0.2.patch
@@ -11,16 +11,39 @@
      mz_uint32 m_total_files;
 --- miniz_3.0.2/miniz.c
 +++ third_party/miniz.c
-@@ -3602,6 +3602,7 @@
+@@ -3464,6 +3464,14 @@
+
+ static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_time, MZ_TIME_T modified_time)
+ {
++#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
++    struct utimbuf t;
++    memset(&t, 0, sizeof(t));
++    t.actime = 0;
++    t.modtime = 0;
++
++    return !utime(pFilename, &t);
++#else
+     struct utimbuf t;
+
+     memset(&t, 0, sizeof(t));
+@@ -3471,6 +3479,7 @@
+     t.modtime = modified_time;
+
+     return !utime(pFilename, &t);
++#endif
+ }
+ #endif /* #ifndef MINIZ_NO_STDIO */
+ #endif /* #ifndef MINIZ_NO_TIME */
+@@ -3602,6 +3611,7 @@
      mz_int64 cur_file_ofs;
      mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
      mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
 +    mz_bool zip_signature_found = 0;
- 
+
      /* Basic sanity checks - reject files which are too small */
      if (pZip->m_archive_size < record_size)
-@@ -3618,25 +3619,28 @@
- 
+@@ -3618,25 +3628,28 @@
+
          for (i = n - 4; i >= 0; --i)
          {
 -            mz_uint s = MZ_READ_LE32(pBuf + i);
@@ -39,37 +62,37 @@
 +                break;
              }
          }
- 
+
 -        if (i >= 0)
 -        {
 +        if (zip_signature_found) {
              cur_file_ofs += i;
              break;
          }
- 
+
          /* Give up if we've searched the entire file, or we've gone back "too far" (~64kb) */
 -        if ((!cur_file_ofs) || ((pZip->m_archive_size - cur_file_ofs) >= (MZ_UINT16_MAX + record_size)))
 +        if ((!cur_file_ofs) || (cur_file_ofs < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE))
              return MZ_FALSE;
- 
+
 -        cur_file_ofs = MZ_MAX(cur_file_ofs - (sizeof(buf_u32) - 3), 0);
 +        cur_file_ofs = MZ_MAX(cur_file_ofs - (mz_int64)(sizeof(buf_u32) - 3), 0);
      }
- 
+
      *pOfs = cur_file_ofs;
-@@ -3701,7 +3705,7 @@
+@@ -3701,7 +3714,7 @@
      num_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_THIS_DISK_OFS);
      cdir_disk_index = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS);
      cdir_size = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_SIZE_OFS);
 -    cdir_ofs = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
 +    cdir_ofs = cur_file_ofs - cdir_size;
- 
+
      if (pZip->m_pState->m_zip64)
      {
-@@ -3755,6 +3759,10 @@
- 
+@@ -3755,6 +3768,10 @@
+
      pZip->m_central_directory_file_ofs = cdir_ofs;
- 
+
 +    pZip->m_archive_file_ofs = cdir_ofs - MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
 +    if (pZip->m_archive_file_ofs > pZip->m_archive_size)
 +        return MZ_FALSE;
@@ -77,7 +100,7 @@
      if (pZip->m_total_files)
      {
          mz_uint i, n;
-@@ -4048,13 +4056,12 @@
+@@ -4048,13 +4065,12 @@
      file_size = archive_size;
      if (!file_size)
      {
@@ -88,27 +111,73 @@
 +        if (0 != MZ_FILE_STAT(pFilename, &file_stat)) {
              return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
          }
- 
+
 -        file_size = MZ_FTELL64(pFile);
 +        file_size = file_stat.st_size;
      }
- 
+
      /* TODO: Better sanity check archive_size and the # of actual remaining bytes */
-@@ -4518,7 +4525,7 @@
+@@ -4518,7 +4534,7 @@
          return mz_zip_set_error(pZip, MZ_ZIP_BUF_TOO_SMALL);
- 
+
      /* Read and parse the local directory entry. */
 -    cur_file_ofs = file_stat.m_local_header_ofs;
 +    cur_file_ofs = pZip->m_archive_file_ofs + file_stat.m_local_header_ofs;
      if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
          return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
- 
-@@ -7040,7 +7047,7 @@
+
+@@ -6084,8 +6100,13 @@
+     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_VERSION_NEEDED_OFS, method ? 20 : 0);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_BIT_FLAG_OFS, bit_flags);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_METHOD_OFS, method);
++#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
++    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, 0);
++    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, 0);
++#else
+     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, dos_time);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, dos_date);
++#endif
+     MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_CRC32_OFS, uncomp_crc32);
+     MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
+     MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
+@@ -6106,8 +6127,13 @@
+     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);
++#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
++    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, 0);
++    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, 0);
++#else
+     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, dos_time);
+     MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, dos_date);
++#endif
+     MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_CRC32_OFS, uncomp_crc32);
+     MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
+     MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
+@@ -6476,10 +6502,17 @@
+                                                            (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+     }
+
++#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
++    if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
++                                          comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, 0, 0, local_dir_header_ofs, ext_attributes,
++                                          user_extra_data_central, user_extra_data_central_len))
++        return MZ_FALSE;
++#else
+     if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
+                                           comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
+                                           user_extra_data_central, user_extra_data_central_len))
+         return MZ_FALSE;
++#endif
+
+     pZip->m_total_files++;
+     pZip->m_archive_size = cur_archive_file_ofs;
+@@ -7040,7 +7073,7 @@
      if (!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, NULL))
          return MZ_FALSE;
- 
+
 -    cur_src_file_ofs = src_file_stat.m_local_header_ofs;
 +    cur_src_file_ofs = pSource_zip->m_archive_file_ofs + src_file_stat.m_local_header_ofs;
      cur_dst_file_ofs = pZip->m_archive_size;
- 
+
      /* Read the source archive's local dir header */

--- a/third_party/patches/miniz_3.0.2.patch
+++ b/third_party/patches/miniz_3.0.2.patch
@@ -11,39 +11,24 @@
      mz_uint32 m_total_files;
 --- miniz_3.0.2/miniz.c
 +++ third_party/miniz.c
-@@ -3464,6 +3464,14 @@
-
- static mz_bool mz_zip_set_file_times(const char *pFilename, MZ_TIME_T access_time, MZ_TIME_T modified_time)
- {
-+#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
-+    struct utimbuf t;
-+    memset(&t, 0, sizeof(t));
-+    t.actime = 0;
-+    t.modtime = 0;
-+
-+    return !utime(pFilename, &t);
-+#else
-     struct utimbuf t;
-
-     memset(&t, 0, sizeof(t));
-@@ -3471,6 +3479,7 @@
-     t.modtime = modified_time;
-
-     return !utime(pFilename, &t);
-+#endif
+@@ -3440,7 +3440,6 @@
+ #else
+     struct tm *tm = localtime(&time);
+ #endif /* #ifdef _MSC_VER */
+-
+     *pDOS_time = (mz_uint16)(((tm->tm_hour) << 11) + ((tm->tm_min) << 5) + ((tm->tm_sec) >> 1));
+     *pDOS_date = (mz_uint16)(((tm->tm_year + 1900 - 1980) << 9) + ((tm->tm_mon + 1) << 5) + tm->tm_mday);
  }
- #endif /* #ifndef MINIZ_NO_STDIO */
- #endif /* #ifndef MINIZ_NO_TIME */
-@@ -3602,6 +3611,7 @@
+@@ -3602,6 +3601,7 @@
      mz_int64 cur_file_ofs;
      mz_uint32 buf_u32[4096 / sizeof(mz_uint32)];
      mz_uint8 *pBuf = (mz_uint8 *)buf_u32;
 +    mz_bool zip_signature_found = 0;
-
+ 
      /* Basic sanity checks - reject files which are too small */
      if (pZip->m_archive_size < record_size)
-@@ -3618,25 +3628,28 @@
-
+@@ -3618,25 +3618,28 @@
+ 
          for (i = n - 4; i >= 0; --i)
          {
 -            mz_uint s = MZ_READ_LE32(pBuf + i);
@@ -62,37 +47,37 @@
 +                break;
              }
          }
-
+ 
 -        if (i >= 0)
 -        {
 +        if (zip_signature_found) {
              cur_file_ofs += i;
              break;
          }
-
+ 
          /* Give up if we've searched the entire file, or we've gone back "too far" (~64kb) */
 -        if ((!cur_file_ofs) || ((pZip->m_archive_size - cur_file_ofs) >= (MZ_UINT16_MAX + record_size)))
 +        if ((!cur_file_ofs) || (cur_file_ofs < MZ_ZIP_END_OF_CENTRAL_DIR_HEADER_SIZE))
              return MZ_FALSE;
-
+ 
 -        cur_file_ofs = MZ_MAX(cur_file_ofs - (sizeof(buf_u32) - 3), 0);
 +        cur_file_ofs = MZ_MAX(cur_file_ofs - (mz_int64)(sizeof(buf_u32) - 3), 0);
      }
-
+ 
      *pOfs = cur_file_ofs;
-@@ -3701,7 +3714,7 @@
+@@ -3701,7 +3704,7 @@
      num_this_disk = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_THIS_DISK_OFS);
      cdir_disk_index = MZ_READ_LE16(pBuf + MZ_ZIP_ECDH_NUM_DISK_CDIR_OFS);
      cdir_size = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_SIZE_OFS);
 -    cdir_ofs = MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
 +    cdir_ofs = cur_file_ofs - cdir_size;
-
+ 
      if (pZip->m_pState->m_zip64)
      {
-@@ -3755,6 +3768,10 @@
-
+@@ -3755,6 +3758,10 @@
+ 
      pZip->m_central_directory_file_ofs = cdir_ofs;
-
+ 
 +    pZip->m_archive_file_ofs = cdir_ofs - MZ_READ_LE32(pBuf + MZ_ZIP_ECDH_CDIR_OFS_OFS);
 +    if (pZip->m_archive_file_ofs > pZip->m_archive_size)
 +        return MZ_FALSE;
@@ -100,7 +85,7 @@
      if (pZip->m_total_files)
      {
          mz_uint i, n;
-@@ -4048,13 +4065,12 @@
+@@ -4048,13 +4055,12 @@
      file_size = archive_size;
      if (!file_size)
      {
@@ -111,39 +96,45 @@
 +        if (0 != MZ_FILE_STAT(pFilename, &file_stat)) {
              return mz_zip_set_error(pZip, MZ_ZIP_FILE_SEEK_FAILED);
          }
-
+ 
 -        file_size = MZ_FTELL64(pFile);
 +        file_size = file_stat.st_size;
      }
-
+ 
      /* TODO: Better sanity check archive_size and the # of actual remaining bytes */
-@@ -4518,7 +4534,7 @@
+@@ -4518,7 +4524,7 @@
          return mz_zip_set_error(pZip, MZ_ZIP_BUF_TOO_SMALL);
-
+ 
      /* Read and parse the local directory entry. */
 -    cur_file_ofs = file_stat.m_local_header_ofs;
 +    cur_file_ofs = pZip->m_archive_file_ofs + file_stat.m_local_header_ofs;
      if (pZip->m_pRead(pZip->m_pIO_opaque, cur_file_ofs, pLocal_header, MZ_ZIP_LOCAL_DIR_HEADER_SIZE) != MZ_ZIP_LOCAL_DIR_HEADER_SIZE)
          return mz_zip_set_error(pZip, MZ_ZIP_FILE_READ_FAILED);
-
-@@ -6084,8 +6100,13 @@
+ 
+@@ -6084,8 +6090,16 @@
      MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_VERSION_NEEDED_OFS, method ? 20 : 0);
      MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_BIT_FLAG_OFS, bit_flags);
      MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_METHOD_OFS, method);
++
++    // If US_DETERMINISTIC_MINIZ_ZIP_FILES is defined, set the time and date fields of the local
++    // directory header to a consistent value.
 +#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
 +    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, 0);
 +    MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, 0);
 +#else
      MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_TIME_OFS, dos_time);
      MZ_WRITE_LE16(pDst + MZ_ZIP_LDH_FILE_DATE_OFS, dos_date);
-+#endif
++#endif    
      MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_CRC32_OFS, uncomp_crc32);
      MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
      MZ_WRITE_LE32(pDst + MZ_ZIP_LDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
-@@ -6106,8 +6127,13 @@
+@@ -6106,8 +6120,16 @@
      MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
      MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
      MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);
++
++    // If US_DETERMINISTIC_MINIZ_ZIP_FILES is defined, set the time and date fields of the central
++    // directory header to a consistent value.
 +#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
 +    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_TIME_OFS, 0);
 +    MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_FILE_DATE_OFS, 0);
@@ -154,30 +145,12 @@
      MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_CRC32_OFS, uncomp_crc32);
      MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS, MZ_MIN(comp_size, MZ_UINT32_MAX));
      MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_MIN(uncomp_size, MZ_UINT32_MAX));
-@@ -6476,10 +6502,17 @@
-                                                            (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
-     }
-
-+#ifdef US_DETERMINISTIC_MINIZ_ZIP_FILES
-+    if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
-+                                          comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, 0, 0, local_dir_header_ofs, ext_attributes,
-+                                          user_extra_data_central, user_extra_data_central_len))
-+        return MZ_FALSE;
-+#else
-     if (!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, (mz_uint16)extra_size, pComment,
-                                           comment_size, uncomp_size, comp_size, uncomp_crc32, method, bit_flags, dos_time, dos_date, local_dir_header_ofs, ext_attributes,
-                                           user_extra_data_central, user_extra_data_central_len))
-         return MZ_FALSE;
-+#endif
-
-     pZip->m_total_files++;
-     pZip->m_archive_size = cur_archive_file_ofs;
-@@ -7040,7 +7073,7 @@
+@@ -7040,7 +7062,7 @@
      if (!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, NULL))
          return MZ_FALSE;
-
+ 
 -    cur_src_file_ofs = src_file_stat.m_local_header_ofs;
 +    cur_src_file_ofs = pSource_zip->m_archive_file_ofs + src_file_stat.m_local_header_ofs;
      cur_dst_file_ofs = pZip->m_archive_size;
-
+ 
      /* Read the source archive's local dir header */


### PR DESCRIPTION
Added support for:
- win64
- maci64
- glnxa64 (works without any changes since `ld` doesn't embed timestamps :) )

Manually verified MD5 hashes of binaries built across time.