### PR TITLE
Remove linking to library rt from Android build as it is apart of stdc++

### DIFF
--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -151,7 +151,7 @@ add_dependencies(${us_configurationadmin_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_configurationadmin_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/DeclarativeServices/test/bench/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/bench/CMakeLists.txt
@@ -139,7 +139,7 @@ add_dependencies(${us_declarativeservices_bench_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_declarativeservices_bench_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -241,7 +241,7 @@ add_dependencies(${us_declarativeservices_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_declarativeservices_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/LogServiceImpl/test/CMakeLists.txt
+++ b/compendium/LogServiceImpl/test/CMakeLists.txt
@@ -105,7 +105,7 @@ target_include_directories(${us_logservice_test_exe_name} PRIVATE
   )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_logservice_test_exe_name} PRIVATE rt)
 endif()
 

--- a/framework/test/bench/CMakeLists.txt
+++ b/framework/test/bench/CMakeLists.txt
@@ -50,7 +50,7 @@ set_property(TARGET ${us_bench_test_exe_name} PROPERTY US_BUNDLE_NAME main)
 
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_bench_test_exe_name} rt)
 endif()
 

--- a/httpservice/CMakeLists.txt
+++ b/httpservice/CMakeLists.txt
@@ -81,7 +81,7 @@ if(MINGW)
 endif()
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(usHttpService PRIVATE rt)
 endif()
 


### PR DESCRIPTION
rt library is in bionic lib
see https://github.com/daniel-yu-papa/Maggie-OpenMax/issues/1#issuecomment-140357059
https://github.com/dotnet/runtime/issues/20180