### PR TITLE
The loop parse the first folder of the zip file and ignores the other folders.

### DIFF
--- a/framework/src/bundle/BundleRegistry.cpp
+++ b/framework/src/bundle/BundleRegistry.cpp
@@ -387,7 +387,7 @@ namespace cppmicroservices
         catch (...)
         {
             // catch any other errors (that we have no information about)
-            std::cerr << "Unknown failure occurred. Possible memory corruption" << std::endl;
+            std::cerr << "Failed to install bundle library at " + location + ": " + util::GetLastExceptionStr() << std::endl;
 
             for (auto& ba : barchives)
             {


### PR DESCRIPTION
The identified problem arises at line **(352 in original file)** which triggers a catch at line **(393 in original file)**.

The loop parse the first folder of the zip file and directly goes into catching the exception at line (375 in original file) (393 in this modified file) by ignoring the other folders in the zip file which is not correct. By adding the additional catch statements the other folders are parsed and an error is shown. If during the parsing a folder in the zip file contains the manifest file the processing continues.

Example of the error messages:

```
Error occurred: bundle.symbolic_name is not defined in the bundle manifest for bundle assets (location=/mnt/dev/c++/bismika/build/plugins/libresources_plugin.so).
Error occurred: bundle.symbolic_name is not defined in the bundle manifest for bundle src (location=/mnt/dev/c++/bismika/build/plugins/libresources_plugin.so).
Error occurred: bundle.symbolic_name is not defined in the bundle manifest for bundle style (location=/mnt/dev/c++/bismika/build/plugins/libresources_plugin.so).
```

in this case the zip file has a **resources_plugin** folder containing the **manifest.json**.

To see how the bundle with the embedded files is handled check the **bundles/resources_plugin** sub-project.