### PR TITLE
New Dynamic Targeting Mechanism

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -1,30 +1,30 @@
- /*=============================================================================
+/*=============================================================================
 
-  Library: CppMicroServices
+ Library: CppMicroServices
 
-  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
-  file at the top-level directory of this distribution and at
-  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 
-  =============================================================================*/
+ =============================================================================*/
 
-#include "../ComponentRegistry.hpp"
-#include "../metadata/ComponentMetadata.hpp"
-#include "../SCRExtensionRegistry.hpp"
-#include "ComponentConfigurationImpl.hpp"
 #include "ComponentFactoryImpl.hpp"
+#include "../ComponentRegistry.hpp"
+#include "../SCRExtensionRegistry.hpp"
+#include "../metadata/ComponentMetadata.hpp"
+#include "ComponentConfigurationImpl.hpp"
 #include "ComponentManagerImpl.hpp"
 #include "ConcurrencyUtil.hpp"
 #include "cppmicroservices/SecurityException.h"
@@ -32,54 +32,131 @@
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
 #include "cppmicroservices/cm/ConfigurationAdmin.hpp"
 
-
 namespace cppmicroservices::scrimpl
+{
+    std::string const targetOpenDelimiter = "${";
+    std::string const targetOpenDelimiterFirstChar = "$";
+    std::string const targetCloseDelimiter = "}";
+    boolean
+    balancedDelimitersOnTargetExpression(std::string expression)
     {
-        using cppmicroservices::scrimpl::metadata::ComponentMetadata;
-
-        ComponentFactoryImpl::ComponentFactoryImpl(
-            cppmicroservices::BundleContext const&  context,
-            std::shared_ptr<cppmicroservices::logservice::LogService> logger,
-            std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkSvc,
-            std::shared_ptr<SCRExtensionRegistry> extensionReg)
-            : bundleContext(context)
-            , logger(std::move(logger))
-            , asyncWorkService(asyncWorkSvc)
-            , extensionRegistry(extensionReg)
+        std::vector<string> stack;
+        for (size_t i = 0; i < expression.length(); ++i)
         {
-            if (!bundleContext || !(this->logger) || !(this->asyncWorkService) || !(this->extensionRegistry))
+            std::string letter = expression[i];
+            if (letter != targetOpenDelimiterFirstChar && letter != targetCloseDelimiter)
             {
-                throw std::invalid_argument("ComponentFactoryImpl Constructor "
-                                            "provided with invalid arguments");
+                continue;
+            }
+            if (letter == targetOpenDelimiterFirstChar)
+            {
+                i += 1;
+                stack.push_back(targetOpenDelimiter);
+            }
+            // end delimiter -
+            // if prev is open:
+            //     - pop it off
+            // else
+            //     - add this to it
+            if (stack.back() == targetOpenDelimiter)
+            {
+                stack.pop_back();
+            }
+            else
+            {
+                stack.push_back(targetCloseDelimiter);
             }
         }
+        return stack.empty();
+    }
 
-
-        void
-        ComponentFactoryImpl::CreateFactoryComponent(std::string const& pid,
-                                                     std::shared_ptr<ComponentConfigurationImpl>& mgr,
-                                                     cppmicroservices::AnyMap const& properties)
+    std::string
+    ReplacePlaceholderInTarget(std::string targetExpression, cppmicroservices::AnyMap const& properties)
+    {
+        if (!balancedDelimitersOnTargetExpression(targetExpression))
         {
-            // Create the virtual metadata for the factory instance. 
-            // Start with the metadata from the factory 
-           auto const newMetadata = std::make_shared<ComponentMetadata>(*mgr->GetMetadata());
+            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                        "CreateFactoryComponent failed because of imbalanced ldap filter substitution"
+                            + " target= " + ref.target);
+            throw std::invalid_argument(e.what());
+        }
+        std::regex pattern(R"(\$\{(.*?)\})");
+        std::string result;
+        std::sregex_iterator currentMatch(input.begin(), input.end(), pattern);
+        std::sregex_iterator lastMatch;
 
-            newMetadata->name = pid;
-            // this is a factory instance not a factory component
-            newMetadata->factoryComponentID = "";
+        size_t lastPos = 0;
+        while (currentMatch != lastMatch)
+        {
+            std::smatch match = *currentMatch;
+            result.append(input, lastPos, match.position() - lastPos);
 
-            // Factory instance is dependent on the factory instance pid
-            newMetadata->configurationPids.clear();
-            newMetadata->configurationPids.emplace_back(pid);
-
-            // Look for dynamic targets in the references.
-            // A dynamic target will appear in the properties for the configuration object
-            // with the referenceName.target as the key and the target as the value. 
-            for (auto& ref : newMetadata->refsMetadata)
+            std::string key = match[1].str();
+            if (replacements.find(key) != replacements.end())
             {
-                auto const target = ref.name + ".target";
-                auto const iter = properties.find(target);
-                if (iter != properties.end()) {
+                result.append(replacements.at(key));
+            }
+            else
+            {
+                result.append(match.str());
+            }
+
+            lastPos = match.position() + match.length();
+            ++currentMatch;
+        }
+        result.append(input, lastPos, std::string::npos);
+
+        return result;
+    }
+
+    using cppmicroservices::scrimpl::metadata::ComponentMetadata;
+
+    ComponentFactoryImpl::ComponentFactoryImpl(cppmicroservices::BundleContext const& context,
+                                               std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+                                               std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkSvc,
+                                               std::shared_ptr<SCRExtensionRegistry> extensionReg)
+        : bundleContext(context)
+        , logger(std::move(logger))
+        , asyncWorkService(asyncWorkSvc)
+        , extensionRegistry(extensionReg)
+    {
+        if (!bundleContext || !(this->logger) || !(this->asyncWorkService) || !(this->extensionRegistry))
+        {
+            throw std::invalid_argument("ComponentFactoryImpl Constructor "
+                                        "provided with invalid arguments");
+        }
+    }
+
+    void
+    ComponentFactoryImpl::CreateFactoryComponent(std::string const& pid,
+                                                 std::shared_ptr<ComponentConfigurationImpl>& mgr,
+                                                 cppmicroservices::AnyMap const& properties)
+    {
+        // Create the virtual metadata for the factory instance.
+        // Start with the metadata from the factory
+        auto const newMetadata = std::make_shared<ComponentMetadata>(*mgr->GetMetadata());
+
+        newMetadata->name = pid;
+        // this is a factory instance not a factory component
+        newMetadata->factoryComponentID = "";
+
+        // Factory instance is dependent on the factory instance pid
+        newMetadata->configurationPids.clear();
+        newMetadata->configurationPids.emplace_back(pid);
+
+        // Look for dynamic targets in the references.
+        // A dynamic target will appear in the properties for the configuration object
+        // with the referenceName.target as the key and the target as the value.
+        for (auto& ref : newMetadata->refsMetadata)
+        {
+            auto const target = ref.name + ".target";
+            auto const iter = properties.find(target);
+
+            // look for targets that are dependent on configuration. They key into the configuration will be ${KEY_HERE}
+            if ()
+            {
+                if (iter != properties.end())
+                {
                     // This reference has a dynamic target
                     ref.target = cppmicroservices::ref_any_cast<std::string>(iter->second);
                     // Verify that the ref.target is a valid LDAPFilter
@@ -94,47 +171,46 @@ namespace cppmicroservices::scrimpl
                                         + newMetadata->name + " target= " + ref.target);
                         throw std::invalid_argument(e.what());
                     }
-                 }
-            }
-
-            auto const bundle = mgr->GetBundle();
-            auto const registry = mgr->GetRegistry();
-            auto const logger = mgr->GetLogger();
-            auto const configNotifier = mgr->GetConfigNotifier();
-            try
-            {
-                auto const compManager = std::make_shared<ComponentManagerImpl>(newMetadata,
-                                                                          registry,
-                                                                          bundle.GetBundleContext(),
-                                                                          logger,
-                                                                          asyncWorkService,
-                                                                          configNotifier);
-                if (registry->AddComponentManager(compManager))
-                {
-                    if (auto const& extension = extensionRegistry->Find(bundle.GetBundleId()); extension)
-                    {
-                        extension->AddComponentManager(compManager);
-                        compManager->Initialize();
-                    }
-                    else
-                    {
-                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                                    "Failed to find ComponentManager with name " + newMetadata->name
-                                        + " from bundle with Id "
-                                        + std::to_string(bundleContext.GetBundle().GetBundleId()));
-                    }
                 }
             }
-            catch (cppmicroservices::SharedLibraryException const&)
-            {
-                throw;
-            }
-            catch (cppmicroservices::SecurityException const&)
-            {
-                throw;
-            }
- 
         }
 
- 
-    } // namespace cppmicroservices::scrimpl
+        auto const bundle = mgr->GetBundle();
+        auto const registry = mgr->GetRegistry();
+        auto const logger = mgr->GetLogger();
+        auto const configNotifier = mgr->GetConfigNotifier();
+        try
+        {
+            auto const compManager = std::make_shared<ComponentManagerImpl>(newMetadata,
+                                                                            registry,
+                                                                            bundle.GetBundleContext(),
+                                                                            logger,
+                                                                            asyncWorkService,
+                                                                            configNotifier);
+            if (registry->AddComponentManager(compManager))
+            {
+                if (auto const& extension = extensionRegistry->Find(bundle.GetBundleId()); extension)
+                {
+                    extension->AddComponentManager(compManager);
+                    compManager->Initialize();
+                }
+                else
+                {
+                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                                "Failed to find ComponentManager with name " + newMetadata->name
+                                    + " from bundle with Id "
+                                    + std::to_string(bundleContext.GetBundle().GetBundleId()));
+                }
+            }
+        }
+        catch (cppmicroservices::SharedLibraryException const&)
+        {
+            throw;
+        }
+        catch (cppmicroservices::SecurityException const&)
+        {
+            throw;
+        }
+    }
+
+} // namespace cppmicroservices::scrimpl

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -115,7 +115,7 @@ namespace cppmicroservices::scrimpl
             auto const target = ref.name + ".target";
             auto const iter = properties.find(target);
 
-            // if manually injecting target in using refName.target, override existing
+            // if manually injecting target using refName.target, override existing
             if (iter != properties.end())
             {
                 // This reference has a dynamic target
@@ -123,8 +123,7 @@ namespace cppmicroservices::scrimpl
             }
             else
             {
-                // look for targets that are dependent on configuration. They key into the configuration will be
-                // {{KEY}}
+                // look for targets that are dependent on configuration. The key into the configuration will be {{KEY}}
                 ref.target = ReplacePlaceholdersInTarget(ref.target, properties);
             }
             // Verify that the ref.target is a valid LDAPFilter

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -36,7 +36,7 @@
 namespace cppmicroservices::scrimpl
 {
     std::string
-    ReplacePlaceholdersInTarget(std::string targetExpression, cppmicroservices::AnyMap const& properties)
+    ReplacePlaceholdersInTarget(std::string const& targetExpression, cppmicroservices::AnyMap const& properties)
     {
         if (targetExpression.empty())
         {

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -99,7 +99,7 @@ namespace cppmicroservices::scrimpl
         // Start with the metadata from the factory
         auto const newMetadata = std::make_shared<ComponentMetadata>(*mgr->GetMetadata());
 
-        newMetadata->name = newMetadata->instanceName + "_" + pid;
+        newMetadata->name = newMetadata->name + "_" + pid;
         // this is a factory instance not a factory component
         newMetadata->factoryComponentID = "";
 

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -72,6 +72,7 @@ set(_declarativeservices_tests
   TestConfigurationPropertiesWithMultipleConfigurations.cpp
   TestFactoryPid.cpp
   TestFactoryTarget.cpp
+  TestComponentFactoryImpl.cpp
   TestFailedBoundServiceActivation.cpp
   TestMetadataParserFactory.cpp
   TestMetadataParserImplV1.cpp

--- a/compendium/DeclarativeServices/test/gtest/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/gtest/Mocks.hpp
@@ -399,7 +399,6 @@ namespace cppmicroservices
             }
             virtual ~MockComponentConfigurationImpl() = default;
             MOCK_METHOD0(GetFactory, std::shared_ptr<ServiceFactory>(void));
-            MOCK_CONST_METHOD0(GetMetadata, std::shared_ptr<metadata::ComponentMetadata const>());
             MOCK_METHOD1(CreateAndActivateComponentInstance,
                          std::shared_ptr<ComponentInstance>(cppmicroservices::Bundle const&));
             MOCK_METHOD1(UnbindAndDeactivateComponentInstance, void(std::shared_ptr<ComponentInstance>));

--- a/compendium/DeclarativeServices/test/gtest/Mocks.hpp
+++ b/compendium/DeclarativeServices/test/gtest/Mocks.hpp
@@ -143,11 +143,10 @@ namespace cppmicroservices
                               cppmicroservices::logservice::SeverityLevel,
                               std::string const&,
                               std::exception_ptr const));
-	    MOCK_CONST_METHOD1(getLogger,
-                     std::shared_ptr<cppmicroservices::logservice::Logger>(const std::string&));
-	    MOCK_CONST_METHOD2(getLogger,
-                     std::shared_ptr<cppmicroservices::logservice::Logger>(const cppmicroservices::Bundle&, const std::string&));
-
+            MOCK_CONST_METHOD1(getLogger, std::shared_ptr<cppmicroservices::logservice::Logger>(std::string const&));
+            MOCK_CONST_METHOD2(getLogger,
+                               std::shared_ptr<cppmicroservices::logservice::Logger>(cppmicroservices::Bundle const&,
+                                                                                     std::string const&));
         };
 
 #ifdef _MSC_VER
@@ -180,13 +179,13 @@ namespace cppmicroservices
                 std::exception_ptr const) override
             {
             }
-	    [[nodiscard]] std::shared_ptr<cppmicroservices::logservice::Logger> 
-	    getLogger(const std::string&) const override
-	    {
-		return nullptr;
-	    }
-	    [[nodiscard]] std::shared_ptr<cppmicroservices::logservice::Logger>
-            getLogger(const cppmicroservices::Bundle&, const std::string&) const override
+            [[nodiscard]] std::shared_ptr<cppmicroservices::logservice::Logger>
+            getLogger(std::string const&) const override
+            {
+                return nullptr;
+            }
+            [[nodiscard]] std::shared_ptr<cppmicroservices::logservice::Logger>
+            getLogger(cppmicroservices::Bundle const&, std::string const&) const override
             {
                 return nullptr;
             }
@@ -400,6 +399,7 @@ namespace cppmicroservices
             }
             virtual ~MockComponentConfigurationImpl() = default;
             MOCK_METHOD0(GetFactory, std::shared_ptr<ServiceFactory>(void));
+            MOCK_CONST_METHOD0(GetMetadata, std::shared_ptr<metadata::ComponentMetadata const>());
             MOCK_METHOD1(CreateAndActivateComponentInstance,
                          std::shared_ptr<ComponentInstance>(cppmicroservices::Bundle const&));
             MOCK_METHOD1(UnbindAndDeactivateComponentInstance, void(std::shared_ptr<ComponentInstance>));

--- a/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
@@ -1,0 +1,335 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  =============================================================================*/
+
+#include <future>
+#include <random>
+#include <thread>
+#include <tuple>
+
+#include "../../src/ConfigurationListenerImpl.hpp"
+#include "../../src/SCRAsyncWorkService.hpp"
+#include "../../src/SCRExtensionRegistry.hpp"
+#include "../../src/SCRLogger.hpp"
+#include "../../src/manager/BundleLoader.hpp"
+#include "../../src/manager/BundleOrPrototypeComponentConfiguration.hpp"
+#include "../../src/manager/ComponentConfigurationImpl.hpp"
+#include "../../src/manager/ReferenceManager.hpp"
+#include "../../src/manager/SingletonComponentConfiguration.hpp"
+#include "../../src/manager/states/CCActiveState.hpp"
+#include "../../src/manager/states/CCRegisteredState.hpp"
+#include "../../src/manager/states/CCUnsatisfiedReferenceState.hpp"
+#include "ConcurrencyTestUtil.hpp"
+#include "Mocks.hpp"
+#include "cppmicroservices/Framework.h"
+#include "cppmicroservices/FrameworkEvent.h"
+#include "cppmicroservices/FrameworkFactory.h"
+#include "cppmicroservices/ServiceInterface.h"
+
+#include "../TestUtils.hpp"
+#include <TestInterfaces/Interfaces.hpp>
+
+using cppmicroservices::service::component::ComponentContext;
+
+namespace cppmicroservices
+{
+    namespace scrimpl
+    {
+
+        class ComponentFactoryImplTest : public ::testing::Test
+        {
+          protected:
+            ComponentFactoryImplTest() : framework(cppmicroservices::FrameworkFactory().NewFramework()) {}
+
+            virtual ~ComponentFactoryImplTest() = default;
+
+            virtual void
+            SetUp()
+            {
+                framework.Start();
+                mockMetadata = std::make_shared<metadata::ComponentMetadata>();
+                mockRegistry = std::make_shared<MockComponentRegistry>();
+                fakeLogger = std::make_shared<FakeLogger>();
+                logger = std::make_shared<SCRLogger>(GetFramework().GetBundleContext());
+                asyncWorkService = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(
+                    GetFramework().GetBundleContext(),
+                    logger);
+                extRegistry = std::make_shared<SCRExtensionRegistry>(logger);
+                notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+                fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
+                                                                                  GetFramework(),
+                                                                                  mockRegistry,
+                                                                                  fakeLogger,
+                                                                                  notifier);
+                EXPECT_CALL(*fakeCompConfig, GetMetadata()).WillRepeatedly(testing::Return(mockMetadata));
+            }
+
+            virtual void
+            TearDown()
+            {
+                framework.Stop();
+                framework.WaitForStop(std::chrono::milliseconds::zero());
+            }
+
+            cppmicroservices::Framework&
+            GetFramework()
+            {
+                return framework;
+            }
+
+          protected:
+            cppmicroservices::Framework framework;
+            cppmicroservices::BundleContext context;
+            std::shared_ptr<metadata::ComponentMetadata> mockMetadata;
+            std::shared_ptr<MockComponentRegistry> mockRegistry;
+            std::shared_ptr<FakeLogger> fakeLogger;
+            std::shared_ptr<SCRLogger> logger;
+            std::shared_ptr<cppmicroservices::scrimpl::SCRAsyncWorkService> asyncWorkService;
+            std::shared_ptr<SCRExtensionRegistry> extRegistry;
+            std::shared_ptr<ConfigurationNotifier> notifier;
+            std::shared_ptr<MockComponentConfigurationImpl> fakeCompConfig;
+        };
+
+        TEST_F(ComponentFactoryImplTest, verifyNameCreation)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            EXPECT_CALL(*mockRegistry,
+                        AddComponentManager(::testing::Truly([compName, id](std::shared_ptr<ComponentManager> manager)
+                                                             { return manager->GetName() == compName + "_" + id; })))
+                .WillRepeatedly(::testing::Return(true));
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            compFact->CreateFactoryComponent(id, compConfigImpl, configData);
+        }
+
+        TEST_F(ComponentFactoryImplTest, verifyDynamicTargetInConfig)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            std::string refName = "someRef";
+            std::string targetKey = refName + ".target";
+            std::string expectedTargetValue = "(someValidLdap=someValidValue)";
+
+            cppmicroservices::scrimpl::metadata::ReferenceMetadata refMetadata;
+            refMetadata.name = refName;
+            refMetadata.target = "(someOtherTarget=ToBeOverwritten)";
+            mockMetadata->refsMetadata.push_back(refMetadata);
+
+            EXPECT_CALL(*mockRegistry,
+                        AddComponentManager(::testing::Truly(
+                            [compName, id, refName, expectedTargetValue](std::shared_ptr<ComponentManager> manager)
+                            {
+                                // Implement your logic to check the property
+                                return manager->GetName() == compName + "_" + id
+                                       && manager->GetMetadata()->refsMetadata[0].name == refName
+                                       && manager->GetMetadata()->refsMetadata[0].target == expectedTargetValue;
+                            })))
+                .WillRepeatedly(::testing::Return(true));
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+            configData[targetKey] = expectedTargetValue;
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            compFact->CreateFactoryComponent(id, compConfigImpl, configData);
+        }
+
+        TEST_F(ComponentFactoryImplTest, verifyDynamicTargetUsingPlaceholder)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            std::string refName = "someRef";
+            std::string expectedTargetValue = "(someValidLdap=someValidValue)";
+
+            cppmicroservices::scrimpl::metadata::ReferenceMetadata refMetadata;
+            refMetadata.name = refName;
+            refMetadata.target = "(someValidLdap={{keyToConfig}})";
+            mockMetadata->refsMetadata.push_back(refMetadata);
+
+            EXPECT_CALL(*mockRegistry,
+                        AddComponentManager(::testing::Truly(
+                            [compName, id, refName, expectedTargetValue](std::shared_ptr<ComponentManager> manager)
+                            {
+                                // Implement your logic to check the property
+                                return manager->GetName() == compName + "_" + id
+                                       && manager->GetMetadata()->refsMetadata[0].name == refName
+                                       && manager->GetMetadata()->refsMetadata[0].target == expectedTargetValue;
+                            })))
+                .WillRepeatedly(::testing::Return(true));
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+            configData["keyToConfig"] = std::string { "someValidValue" };
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            compFact->CreateFactoryComponent(id, compConfigImpl, configData);
+        }
+
+        TEST_F(ComponentFactoryImplTest, verify2DynamicTargetUsingPlaceholder)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            std::string refName = "someRef";
+            std::string expectedTargetValue = "(&(whatIf=Woah)(IWanted=What))";
+
+            cppmicroservices::scrimpl::metadata::ReferenceMetadata refMetadata;
+            refMetadata.name = refName;
+            refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}}))";
+            mockMetadata->refsMetadata.push_back(refMetadata);
+
+            EXPECT_CALL(*mockRegistry,
+                        AddComponentManager(::testing::Truly(
+                            [compName, id, refName, expectedTargetValue](std::shared_ptr<ComponentManager> manager)
+                            {
+                                // Implement your logic to check the property
+                                return manager->GetName() == compName + "_" + id
+                                       && manager->GetMetadata()->refsMetadata[0].name == refName
+                                       && manager->GetMetadata()->refsMetadata[0].target == expectedTargetValue;
+                            })))
+                .WillRepeatedly(::testing::Return(true));
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+            configData["TwoKeys"] = std::string { "Woah" };
+            configData["ToTheConfig"] = std::string { "What" };
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            compFact->CreateFactoryComponent(id, compConfigImpl, configData);
+        }
+
+        TEST_F(ComponentFactoryImplTest, prioritizeOSGITarget)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            std::string refName = "someRef";
+            std::string targetKey = refName + ".target";
+            std::string expectedTargetValue = "(&(We=Prioritize)(OSGI=behavior))";
+
+            cppmicroservices::scrimpl::metadata::ReferenceMetadata refMetadata;
+            refMetadata.name = refName;
+            refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}}))";
+            mockMetadata->refsMetadata.push_back(refMetadata);
+
+            EXPECT_CALL(*mockRegistry,
+                        AddComponentManager(::testing::Truly(
+                            [compName, id, refName, expectedTargetValue](std::shared_ptr<ComponentManager> manager)
+                            {
+                                // Implement your logic to check the property
+                                return manager->GetName() == compName + "_" + id
+                                       && manager->GetMetadata()->refsMetadata[0].name == refName
+                                       && manager->GetMetadata()->refsMetadata[0].target == expectedTargetValue;
+                            })))
+                .WillRepeatedly(::testing::Return(true));
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+            configData[targetKey] = expectedTargetValue;
+            configData["TwoKeys"] = std::string { "Woah" };
+            configData["ToTheConfig"] = std::string { "What" };
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            compFact->CreateFactoryComponent(id, compConfigImpl, configData);
+        }
+
+        TEST_F(ComponentFactoryImplTest, failureModes)
+        {
+            std::string compName = "someName";
+            std::string id = "123";
+            mockMetadata->name = compName;
+
+            std::string refName = "someRef";
+            std::string targetKey = refName + ".target";
+
+            cppmicroservices::scrimpl::metadata::ReferenceMetadata refMetadata;
+            refMetadata.name = refName;
+            refMetadata.target = "(&(whatIf={{TwoKeysOops}})(IWanted={{ToTheConfig}}))";
+            mockMetadata->refsMetadata.push_back(refMetadata);
+
+            cppmicroservices::AnyMap configData(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            configData["bar"] = std::string { "baz" };
+            configData["TwoKeys"] = std::string { "Woah" };
+            configData["ToTheConfig"] = std::string { "What" };
+
+            auto compFact = std::make_shared<ComponentFactoryImpl>(GetFramework().GetBundleContext(),
+                                                                   fakeLogger,
+                                                                   asyncWorkService,
+                                                                   extRegistry);
+
+            std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
+
+            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+            // valid keys, but invalid ldap
+            refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}))";
+            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+            // extra "{"
+            refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}}{))";
+            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+        }
+    } // namespace scrimpl
+} // namespace cppmicroservices

--- a/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
@@ -54,6 +54,21 @@ namespace cppmicroservices
     namespace scrimpl
     {
 
+        class MockCompConfigImplWithOverridenGetMetadata : public MockComponentConfigurationImpl
+        {
+          public:
+            MockCompConfigImplWithOverridenGetMetadata(std::shared_ptr<metadata::ComponentMetadata const> metadata,
+                                                       Bundle const& bundle,
+                                                       std::shared_ptr<ComponentRegistry> registry,
+                                                       std::shared_ptr<cppmicroservices::logservice::LogService> logger,
+                                                       std::shared_ptr<ConfigurationNotifier> notifier)
+                : MockComponentConfigurationImpl(metadata, bundle, registry, logger, notifier)
+            {
+            }
+            virtual ~MockCompConfigImplWithOverridenGetMetadata() = default;
+            MOCK_CONST_METHOD0(GetMetadata, std::shared_ptr<metadata::ComponentMetadata const>());
+        };
+
         class ComponentFactoryImplTest : public ::testing::Test
         {
           protected:
@@ -78,11 +93,11 @@ namespace cppmicroservices
                                                                    asyncWorkService,
                                                                    extRegistry);
 
-                fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
-                                                                                  GetFramework(),
-                                                                                  mockRegistry,
-                                                                                  fakeLogger,
-                                                                                  notifier);
+                fakeCompConfig = std::make_shared<MockCompConfigImplWithOverridenGetMetadata>(mockMetadata,
+                                                                                              GetFramework(),
+                                                                                              mockRegistry,
+                                                                                              fakeLogger,
+                                                                                              notifier);
                 EXPECT_CALL(*fakeCompConfig, GetMetadata()).WillRepeatedly(testing::Return(mockMetadata));
             }
 
@@ -109,7 +124,7 @@ namespace cppmicroservices
             std::shared_ptr<cppmicroservices::scrimpl::SCRAsyncWorkService> asyncWorkService;
             std::shared_ptr<SCRExtensionRegistry> extRegistry;
             std::shared_ptr<ConfigurationNotifier> notifier;
-            std::shared_ptr<MockComponentConfigurationImpl> fakeCompConfig;
+            std::shared_ptr<MockCompConfigImplWithOverridenGetMetadata> fakeCompConfig;
         };
 
         TEST_F(ComponentFactoryImplTest, verifyNameCreation)

--- a/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentFactoryImpl.cpp
@@ -323,13 +323,13 @@ namespace cppmicroservices
 
             std::shared_ptr<ComponentConfigurationImpl> compConfigImpl = fakeCompConfig;
 
-            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+            EXPECT_THROW({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
             // valid keys, but invalid ldap
             refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}))";
-            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+            EXPECT_THROW({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
             // extra "{"
             refMetadata.target = "(&(whatIf={{TwoKeys}})(IWanted={{ToTheConfig}}{))";
-            EXPECT_expectedTargetValue({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
+            EXPECT_THROW({ compFact->CreateFactoryComponent(id, compConfigImpl, configData); }, std::invalid_argument);
         }
     } // namespace scrimpl
 } // namespace cppmicroservices

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
@@ -72,7 +72,7 @@ namespace test
         auto fut = factoryConfig->Update(props);
         fut.get();
         // Confirm the properties have been updated in DS.
-        compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, factoryInstance);
+        compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, factoryComponentName + "_" + factoryInstance);
         EXPECT_EQ(compDescDTO.implementationClass, factoryComponentName)
             << "Implementation class in the returned component description must be " << factoryComponentName;
 

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryTarget.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryTarget.cpp
@@ -48,7 +48,7 @@ namespace test
         getFactoryService(std::string factoryPid,
                           std::string factoryInstance,
                           cppmicroservices::AnyMap const& props,
-                          std::string implClass = "")
+                          std::string implClass)
         {
 
             // Get a service reference to ConfigAdmin to create the factory component instance.

--- a/compendium/test_bundles/TestBundleDSFAC1/resources/manifest.json
+++ b/compendium/test_bundles/TestBundleDSFAC1/resources/manifest.json
@@ -54,6 +54,52 @@
             {
                 "enabled" : true,
                 "immediate": true,
+                "implementation-class": "sample::ServiceAImpl4",
+                "configuration-policy" : "require",
+                "configuration-pid" : ["ServiceA4"],
+                "factory" : "ServiceA4 Factory",
+                "inject-references" : true,
+                "references":[{
+                    "name": "ServiceB",
+                    "interface" : "test::ServiceBInt",
+                    "target": "(ServiceBId={{valueFromConfig}})"
+                }],
+                "service": {
+                    "interfaces": ["test::ServiceAInt"]
+                }
+            },
+            {
+                "enabled" : true,
+                "immediate": true,
+                "implementation-class": "sample::ServiceAImpl5",
+                "configuration-policy" : "require",
+                "configuration-pid" : ["sharedConfiguration"],
+                "factory" : "ServiceA5 Factory",
+                "inject-references" : true,
+                "references":[{
+                    "name": "ServiceB",
+                    "interface" : "test::ServiceBInt",
+                    "target": "(sharedConfigurationKey={{sharedConfigurationKey}})"
+                }],
+                "service": {
+                    "interfaces": ["test::ServiceAInt"]
+                }
+            },
+            {
+                "enabled" : true,
+                "immediate": true,
+                "implementation-class": "sample::ServiceBImpl3",
+                "configuration-policy" : "require",
+                "factory" : "ServiceB3 Factory",
+                "configuration-pid" : ["sharedConfiguration"],
+                "service": {
+                    "interfaces": ["test::ServiceBInt"],
+                    "scope" : "singleton"
+                }
+            },
+            {
+                "enabled" : true,
+                "immediate": true,
                 "implementation-class": "sample::ServiceBImpl2",
                 "configuration-policy" : "require",
                 "configuration-pid" : ["scopetestpid"],

--- a/compendium/test_bundles/TestBundleDSFAC1/src/ServiceImpl.cpp
+++ b/compendium/test_bundles/TestBundleDSFAC1/src/ServiceImpl.cpp
@@ -5,14 +5,14 @@ namespace sample
 {
 
     ServiceAImpl::ServiceAImpl(std::shared_ptr<cppmicroservices::AnyMap> const& props,
-                                               const std::shared_ptr<test::ServiceBInt> interface1)
+                               std::shared_ptr<test::ServiceBInt> const interface1)
         : properties(*props)
         , serviceB(interface1)
     {
     }
     void
     ServiceAImpl::Modified(std::shared_ptr<ComponentContext> const& /*context*/,
-                                   std::shared_ptr<cppmicroservices::AnyMap> const& configuration)
+                           std::shared_ptr<cppmicroservices::AnyMap> const& configuration)
     {
         std::lock_guard<std::mutex> lock(propertiesLock);
         properties = *configuration;
@@ -32,6 +32,16 @@ namespace sample
     ServiceAImpl3::ServiceAImpl3(std::shared_ptr<cppmicroservices::AnyMap> const&,
                                  std::shared_ptr<test::ServiceCInt> const interface1)
         : serviceC(interface1)
+    {
+    }
+    ServiceAImpl4::ServiceAImpl4(std::shared_ptr<cppmicroservices::AnyMap> const&,
+                                 std::shared_ptr<test::ServiceBInt> const interface1)
+        : serviceB(interface1)
+    {
+    }
+    ServiceAImpl5::ServiceAImpl5(std::shared_ptr<cppmicroservices::AnyMap> const&,
+                                 std::shared_ptr<test::ServiceBInt> const interface1)
+        : serviceB(interface1)
     {
     }
 

--- a/compendium/test_bundles/TestBundleDSFAC1/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/TestBundleDSFAC1/src/ServiceImpl.hpp
@@ -1,8 +1,8 @@
 #ifndef SERVICE_IMPL_HPP_
 #define SERVICE_IMPL_HPP_
 
-#include <TestInterfaces/Interfaces.hpp>
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
+#include <TestInterfaces/Interfaces.hpp>
 #include <mutex>
 
 using ComponentContext = cppmicroservices::service::component::ComponentContext;
@@ -100,6 +100,93 @@ namespace sample
       private:
         std::shared_ptr<test::ServiceCInt> serviceC {};
     };
+    class ServiceAImpl4 : public test::ServiceAInt
+    {
+      public:
+        ServiceAImpl4(std::shared_ptr<cppmicroservices::AnyMap> const& props,
+                      std::shared_ptr<test::ServiceBInt> const interface1);
+        ServiceAImpl4() = default;
+        ServiceAImpl4(ServiceAImpl const&) = delete;
+        ServiceAImpl4(ServiceAImpl&&) = delete;
+        ServiceAImpl4& operator=(ServiceAImpl const&) = delete;
+        ServiceAImpl4& operator=(ServiceAImpl&&) = delete;
+        ~ServiceAImpl4() = default;
+
+        void
+        Modified(std::shared_ptr<ComponentContext> const&, std::shared_ptr<cppmicroservices::AnyMap> const&)
+        {
+        }
+        cppmicroservices::AnyMap
+        GetProperties() override
+        {
+            return {};
+        }
+
+        [[nodiscard]] void*
+        GetRefAddr() const override
+        {
+            return static_cast<void*>(serviceB.get());
+        }
+
+      private:
+        std::shared_ptr<test::ServiceBInt> serviceB {};
+    };
+
+    class ServiceAImpl5 : public test::ServiceAInt
+    {
+      public:
+        ServiceAImpl5(std::shared_ptr<cppmicroservices::AnyMap> const& props,
+                      std::shared_ptr<test::ServiceBInt> const interface1);
+        ServiceAImpl5() = default;
+        ServiceAImpl5(ServiceAImpl const&) = delete;
+        ServiceAImpl5(ServiceAImpl&&) = delete;
+        ServiceAImpl5& operator=(ServiceAImpl const&) = delete;
+        ServiceAImpl5& operator=(ServiceAImpl&&) = delete;
+        ~ServiceAImpl5() = default;
+
+        void
+        Modified(std::shared_ptr<ComponentContext> const&, std::shared_ptr<cppmicroservices::AnyMap> const&)
+        {
+        }
+        cppmicroservices::AnyMap
+        GetProperties() override
+        {
+            return {};
+        }
+
+        [[nodiscard]] void*
+        GetRefAddr() const override
+        {
+            return static_cast<void*>(serviceB.get());
+        }
+
+      private:
+        std::shared_ptr<test::ServiceBInt> serviceB {};
+    };
+
+    class ServiceBImpl3 : public test::ServiceBInt
+    {
+      public:
+        ServiceBImpl3(std::shared_ptr<cppmicroservices::AnyMap> const&) {}
+        ServiceBImpl3() = default;
+        ServiceBImpl3(ServiceBImpl3 const&) = delete;
+        ServiceBImpl3(ServiceBImpl3&&) = delete;
+        ServiceBImpl3& operator=(ServiceBImpl3 const&) = delete;
+        ServiceBImpl3& operator=(ServiceBImpl3&&) = delete;
+        ~ServiceBImpl3() = default;
+
+        cppmicroservices::AnyMap
+        GetProperties() override
+        {
+            return {};
+        }
+
+        void
+        Modified(std::shared_ptr<ComponentContext> const&, std::shared_ptr<cppmicroservices::AnyMap> const&)
+        {
+        }
+    };
+
     class ServiceBImpl2 : public test::ServiceBInt
     {
       public:


### PR DESCRIPTION
This change allows users to, for Factory Components, create 'injection tags' in their reference targets. These tags, enclosed in `{{someKey}}`, correspond to the Configuration that is used to create a specific factory instance.

- If the key does not exist in the configuration that causes the factory instance to be created, an error is thrown.
- If the resulting LDAP filter is invalid, an error is thrown. 

This allows dynamic targeting based on the value of the configuration without forcing a user to create an intermediary to listen for specific configs and then manually inject a `refName.target=...` value.