### PR TITLE
compartmentalize bundleBinary locations per framework fixes #1080

### DIFF
--- a/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.hpp
@@ -35,9 +35,9 @@
 #include "cppmicroservices/Any.h"
 #include "cppmicroservices/Bundle.h"
 #include "cppmicroservices/BundleContext.h"
+#include "cppmicroservices/GuardedObject.h"
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 #include "manager/ComponentConfiguration.hpp"
-#include "manager/ConcurrencyUtil.hpp"
 
 namespace cppmicroservices
 {
@@ -250,7 +250,7 @@ namespace cppmicroservices
             cppmicroservices::Bundle usingBundle;
             // map of reference name to std::vector of pairs of ServiceReferenceBase to std::shared_ptr<void> of bound
             // service in order that they were added to the boundServiceCache
-            mutable Guarded<std::unordered_map<
+            mutable cppmicroservices::Guarded<std::unordered_map<
                 std::string,
                 std::vector<std::pair<cppmicroservices::ServiceReferenceBase, InterfaceMapConstPtr>>>>
                 boundServicesCache;

--- a/compendium/DeclarativeServices/src/ConfigurationListenerImpl.hpp
+++ b/compendium/DeclarativeServices/src/ConfigurationListenerImpl.hpp
@@ -25,7 +25,6 @@
 
 #include "SCRLogger.hpp"
 #include "cppmicroservices/cm/ConfigurationListener.hpp"
-#include "manager/ConcurrencyUtil.hpp"
 #include "manager/ConfigurationNotifier.hpp"
 
 namespace cppmicroservices

--- a/compendium/DeclarativeServices/src/manager/BundleLoader.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleLoader.hpp
@@ -23,7 +23,6 @@
 #ifndef BUNDLELOADER_HPP
 #define BUNDLELOADER_HPP
 
-#include "ConcurrencyUtil.hpp"
 #include "cppmicroservices/logservice/LogService.hpp"
 #include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
 #include <map>

--- a/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/BundleOrPrototypeComponentConfiguration.hpp
@@ -24,7 +24,7 @@
 #define BUNDLEORPROTOTYPECOMPONENTCONFIGURATIONIMPL_HPP
 
 #include "ComponentConfigurationImpl.hpp"
-#include "ConcurrencyUtil.hpp"
+#include "cppmicroservices/GuardedObject.h"
 #include <cppmicroservices/ServiceFactory.h>
 
 namespace cppmicroservices
@@ -121,7 +121,7 @@ namespace cppmicroservices
              */
             void DeactivateComponentInstance(InstanceContextPair const& instCtxt);
 
-            Guarded<std::vector<InstanceContextPair>>
+            cppmicroservices::Guarded<std::vector<InstanceContextPair>>
                 compInstanceMap; ///< map of component instance and context objects associated with this configuration
         };
     } // namespace scrimpl

--- a/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConcurrencyUtil.hpp
@@ -43,65 +43,6 @@ namespace cppmicroservices
             return (futObj.wait_for(std::chrono::seconds::zero()) == std::future_status::ready);
         }
 
-        /**
-         * Utility class to help developers avoid mistakes with locking data members
-         * in a class. This code is based on the Guarded idiom as described in
-         * "Mastering the C++17 STL" by Arthur O'Dwyer
-         */
-        template <class Data>
-        class Guarded
-        {
-            std::mutex mtx;
-            Data data;
-            class Handle
-            {
-                std::unique_lock<std::mutex> lk;
-                Data* ptr;
-
-              public:
-                Handle(std::unique_lock<std::mutex> lk, Data* p) : lk(std::move(lk)), ptr(p) {}
-
-                Handle(Handle const&) = delete;
-                Handle& operator=(Handle const&) = delete;
-
-                Handle(Handle&& rhs) : lk(std::move(rhs.lk)), ptr(std::move(rhs.ptr)) {}
-
-                Handle&
-                operator=(Handle&& rhs)
-                {
-                    lk = std::move(rhs.lk);
-                    ptr = std::move(rhs.ptr);
-                }
-
-                ~Handle() = default;
-
-                Data*
-                operator->() const
-                {
-                    return ptr;
-                }
-                Data&
-                operator*() const
-                {
-                    return *ptr;
-                }
-            };
-
-          public:
-            /**
-             * Locks the member mutex and returns an RAII object responsible for
-             * unlocking the mutex.
-             *
-             * \return a RAII style wrapper object used to access the data
-             */
-            Handle
-            lock()
-            {
-                std::unique_lock<std::mutex> lock(mtx);
-                return Handle { std::move(lock), &data };
-            }
-        };
-
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
@@ -24,7 +24,6 @@
 #define CONFIGURATIONMANAGER_HPP
 
 #include "../metadata/ComponentMetadata.hpp"
-#include "ConcurrencyUtil.hpp"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/cm/ConfigurationListener.hpp"
 #include "cppmicroservices/logservice/LogService.hpp"

--- a/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationNotifier.hpp
@@ -25,8 +25,8 @@
 
 #include "../SCRLogger.hpp"
 #include "ComponentFactoryImpl.hpp"
-#include "ConcurrencyUtil.hpp"
 #include "cppmicroservices/cm/ConfigurationListener.hpp"
+#include "cppmicroservices/GuardedObject.h"
 
 namespace cppmicroservices
 {
@@ -114,7 +114,7 @@ namespace cppmicroservices
           private:
             using TokenMap = std::unordered_map<ListenerTokenId, Listener>;
 
-            cppmicroservices::scrimpl::Guarded<std::unordered_map<std::string, std::shared_ptr<TokenMap>>> listenersMap;
+            cppmicroservices::Guarded<std::unordered_map<std::string, std::shared_ptr<TokenMap>>> listenersMap;
 
             std::atomic<cppmicroservices::ListenerTokenId> tokenCounter; ///< used to
                                                                          /// generate unique

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -30,7 +30,7 @@
 #else
 #    define FRIEND_TEST(x, y)
 #endif
-#include "ConcurrencyUtil.hpp"
+#include "cppmicroservices/GuardedObject.h"
 #include "ReferenceManager.hpp"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/ServiceTracker.h"
@@ -285,12 +285,12 @@ namespace cppmicroservices
             const std::string
                 configName_; ///< Keep track of which component configuration object this reference manager belongs to.
 
-            mutable Guarded<std::set<cppmicroservices::ServiceReferenceBase>>
+            mutable cppmicroservices::Guarded<std::set<cppmicroservices::ServiceReferenceBase>>
                 boundRefs; ///< guarded set of bound references
-            mutable Guarded<std::set<cppmicroservices::ServiceReferenceBase>>
+            mutable cppmicroservices::Guarded<std::set<cppmicroservices::ServiceReferenceBase>>
                 matchedRefs; ///< guarded set of matched references
 
-            mutable Guarded<RefMgrListenerMap> listenersMap;                    ///< guarded map of listeners
+            mutable cppmicroservices::Guarded<RefMgrListenerMap> listenersMap;                    ///< guarded map of listeners
             static std::atomic<cppmicroservices::ListenerTokenId> tokenCounter; ///< used to
                                                                                 /// generate unique
                                                                                 /// tokens for

--- a/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
+++ b/compendium/DeclarativeServices/src/manager/SingletonComponentConfiguration.hpp
@@ -24,8 +24,8 @@
 #define SINGLETONCOMPONENTCONFIGURATION_HPP
 
 #include "ComponentConfigurationImpl.hpp"
-#include "ConcurrencyUtil.hpp"
 #include "ConfigurationNotifier.hpp"
+#include "cppmicroservices/GuardedObject.h"
 
 namespace cppmicroservices
 {
@@ -142,7 +142,7 @@ namespace cppmicroservices
              */
             std::shared_ptr<ComponentInstance> GetComponentInstance();
 
-            Guarded<InstanceContextPair>
+            cppmicroservices::Guarded<InstanceContextPair>
                 data; ///< singleton pair of component instance and context associated with this configuration
         };
     } // namespace scrimpl

--- a/framework/include/CMakeLists.txt
+++ b/framework/include/CMakeLists.txt
@@ -62,6 +62,7 @@ set(_public_headers
   cppmicroservices/BundleTrackerCustomizer.h
   cppmicroservices/Constants.h
   cppmicroservices/GetBundleContext.h
+  cppmicroservices/GuardedObject.h
   cppmicroservices/detail/BundleTrackerPrivate.h
   cppmicroservices/detail/BundleAbstractTracked.h
   cppmicroservices/detail/BundleAbstractTracked.hpp

--- a/framework/include/cppmicroservices/Constants.h
+++ b/framework/include/cppmicroservices/Constants.h
@@ -317,6 +317,12 @@ namespace cppmicroservices
         US_Framework_EXPORT extern const std::string
             FRAMEWORK_BUNDLE_VALIDATION_FUNC; // = "org.cppmicroservices.framework.bundle.validation.function"
 
+        /**
+         * Framework bundle validation property specifying a all bundles validated by this framework
+         */
+        US_Framework_EXPORT extern const std::string
+            FRAMEORK_BUNDLES_VALIDATED; // = "org.cppmicroservices.framework.bundle.validated.bundles"
+
         /*
          * Service properties.
          */

--- a/framework/include/cppmicroservices/GuardedObject.h
+++ b/framework/include/cppmicroservices/GuardedObject.h
@@ -1,0 +1,89 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=============================================================================*/
+#ifndef CPPMICROSERVICES_GUARDEDOBJECT_H
+#define CPPMICROSERVICES_GUARDEDOBJECT_H
+
+#include <memory>
+#include <mutex>
+
+namespace cppmicroservices {
+/**
+         * Utility class to help developers avoid mistakes with locking data members
+         * in a class. This code is based on the Guarded idiom as described in
+         * "Mastering the C++17 STL" by Arthur O'Dwyer
+         */
+        template <class Data>
+        class Guarded
+        {
+            std::mutex mtx;
+            Data data;
+            class Handle
+            {
+                std::unique_lock<std::mutex> lk;
+                Data* ptr;
+
+              public:
+                Handle(std::unique_lock<std::mutex> lk, Data* p) : lk(std::move(lk)), ptr(p) {}
+
+                Handle(Handle const&) = delete;
+                Handle& operator=(Handle const&) = delete;
+
+                Handle(Handle&& rhs) : lk(std::move(rhs.lk)), ptr(std::move(rhs.ptr)) {}
+
+                Handle&
+                operator=(Handle&& rhs)
+                {
+                    lk = std::move(rhs.lk);
+                    ptr = std::move(rhs.ptr);
+                }
+
+                ~Handle() = default;
+
+                Data*
+                operator->() const
+                {
+                    return ptr;
+                }
+                Data&
+                operator*() const
+                {
+                    return *ptr;
+                }
+            };
+
+          public:
+            /**
+             * Locks the member mutex and returns an RAII object responsible for
+             * unlocking the mutex.
+             *
+             * \return a RAII style wrapper object used to access the data
+             */
+            Handle
+            lock()
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                return Handle { std::move(lock), &data };
+            }
+        };
+}
+
+#endif

--- a/framework/src/bundle/Constants.cpp
+++ b/framework/src/bundle/Constants.cpp
@@ -57,6 +57,8 @@ namespace cppmicroservices
         const std::string FRAMEWORK_WORKING_DIR = "org.cppmicroservices.framework.working.dir";
         const std::string FRAMEWORK_BUNDLE_VALIDATION_FUNC
             = "org.cppmicroservices.framework.bundle.validation.function";
+        const std::string FRAMEORK_BUNDLES_VALIDATED
+            = "org.cppmicroservices.framework.bundle.validated.bundles";
         const std::string OBJECTCLASS = "objectclass";
         const std::string SERVICE_ID = "service.id";
         const std::string SERVICE_PID = "service.pid";

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -28,6 +28,7 @@ US_MSVC_DISABLE_WARNING(4355)
 
 #include "cppmicroservices/BundleInitialization.h"
 #include "cppmicroservices/Constants.h"
+#include "cppmicroservices/GuardedObject.h"
 #include "cppmicroservices/FrameworkFactory.h"
 #include "cppmicroservices/GetBundleContext.h"
 
@@ -137,7 +138,7 @@ namespace cppmicroservices
         ss << sid_base << std::setfill('0') << std::setw(8) << std::hex << static_cast<int32_t>(id * 65536 + initCount);
 
         frameworkProperties[Constants::FRAMEWORK_UUID] = ss.str();
-
+        frameworkProperties[Constants::FRAMEORK_BUNDLES_VALIDATED] = std::make_shared<cppmicroservices::Guarded<std::map<std::string, void*>>>();
         // $TODO we only support non-persistent (main memory) storage yet
         storage = std::make_unique<BundleStorageMemory>();
         //  if (frameworkProperties[FWProps::READ_ONLY_PROP] == true)


### PR DESCRIPTION
inserts bundleBinaries into the coreBundleContext propeerties anymap rather than a thread local. This guarentees that for each framework, the bundle is read in and validated