### PR TITLE
Fix logic for when to require dynamic binding methods (issue #1041)

### DIFF
--- a/compendium/DeclarativeServices/test/gtest/TestBindingPolicies.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestBindingPolicies.cpp
@@ -34,10 +34,10 @@
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
 #include "../../src/SCRLogger.hpp"
+#include "../TestUtils.hpp"
 #include "ConcurrencyTestUtil.hpp"
 #include "Mocks.hpp"
 #include "TestInterfaces/Interfaces.hpp"
-#include "../TestUtils.hpp"
 
 namespace scr = cppmicroservices::service::component::runtime;
 
@@ -58,8 +58,8 @@ namespace
     void
     CheckComponentConfigurationState(std::shared_ptr<scr::ServiceComponentRuntime> dsRuntime,
                                      cppmicroservices::Bundle const& bundle,
-                                     const std::string svcComponentName,
-                                     const scr::dto::ComponentState compState)
+                                     std::string const svcComponentName,
+                                     scr::dto::ComponentState const compState)
     {
         auto compDescDTO = dsRuntime->GetComponentDescriptionDTO(bundle, svcComponentName);
         auto compConfigDTOs = dsRuntime->GetComponentConfigurationDTOs(compDescDTO);
@@ -190,7 +190,9 @@ namespace cppmicroservices
 
         // utility method for creating different types of reference metadata objects used in testing
         metadata::ReferenceMetadata
-        CreateFakeReferenceMetadata(std::string const& policy, std::string const& policyOption, std::string const& cardinality = "0..1")
+        CreateFakeReferenceMetadata(std::string const& policy,
+                                    std::string const& policyOption,
+                                    std::string const& cardinality = "0..1")
         {
             metadata::ReferenceMetadata fakeMetadata {};
             fakeMetadata.name = "ref";
@@ -203,7 +205,7 @@ namespace cppmicroservices
 
             fakeMetadata.minCardinality = std::get<0>(cardLimits);
             fakeMetadata.maxCardinality = std::get<1>(cardLimits);
-            
+
             return fakeMetadata;
         }
 
@@ -255,7 +257,7 @@ namespace cppmicroservices
         INSTANTIATE_TEST_SUITE_P(
             DynamicReferencePolicies,
             DynamicRefPolicyTest,
-            testing::Values(DynamicRefPolicy { "TestBundleDSDRMU", 
+            testing::Values(DynamicRefPolicy { "TestBundleDSDRMU",
                                                "ServiceComponentDynamicReluctantMandatoryUnary depends on "
                                                "ServiceComponentDynamicReluctantMandatoryUnary Interface1",
                                                "",
@@ -471,7 +473,7 @@ namespace cppmicroservices
             auto higherRankedSvc = bc.RegisterService<test::Interface1>(
                 std::make_shared<test::InterfaceImpl>("higher ranked Interface1"),
                 {
-                    {Constants::SERVICE_RANKING, Any(10000)}
+                    { Constants::SERVICE_RANKING, Any(10000) }
             });
             ASSERT_TRUE(higherRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -485,7 +487,7 @@ namespace cppmicroservices
             auto lowerRankedSvc
                 = bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>("lower ranked Interface1"),
                                                        {
-                                                           {Constants::SERVICE_RANKING, Any(1)}
+                                                           { Constants::SERVICE_RANKING, Any(1) }
             });
             ASSERT_TRUE(lowerRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -518,7 +520,7 @@ namespace cppmicroservices
             EXPECT_FALSE(bc.GetServiceReference<test::Interface2>()) << "Service should NOT be available";
             EXPECT_THROW(svc->ExtendedDescription(), std::runtime_error);
             testBundle.Stop();
-        }        
+        }
 
         // test that:
         //  a new higher ranked service causes a re-bind
@@ -574,7 +576,7 @@ namespace cppmicroservices
             auto higherRankedSvc = bc.RegisterService<test::Interface1>(
                 std::make_shared<test::InterfaceImpl>("higher ranked Interface1"),
                 {
-                    {Constants::SERVICE_RANKING, Any(10000)}
+                    { Constants::SERVICE_RANKING, Any(10000) }
             });
             ASSERT_TRUE(higherRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -588,7 +590,7 @@ namespace cppmicroservices
             auto lowerRankedSvc
                 = bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>("lower ranked Interface1"),
                                                        {
-                                                           {Constants::SERVICE_RANKING, Any(1)}
+                                                           { Constants::SERVICE_RANKING, Any(1) }
             });
             ASSERT_TRUE(lowerRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -668,7 +670,7 @@ namespace cppmicroservices
             auto higherRankedSvc = bc.RegisterService<test::Interface1>(
                 std::make_shared<test::InterfaceImpl>("higher ranked Interface1"),
                 {
-                    {Constants::SERVICE_RANKING, Any(10000)}
+                    { Constants::SERVICE_RANKING, Any(10000) }
             });
             ASSERT_TRUE(higherRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -682,7 +684,7 @@ namespace cppmicroservices
             auto lowerRankedSvc
                 = bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>("lower ranked Interface1"),
                                                        {
-                                                           {Constants::SERVICE_RANKING, Any(1)}
+                                                           { Constants::SERVICE_RANKING, Any(1) }
             });
             ASSERT_TRUE(lowerRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -769,7 +771,7 @@ namespace cppmicroservices
             auto higherRankedSvc = bc.RegisterService<test::Interface1>(
                 std::make_shared<test::InterfaceImpl>("higher ranked Interface1"),
                 {
-                    {Constants::SERVICE_RANKING, Any(10000)}
+                    { Constants::SERVICE_RANKING, Any(10000) }
             });
             ASSERT_TRUE(higherRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -783,7 +785,7 @@ namespace cppmicroservices
             auto lowerRankedSvc
                 = bc.RegisterService<test::Interface1>(std::make_shared<test::InterfaceImpl>("lower ranked Interface1"),
                                                        {
-                                                           {Constants::SERVICE_RANKING, Any(1)}
+                                                           { Constants::SERVICE_RANKING, Any(1) }
             });
             ASSERT_TRUE(lowerRankedSvc);
             EXPECT_NO_THROW(svc->ExtendedDescription());
@@ -848,14 +850,14 @@ namespace cppmicroservices
                 auto higherRankedSvc = bc.RegisterService<test::Interface1>(
                     std::make_shared<test::InterfaceImpl>("higher ranked Interface1"),
                     {
-                        {Constants::SERVICE_RANKING, Any(10000)}
+                        { Constants::SERVICE_RANKING, Any(10000) }
                 });
 
                 // registering a new service with a lower rank should NOT cause re-binding
                 auto lowerRankedSvc = bc.RegisterService<test::Interface1>(
                     std::make_shared<test::InterfaceImpl>("lower ranked Interface1"),
                     {
-                        {Constants::SERVICE_RANKING, Any(1)}
+                        { Constants::SERVICE_RANKING, Any(1) }
                 });
 
                 depSvcReg.Unregister();
@@ -870,7 +872,8 @@ namespace cppmicroservices
             testBundle.Stop();
         }
 
-        struct MultipleCardinalityDynamicPolicy {
+        struct MultipleCardinalityDynamicPolicy
+        {
             metadata::ReferenceMetadata fakeMetadata;
 
             int numBindNotifs[3];
@@ -878,88 +881,104 @@ namespace cppmicroservices
             int numLoggerCalls;
 
             friend std::ostream&
-                operator<<(std::ostream& os, MultipleCardinalityDynamicPolicy const& obj)
+            operator<<(std::ostream& os, MultipleCardinalityDynamicPolicy const& obj)
             {
                 return os << "Metadata name: " << obj.fakeMetadata.name << "\n"
-                    << "Bind notification count: " << obj.numBindNotifs << "\n"
-                    << "Unbind notification count: " << obj.numUnbindNotifs << "\n"
-                    << "Logger calls count: " << obj.numLoggerCalls << "\n";
+                          << "Bind notification count: " << obj.numBindNotifs << "\n"
+                          << "Unbind notification count: " << obj.numUnbindNotifs << "\n"
+                          << "Logger calls count: " << obj.numLoggerCalls << "\n";
             }
         };
 
         class DynamicPolicyMultipleCardinalityTest : public ::testing::TestWithParam<MultipleCardinalityDynamicPolicy>
         {
-        protected:
+          protected:
             DynamicPolicyMultipleCardinalityTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {}
 
             virtual ~DynamicPolicyMultipleCardinalityTest() = default;
 
             virtual void
-                SetUp()
+            SetUp()
             {
                 framework.Start();
                 mockLogger = std::make_shared<MockLogger>();
             }
 
             virtual void
-                TearDown()
+            TearDown()
             {
                 framework.Stop();
                 framework.WaitForStop(std::chrono::milliseconds::zero());
             }
 
             cppmicroservices::Framework&
-                GetFramework()
+            GetFramework()
             {
                 return framework;
             }
 
-            ListenerTokenId CreateListener(ReferenceManagerImpl& refManager) {
+            ListenerTokenId
+            CreateListener(ReferenceManagerImpl& refManager)
+            {
                 return refManager.RegisterListener(
                     [&](RefChangeNotification const& notification)
                     {
                         switch (notification.event)
                         {
-                        case RefEvent::BECAME_SATISFIED:
-                            satisfiedNotificationCount++;
-                            break;
-                        case RefEvent::BECAME_UNSATISFIED:
-                            unsatisfiedNotificationCount++;
-                            break;
-                        case RefEvent::REBIND:
-                            if (notification.serviceRefToBind)
-                            {
-                                bindNotificationCount++;
-                            }
-                            if (notification.serviceRefToUnbind)
-                            {
-                                unbindNotificationCount++;
-                            }
-                            break;
-                        default:
-                            break;
+                            case RefEvent::BECAME_SATISFIED:
+                                satisfiedNotificationCount++;
+                                break;
+                            case RefEvent::BECAME_UNSATISFIED:
+                                unsatisfiedNotificationCount++;
+                                break;
+                            case RefEvent::REBIND:
+                                if (notification.serviceRefToBind)
+                                {
+                                    bindNotificationCount++;
+                                }
+                                if (notification.serviceRefToUnbind)
+                                {
+                                    unbindNotificationCount++;
+                                }
+                                break;
+                            default:
+                                break;
                         }
                     });
             }
 
             cppmicroservices::Framework framework;
             std::shared_ptr<cppmicroservices::scrimpl::MockLogger> mockLogger;
-            ListenerTokenId listenerToken{ 0 };
+            ListenerTokenId listenerToken { 0 };
 
-            int satisfiedNotificationCount{ 0 };
-            int unsatisfiedNotificationCount{ 0 };
-            int bindNotificationCount{ 0 };
-            int unbindNotificationCount{ 0 };
+            int satisfiedNotificationCount { 0 };
+            int unsatisfiedNotificationCount { 0 };
+            int bindNotificationCount { 0 };
+            int unbindNotificationCount { 0 };
         };
 
         INSTANTIATE_TEST_SUITE_P(
             MultipleCardinalityTests,
             DynamicPolicyMultipleCardinalityTest,
             testing::Values(
-                MultipleCardinalityDynamicPolicy{ CreateFakeReferenceMetadata("dynamic", "greedy", "1..n"), {0, 1, 2}, {1,2,2}, 4 },
-                MultipleCardinalityDynamicPolicy{ CreateFakeReferenceMetadata("dynamic", "greedy", "0..n"), {1, 2, 3}, {1,2,3}, 3 },
-                MultipleCardinalityDynamicPolicy{ CreateFakeReferenceMetadata("dynamic", "reluctant", "1..n"), {0, 1, 2}, {1, 2, 2}, 6 },
-                MultipleCardinalityDynamicPolicy{ CreateFakeReferenceMetadata("dynamic", "reluctant", "0..n"), {2, 3, 4}, {1, 2, 3}, 7 }));
+                MultipleCardinalityDynamicPolicy {
+                    CreateFakeReferenceMetadata("dynamic", "greedy", "1..n"),
+                    { 0, 1, 2 },
+                    { 1, 2, 2 },
+                    4
+        },
+                MultipleCardinalityDynamicPolicy { CreateFakeReferenceMetadata("dynamic", "greedy", "0..n"),
+                                                   { 1, 2, 3 },
+                                                   { 1, 2, 3 },
+                                                   3 },
+                MultipleCardinalityDynamicPolicy { CreateFakeReferenceMetadata("dynamic", "reluctant", "1..n"),
+                                                   { 0, 1, 2 },
+                                                   { 1, 2, 2 },
+                                                   6 },
+                MultipleCardinalityDynamicPolicy { CreateFakeReferenceMetadata("dynamic", "reluctant", "0..n"),
+                                                   { 2, 3, 4 },
+                                                   { 1, 2, 3 },
+                                                   7 }));
 
         // test that:
         //  any new service causes a re-bind
@@ -968,40 +987,34 @@ namespace cppmicroservices
         {
             auto bc = GetFramework().GetBundleContext();
 
-            ReferenceManagerImpl refManager(GetParam().fakeMetadata,
-                bc,
-                mockLogger,
-                "foo");
+            ReferenceManagerImpl refManager(GetParam().fakeMetadata, bc, mockLogger, "foo");
 
             CreateListener(refManager);
 
             EXPECT_CALL(*(mockLogger).get(), Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, testing::_))
                 .Times(GetParam().numLoggerCalls);
 
-            auto depSvcReg = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(10000)}
-                });
+            auto depSvcReg = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                   {
+                                                                       { Constants::SERVICE_RANKING, Any(10000) }
+            });
             ASSERT_TRUE(depSvcReg);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 1);
 
-            auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(1)}
-                });
+            auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                    {
+                                                                        { Constants::SERVICE_RANKING, Any(1) }
+            });
             ASSERT_TRUE(depSvcReg1);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 2);
             EXPECT_EQ(bindNotificationCount, GetParam().numBindNotifs[1]);
 
-            auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(100)}
-                });
+            auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                    {
+                                                                        { Constants::SERVICE_RANKING, Any(100) }
+            });
             ASSERT_TRUE(depSvcReg2);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 3);
@@ -1025,7 +1038,8 @@ namespace cppmicroservices
             refManager.UnregisterListener(listenerToken);
         }
 
-        struct MultipleCardinalityStaticPolicy {
+        struct MultipleCardinalityStaticPolicy
+        {
             metadata::ReferenceMetadata fakeMetadata;
 
             int numSatisfiedNotifs[6];
@@ -1033,120 +1047,124 @@ namespace cppmicroservices
             int numLoggerCalls;
 
             friend std::ostream&
-                operator<<(std::ostream& os, MultipleCardinalityStaticPolicy const& obj)
+            operator<<(std::ostream& os, MultipleCardinalityStaticPolicy const& obj)
             {
                 return os << "Metadata name: " << obj.fakeMetadata.name << "\n"
-                    << "Bind notification count: " << obj.numSatisfiedNotifs << "\n"
-                    << "Unbind notification count: " << obj.numUnsatisfiedNotifs << "\n"
-                    << "Logger calls count: " << obj.numLoggerCalls << "\n";
+                          << "Bind notification count: " << obj.numSatisfiedNotifs << "\n"
+                          << "Unbind notification count: " << obj.numUnsatisfiedNotifs << "\n"
+                          << "Logger calls count: " << obj.numLoggerCalls << "\n";
             }
         };
 
         class StaticPolicyMultipleCardinalityTest : public ::testing::TestWithParam<MultipleCardinalityStaticPolicy>
         {
-        protected:
+          protected:
             StaticPolicyMultipleCardinalityTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {}
 
             virtual ~StaticPolicyMultipleCardinalityTest() = default;
 
             virtual void
-                SetUp()
+            SetUp()
             {
                 framework.Start();
                 mockLogger = std::make_shared<MockLogger>();
             }
 
             virtual void
-                TearDown()
+            TearDown()
             {
                 framework.Stop();
                 framework.WaitForStop(std::chrono::milliseconds::zero());
             }
 
             cppmicroservices::Framework&
-                GetFramework()
+            GetFramework()
             {
                 return framework;
             }
 
-            ListenerTokenId CreateListener(ReferenceManagerImpl & refManager) {
+            ListenerTokenId
+            CreateListener(ReferenceManagerImpl& refManager)
+            {
                 return refManager.RegisterListener(
                     [&](RefChangeNotification const& notification)
                     {
                         switch (notification.event)
                         {
-                        case RefEvent::BECAME_SATISFIED:
-                            satisfiedNotificationCount++;
-                            break;
-                        case RefEvent::BECAME_UNSATISFIED:
-                            unsatisfiedNotificationCount++;
-                            break;
-                        default:
-                            break;
+                            case RefEvent::BECAME_SATISFIED:
+                                satisfiedNotificationCount++;
+                                break;
+                            case RefEvent::BECAME_UNSATISFIED:
+                                unsatisfiedNotificationCount++;
+                                break;
+                            default:
+                                break;
                         }
                     });
             }
 
             cppmicroservices::Framework framework;
             std::shared_ptr<cppmicroservices::scrimpl::MockLogger> mockLogger;
-            ListenerTokenId listenerToken{ 0 };
+            ListenerTokenId listenerToken { 0 };
 
-            int satisfiedNotificationCount{ 0 };
-            int unsatisfiedNotificationCount{ 0 };
+            int satisfiedNotificationCount { 0 };
+            int unsatisfiedNotificationCount { 0 };
         };
 
-        INSTANTIATE_TEST_SUITE_P(
-            MultipleCardinalityTests,
-            StaticPolicyMultipleCardinalityTest,
-            testing::Values(
-                MultipleCardinalityStaticPolicy{ CreateFakeReferenceMetadata("static", "greedy", "1..n"), {1, 2, 3, 1, 2, 2}, {0, 1, 2, 1, 2, 3}, 10 },
-                MultipleCardinalityStaticPolicy{ CreateFakeReferenceMetadata("static", "greedy", "0..n"), {2, 3, 4, 1, 2, 3}, {1, 2, 3, 1, 2, 3}, 12 }
-                ));
+        INSTANTIATE_TEST_SUITE_P(MultipleCardinalityTests,
+                                 StaticPolicyMultipleCardinalityTest,
+                                 testing::Values(
+                                     MultipleCardinalityStaticPolicy {
+                                         CreateFakeReferenceMetadata("static", "greedy", "1..n"),
+                                         { 1, 2, 3, 1, 2, 2 },
+                                         { 0, 1, 2, 1, 2, 3 },
+                                         10
+        },
+                                     MultipleCardinalityStaticPolicy {
+                                         CreateFakeReferenceMetadata("static", "greedy", "0..n"),
+                                         { 2, 3, 4, 1, 2, 3 },
+                                         { 1, 2, 3, 1, 2, 3 },
+                                         12 }));
 
         // test that:
         //  any new service causes a reactivation of component
         //  unregistering services keeps other bound services intact and reactivates component
-        TEST_P(StaticPolicyMultipleCardinalityTest, TestStaticPolicyWithMultipleCardinality) {
+        TEST_P(StaticPolicyMultipleCardinalityTest, TestStaticPolicyWithMultipleCardinality)
+        {
 
             auto bc = GetFramework().GetBundleContext();
 
-            ReferenceManagerImpl refManager(GetParam().fakeMetadata,
-                bc,
-                mockLogger,
-                "foo");
+            ReferenceManagerImpl refManager(GetParam().fakeMetadata, bc, mockLogger, "foo");
 
             CreateListener(refManager);
 
             EXPECT_CALL(*mockLogger.get(), Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG, testing::_))
                 .Times(GetParam().numLoggerCalls);
 
-            auto depSvcReg = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(10000)}
-                });
+            auto depSvcReg = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                   {
+                                                                       { Constants::SERVICE_RANKING, Any(10000) }
+            });
             ASSERT_TRUE(depSvcReg);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 1);
             EXPECT_EQ(unsatisfiedNotificationCount, GetParam().numUnsatisfiedNotifs[0]);
             EXPECT_EQ(satisfiedNotificationCount, GetParam().numSatisfiedNotifs[0]);
 
-            auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(1)}
-                });
+            auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                    {
+                                                                        { Constants::SERVICE_RANKING, Any(1) }
+            });
             ASSERT_TRUE(depSvcReg1);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 2);
             EXPECT_EQ(unsatisfiedNotificationCount, GetParam().numUnsatisfiedNotifs[1]);
             EXPECT_EQ(satisfiedNotificationCount, GetParam().numSatisfiedNotifs[1]);
 
-            auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(
-                std::make_shared<dummy::Reference1>(),
-                {
-                    {Constants::SERVICE_RANKING, Any(100)}
-                });
+            auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                    {
+                                                                        { Constants::SERVICE_RANKING, Any(100) }
+            });
             ASSERT_TRUE(depSvcReg2);
 
             EXPECT_EQ(refManager.GetBoundReferences().size(), 3);
@@ -1177,33 +1195,33 @@ namespace cppmicroservices
             refManager.UnregisterListener(listenerToken);
         }
 
-        TEST_P(BindingPolicyTest, TestMaxLimitOfMultipleReferences) {
+        TEST_P(BindingPolicyTest, TestMaxLimitOfMultipleReferences)
+        {
             auto bc = GetFramework().GetBundleContext();
             auto const& param = GetParam();
 
             auto fakeMetadata = CreateFakeReferenceMetadata(param.policy, param.policyOption, "0..n");
-            fakeMetadata.maxCardinality = 10; //overriding default values set for max cardinality for testing purpose
+            fakeMetadata.maxCardinality = 10; // overriding default values set for max cardinality for testing purpose
 
             auto mockLogger = std::make_shared<MockLogger>();
-            ReferenceManagerImpl refManager(fakeMetadata,
-                bc,
-                mockLogger,
-                "foo");
+            ReferenceManagerImpl refManager(fakeMetadata, bc, mockLogger, "foo");
 
-            for (int i = 0; i < 15; i++) {
-                auto depSvcReg = bc.RegisterService<dummy::Reference1>(
-                    std::make_shared<dummy::Reference1>(),
-                    {
-                        {Constants::SERVICE_RANKING, Any(i)}
-                    });
+            for (int i = 0; i < 15; i++)
+            {
+                auto depSvcReg = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                       {
+                                                                           { Constants::SERVICE_RANKING, Any(i) }
+                });
                 ASSERT_TRUE(depSvcReg);
             }
 
-            if (std::string(param.policy) == "static" && std::string(param.policyOption) == "reluctant") {
-                // in case of static reluctant, there's no bind even with multiple cardinality 
+            if (std::string(param.policy) == "static" && std::string(param.policyOption) == "reluctant")
+            {
+                // in case of static reluctant, there's no bind even with multiple cardinality
                 EXPECT_EQ(refManager.GetBoundReferences().size(), 0);
             }
-            else {
+            else
+            {
                 EXPECT_EQ(refManager.GetBoundReferences().size(), 10);
             }
         }
@@ -1216,31 +1234,25 @@ namespace cppmicroservices
 
             auto fakeMetadata = CreateFakeReferenceMetadata("dynamic", "greedy", "0..n");
             auto mockLogger = std::make_shared<MockLogger>();
-            ReferenceManagerImpl refManager(fakeMetadata,
-                bc,
-                mockLogger,
-                "foo");
+            ReferenceManagerImpl refManager(fakeMetadata, bc, mockLogger, "foo");
 
             std::function<bool()> func = [&bc]() -> bool
             {
-                auto depSvcReg = bc.RegisterService<dummy::Reference1>(
-                    std::make_shared<dummy::Reference1>(),
-                    {
-                        {Constants::SERVICE_RANKING, Any(10000)}
-                    });
+                auto depSvcReg
+                    = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                            {
+                                                                { Constants::SERVICE_RANKING, Any(10000) }
+                });
 
+                auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                        {
+                                                                            { Constants::SERVICE_RANKING, Any(1) }
+                });
 
-                auto depSvcReg1 = bc.RegisterService<dummy::Reference1>(
-                    std::make_shared<dummy::Reference1>(),
-                    {
-                        {Constants::SERVICE_RANKING, Any(1)}
-                    });
-
-                auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(
-                    std::make_shared<dummy::Reference1>(),
-                    {
-                        {Constants::SERVICE_RANKING, Any(100)}
-                    });
+                auto depSvcReg2 = bc.RegisterService<dummy::Reference1>(std::make_shared<dummy::Reference1>(),
+                                                                        {
+                                                                            { Constants::SERVICE_RANKING, Any(100) }
+                });
 
                 depSvcReg.Unregister();
                 depSvcReg1.Unregister();

--- a/compendium/test_bundles/TestBindUnbindThrows/resources/manifest.json
+++ b/compendium/test_bundles/TestBindUnbindThrows/resources/manifest.json
@@ -1,51 +1,62 @@
 {
-    "bundle.symbolic_name" : "TestBindUnbindThrows",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponentDGMU",
-            "service": {
-                "interfaces": ["test::Interface2"]
+    "bundle.symbolic_name": "TestBindUnbindThrows",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDGMU",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "policy": "dynamic",
+                        "policy-option": "greedy",
+                        "interface": "test::Interface1"
+                    }
+                ]
             },
-            "references":[{
-                "name" : "foo",
-                "policy" : "dynamic",
-                "policy-option" : "greedy",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-        },
-		{
-		    "immediate": true,
-            "implementation-class": "sample::ServiceComponentDGOU",
-            "service": {
-                "interfaces": ["test::Interface2"]
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDGOU",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "bar",
+                        "cardinality": "0..1",
+                        "policy": "dynamic",
+                        "policy-option": "greedy",
+                        "interface": "test::Interface1"
+                    }
+                ]
             },
-            "references":[{
-                "name" : "bar",
-				"cardinality" : "0..1",
-                "policy" : "dynamic",
-                "policy-option" : "greedy",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-		},
-		{
-		    "immediate": true,
-            "implementation-class": "sample::ServiceComponentFactory",
-            "service": {
-			    "scope" : "prototype",
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "factory",
-				"cardinality" : "0..1",
-                "policy" : "dynamic",
-                "policy-option" : "greedy",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-		}]
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentFactory",
+                "service": {
+                    "scope": "prototype",
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "factory",
+                        "cardinality": "0..1",
+                        "policy": "dynamic",
+                        "policy-option": "greedy",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSDGMU/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSDGMU/resources/manifest.json
@@ -1,20 +1,25 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSDGMU",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponentDynamicGreedyMandatoryUnary",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-                "policy" : "dynamic",
-                "policy-option" : "greedy",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-		}]
+    "bundle.symbolic_name": "TestBundleDSDGMU",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDynamicGreedyMandatoryUnary",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "policy": "dynamic",
+                        "policy-option": "greedy",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSDGOU/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSDGOU/resources/manifest.json
@@ -1,21 +1,26 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSDGOU",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponentDynamicGreedyOptionalUnary",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-				"cardinality" : "0..1",
-                "policy" : "dynamic",
-                "policy-option" : "greedy",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-		}]
+    "bundle.symbolic_name": "TestBundleDSDGOU",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDynamicGreedyOptionalUnary",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "cardinality": "0..1",
+                        "policy": "dynamic",
+                        "policy-option": "greedy",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSDRMU/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSDRMU/resources/manifest.json
@@ -1,20 +1,25 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSDRMU",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponentDynamicReluctantMandatoryUnary",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-                "policy" : "dynamic",
-                "policy-option" : "reluctant",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-        }]
+    "bundle.symbolic_name": "TestBundleDSDRMU",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDynamicReluctantMandatoryUnary",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "policy": "dynamic",
+                        "policy-option": "reluctant",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSDROU/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSDROU/resources/manifest.json
@@ -1,21 +1,26 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSDROU",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponentDynamicReluctantOptionalUnary",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-				"cardinality" : "0..1",
-                "policy" : "dynamic",
-                "policy-option" : "reluctant",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-		}]
+    "bundle.symbolic_name": "TestBundleDSDROU",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponentDynamicReluctantOptionalUnary",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "cardinality": "0..1",
+                        "policy": "dynamic",
+                        "policy-option": "reluctant",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSTOI19/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSTOI19/resources/manifest.json
@@ -1,19 +1,25 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSTOI19",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponent19",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-                "interface" : "test::Interface1",
-				"target": "(Service.vendor=Sample Vendor)"
-            }],
-            "inject-references": false
-        }]
+    "bundle.symbolic_name": "TestBundleDSTOI19",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponent19",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "interface": "test::Interface1",
+                        "target": "(Service.vendor=Sample Vendor)",
+                        "policy": "dynamic"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSTOI5/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSTOI5/resources/manifest.json
@@ -1,18 +1,24 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSTOI5",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponent5",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-        }]
+    "bundle.symbolic_name": "TestBundleDSTOI5",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponent5",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "interface": "test::Interface1",
+                        "policy": "dynamic"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/test_bundles/TestBundleDSTOI7/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSTOI7/resources/manifest.json
@@ -1,19 +1,24 @@
 {
-    "bundle.symbolic_name" : "TestBundleDSTOI7",
-    "scr" : {
-        "version" : 1,
-        "components" : [{
-            "immediate": true,
-            "implementation-class": "sample::ServiceComponent7",
-            "service": {
-                "interfaces": ["test::Interface2"]
-            },
-            "references":[{
-                "name" : "foo",
-                "policy" : "Dynamic",
-                "interface" : "test::Interface1"
-            }],
-            "inject-references": false
-        }]
+    "bundle.symbolic_name": "TestBundleDSTOI7",
+    "scr": {
+        "version": 1,
+        "components": [
+            {
+                "immediate": true,
+                "implementation-class": "sample::ServiceComponent7",
+                "service": {
+                    "interfaces": [
+                        "test::Interface2"
+                    ]
+                },
+                "references": [
+                    {
+                        "name": "foo",
+                        "policy": "dynamic",
+                        "interface": "test::Interface1"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
@@ -112,7 +112,7 @@ namespace codegen
                     {
                         mStrStream << "  binders.push_back("
                                    << util::Substitute(
-                                          datamodel::GetReferenceBinderStr(ref, componentInfo.injectReferences),
+                                          datamodel::GetReferenceBinderStr(ref),
                                           componentInfo.implClassName)
                                    << ");" << std::endl;
                     }

--- a/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
@@ -99,7 +99,7 @@ namespace codegen
                            << "{" << std::endl;
 
                 auto isReferencesEmpty = componentInfo.references.empty();
-                if (false == isReferencesEmpty)
+                if (!isReferencesEmpty)
                 {
                     mStrStream << util::Substitute("  std::vector<std::shared_ptr<scd::Binder<{0}>>> binders;",
                                                    componentInfo.implClassName)
@@ -108,7 +108,7 @@ namespace codegen
 
                 for (auto const& ref : componentInfo.references)
                 {
-                    if ((true == componentInfo.injectReferences) && (ref.policy == "dynamic"))
+                    if (componentInfo.injectReferences && ref.policy == "dynamic")
                     {
                         mStrStream << "  binders.push_back("
                                    << util::Substitute(
@@ -123,7 +123,7 @@ namespace codegen
                     << componentInfo.implClassName << ", std::tuple<"
                     << datamodel::GetServiceInterfacesStr(componentInfo.service) << ">";
 
-                if (true == isReferencesEmpty)
+                if (isReferencesEmpty)
                 {
                     mStrStream << ">();";
                 }

--- a/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
@@ -108,7 +108,7 @@ namespace codegen
 
                 for (auto const& ref : componentInfo.references)
                 {
-                    if ((false == componentInfo.injectReferences) || (ref.policy == "dynamic"))
+                    if ((true == componentInfo.injectReferences) && (ref.policy == "dynamic"))
                     {
                         mStrStream << "  binders.push_back("
                                    << util::Substitute(
@@ -131,8 +131,8 @@ namespace codegen
                 {
 
                     mStrStream << datamodel::GetCtorInjectedRefParameters(componentInfo) << ">("
-                        << datamodel::GetCtorInjectedRefNames(componentInfo) << ", binders"
-                        << ");";
+                               << datamodel::GetCtorInjectedRefNames(componentInfo) << ", binders"
+                               << ");";
                 }
 
                 mStrStream << std::endl << std::endl << "  return componentInstance;" << std::endl << "}" << std::endl;
@@ -151,8 +151,8 @@ namespace codegen
             }
         }
 
-        const std::vector<std::string> mHeaderIncludes;
-        const std::vector<ComponentInfo> mComponentInfos;
+        std::vector<std::string> const mHeaderIncludes;
+        std::vector<ComponentInfo> const mComponentInfos;
         std::stringstream mStrStream;
     };
 

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -99,15 +99,12 @@ namespace codegen
         }
 
         std::string
-        GetReferenceBinderStr(ReferenceInfo const& ref, bool injectReferences)
+        GetReferenceBinderStr(ReferenceInfo const& ref)
         {
             std::stringstream binderObjStr;
-            if (injectReferences && ref.policy == "dynamic")
-            {
-                binderObjStr << "std::make_shared<scd::DynamicBinder<{0}, "
-                             << ref.interface << ">>(\"" + ref.name + "\"" << ", &{0}::Bind" << ref.name
-                             << ", &{0}::Unbind" << ref.name << ")";
-            }
+            binderObjStr << "std::make_shared<scd::DynamicBinder<{0}, "
+                         << ref.interface << ">>(\"" + ref.name + "\"" << ", &{0}::Bind" << ref.name
+                         << ", &{0}::Unbind" << ref.name << ")";
             return binderObjStr.str();
         }
 

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -64,7 +64,7 @@ namespace codegen
             auto sep = ", ";
             for (auto const& reference : compInfo.references)
             {
-                if ((true == compInfo.injectReferences) && (reference.policy == "static"))
+                if (compInfo.injectReferences && reference.policy == "static")
                 {
                     if (reference.cardinality == "0..n" || reference.cardinality == "1..n")
                     {
@@ -88,7 +88,7 @@ namespace codegen
             resultStr << "{{";
             for (auto const& reference : compInfo.references)
             {
-                if ((true == compInfo.injectReferences) && (reference.policy == "static"))
+                if (compInfo.injectReferences && reference.policy == "static")
                 {
                     resultStr << sep << "\"" << reference.name << "\"";
                     sep = ", ";
@@ -101,9 +101,8 @@ namespace codegen
         std::string
         GetReferenceBinderStr(ReferenceInfo const& ref, bool injectReferences)
         {
-            auto isDynamic = (ref.policy == "dynamic");
             std::stringstream binderObjStr;
-            if (isDynamic && injectReferences)
+            if (injectReferences && ref.policy == "dynamic")
             {
                 binderObjStr << "std::make_shared<scd::DynamicBinder<{0}, "
                              << ref.interface << ">>(\"" + ref.name + "\"" << ", &{0}::Bind" << ref.name

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -30,9 +30,9 @@ namespace codegen
 {
     namespace datamodel
     {
-        const std::string ComponentInfo::CONFIG_POLICY_IGNORE = "ignore";
-        const std::string ComponentInfo::CONFIG_POLICY_REQUIRE = "require";
-        const std::string ComponentInfo::CONFIG_POLICY_OPTIONAL = "optional";
+        std::string const ComponentInfo::CONFIG_POLICY_IGNORE = "ignore";
+        std::string const ComponentInfo::CONFIG_POLICY_REQUIRE = "require";
+        std::string const ComponentInfo::CONFIG_POLICY_OPTIONAL = "optional";
 
         std::string
         GetComponentNameStr(ComponentInfo const& compInfo)
@@ -66,10 +66,12 @@ namespace codegen
             {
                 if ((true == compInfo.injectReferences) && (reference.policy == "static"))
                 {
-                    if (reference.cardinality == "0..n" || reference.cardinality == "1..n") {
+                    if (reference.cardinality == "0..n" || reference.cardinality == "1..n")
+                    {
                         result += (sep + std::string("std::vector<std::shared_ptr<") + reference.interface + ">>");
                     }
-                    else {
+                    else
+                    {
                         result += (sep + std::string("std::shared_ptr<") + reference.interface + ">");
                     }
                 }
@@ -99,13 +101,13 @@ namespace codegen
         std::string
         GetReferenceBinderStr(ReferenceInfo const& ref, bool injectReferences)
         {
-            auto isStatic = (ref.policy == "static");
+            auto isDynamic = (ref.policy == "dynamic");
             std::stringstream binderObjStr;
-            if (!isStatic || !injectReferences)
+            if (isDynamic && injectReferences)
             {
                 binderObjStr << "std::make_shared<scd::DynamicBinder<{0}, "
-                             << ref.interface << ">>(\"" + ref.name + "\""
-                             << ", &{0}::Bind" << ref.name << ", &{0}::Unbind" << ref.name << ")";
+                             << ref.interface << ">>(\"" + ref.name + "\"" << ", &{0}::Bind" << ref.name
+                             << ", &{0}::Unbind" << ref.name << ")";
             }
             return binderObjStr.str();
         }

--- a/compendium/tools/SCRCodeGen/ComponentInfo.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.hpp
@@ -66,7 +66,7 @@ namespace codegen
         std::string GetServiceInterfacesStr(ServiceInfo const& compInfo);
         std::string GetCtorInjectedRefTypes(ComponentInfo const& compInfo);
         std::string GetCtorInjectedRefNames(ComponentInfo const& compInfo);
-        std::string GetReferenceBinderStr(ReferenceInfo const& ref, bool injectReferences);
+        std::string GetReferenceBinderStr(ReferenceInfo const& ref);
         std::string GetCtorInjectedRefParameters(ComponentInfo const& compInfo);
 
     } // namespace datamodel


### PR DESCRIPTION
Current logic requires and uses the bind and unbind methods when inject-references is _false, or_ policy is dynamic. According to the RFC, this should only occur when inject-references is _true, and_ policy is dynamic.

We do have tests that lock down this behavior, but corresponding to the incorrect logic, they use bundles with incorrect manifest.json files. This fix corrects both the logic and the relevant bundle manifests so that tests continue to pass.

Some additional lines show as being changed, particularly in the manifests, due to clang-format.