### PR TITLE
latent bug -- concurrent configuration creations for factories race

### DIFF
--- a/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.hpp
@@ -99,7 +99,8 @@ namespace cppmicroservices
             cppmicroservices::Bundle bundle_;
             std::shared_ptr<ComponentRegistry> registry;
             std::shared_ptr<LogService> logger;
-            std::shared_ptr<std::vector<std::shared_ptr<ComponentManager>>> managers;
+            std::vector<std::shared_ptr<ComponentManager>> managers;
+            std::mutex managersMutex; // protects the managers
             std::shared_ptr<ConfigurationNotifier> configNotifier;
         };
     } // namespace scrimpl

--- a/compendium/DeclarativeServices/test/gtest/ConcurrencyTestUtil.hpp
+++ b/compendium/DeclarativeServices/test/gtest/ConcurrencyTestUtil.hpp
@@ -49,4 +49,34 @@ ConcurrentInvoke(std::function<R(Args...)> func)
     return returnVals;
 }
 
+class Barrier
+{
+  public:
+    Barrier(std::size_t count) : threshold(count), count(count), generation(0) {}
+
+    void
+    Wait()
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        auto gen = generation;
+        if (--count == 0)
+        {
+            generation++;
+            count = threshold;
+            cond.notify_all();
+        }
+        else
+        {
+            cond.wait(lock, [this, gen] { return gen != generation; });
+        }
+    }
+
+  private:
+    std::mutex mutex;
+    std::condition_variable cond;
+    std::size_t threshold;
+    std::size_t count;
+    std::size_t generation;
+};
+
 #endif /* ConcurrencyTestUtil_hpp */

--- a/compendium/DeclarativeServices/test/gtest/ConcurrencyTestUtil.hpp
+++ b/compendium/DeclarativeServices/test/gtest/ConcurrencyTestUtil.hpp
@@ -76,7 +76,7 @@ class Barrier
     std::condition_variable cond;
     std::size_t threshold;
     std::size_t count;
-    std::size_t generation;
+    std::size_t generation{0};
 };
 
 #endif /* ConcurrencyTestUtil_hpp */

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -1271,36 +1271,6 @@ namespace cppmicroservices
             framework.WaitForStop(std::chrono::milliseconds::zero());
         }
 
-        class Barrier
-        {
-          public:
-            Barrier(std::size_t count) : threshold(count), count(count), generation(0) {}
-
-            void
-            Wait()
-            {
-                std::unique_lock<std::mutex> lock(mutex);
-                auto gen = generation;
-                if (--count == 0)
-                {
-                    generation++;
-                    count = threshold;
-                    cond.notify_all();
-                }
-                else
-                {
-                    cond.wait(lock, [this, gen] { return gen != generation; });
-                }
-            }
-
-          private:
-            std::mutex mutex;
-            std::condition_variable cond;
-            std::size_t threshold;
-            std::size_t count;
-            std::size_t generation;
-        };
-
         /**
          * Test that the Modified method on a component configuration that is
          * lazily loaded and requires two configuration objects where one is

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
@@ -20,6 +20,7 @@
 
 =============================================================================*/
 
+#include "ConcurrencyTestUtil.hpp"
 #include "TestFixture.hpp"
 #include "gtest/gtest.h"
 
@@ -72,7 +73,8 @@ namespace test
         auto fut = factoryConfig->Update(props);
         fut.get();
         // Confirm the properties have been updated in DS.
-        compDescDTO = dsRuntimeService->GetComponentDescriptionDTO(testBundle, factoryComponentName + "_" + factoryInstance);
+        compDescDTO
+            = dsRuntimeService->GetComponentDescriptionDTO(testBundle, factoryComponentName + "_" + factoryInstance);
         EXPECT_EQ(compDescDTO.implementationClass, factoryComponentName)
             << "Implementation class in the returned component description must be " << factoryComponentName;
 
@@ -196,6 +198,61 @@ namespace test
             props["uniqueProp"] = instanceId;
             auto fut = factoryConfig->Update(props);
             futures.push_back(fut);
+        }
+
+        // Wait for all factory objects to finish updating.
+        for (auto const& item : futures)
+        {
+            item.get();
+        }
+
+        // Request service references to the new component instances. This will
+        // cause DS to construct the factory instances.
+        auto instances = GetInstances<test::CAInterface>();
+        EXPECT_EQ(instances.size(), count);
+    }
+
+    /* test concurrentFactoryCreation.
+     * This test creates 1000 factory objects without waiting for the previous one to complete.
+     */
+    TEST_F(tServiceComponent, testConcurrentFactoryCreation)
+    {
+        auto const& param = std::make_shared<AsyncWorkServiceThreadPool>(10);
+        auto reg = context.RegisterService<cppmicroservices::async::AsyncWorkService>(param);
+
+        std::string configurationPid = "ServiceComponentPid";
+
+        // Start the test bundle containing the factory component.
+        cppmicroservices::Bundle testBundle = StartTestBundle("TestBundleDSCA21");
+
+        // Get a service reference to ConfigAdmin to create the factory component instances.
+        auto configAdminService = GetInstance<cppmicroservices::service::cm::ConfigurationAdmin>();
+        ASSERT_TRUE(configAdminService) << "GetService failed for ConfigurationAdmin";
+
+        // Create some factory configuration objects. Don't wait for one to complete before
+        // creating the next one.
+        constexpr auto count = 100;
+        std::vector<std::shared_future<void>> futures;
+        Barrier sync_point(count); // 60 threads to synchronize
+
+        for (int i = 0; i < count; i++)
+        {
+            auto processConfiguration
+                = [&sync_point](std::shared_ptr<cppmicroservices::service::cm::Configuration> factoryConfig)
+            {
+                sync_point.Wait();
+                auto fut = factoryConfig->Update({});
+                fut.wait();
+            };
+
+            // Create the factory configuration object
+            auto factoryConfig = configAdminService->CreateFactoryConfiguration(configurationPid);
+
+            // Update the properties for the factory configuration object
+            cppmicroservices::AnyMap props(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
+            std::string const instanceId { "instance" + std::to_string(i) };
+            props["uniqueProp"] = instanceId;
+            futures.emplace_back(std::async(std::launch::async, processConfiguration, factoryConfig));
         }
 
         // Wait for all factory objects to finish updating.

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
@@ -213,7 +213,7 @@ namespace test
     }
 
     /* test concurrentFactoryCreation.
-     * This test creates 1000 factory objects without waiting for the previous one to complete.
+     * This test creates 100 factory objects concurrently 
      */
     TEST_F(tServiceComponent, testConcurrentFactoryCreation)
     {
@@ -233,7 +233,7 @@ namespace test
         // creating the next one.
         constexpr auto count = 100;
         std::vector<std::shared_future<void>> futures;
-        Barrier sync_point(count); // 60 threads to synchronize
+        Barrier sync_point(count); // 100 threads to synchronize
 
         for (int i = 0; i < count; i++)
         {
@@ -248,10 +248,6 @@ namespace test
             // Create the factory configuration object
             auto factoryConfig = configAdminService->CreateFactoryConfiguration(configurationPid);
 
-            // Update the properties for the factory configuration object
-            cppmicroservices::AnyMap props(cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS);
-            std::string const instanceId { "instance" + std::to_string(i) };
-            props["uniqueProp"] = instanceId;
             futures.emplace_back(std::async(std::launch::async, processConfiguration, factoryConfig));
         }
 

--- a/compendium/DeclarativeServices/test/gtest/TestSCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestSCRBundleExtension.cpp
@@ -165,12 +165,12 @@ namespace cppmicroservices
             EXPECT_NO_THROW({
                 SCRBundleExtension bundleExt = SCRBundleExtension(GetFramework(), mockRegistry, fakeLogger, notifier);
                 bundleExt.Initialize(scr, asyncWorkService);
-                EXPECT_EQ(bundleExt.managers->size(), 0u);
+                EXPECT_EQ(bundleExt.managers.size(), 0u);
             });
             EXPECT_NO_THROW({
                 SCRBundleExtension bundleExt(GetFramework(), mockRegistry, fakeLogger, notifier);
                 bundleExt.Initialize(scr, asyncWorkService);
-                EXPECT_EQ(bundleExt.managers->size(), 1u);
+                EXPECT_EQ(bundleExt.managers.size(), 1u);
             });
         }
 


### PR DESCRIPTION
Similar to #834

Lock down the `managers` object within `SCRBundleExtension` to make sure concurrent updates don't happen

before fix, the new test cases failed 50-80% of the time either at:

`            managers.push_back(std::move(compManager));` 

or

`                auto fut = compManager->Disable(singleInvoke);`

After fix, ran 1000 times with no failure