### PR TITLE
Revert conversion of serviceProperties to anymap

### DIFF
--- a/framework/include/cppmicroservices/ServiceProperties.h
+++ b/framework/include/cppmicroservices/ServiceProperties.h
@@ -35,7 +35,7 @@ namespace cppmicroservices
      * type. It is typically used for passing service properties to
      * BundleContext::RegisterService.
      */
-    using ServiceProperties = AnyMap;
+    using ServiceProperties = std::unordered_map<std::string, Any>;
 } // namespace cppmicroservices
 
 #endif // CPPMICROSERVICES_SERVICEPROPERTIES_H


### PR DESCRIPTION
This causes issues in downstream users who rely on the functionality of the std::unordered_map implementation. 