### PR TITLE
Fixed clang-tidy warnings

### DIFF
--- a/compendium/AsyncWorkService/include/cppmicroservices/asyncworkservice/AsyncWorkService.hpp
+++ b/compendium/AsyncWorkService/include/cppmicroservices/asyncworkservice/AsyncWorkService.hpp
@@ -19,8 +19,8 @@
   limitations under the License.
 
   =============================================================================*/
-#ifndef CPPMICROSERVICES_ASYNC_WORK_SERVICE_H__
-#define CPPMICROSERVICES_ASYNC_WORK_SERVICE_H__
+#ifndef CPPMICROSERVICES_ASYNC_WORK_SERVICE_HPP
+#define CPPMICROSERVICES_ASYNC_WORK_SERVICE_HPP
 
 #include "cppmicroservices/asyncworkservice/AsyncWorkServiceExport.h"
 
@@ -71,4 +71,4 @@ namespace cppmicroservices
     } // namespace async
 } // namespace cppmicroservices
 
-#endif // CPPMICROSERVICES_ASYNC_WORK_SERVICE_H__
+#endif // CPPMICROSERVICES_ASYNC_WORK_SERVICE_HPP

--- a/compendium/ConfigurationAdmin/src/CMAsyncWorkService.hpp
+++ b/compendium/ConfigurationAdmin/src/CMAsyncWorkService.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __CMASYNCWORKSERVICE_HPP__
-#define __CMASYNCWORKSERVICE_HPP__
+#ifndef CMASYNCWORKSERVICE_HPP
+#define CMASYNCWORKSERVICE_HPP
 
 #include "CMLogger.hpp"
 #include <cppmicroservices/ServiceTracker.h>

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENT_CONTEXT_IMPL_HPP__
-#define __COMPONENT_CONTEXT_IMPL_HPP__
+#ifndef COMPONENT_CONTEXT_IMPL_HPP
+#define COMPONENT_CONTEXT_IMPL_HPP
 
 #include <memory>
 #include <string>

--- a/compendium/DeclarativeServices/src/ComponentRegistry.hpp
+++ b/compendium/DeclarativeServices/src/ComponentRegistry.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENT_REGISTRY_HPP__
-#define __COMPONENT_REGISTRY_HPP__
+#ifndef COMPONENT_REGISTRY_HPP
+#define COMPONENT_REGISTRY_HPP
 
 #include "manager/ComponentManager.hpp"
 #include <memory>
@@ -129,4 +129,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif // __COMPONENT_REGISTRY_HPP__
+#endif // COMPONENT_REGISTRY_HPP

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SCRASYNCWORKSERVICE_HPP__
-#define __SCRASYNCWORKSERVICE_HPP__
+#ifndef SCRASYNCWORKSERVICE_HPP
+#define SCRASYNCWORKSERVICE_HPP
 
 #include "SCRLogger.hpp"
 #include <cppmicroservices/ServiceTracker.h>

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SCRBUNDLEEXTENSION_HPP__
-#define __SCRBUNDLEEXTENSION_HPP__
+#ifndef SCRBUNDLEEXTENSION_HPP
+#define SCRBUNDLEEXTENSION_HPP
 
 #include <memory>
 #if defined(USING_GTEST)
@@ -105,4 +105,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif // __SCRBUNDLEEXTENSION_HPP__
+#endif // SCRBUNDLEEXTENSION_HPP

--- a/compendium/DeclarativeServices/src/SCRExtensionRegistry.hpp
+++ b/compendium/DeclarativeServices/src/SCRExtensionRegistry.hpp
@@ -20,8 +20,8 @@
 
  =============================================================================*/
 
-#ifndef __CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__
-#define __CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__
+#ifndef CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP
+#define CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP
 
 #include "SCRBundleExtension.hpp"
 #include "cppmicroservices/logservice/LogService.hpp"
@@ -100,4 +100,4 @@ namespace cppmicroservices
 
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif //__CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP__
+#endif // CPPMICROSERVICES_SCRIMPL_SCREXTENSIONREGISTRY_HPP

--- a/compendium/DeclarativeServices/src/SCRLogger.hpp
+++ b/compendium/DeclarativeServices/src/SCRLogger.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SCRLOGGER_HPP__
-#define __SCRLOGGER_HPP__
+#ifndef SCRLOGGER_HPP
+#define SCRLOGGER_HPP
 #include <cppmicroservices/ServiceTracker.h>
 #include <cppmicroservices/logservice/LogService.hpp>
 
@@ -79,4 +79,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif // __SCRLOGGER_HPP__
+#endif // SCRLOGGER_HPP

--- a/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.hpp
+++ b/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SERVICECOMPONENTRUNTIMEIMPL_HPP__
-#define __SERVICECOMPONENTRUNTIMEIMPL_HPP__
+#ifndef SERVICECOMPONENTRUNTIMEIMPL_HPP
+#define SERVICECOMPONENTRUNTIMEIMPL_HPP
 
 #if defined(USING_GTEST)
 #    include "gtest/gtest_prod.h"
@@ -139,4 +139,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __SERVICECOMPONENTRUNTIMEIMPL_HPP__ */
+#endif /* SERVICECOMPONENTRUNTIMEIMPL_HPP */

--- a/compendium/DeclarativeServices/src/ServiceReferenceComparator.hpp
+++ b/compendium/DeclarativeServices/src/ServiceReferenceComparator.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SERVICEREFERENCECOMPARATOR_HPP__
-#define __SERVICEREFERENCECOMPARATOR_HPP__
+#ifndef SERVICEREFERENCECOMPARATOR_HPP
+#define SERVICEREFERENCECOMPARATOR_HPP
 
 #include "cppmicroservices/Constants.h"
 
@@ -64,4 +64,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __SERVICEREFERENCECOMPARATOR_HPP__ */
+#endif /* SERVICEREFERENCECOMPARATOR_HPP */

--- a/compendium/DeclarativeServices/src/manager/BundleLoader.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleLoader.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __BUNDLELOADER_HPP__
-#define __BUNDLELOADER_HPP__
+#ifndef BUNDLELOADER_HPP
+#define BUNDLELOADER_HPP
 
 #include "ConcurrencyUtil.hpp"
 #include "cppmicroservices/logservice/LogService.hpp"
@@ -57,4 +57,4 @@ namespace cppmicroservices
                                     std::shared_ptr<cppmicroservices::logservice::LogService> const& logger);
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif /* __BUNDLELOADER_HPP__ */
+#endif /* BUNDLELOADER_HPP */

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP__
-#define __BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP__
+#ifndef BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP
+#define BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP
 
 #include "ComponentConfigurationImpl.hpp"
 #include "ConcurrencyUtil.hpp"
@@ -126,4 +126,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif /* __BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP__ */
+#endif /* BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP */

--- a/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfiguration.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENTCONFIGURATION_HPP__
-#define __COMPONENTCONFIGURATION_HPP__
+#ifndef COMPONENTCONFIGURATION_HPP
+#define COMPONENTCONFIGURATION_HPP
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/ServiceReference.h"
 #include "cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp"
@@ -109,4 +109,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif /* __COMPONENTCONFIGURATION_HPP__ */
+#endif /* COMPONENTCONFIGURATION_HPP */

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationFactory.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENTCONFIGURATIONFACTORY_HPP__
-#define __COMPONENTCONFIGURATIONFACTORY_HPP__
+#ifndef COMPONENTCONFIGURATIONFACTORY_HPP
+#define COMPONENTCONFIGURATIONFACTORY_HPP
 
 #include "ComponentConfigurationImpl.hpp"
 #include "ConfigurationNotifier.hpp"
@@ -49,4 +49,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __COMPONENTCONFIGURATIONFACTORY_HPP__ */
+#endif /* COMPONENTCONFIGURATIONFACTORY_HPP */

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef COMPONENTCONFIGURATIONIMPL_HPP__
-#define COMPONENTCONFIGURATIONIMPL_HPP__
+#ifndef COMPONENTCONFIGURATIONIMPL_HPP
+#define COMPONENTCONFIGURATIONIMPL_HPP
 
 #include <memory>
 #if defined(USING_GTEST)
@@ -431,4 +431,4 @@ namespace cppmicroservices::scrimpl
                                         ///< class from the component's bundle
         };
     } // namespace cppmicroservices::scrimpl
-#endif /* COMPONENTCONFIGURATIONIMPL_HPP__ */
+#endif /* COMPONENTCONFIGURATIONIMPL_HPP */

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.hpp
@@ -20,8 +20,8 @@
 
  =============================================================================*/
 
-#ifndef CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP__
-#define CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP__
+#ifndef CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP
+#define CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP
 
 #include "../SCRLogger.hpp"
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
@@ -68,4 +68,4 @@ namespace cppmicroservices::scrimpl {
     };
 
 } // cppmicroservices::scrimpl namespace 
-#endif //__CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP__
+#endif //CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP

--- a/compendium/DeclarativeServices/src/manager/ComponentManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManager.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENTMANAGER_HPP__
-#define __COMPONENTMANAGER_HPP__
+#ifndef COMPONENTMANAGER_HPP
+#define COMPONENTMANAGER_HPP
 
 #include "../metadata/ComponentMetadata.hpp"
 #include "cppmicroservices/Bundle.h"
@@ -128,4 +128,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif // __COMPONENTMANAGER_HPP__
+#endif // COMPONENTMANAGER_HPP

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __COMPONENTMANAGERIMPL_HPP__
-#define __COMPONENTMANAGERIMPL_HPP__
+#ifndef COMPONENTMANAGERIMPL_HPP
+#define COMPONENTMANAGERIMPL_HPP
 
 #if defined(USING_GTEST)
 #    include "gtest/gtest_prod.h"
@@ -242,4 +242,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __COMPONENTMANAGERIMPL_HPP__ */
+#endif /* COMPONENTMANAGERIMPL_HPP */

--- a/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __CONCURRENCYUTIL_HPP__
-#define __CONCURRENCYUTIL_HPP__
+#ifndef CONCURRENCYUTIL_HPP
+#define CONCURRENCYUTIL_HPP
 
 #include <chrono>
 #include <future>
@@ -105,4 +105,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __CONCURRENCYUTIL_HPP__ */
+#endif /* CONCURRENCYUTIL_HPP */

--- a/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __CONFIGURATIONMANAGER_HPP__
-#define __CONFIGURATIONMANAGER_HPP__
+#ifndef CONFIGURATIONMANAGER_HPP
+#define CONFIGURATIONMANAGER_HPP
 
 #include "../metadata/ComponentMetadata.hpp"
 #include "ConcurrencyUtil.hpp"
@@ -106,4 +106,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif // __CONFIGURATIONMANAGER_HPP__
+#endif // CONFIGURATIONMANAGER_HPP

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
@@ -20,8 +20,8 @@
 
  =============================================================================*/
 
-#ifndef __CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP__
-#define __CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP__
+#ifndef CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP
+#define CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP
 
 #include "../SCRLogger.hpp"
 #include "ComponentFactoryImpl.hpp"
@@ -127,4 +127,4 @@ namespace cppmicroservices
 
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif //__CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP__
+#endif //CPPMICROSERVICES_SCRIMPL_CONFIGURATIONNOTIFIER_HPP

--- a/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManager.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __REFERENCEMANAGER_HPP__
-#define __REFERENCEMANAGER_HPP__
+#ifndef REFERENCEMANAGER_HPP
+#define REFERENCEMANAGER_HPP
 
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/ServiceTracker.h"
@@ -156,4 +156,4 @@ namespace cppmicroservices
         };
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif // __REFERENCEMANAGER_HPP__
+#endif // REFERENCEMANAGER_HPP

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __REFERENCEMANAGERIMPL_HPP__
-#define __REFERENCEMANAGERIMPL_HPP__
+#ifndef REFERENCEMANAGERIMPL_HPP
+#define REFERENCEMANAGERIMPL_HPP
 
 #include <mutex>
 
@@ -315,4 +315,4 @@ namespace cppmicroservices
 
     } // namespace scrimpl
 } // namespace cppmicroservices
-#endif // __REFERENCEMANAGERIMPL_HPP__
+#endif // REFERENCEMANAGERIMPL_HPP

--- a/compendium/DeclarativeServices/src/manager/RegistrationManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/RegistrationManager.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __REGISTRATION_MANAGER_HPP__
-#define __REGISTRATION_MANAGER_HPP__
+#ifndef REGISTRATION_MANAGER_HPP
+#define REGISTRATION_MANAGER_HPP
 #if defined(USING_GTEST)
 #    include "gtest/gtest_prod.h"
 #else
@@ -132,4 +132,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif // __REGISTRATION_MANAGER_HPP__
+#endif // REGISTRATION_MANAGER_HPP

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -20,8 +20,8 @@
 
   =============================================================================*/
 
-#ifndef __SINGLETONCOMPONENTCONFIGURATION_HPP__
-#define __SINGLETONCOMPONENTCONFIGURATION_HPP__
+#ifndef SINGLETONCOMPONENTCONFIGURATION_HPP
+#define SINGLETONCOMPONENTCONFIGURATION_HPP
 
 #include "ComponentConfigurationImpl.hpp"
 #include "ConcurrencyUtil.hpp"
@@ -147,4 +147,4 @@ namespace cppmicroservices
     } // namespace scrimpl
 } // namespace cppmicroservices
 
-#endif /* __SINGLETONCOMPONENTCONFIGURATION_HPP__ */
+#endif /* SINGLETONCOMPONENTCONFIGURATION_HPP */


### PR DESCRIPTION
Fix warnings related to the [bugprone-reserved-identifier] rule