### PR TITLE
Fix RemoveFromBoundServicesCache to handle invalid service objects

### DIFF
--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -409,6 +409,10 @@ namespace cppmicroservices
             cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(ServiceReferenceU(sRef));
 
             auto const removedService = sObjs.GetService();
+            if (!removedService)
+            {
+                return;
+            }
             auto const& serviceInterface = removedService->begin()->first;
             auto boundServicesCacheHandle = boundServicesCache.lock();
             auto& services = boundServicesCacheHandle->at(refName);


### PR DESCRIPTION
If an invalid ServiceObject is returned from `bc.GetServiceObjects`, calling GetService will return an invalid service. If we see this, we should not continue to removeFromBoundServicesCache. 