### PR TITLE
Merged zip files structure not taken into consideration when fetching a resource from a bundle.

### DIFF
--- a/framework/include/cppmicroservices/Bundle.h
+++ b/framework/include/cppmicroservices/Bundle.h
@@ -569,7 +569,7 @@ namespace cppmicroservices
          *
          * @throws std::invalid_argument if this bundle is not initialized.
          */
-        BundleResource GetResource(std::string const& path) const;
+        BundleResource GetResource(std::string const& path, bool bypassPrefix = false) const;
 
         /**
          * Returns resources in this bundle.

--- a/framework/include/cppmicroservices/BundleResource.h
+++ b/framework/include/cppmicroservices/BundleResource.h
@@ -299,7 +299,7 @@ namespace cppmicroservices
         uint32_t GetCrc32() const;
 
       private:
-        BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive);
+        BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive, bool bypassPrefix = false);
 
         BundleResource(int index, std::shared_ptr<BundleArchive const> const& archive);
 

--- a/framework/src/bundle/Bundle.cpp
+++ b/framework/src/bundle/Bundle.cpp
@@ -309,7 +309,7 @@ namespace cppmicroservices
     }
 
     BundleResource
-    Bundle::GetResource(std::string const& path, bool bypassPrefix = false) const
+    Bundle::GetResource(std::string const& path, bool const bypassPrefix) const
     {
         if (!d)
         {
@@ -317,7 +317,7 @@ namespace cppmicroservices
         }
 
         d->CheckUninstalled();
-        return d->barchive ? d->barchive->GetResource(path) : BundleResource();
+        return d->barchive ? d->barchive->GetResource(path, bypassPrefix) : BundleResource();
     }
 
     std::vector<BundleResource>

--- a/framework/src/bundle/Bundle.cpp
+++ b/framework/src/bundle/Bundle.cpp
@@ -309,7 +309,7 @@ namespace cppmicroservices
     }
 
     BundleResource
-    Bundle::GetResource(std::string const& path) const
+    Bundle::GetResource(std::string const& path, bool bypassPrefix = false) const
     {
         if (!d)
         {

--- a/framework/src/bundle/BundleArchive.cpp
+++ b/framework/src/bundle/BundleArchive.cpp
@@ -110,7 +110,7 @@ namespace cppmicroservices
     }
 
     BundleResource
-    BundleArchive::GetResource(std::string const& path) const
+    BundleArchive::GetResource(std::string const& path, bool bypassPrefix = false) const
     {
         if (!resourceContainer)
         {

--- a/framework/src/bundle/BundleArchive.cpp
+++ b/framework/src/bundle/BundleArchive.cpp
@@ -110,13 +110,13 @@ namespace cppmicroservices
     }
 
     BundleResource
-    BundleArchive::GetResource(std::string const& path, bool bypassPrefix = false) const
+    BundleArchive::GetResource(std::string const& path, bool bypassPrefix) const
     {
         if (!resourceContainer)
         {
             return BundleResource();
         }
-        BundleResource result(path, this->shared_from_this());
+        BundleResource result(path, this->shared_from_this(), bypassPrefix);
         if (result)
             return result;
         return BundleResource();

--- a/framework/src/bundle/BundleArchive.h
+++ b/framework/src/bundle/BundleArchive.h
@@ -111,7 +111,7 @@ namespace cppmicroservices
          * @param path Entry to get reference to.
          * @return BundleResource to entry.
          */
-        BundleResource GetResource(std::string const& path) const;
+        BundleResource GetResource(std::string const& path, bool bypassPrefix = false) const;
 
         /**
          * Returns a list of all the paths to entries within the bundle matching

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -100,12 +100,15 @@ namespace cppmicroservices
 
     BundleResource::BundleResource(BundleResource const& resource) : d(resource.d) {}
 
-    BundleResource::BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive)
+    BundleResource::BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive, bool bypassPrefix = false)
         : d(std::make_shared<BundleResourcePrivate>(archive))
     {
         d->InitFilePath(file);
 
-        d->stat.filePath = d->archive->GetResourcePrefix() + d->path + d->fileName;
+        if (bypassPrefix)
+            d->stat.filePath = d->path + d->fileName;
+        else
+            d->stat.filePath = d->archive->GetResourcePrefix() + d->path + d->fileName;
 
         d->archive->GetResourceContainer()->GetStat(d->stat);
 

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -58,10 +58,11 @@ namespace cppmicroservices
     BundleResourcePrivate::InitFilePath(std::string const& file)
     {
         std::string normalizedFile = file;
+        /*
         if (normalizedFile.empty() || normalizedFile[0] != '/')
         {
             normalizedFile = '/' + normalizedFile;
-        }
+        }*/
 
         std::string rawPath;
         std::size_t index = normalizedFile.find_last_of('/');

--- a/framework/src/bundle/BundleResource.cpp
+++ b/framework/src/bundle/BundleResource.cpp
@@ -100,7 +100,7 @@ namespace cppmicroservices
 
     BundleResource::BundleResource(BundleResource const& resource) : d(resource.d) {}
 
-    BundleResource::BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive, bool bypassPrefix = false)
+    BundleResource::BundleResource(std::string const& file, std::shared_ptr<BundleArchive const> const& archive, bool bypassPrefix)
         : d(std::make_shared<BundleResourcePrivate>(archive))
     {
         d->InitFilePath(file);


### PR DESCRIPTION
Added a parameter to bypass the prefix which is causing problem for merged zip files with the main res-0.zip resources file. The usResourceCompiler3 creates a default folder named after the symbolic.name property and adds the manifest in it. Independent zip files can be merged with the res-0.zip file but those are not aware of symbolic.name property causing the call to Bundle.GetResource function to never find the merged files with res-0.zip file.