### PR TITLE
`getServiceObjects` fix to use `customDeleter`

### DIFF
--- a/compendium/DeclarativeServices/test/gtest/TestServiceReferenceRetrieval.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestServiceReferenceRetrieval.cpp
@@ -84,9 +84,13 @@ namespace test
         auto dsRef = context.GetServiceReference<test::CAInterface>();
         ASSERT_TRUE(dsRef);
         auto dsSvc = context.GetService<test::CAInterface>(dsRef);
+        auto dsSvcServiceObject = context.GetServiceObjects<test::CAInterface>(dsRef).GetService();
         auto retSRef = cppmicroservices::ServiceReferenceFromService(dsSvc);
+        auto retSRefServiceObject = cppmicroservices::ServiceReferenceFromService(dsSvcServiceObject);
         ASSERT_EQ(retSRef, dsRef);
+        ASSERT_EQ(retSRefServiceObject, dsRef);
         ASSERT_EQ(cppmicroservices::any_cast<std::string>(retSRef.GetProperty("ManifestProp")), "abc");
+        ASSERT_EQ(cppmicroservices::any_cast<std::string>(retSRefServiceObject.GetProperty("ManifestProp")), "abc");
 
         ASSERT_THROW(cppmicroservices::ServiceReferenceFromService(std::make_shared<TestServiceA>(id1)),
                      std::runtime_error);

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -104,7 +104,8 @@ namespace cppmicroservices
             return nullptr;
         }
 
-        auto h = std::make_shared<ServiceHolder<void>>(bundle_, d->m_reference, nullptr, interfaceMap);
+        auto serviceHolder = new ServiceHolder<void>(bundle_, d->m_reference, nullptr, interfaceMap);
+        std::shared_ptr<ServiceHolder<void>> h(serviceHolder, CustomServiceDeleter { serviceHolder });
         auto deleter = h->interfaceMap->find(d->m_reference.GetInterfaceId())->second.get();
         return std::shared_ptr<void>(h, deleter);
     }


### PR DESCRIPTION
Not sure how I missed this in #1044, but GetServiceObjects doesn't use the custom deleter. That is a problem.