### PR TITLE
Add support for C++ Style Comments

### DIFF
--- a/compendium/tools/SCRCodeGen/Util.cpp
+++ b/compendium/tools/SCRCodeGen/Util.cpp
@@ -32,6 +32,7 @@ namespace codegen
             Json::Value root;
             Json::CharReaderBuilder rbuilder;
             rbuilder["rejectDupKeys"] = true;
+            rbuilder["allowComments"] = true;
             std::string errs;
 
             if (!Json::parseFromStream(rbuilder, jsonStream, &root, &errs))

--- a/framework/src/bundle/BundleManifest.cpp
+++ b/framework/src/bundle/BundleManifest.cpp
@@ -172,7 +172,7 @@ namespace cppmicroservices
     {
         rapidjson::IStreamWrapper jsonStream(is);
         rapidjson::Document root;
-        if (root.ParseStream(jsonStream).HasParseError())
+        if (root.ParseStream<rapidjson::ParseFlag::kParseCommentsFlag>(jsonStream).HasParseError())
         {
             throw std::runtime_error(rapidjson::GetParseError_En(root.GetParseError()));
         }

--- a/framework/test/bundles/libM/resources/manifest.json
+++ b/framework/test/bundles/libM/resources/manifest.json
@@ -1,18 +1,19 @@
 {
+  // Adding comments to see if parsing test still work
   "bundle.symbolic_name": "TestBundleM",
   "bundle.description": "My Bundle description",
   "bundle.version": "1.0.0",
-  "bundle.activator" : true,
+  "bundle.activator": true, /* C style comments are enabled now. */
   "number": 5,
   "double": 1.1,
   "vector": [
     "first",
     2,
     "third"
-    ],
+  ],
   "map": {
     "string": "hi",
     "number": 4,
     "list": [ "a", "b" ]
-    }
+  }
 }

--- a/tools/jsonschemavalidator/main.cpp
+++ b/tools/jsonschemavalidator/main.cpp
@@ -52,7 +52,7 @@ ReadJSONDocument(std::string const& filePath)
     }
     rapidjson::IStreamWrapper streamWrapper(fileStream);
     rapidjson::Document doc;
-    doc.ParseStream(streamWrapper);
+    doc.ParseStream<rapidjson::ParseFlag::kParseCommentsFlag>(streamWrapper);
     if (doc.HasParseError())
     {
         throw std::runtime_error("File '" + filePath + "' is not a valid JSON\n Error(offset "

--- a/tools/rc/ResourceCompiler.cpp
+++ b/tools/rc/ResourceCompiler.cpp
@@ -149,7 +149,7 @@ namespace
     {
         Json::CharReaderBuilder rbuilder;
         rbuilder["rejectDupKeys"] = true;
-        rbuilder["allowComments"] = false;
+        rbuilder["allowComments"] = true;
         std::string errs;
 
         if (!Json::parseFromStream(rbuilder, jsonContent, &root, &errs))


### PR DESCRIPTION
#1005

The jsoncpp and rapidjson libraries both support C++ style comments now. Enabling them in the code.

Updated a testbundle to validate if parsing is working as expected.