### PR TITLE
Fix benchmark workflow

### DIFF
--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -68,4 +68,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Performance Results - ${{ github.event.head_commit.author.name }} - ${{ github.sha }}
-        path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
+        path: ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -4,8 +4,8 @@ on:
   push:
   #This workflow runs only on development branch
   #If you want to run performance tests on a particular branch
-    #Please add your branch name in branches, e.g. branches: [ development, your_branch_name ]
-    branches: [ development , fix-benchmark-workflow]
+  #Please add your branch name in branches, e.g. branches: [ development, your_branch_name ]
+    branches: [ development ]
   workflow_dispatch:
 
 permissions:
@@ -77,7 +77,7 @@ jobs:
 
     - name: Deploy results
       # Condition the step on the 'development' branch only
-      #if: github.ref == 'refs/heads/development'
+      if: github.ref == 'refs/heads/development'
       uses: benchmark-action/github-action-benchmark@v1.16.1
       with:
         name: C++ Benchmark

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -74,3 +74,19 @@ jobs:
       with:
         name: Performance Results - ${{ github.event.head_commit.author.name }} - ${{ github.sha }}
         path: ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json
+
+    - name: Deploy results
+      # Condition the step on the 'development' branch only
+      #if: github.ref == 'refs/heads/development'
+      uses: benchmark-action/github-action-benchmark@v1.16.1
+      with:
+        name: C++ Benchmark
+        tool: 'googlecpp'
+        output-file-path: ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: false
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '20%'
+        comment-on-alert: true
+        fail-on-alert: false
+

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -5,7 +5,7 @@ on:
   #This workflow runs only on development branch
   #If you want to run performance tests on a particular branch
     #Please add your branch name in branches, e.g. branches: [ development, your_branch_name ]
-    branches: [ development ]
+    branches: [ development , fix-benchmark-workflow]
   workflow_dispatch:
 
 permissions:
@@ -56,28 +56,16 @@ jobs:
 
     - name: Run benchmark and store result in json format
       run: |
-        ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-        ${{ env.BUILD_DIR }}\bin\Release\usConfigurationAdminBenchmarkTests.exe --benchmark_format=json | tee -a ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-        ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee -a ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
+        ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result1.json
+        ${{ env.BUILD_DIR }}\bin\Release\usConfigurationAdminBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json
+        ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result3.json
+
+    - name: Merge Benchmark JSON Files
+      run: |
+        jq -s '[.[][]]' ${{ env.BUILD_DIR }}\bin\Release\benchmark_result1.json ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json > ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json
 
     - name: Upload Performance Results as Artifact
       uses: actions/upload-artifact@v4
       with:
         name: Performance Results - ${{ github.event.head_commit.author.name }} - ${{ github.sha }}
         path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-
-    - name: Deploy results
-      # Condition the step on the 'development' branch only
-      if: github.ref == 'refs/heads/development'
-      uses: benchmark-action/github-action-benchmark@v1.16.1
-      with:
-        name: C++ Benchmark
-        tool: 'googlecpp'
-        output-file-path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
-        # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '20%'
-        comment-on-alert: true
-        fail-on-alert: false
-

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -57,8 +57,8 @@ jobs:
     - name: Run benchmark and store result in json format
       run: |
         ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result1.json
-        ${{ env.BUILD_DIR }}\bin\Release\usConfigurationAdminBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json
-        ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result3.json
+        ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json
+        ${{ env.BUILD_DIR }}\bin\Release\usConfigurationAdminBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result3.json
 
     - name: Merge 3 Benchmark JSON Files with All Contexts
       shell: pwsh
@@ -67,6 +67,9 @@ jobs:
           "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `
+          | jq '.benchmarks |= map(.name |= "usFrameworkBenchTests/" + .name)' `
+          | jq '.benchmarks |= map(.name |= "usDeclarativeServicesBenchmarkTests/" + .name)' `
+          | jq '.benchmarks |= map(.name |= "usConfigurationAdminBenchmarkTests/" + .name)' `
           > "${env:BUILD_DIR}/bin/Release/merged_benchmark_result.json"
 
     - name: Upload Performance Results as Artifact

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -63,10 +63,7 @@ jobs:
     - name: Merge 3 Benchmark JSON Files with All Contexts
       shell: pwsh
       run: |
-        jq -s '{ 
-          contexts: [.[].context], 
-          benchmarks: ([.[].benchmarks] | add) 
-        }' `
+        jq -s "{\"contexts\": [.[].context], \"benchmarks\": ([.[].benchmarks] | add)}" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -61,8 +61,13 @@ jobs:
         ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result3.json
 
     - name: Merge Benchmark JSON Files
+      shell: pwsh
       run: |
-        jq -s '[.[][]]' ${{ env.BUILD_DIR }}\bin\Release\benchmark_result1.json ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json > ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json
+        jq -s '[.[0] + .[1] + .[2]]' `
+          "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
+          "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
+          "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `
+          > "${env:BUILD_DIR}/bin/Release/merged_benchmark_result.json"
 
     - name: Upload Performance Results as Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -60,10 +60,13 @@ jobs:
         ${{ env.BUILD_DIR }}\bin\Release\usConfigurationAdminBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result2.json
         ${{ env.BUILD_DIR }}\bin\Release\usDeclarativeServicesBenchmarkTests.exe --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result3.json
 
-    - name: Merge Benchmark JSON Files
+    - name: Merge 3 Benchmark JSON Files with All Contexts
       shell: pwsh
       run: |
-        jq -s '[.[0] + .[1] + .[2]]' `
+        jq -s '{ 
+          contexts: [.[].context], 
+          benchmarks: ([.[].benchmarks] | add) 
+        }' `
           "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -67,9 +67,6 @@ jobs:
           "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `
-          | jq '.benchmarks |= map(.name |= "usFrameworkBenchTests/" + .name)' `
-          | jq '.benchmarks |= map(.name |= "usDeclarativeServicesBenchmarkTests/" + .name)' `
-          | jq '.benchmarks |= map(.name |= "usConfigurationAdminBenchmarkTests/" + .name)' `
           > "${env:BUILD_DIR}/bin/Release/merged_benchmark_result.json"
 
     - name: Upload Performance Results as Artifact

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Merge 3 Benchmark JSON Files with All Contexts
       shell: pwsh
       run: |
-        jq -s "{\"contexts\": [.[].context], \"benchmarks\": ([.[].benchmarks] | add)}" `
+        jq -s "{`"contexts`": [.[].context], `"benchmarks`": ([.[].benchmarks] | add)}" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result1.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result2.json" `
           "${env:BUILD_DIR}/bin/Release/benchmark_result3.json" `

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -84,7 +84,7 @@ jobs:
         tool: 'googlecpp'
         output-file-path: ${{ env.BUILD_DIR }}\bin\Release\merged_benchmark_result.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: false
+        auto-push: true
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '20%'
         comment-on-alert: true


### PR DESCRIPTION
Modified the performance workflow to include: 
- usFrameworkBenchTests
- usDeclarativeServicesBenchmarkTests
- usConfigurationAdminBenchmarkTests

Merging the benchmark results and deploying all on the same page.

I could modify the test name to include suite name as prefix, however, we will lose the history due to the name change.