### PR TITLE
Fixes a race condition in Config Admin shutdown

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMActivator.cpp
+++ b/compendium/ConfigurationAdmin/src/CMActivator.cpp
@@ -76,6 +76,9 @@ namespace cppmicroservices
                     bundleRegistry.clear();
                 }
                 // Clean up the ConfigurationAdminImpl
+                // WAITFOR all configAdmin work to stop
+                // dont queue any new work and wait for existing work
+                configAdminImpl->StopAndWaitForAllAsync();
                 configAdminImpl = nullptr;
                 logger->Log(SeverityLevel::LOG_DEBUG, "CM Bundle stopped.");
             }

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -623,7 +623,7 @@ namespace cppmicroservices
                         managedServiceFactoryWrappers;
                     {
                         std::lock_guard<std::mutex> lk { configurationsMutex };
-                        const auto it = configurations.find(pid);
+                        auto const it = configurations.find(pid);
                         if (it == std::end(configurations))
                         {
                             removed = true;
@@ -636,7 +636,7 @@ namespace cppmicroservices
                                 hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
                                 properties = it->second->GetProperties();
                             }
-                            catch (const std::runtime_error&)
+                            catch (std::runtime_error const&)
                             {
                                 // Configuration is being removed
                                 removed = true;
@@ -669,7 +669,7 @@ namespace cppmicroservices
 
                     auto configurationListeners = configListenerTracker.GetServices();
                     auto configAdminRef = cmContext.GetServiceReference<ConfigurationAdmin>();
-                    for (const auto& it : configurationListeners)
+                    for (auto const& it : configurationListeners)
                     {
                         auto configEvent
                             = cppmicroservices::service::cm::ConfigurationEvent(configAdminRef, type, fPid, nonFPid);
@@ -679,7 +679,7 @@ namespace cppmicroservices
                     std::for_each(
                         managedServiceWrappers.begin(),
                         managedServiceWrappers.end(),
-                        [&](const auto& managedServiceWrapper)
+                        [&](auto const& managedServiceWrapper)
                         {
                             // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
                             // that we aren't tracking. We must be careful not to dereference these!
@@ -703,7 +703,7 @@ namespace cppmicroservices
                             }
                         });
 
-                    const auto factoryPid = getFactoryPid(pid);
+                    auto const factoryPid = getFactoryPid(pid);
                     if (factoryPid.empty())
                     {
                         return;
@@ -712,7 +712,7 @@ namespace cppmicroservices
                     std::for_each(
                         managedServiceFactoryWrappers.begin(),
                         managedServiceFactoryWrappers.end(),
-                        [&](const auto& managedServiceFactoryWrapper)
+                        [&](auto const& managedServiceFactoryWrapper)
                         {
                             // The ServiceTracker will return a default constructed shared_ptr for each
                             // ManagedServiceFactory that we aren't tracking. We must be careful not to dereference
@@ -864,7 +864,7 @@ namespace cppmicroservices
                         "New ManagedService with PID " + pid + " has been added.");
 
             std::unordered_map<std::string, unsigned long> initialChangeCountByPid = {
-                {pid, initialChangeCount}
+                { pid, initialChangeCount }
             };
             auto trackedManagedService
                 = std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>(
@@ -974,7 +974,7 @@ namespace cppmicroservices
                 PerformAsync(
                     [this, pid, managedServiceFactory, pidsAndProperties]
                     {
-                        for (const auto& pidAndProperties : pidsAndProperties)
+                        for (auto const& pidAndProperties : pidsAndProperties)
                         {
                             notifyServiceUpdated(pidAndProperties.first,
                                                  *managedServiceFactory,
@@ -1038,6 +1038,14 @@ namespace cppmicroservices
         {
 
             std::lock_guard<std::mutex> lk { futuresMutex };
+            // if this configAdminImpl has been marked as inactive by the CMActivator, it should not queue any work
+            if (!active)
+            {
+                // we return a default future which will always return immediately if waited on...
+                // this isn't really a 'valid' future, but when the activator as stopped the bundle, we should be making
+                // configAdmin essentially non functional
+                return std::make_shared<ThreadpoolSafeFuturePrivate>();
+            }
             decltype(completeFutures) {}.swap(completeFutures);
             auto id = ++futuresID;
 
@@ -1130,6 +1138,15 @@ namespace cppmicroservices
             {
                 futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
             }
+        }
+        void
+        ConfigurationAdminImpl::StopAndWaitForAllAsync()
+        {
+            {
+                std::lock_guard<std::mutex> lk { futuresMutex };
+                active = false;
+            }
+            WaitForAllAsync();
         }
     } // namespace cmimpl
 } // namespace cppmicroservices

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -1042,8 +1042,8 @@ namespace cppmicroservices
             if (!active)
             {
                 // we return a default future which will always return immediately if waited on...
-                // this isn't really a 'valid' future, but when the activator as stopped the bundle, we should be making
-                // configAdmin essentially non functional
+                // this isn't really a 'valid' future, but when the activator has stopped the bundle,
+                // configAdmin can be assumed to be non functional
                 return std::make_shared<ThreadpoolSafeFuturePrivate>();
             }
             decltype(completeFutures) {}.swap(completeFutures);

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -252,8 +252,10 @@ namespace cppmicroservices
             template <typename Functor>
             std::shared_ptr<ThreadpoolSafeFuturePrivate> PerformAsync(Functor&& f);
 
-            // Used to generate a random instance name for CreateFactoryConfiguration
+            // Flag set to false when the activator has stopped the bundle
             bool active = true;
+
+            // Used to generate a random instance name for CreateFactoryConfiguration
             std::string RandomInstanceName();
 
             // Used to keep track of the instances of each ManagedServiceFactory

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.hpp
@@ -214,8 +214,8 @@ namespace cppmicroservices
              * See {@code ConfigurationAdminPrivate#NotifyConfigurationRemoved}
              */
             std::shared_ptr<ThreadpoolSafeFuturePrivate> NotifyConfigurationRemoved(std::string const& pid,
-                                                            std::uintptr_t configurationId,
-                                                            unsigned long changeCount) override;
+                                                                                    std::uintptr_t configurationId,
+                                                                                    unsigned long changeCount) override;
 
             // methods from the cppmicroservices::ServiceTrackerCustomizer interface for ManagedService
             std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> AddingService(
@@ -240,10 +240,12 @@ namespace cppmicroservices
                 ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& reference,
                 std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> const&
                     service) override;
-
-            // Used by tests to avoid race conditions and CMBundleExtension destructor to make sure all asynchronous
-            // threads have completed.
+            // Used by tests to avoid race conditions
+            // Used by CMActivator to ensure all async work is finished BEFORE shutdown
             void WaitForAllAsync();
+
+            //  prohibits any further async work from being queued in the CMAsyncWorkService
+            void StopAndWaitForAllAsync();
 
           private:
             // Convenience wrapper which is used to perform asyncronous operations
@@ -251,6 +253,7 @@ namespace cppmicroservices
             std::shared_ptr<ThreadpoolSafeFuturePrivate> PerformAsync(Functor&& f);
 
             // Used to generate a random instance name for CreateFactoryConfiguration
+            bool active = true;
             std::string RandomInstanceName();
 
             // Used to keep track of the instances of each ManagedServiceFactory

--- a/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
+++ b/compendium/ConfigurationAdmin/test/TestAsyncWorkService.cpp
@@ -385,6 +385,10 @@ namespace test
         });
     }
 
+    // Ensures that when ConfigAdmin is shut down, even if work is still being queued or is running,
+    // no new work is posted to the asyncWorkService
+
+    // NOTE: intended to be run on repeat as this used to fail sporadically before fix
     TEST_F(TestAsyncWorkServiceEndToEnd, TestShutdownWithWorkRunning)
     {
         auto const& param = std::make_shared<AsyncWorkServiceThreadPool>(2);


### PR DESCRIPTION
In the current implementation, the **ConfigurationAdminImpl** object is being destroyed from a thread posted to the **AsyncWorkService**. This occurs because the **ConfigurationListenerImpl** holds the last reference to **configAdmin**. When **ConfigurationListenerImpl** completes its task of notifying listeners, it releases its reference, triggering the destruction of **configAdminImpl**. During its destruction, **configAdminImpl** waits for all its posted tasks to complete, including the **NotifyConfigurationUpdated** tasks in the **AsyncWorkService** (which this thread itself is), leading to a deadlock as these tasks can never complete.

**Solution**
To resolve this issue, I modified the **Activator::Stop** method for **ConfigAdminImpl**. Instead of setting **configAdminImpl** to nullptr immediately after unregistering, ensure that **configAdminImpl** stops posting new asynchronous work and waits for all existing tasks to complete. This ensures that **ConfigurationListenerImpl** does not hold the last reference to **configAdmin**, preventing its premature destruction and avoiding the deadlock

**Test Case:**
**Before change**: deadlocks roughly every 1/300 runs
**After change:** didn't deadlock after 120,000 runs