### PR TITLE
Fix GetPathInfo

### DIFF
--- a/compendium/DeclarativeServices/test/TestUtils.cpp
+++ b/compendium/DeclarativeServices/test/TestUtils.cpp
@@ -59,11 +59,11 @@ namespace test
     GetPathInfo()
     {
         std::unordered_map<std::string, std::string> pathInfo = {
-            {     "libPath",             cppmicroservices::testing::LIB_PATH},
-            {      "dirSep", std::to_string(cppmicroservices::util::DIR_SEP)},
-            { "usLibPrefix",                                   US_LIB_PREFIX},
-            {"usLibPostfix",                                  US_LIB_POSTFIX},
-            {    "usLibExt",                                      US_LIB_EXT}
+            { "libPath", cppmicroservices::testing::LIB_PATH },
+            { "dirSep", std::string(1, cppmicroservices::util::DIR_SEP) },
+            { "usLibPrefix", US_LIB_PREFIX },
+            { "usLibPostfix", US_LIB_POSTFIX },
+            { "usLibExt", US_LIB_EXT }
         };
         return pathInfo;
     }


### PR DESCRIPTION
Need to use string constructor with const char (not const char*) as input -- this fix specifies the length of the char and the input