### PR TITLE
Test Case for Race Condition in Config Notifier

### DIFF
--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -125,6 +125,7 @@ namespace cppmicroservices
             FRIEND_TEST(ConfigAdminComponentCreationRace, TestModifiedIsNeverCalled);
             FRIEND_TEST(ConfigAdminComponentCreationRace, TestMultipleConfigsNoModifiedCall);
             FRIEND_TEST(ConfigAdminComponentCreationRace, TestMultipleConfigsModifiedCalled);
+            FRIEND_TEST(ConfigAdminComponentCreationRace, TestConfigNotifierSafeWithNoListenersForPid);
 
             /**
              * Set the member data, only used in tests

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -1125,7 +1125,7 @@ namespace cppmicroservices
 
             auto bundleT = std::thread([&compConfig]() { compConfig->Initialize(); });
             auto frameworkT = std::thread(
-                [configAdminService=configAdminService]()
+                [configAdminService = configAdminService]()
                 {
                     auto configuration = configAdminService->GetConfiguration("sample::config");
                     auto fut = configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
@@ -1191,7 +1191,7 @@ namespace cppmicroservices
 
             auto bundleT = std::thread([&compConfig]() { compConfig->Initialize(); });
             auto frameworkT = std::thread(
-                [configAdminService=configAdminService]()
+                [configAdminService = configAdminService]()
                 {
                     auto configuration = configAdminService->GetConfiguration("sample::config");
                     auto fut = configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
@@ -1359,7 +1359,7 @@ namespace cppmicroservices
 
             auto frameworkT = std::async(
                 std::launch::async,
-                [configAdminService=configAdminService, &sync_point]()
+                [configAdminService = configAdminService, &sync_point]()
                 {
                     sync_point.Wait(); // Wait for all threads to reach this point
                     auto configuration = configAdminService->GetConfiguration("sample::config");
@@ -1409,6 +1409,18 @@ namespace cppmicroservices
             bundleT1.wait();
             bundleT2.wait();
             bundleT3.wait();
+
+            compConfig->Deactivate();
+            compConfig->Stop();
+
+            compConfig1->Deactivate();
+            compConfig1->Stop();
+
+            compConfig2->Deactivate();
+            compConfig2->Stop();
+
+            compConfig3->Deactivate();
+            compConfig3->Stop();
 
             framework.Stop();
             framework.WaitForStop(std::chrono::milliseconds::zero());

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -1126,7 +1126,7 @@ namespace cppmicroservices
 
             auto bundleT = std::thread([&compConfig]() { compConfig->Initialize(); });
             auto frameworkT = std::thread(
-                [&configAdminService]()
+                [configAdminService=configAdminService]()
                 {
                     auto configuration = configAdminService->GetConfiguration("sample::config");
                     auto fut = configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
@@ -1140,6 +1140,9 @@ namespace cppmicroservices
 
             compConfig->Deactivate();
             compConfig->Stop();
+
+            framework.Stop();
+            framework.WaitForStop(std::chrono::milliseconds::zero());
         }
 
         /**
@@ -1189,7 +1192,7 @@ namespace cppmicroservices
 
             auto bundleT = std::thread([&compConfig]() { compConfig->Initialize(); });
             auto frameworkT = std::thread(
-                [&configAdminService]()
+                [configAdminService=configAdminService]()
                 {
                     auto configuration = configAdminService->GetConfiguration("sample::config");
                     auto fut = configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
@@ -1357,7 +1360,7 @@ namespace cppmicroservices
 
             auto frameworkT = std::async(
                 std::launch::async,
-                [&configAdminService, &sync_point]()
+                [configAdminService=configAdminService, &sync_point]()
                 {
                     sync_point.Wait(); // Wait for all threads to reach this point
                     auto configuration = configAdminService->GetConfiguration("sample::config");
@@ -1407,6 +1410,9 @@ namespace cppmicroservices
             bundleT1.wait();
             bundleT2.wait();
             bundleT3.wait();
+
+            framework.Stop();
+            framework.WaitForStop(std::chrono::milliseconds::zero());
         }
 #endif
     } // namespace scrimpl

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -1045,7 +1045,6 @@ namespace cppmicroservices
                    std::shared_ptr<metadata::ComponentMetadata>,
                    std::shared_ptr<MockComponentRegistry>,
                    std::shared_ptr<FakeLogger>,
-                   std::shared_ptr<SCRLogger>,
                    std::shared_ptr<ConfigurationNotifier>,
                    std::shared_ptr<cppmicroservices::service::cm::ConfigurationAdmin>>
         mySetUp()
@@ -1091,7 +1090,7 @@ namespace cppmicroservices
                 = frameworkContext.GetServiceReference<cppmicroservices::service::cm::ConfigurationAdmin>();
             auto configAdminService = frameworkContext.GetService(configAdminServiceRef);
 
-            return { framework, compMetadata, mockRegistry, fakeLogger, logger, notifier, configAdminService };
+            return { framework, compMetadata, mockRegistry, fakeLogger, notifier, configAdminService };
         }
         /**
          * Test that the Modified method on a component configuration that is
@@ -1101,7 +1100,7 @@ namespace cppmicroservices
          */
         TEST(ConfigAdminComponentCreationRace, TestModifiedIsNeverCalled)
         {
-            auto [framework, compMetadata, mockRegistry, fakeLogger, logger, notifier, configAdminService] = mySetUp();
+            auto [framework, compMetadata, mockRegistry, fakeLogger, notifier, configAdminService] = mySetUp();
             compMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             compMetadata->immediate = true;
             compMetadata->configurationPolicy = "require";
@@ -1153,7 +1152,7 @@ namespace cppmicroservices
          */
         TEST(ConfigAdminComponentCreationRace, TestMultipleConfigsNoModifiedCall)
         {
-            auto [framework, compMetadata, mockRegistry, fakeLogger, logger, notifier, configAdminService] = mySetUp();
+            auto [framework, compMetadata, mockRegistry, fakeLogger, notifier, configAdminService] = mySetUp();
 
             compMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             compMetadata->immediate = true;
@@ -1219,7 +1218,7 @@ namespace cppmicroservices
          */
         TEST(ConfigAdminComponentCreationRace, TestMultipleConfigsModifiedCalled)
         {
-            auto [framework, compMetadata, mockRegistry, fakeLogger, logger, notifier, configAdminService] = mySetUp();
+            auto [framework, compMetadata, mockRegistry, fakeLogger, notifier, configAdminService] = mySetUp();
 
             compMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             compMetadata->immediate = true;
@@ -1310,7 +1309,7 @@ namespace cppmicroservices
          */
         TEST(ConfigAdminComponentCreationRace, TestConfigNotifierSafeWithNoListenersForPid)
         {
-            auto [framework, compMetadata, mockRegistry, fakeLogger, logger, notifier, configAdminService] = mySetUp();
+            auto [framework, compMetadata, mockRegistry, fakeLogger, notifier, configAdminService] = mySetUp();
 
             compMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
             compMetadata->immediate = true;

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -1313,15 +1313,34 @@ namespace cppmicroservices
             compConfig->Initialize();
 
             auto compConfig1 = std::make_shared<SingletonComponentConfigurationImpl>(compMetadata,
-                                                                                    framework,
-                                                                                    mockRegistry,
-                                                                                    fakeLogger,
-                                                                                    notifier);
+                                                                                     framework,
+                                                                                     mockRegistry,
+                                                                                     fakeLogger,
+                                                                                     notifier);
             auto mockCompContext1 = std::make_shared<MockComponentContextImpl>(compConfig);
             auto mockCompInstance1 = std::make_shared<MockComponentInstance>();
             compConfig1->SetComponentInstancePair(InstanceContextPair(mockCompInstance, mockCompContext));
             compConfig1->Initialize();
 
+            auto compConfig2 = std::make_shared<SingletonComponentConfigurationImpl>(compMetadata,
+                                                                                     framework,
+                                                                                     mockRegistry,
+                                                                                     fakeLogger,
+                                                                                     notifier);
+            auto mockCompContext2 = std::make_shared<MockComponentContextImpl>(compConfig);
+            auto mockCompInstance2 = std::make_shared<MockComponentInstance>();
+            compConfig2->SetComponentInstancePair(InstanceContextPair(mockCompInstance, mockCompContext));
+            compConfig2->Initialize();
+
+            auto compConfig3 = std::make_shared<SingletonComponentConfigurationImpl>(compMetadata,
+                                                                                     framework,
+                                                                                     mockRegistry,
+                                                                                     fakeLogger,
+                                                                                     notifier);
+            auto mockCompContext3 = std::make_shared<MockComponentContextImpl>(compConfig);
+            auto mockCompInstance3 = std::make_shared<MockComponentInstance>();
+            compConfig3->SetComponentInstancePair(InstanceContextPair(mockCompInstance, mockCompContext));
+            compConfig3->Initialize();
             auto frameworkT = std::thread(
                 [this]()
                 {
@@ -1330,16 +1349,24 @@ namespace cppmicroservices
                         {"foo", true}
                     });
                     fut.second.wait();
-                    configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
+                    fut = configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
                         {"foo", false}
+                    });
+                    fut.second.wait();
+                    configuration->UpdateIfDifferent(std::unordered_map<std::string, cppmicroservices::Any> {
+                        {"foo", true}
                     });
                 });
             auto bundleT = std::thread([&compConfig]() { compConfig->Stop(); });
             auto bundleT1 = std::thread([&compConfig1]() { compConfig1->Stop(); });
+            auto bundleT2 = std::thread([&compConfig2]() { compConfig2->Stop(); });
+            auto bundleT3 = std::thread([&compConfig3]() { compConfig3->Stop(); });
 
             frameworkT.join();
             bundleT.join();
             bundleT1.join();
+            bundleT2.join();
+            bundleT3.join();
         }
 #endif
     } // namespace scrimpl


### PR DESCRIPTION
This test case does expose the bug fixed in #1016 for the ConfigNotifier. Essentially if we have a race between unregistering a listener for a config and then notifying of a config change, it can get past the `AnyListenersForPid` call made in `ConfigurationListenerImpl::ConfigurationEvent` and into `NotifyAllListeners` with an empty map. All this means is that the check, already implemented in #1016, needs to done. 

Of note, this is a *very sporadic* occurence even in this test case, on the order of 1/500 runs. I am not sure how common this is in real life examples, I have seen it on a much more common level i.e. 1/3 runs in the wild. 