### PR TITLE
[ci skip] Update clang_tidy_complete_code_review.yml

### DIFF
--- a/.github/workflows/clang_tidy_complete_code_review.yml
+++ b/.github/workflows/clang_tidy_complete_code_review.yml
@@ -20,7 +20,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - run: cargo install clang-tidy-sarif sarif-fmt
 


### PR DESCRIPTION
[ci skip] Update to Swatinem/rust-cache@v2 to get off of deprecated Node 16