### PR TITLE
Fix clang-tidy warnings in DeclarativeServices, LogServiceImpl, AsyncWorkService

### DIFF
--- a/compendium/AsyncWorkService/src/AsyncWorkService.cpp
+++ b/compendium/AsyncWorkService/src/AsyncWorkService.cpp
@@ -22,12 +22,9 @@
 
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::async
 {
-    namespace async
-    {
 
-        AsyncWorkService::~AsyncWorkService() = default;
+    AsyncWorkService::~AsyncWorkService() = default;
 
-    }
-} // namespace cppmicroservices
+} // namespace cppmicroservices::async

--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -35,422 +35,419 @@
 using cppmicroservices::ServiceReferenceBase;
 using cppmicroservices::service::component::ComponentException;
 
-namespace cppmicroservices
+namespace cppmicroservices::scrimpl
 {
-    namespace scrimpl
+
+    ComponentContextImpl::ComponentContextImpl(std::weak_ptr<ComponentConfiguration> cm)
+        : configManager(std::move(cm))
+        , usingBundle(Bundle())
     {
+        InitializeServicesCache();
+    }
 
-        ComponentContextImpl::ComponentContextImpl(std::weak_ptr<ComponentConfiguration> cm)
-            : configManager(std::move(cm))
-            , usingBundle(Bundle())
+    ComponentContextImpl::ComponentContextImpl(std::weak_ptr<ComponentConfiguration> cm,
+                                               cppmicroservices::Bundle usingBundle)
+        : configManager(std::move(cm))
+        , usingBundle(std::move(usingBundle))
+    {
+        InitializeServicesCache();
+    }
+
+    void
+    ComponentContextImpl::InitializeServicesCache()
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
         {
-            InitializeServicesCache();
+            throw ComponentException("Context is invalid");
         }
 
-        ComponentContextImpl::ComponentContextImpl(std::weak_ptr<ComponentConfiguration> cm,
-                                                   cppmicroservices::Bundle usingBundle)
-            : configManager(std::move(cm))
-            , usingBundle(std::move(usingBundle))
+        auto const refManagers = configManagerPtr->GetAllDependencyManagers();
+        for (auto const& refManager : refManagers)
         {
-            InitializeServicesCache();
-        }
-
-        void
-        ComponentContextImpl::InitializeServicesCache()
-        {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
-
-            auto const refManagers = configManagerPtr->GetAllDependencyManagers();
-            for (auto const& refManager : refManagers)
-            {
-                auto const& sRefs = refManager->GetBoundReferences();
-                auto const& refName = refManager->GetReferenceName();
-                bool foundAtLeastOneValidBoundService = false;
-                std::for_each(sRefs.rbegin(),
-                              sRefs.rend(),
-                              [&](cppmicroservices::ServiceReferenceBase const& sRef)
+            auto const& sRefs = refManager->GetBoundReferences();
+            auto const& refName = refManager->GetReferenceName();
+            bool foundAtLeastOneValidBoundService = false;
+            std::for_each(sRefs.rbegin(),
+                          sRefs.rend(),
+                          [&](cppmicroservices::ServiceReferenceBase const& sRef)
+                          {
+                              if (sRef)
                               {
-                                  if (sRef)
+                                  ServiceReferenceU sRefU(sRef);
+                                  auto bc = GetBundleContext();
+                                  auto boundServicesCacheHandle = boundServicesCache.lock();
+                                  auto& serviceMap = (*boundServicesCacheHandle)[refName];
+                                  // get us the service instance
+                                  cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(sRefU);
+                                  auto interfaceMap = sObjs.GetService();
+                                  if (interfaceMap && !interfaceMap->empty())
                                   {
-                                      ServiceReferenceU sRefU(sRef);
-                                      auto bc = GetBundleContext();
-                                      auto boundServicesCacheHandle = boundServicesCache.lock();
-                                      auto& serviceMap = (*boundServicesCacheHandle)[refName];
-                                      // get us the service instance
-                                      cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(sRefU);
-                                      auto interfaceMap = sObjs.GetService();
-                                      if (interfaceMap && !interfaceMap->empty())
-                                      {
-                                          foundAtLeastOneValidBoundService = true;
-                                          serviceMap.emplace_back(std::make_pair(sRef, interfaceMap));
-                                      }
+                                      foundAtLeastOneValidBoundService = true;
+                                      serviceMap.emplace_back(std::make_pair(sRef, interfaceMap));
                                   }
-                              });
+                              }
+                          });
 
-                // Check that all the refernece managers have a valid bound service reference if one
-                // is manodatory.
-                // If this check fails, it's usually because a dependent service was unregistered
-                // while the service object was being retrieved to add to the container of bound services.
-                if (!refManager->IsOptional() && !foundAtLeastOneValidBoundService)
-                {
-                    throw ComponentException(
-                        "Failed to construct a component context for " + configManagerPtr->GetMetadata()->implClassName
-                        + ". No services were found which satisfy the mandatory service dependency " + refName
-                        + ". This typically occurs because the dependent service was unregistered before it could be "
-                          "used.");
-                }
+            // Check that all the refernece managers have a valid bound service reference if one
+            // is manodatory.
+            // If this check fails, it's usually because a dependent service was unregistered
+            // while the service object was being retrieved to add to the container of bound services.
+            if (!refManager->IsOptional() && !foundAtLeastOneValidBoundService)
+            {
+                throw ComponentException(
+                    "Failed to construct a component context for " + configManagerPtr->GetMetadata()->implClassName
+                    + ". No services were found which satisfy the mandatory service dependency " + refName
+                    + ". This typically occurs because the dependent service was unregistered before it could be "
+                      "used.");
+            }
+        }
+    }
+
+    std::unordered_map<std::string, cppmicroservices::Any>
+    ComponentContextImpl::GetProperties() const
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
+        {
+            throw ComponentException("Context is invalid");
+        }
+        return configManagerPtr->GetProperties();
+    }
+
+    bool
+    ServiceReferenceTargetIsMandatory(std::shared_ptr<ComponentConfiguration> const& configManagerPtr,
+                                      std::string const& svcRefTargetName)
+    {
+        auto metadata = configManagerPtr->GetMetadata();
+        for (auto const& _data : metadata->refsMetadata)
+        {
+            if (auto cardinality = _data.cardinality; _data.name == svcRefTargetName)
+            {
+                return (cardinality.empty()) ? true : (cardinality.find("1..") != std::string::npos);
             }
         }
 
-        std::unordered_map<std::string, cppmicroservices::Any>
-        ComponentContextImpl::GetProperties() const
+        return true;
+    }
+
+    /**
+     * The ServiceInterfacePointerLookupInfo struct is used to pass back
+     * the shared_ptr from GetInterfacePointer in addition to a boolean
+     * which is used to determine whether or not the pointer was retrieved
+     * from the map or if the map is null.
+     *
+     * wasFoundInMapOrMapEmpty:
+     *   - true, if the service pointer was in the map
+     *       or if the map if null (service can be either
+     *       valid or a nullptr)
+     *    - false if the service pointer was not found
+     *       in the map (implies service is nullptr)
+     */
+    struct ServiceInterfacePointerLookupInfo
+    {
+        std::shared_ptr<void> service = nullptr;
+        bool wasFoundInMapOrMapEmpty = false;
+
+        [[nodiscard]] bool
+        IsValid() const
         {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
-            return configManagerPtr->GetProperties();
+            return static_cast<bool>(service) == wasFoundInMapOrMapEmpty;
         }
+    };
 
-        bool
-        ServiceReferenceTargetIsMandatory(std::shared_ptr<ComponentConfiguration> const& configManagerPtr,
-                                          std::string const& svcRefTargetName)
+    /**
+     * Returns a ServiceInterfacePointerLookup struct containing the service interface
+     * pointer from the InterfaceMapConstPtr given the interfaceid as the key.
+     *
+     * This function has a similar implementation to ExtractService except it returns
+     * an instance of the ServiceInterfacePointerLookupInfo struct to do error handling
+     * if necessary.
+     *
+     * - map, a InterfaceMap instance.
+     * - interfaceId, The interface id string.
+     * - return value: ServiceInterfacePointerLookupInfo
+     */
+    ServiceInterfacePointerLookupInfo
+    GetInterfacePointer(InterfaceMapConstPtr const& map, std::string const& interfaceId)
+    {
+        ServiceInterfacePointerLookupInfo lookupInfo {};
+
+        if (!map)
         {
-            auto metadata = configManagerPtr->GetMetadata();
-            for (auto const& _data : metadata->refsMetadata)
-            {
-                if (auto cardinality = _data.cardinality; _data.name == svcRefTargetName)
-                {
-                    return (cardinality.empty()) ? true : (cardinality.find("1..") != std::string::npos);
-                }
-            }
-
-            return true;
-        }
-
-        /**
-         * The ServiceInterfacePointerLookupInfo struct is used to pass back
-         * the shared_ptr from GetInterfacePointer in addition to a boolean
-         * which is used to determine whether or not the pointer was retrieved
-         * from the map or if the map is null.
-         *
-         * wasFoundInMapOrMapEmpty:
-         *   - true, if the service pointer was in the map
-         *       or if the map if null (service can be either
-         *       valid or a nullptr)
-         *    - false if the service pointer was not found
-         *       in the map (implies service is nullptr)
-         */
-        struct ServiceInterfacePointerLookupInfo
-        {
-            std::shared_ptr<void> service = nullptr;
-            bool wasFoundInMapOrMapEmpty = false;
-
-            bool
-            IsValid() const
-            {
-                return static_cast<bool>(service) == wasFoundInMapOrMapEmpty;
-            }
-        };
-
-        /**
-         * Returns a ServiceInterfacePointerLookup struct containing the service interface
-         * pointer from the InterfaceMapConstPtr given the interfaceid as the key.
-         *
-         * This function has a similar implementation to ExtractService except it returns
-         * an instance of the ServiceInterfacePointerLookupInfo struct to do error handling
-         * if necessary.
-         *
-         * - map, a InterfaceMap instance.
-         * - interfaceId, The interface id string.
-         * - return value: ServiceInterfacePointerLookupInfo
-         */
-        ServiceInterfacePointerLookupInfo
-        GetInterfacePointer(InterfaceMapConstPtr const& map, std::string const& interfaceId)
-        {
-            ServiceInterfacePointerLookupInfo lookupInfo {};
-
-            if (!map)
-            {
-                lookupInfo.wasFoundInMapOrMapEmpty = true;
-                lookupInfo.service = nullptr;
-                return lookupInfo;
-            }
-
-            if (interfaceId.empty() && map && !map->empty())
-            {
-                lookupInfo.wasFoundInMapOrMapEmpty = true;
-                lookupInfo.service = map->begin()->second;
-                return lookupInfo;
-            }
-
-            auto iter = map->find(interfaceId);
-            if (iter != map->end())
-            {
-                lookupInfo.wasFoundInMapOrMapEmpty = true;
-                lookupInfo.service = iter->second;
-                return lookupInfo;
-            }
-
+            lookupInfo.wasFoundInMapOrMapEmpty = true;
+            lookupInfo.service = nullptr;
             return lookupInfo;
         }
 
-        /**
-         * This function returns the service interface pointer from the InterfaceMap.
+        if (interfaceId.empty() && map && !map->empty())
+        {
+            lookupInfo.wasFoundInMapOrMapEmpty = true;
+            lookupInfo.service = map->begin()->second;
+            return lookupInfo;
+        }
+
+        auto iter = map->find(interfaceId);
+        if (iter != map->end())
+        {
+            lookupInfo.wasFoundInMapOrMapEmpty = true;
+            lookupInfo.service = iter->second;
+            return lookupInfo;
+        }
+
+        return lookupInfo;
+    }
+
+    /**
+     * This function returns the service interface pointer from the InterfaceMap.
+     *
+     * If the returned pointer is not valid, then error checking is done to ensure
+     * that if this failure of construction/activation of the searched service
+     * violates the service's cardinality conditions, an exception is thrown.
+     *
+     * This function throws an exception when the service pointer was found in the map
+     * and the value of that service pointer is nullptr.
+     */
+    std::shared_ptr<void>
+    GetServicePointer(std::shared_ptr<ComponentConfiguration> const& configManagerPtr,
+                      cppmicroservices::InterfaceMapConstPtr const& m,
+                      std::string const& name,
+                      std::string const& type)
+    {
+        ServiceInterfacePointerLookupInfo lookupInfo = GetInterfacePointer(m, type);
+
+        /* The returned service and boolean in the ServiceInterfacePointerLookupInfo struct
+         * are valid if
+            1) service pointer matching the type was not found in the map or
+            2) service pointer is found in map AND non null
          *
-         * If the returned pointer is not valid, then error checking is done to ensure
-         * that if this failure of construction/activation of the searched service
-         * violates the service's cardinality conditions, an exception is thrown.
-         *
-         * This function throws an exception when the service pointer was found in the map
-         * and the value of that service pointer is nullptr.
+         * If this condition is not true, then we proceed with error checking and throw
+         * a ComponentException if the service's cardinality conditions were violated.
          */
-        std::shared_ptr<void>
-        GetServicePointer(std::shared_ptr<ComponentConfiguration> const& configManagerPtr,
-                          cppmicroservices::InterfaceMapConstPtr const& m,
-                          std::string const& name,
-                          std::string const& type)
+        bool isValid = lookupInfo.IsValid();
+        if (isValid)
         {
-            ServiceInterfacePointerLookupInfo lookupInfo = GetInterfacePointer(m, type);
-
-            /* The returned service and boolean in the ServiceInterfacePointerLookupInfo struct
-             * are valid if
-                1) service pointer matching the type was not found in the map or
-                2) service pointer is found in map AND non null
-             *
-             * If this condition is not true, then we proceed with error checking and throw
-             * a ComponentException if the service's cardinality conditions were violated.
-             */
-            bool isValid = lookupInfo.IsValid();
-            if (isValid)
-            {
-                return lookupInfo.service;
-            }
-
-            // Checking for error condition and throwing if necessary
-            // In the case of service being a nullptr, we throw because this implies
-            // that the construction or activation of the service failed.
-            if (ServiceReferenceTargetIsMandatory(configManagerPtr, name))
-            {
-                std::string errMsg = "Service ";
-                errMsg += name;
-                errMsg += " with type ";
-                errMsg += type;
-                errMsg += " failed to construct or activate.";
-
-                throw ComponentException(errMsg);
-            }
-
-            return nullptr;
+            return lookupInfo.service;
         }
 
-        std::shared_ptr<void>
-        ComponentContextImpl::LocateService(std::string const& refName, std::string const& type) const
+        // Checking for error condition and throwing if necessary
+        // In the case of service being a nullptr, we throw because this implies
+        // that the construction or activation of the service failed.
+        if (ServiceReferenceTargetIsMandatory(configManagerPtr, name))
         {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
+            std::string errMsg = "Service ";
+            errMsg += name;
+            errMsg += " with type ";
+            errMsg += type;
+            errMsg += " failed to construct or activate.";
+
+            throw ComponentException(errMsg);
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<void>
+    ComponentContextImpl::LocateService(std::string const& refName, std::string const& type) const
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
+        {
+            throw ComponentException("Context is invalid");
+        }
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        auto serviceMapItr = boundServicesCacheHandle->find(refName);
+        if (serviceMapItr != boundServicesCacheHandle->end())
+        {
+            if (auto& services = serviceMapItr->second; !services.empty())
             {
-                throw ComponentException("Context is invalid");
+                auto& interfaceMapPtr = std::get<1>(services[0]);
+
+                return GetServicePointer(configManagerPtr, interfaceMapPtr, refName, type);
             }
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            auto serviceMapItr = boundServicesCacheHandle->find(refName);
-            if (serviceMapItr != boundServicesCacheHandle->end())
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<void>
+    ComponentContextImpl::LocateService(std::string const& refName,
+                                        cppmicroservices::ServiceReferenceBase const& sRef) const
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
+        {
+            throw ComponentException("Context is invalid");
+        }
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        auto serviceMapItr = boundServicesCacheHandle->find(refName);
+        if (serviceMapItr != boundServicesCacheHandle->end())
+        {
+            // vector of serviceInterfaceMapConstPtr
+            auto& services = serviceMapItr->second;
+
+            auto matchingServiceInterfaceMapPtr = std::find_if(
+                services.begin(),
+                services.end(),
+                [&sRef](std::pair<cppmicroservices::ServiceReferenceBase, InterfaceMapConstPtr> const& pair)
+                { return pair.first == sRef; });
+
+            if (matchingServiceInterfaceMapPtr != services.end())
             {
-                if (auto& services = serviceMapItr->second; !services.empty())
+                // returns the service at the interfacemap::begin() position
+                return GetServicePointer(configManagerPtr, matchingServiceInterfaceMapPtr->second, refName, "");
+            }
+        }
+
+        return nullptr;
+    }
+
+    std::vector<std::shared_ptr<void>>
+    ComponentContextImpl::LocateServices(std::string const& refName, std::string const& type) const
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
+        {
+            throw ComponentException("Context is invalid");
+        }
+        std::vector<std::shared_ptr<void>> services;
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        auto serviceMapItr = boundServicesCacheHandle->find(refName);
+        if (serviceMapItr != boundServicesCacheHandle->end())
+        {
+            auto& serviceInfos = serviceMapItr->second;
+            std::for_each(
+                serviceInfos.begin(),
+                serviceInfos.end(),
+                [&services, &configManagerPtr, &refName, &type](
+                    std::pair<cppmicroservices::ServiceReferenceBase, InterfaceMapConstPtr> const& serviceInfo)
                 {
-                    auto& interfaceMapPtr = std::get<1>(services[0]);
-
-                    return GetServicePointer(configManagerPtr, interfaceMapPtr, refName, type);
-                }
-            }
-
-            return nullptr;
-        }
-
-        std::shared_ptr<void>
-        ComponentContextImpl::LocateService(std::string const& refName,
-                                            cppmicroservices::ServiceReferenceBase const& sRef) const
-        {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            auto serviceMapItr = boundServicesCacheHandle->find(refName);
-            if (serviceMapItr != boundServicesCacheHandle->end())
-            {
-                // vector of serviceInterfaceMapConstPtr
-                auto& services = serviceMapItr->second;
-
-                auto matchingServiceInterfaceMapPtr
-                    = std::find_if(services.begin(),
-                                   services.end(),
-                                   [&sRef](std::pair<cppmicroservices::ServiceReferenceBase, InterfaceMapConstPtr> const &pair)
-                                   { return pair.first == sRef; });
-
-                if (matchingServiceInterfaceMapPtr != services.end())
-                {
-                    // returns the service at the interfacemap::begin() position
-                    return GetServicePointer(configManagerPtr, matchingServiceInterfaceMapPtr->second, refName, "");
-                }
-            }
-
-            return nullptr;
-        }
-
-        std::vector<std::shared_ptr<void>>
-        ComponentContextImpl::LocateServices(std::string const& refName, std::string const& type) const
-        {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
-            std::vector<std::shared_ptr<void>> services;
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            auto serviceMapItr = boundServicesCacheHandle->find(refName);
-            if (serviceMapItr != boundServicesCacheHandle->end())
-            {
-                auto& serviceInfos = serviceMapItr->second;
-                std::for_each(
-                    serviceInfos.begin(),
-                    serviceInfos.end(),
-                    [&services, &configManagerPtr, &refName, &type](
-                        std::pair<cppmicroservices::ServiceReferenceBase, InterfaceMapConstPtr> const& serviceInfo)
+                    auto const& intMapPtr = serviceInfo.second;
+                    auto const servicePtr = GetServicePointer(configManagerPtr, intMapPtr, refName, type);
+                    if (servicePtr)
                     {
-                        auto const& intMapPtr = serviceInfo.second;
-                        auto const servicePtr = GetServicePointer(configManagerPtr, intMapPtr, refName, type);
-                        if (servicePtr)
-                        {
-                            services.push_back(servicePtr);
-                        }
-                    });
-            }
-            return services;
+                        services.push_back(servicePtr);
+                    }
+                });
         }
+        return services;
+    }
 
-        cppmicroservices::BundleContext
-        ComponentContextImpl::GetBundleContext() const
+    cppmicroservices::BundleContext
+    ComponentContextImpl::GetBundleContext() const
+    {
+        auto const configManagerPtr = configManager.lock();
+        return (configManagerPtr ? (configManagerPtr->GetBundle()).GetBundleContext() : BundleContext());
+    }
+
+    unsigned long
+    ComponentContextImpl::GetBundleId() const
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
         {
-            auto const configManagerPtr = configManager.lock();
-            return (configManagerPtr ? (configManagerPtr->GetBundle()).GetBundleContext() : BundleContext());
+            throw ComponentException("Context is invalid");
         }
+        return configManagerPtr->GetBundle().GetBundleId();
+    }
 
-        unsigned long
-        ComponentContextImpl::GetBundleId() const
+    cppmicroservices::Bundle
+    ComponentContextImpl::GetUsingBundle() const
+    {
+        return usingBundle;
+    }
+
+    void
+    ComponentContextImpl::EnableComponent(std::string const& name)
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
         {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
-            return configManagerPtr->GetBundle().GetBundleId();
+            throw ComponentException("Context is invalid");
         }
-
-        cppmicroservices::Bundle
-        ComponentContextImpl::GetUsingBundle() const
+        auto const reg = configManagerPtr->GetRegistry();
+        if (name.empty())
         {
-            return usingBundle;
-        }
-
-        void
-        ComponentContextImpl::EnableComponent(std::string const& name)
-        {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
+            auto mgrs = reg->GetComponentManagers(GetBundleId());
+            for (auto& mgr : mgrs)
             {
-                throw ComponentException("Context is invalid");
-            }
-            auto const reg = configManagerPtr->GetRegistry();
-            if (name.empty())
-            {
-                auto mgrs = reg->GetComponentManagers(GetBundleId());
-                for (auto& mgr : mgrs)
-                {
-                    mgr->Enable();
-                }
-            }
-            else
-            {
-                auto mgr = reg->GetComponentManager(GetBundleId(), name);
                 mgr->Enable();
             }
         }
-
-        void
-        ComponentContextImpl::DisableComponent(std::string const& name)
+        else
         {
-            auto const configManagerPtr = configManager.lock();
-            if (!configManagerPtr)
-            {
-                throw ComponentException("Context is invalid");
-            }
+            auto mgr = reg->GetComponentManager(GetBundleId(), name);
+            mgr->Enable();
+        }
+    }
 
-            auto const reg = configManagerPtr->GetRegistry();
-            if (reg)
-            {
-                auto cm = reg->GetComponentManager(GetBundleId(), name);
-                cm->Disable();
-            }
+    void
+    ComponentContextImpl::DisableComponent(std::string const& name)
+    {
+        auto const configManagerPtr = configManager.lock();
+        if (!configManagerPtr)
+        {
+            throw ComponentException("Context is invalid");
         }
 
-        ServiceReferenceBase
-        ComponentContextImpl::GetServiceReference() const
+        auto const reg = configManagerPtr->GetRegistry();
+        if (reg)
         {
-            auto const configManagerPtr = configManager.lock();
-            return configManagerPtr ? configManagerPtr->GetServiceReference() : ServiceReferenceU();
+            auto cm = reg->GetComponentManager(GetBundleId(), name);
+            cm->Disable();
         }
+    }
 
-        void
-        ComponentContextImpl::Invalidate()
+    ServiceReferenceBase
+    ComponentContextImpl::GetServiceReference() const
+    {
+        auto const configManagerPtr = configManager.lock();
+        return configManagerPtr ? configManagerPtr->GetServiceReference() : ServiceReferenceU();
+    }
+
+    void
+    ComponentContextImpl::Invalidate()
+    {
+        configManager = std::weak_ptr<ComponentConfiguration>();
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        boundServicesCacheHandle->clear();
+    }
+
+    std::shared_ptr<void>
+    ComponentContextImpl::AddToBoundServicesCache(std::string const& refName,
+                                                  cppmicroservices::ServiceReferenceBase const& sRef)
+    {
+        auto bc = GetBundleContext();
+        cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(ServiceReferenceU(sRef));
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        auto interfaceMap = sObjs.GetService();
+        if (!interfaceMap || interfaceMap->empty())
         {
-            configManager = std::weak_ptr<ComponentConfiguration>();
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            boundServicesCacheHandle->clear();
+            return nullptr;
         }
+        std::shared_ptr<void> svcToBind = interfaceMap->begin()->second;
+        (*boundServicesCacheHandle)[refName].emplace_back(std::make_pair(sRef, interfaceMap));
+        return svcToBind;
+    }
 
-        std::shared_ptr<void>
-        ComponentContextImpl::AddToBoundServicesCache(std::string const& refName,
-                                                      cppmicroservices::ServiceReferenceBase const& sRef)
-        {
-            auto bc = GetBundleContext();
-            cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(ServiceReferenceU(sRef));
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            auto interfaceMap = sObjs.GetService();
-            if (!interfaceMap || interfaceMap->empty())
-            {
-                return nullptr;
-            }
-            std::shared_ptr<void> svcToBind = interfaceMap->begin()->second;
-            (*boundServicesCacheHandle)[refName].emplace_back(std::make_pair(sRef, interfaceMap));
-            return svcToBind;
-        }
+    void
+    ComponentContextImpl::RemoveFromBoundServicesCache(std::string const& refName,
+                                                       cppmicroservices::ServiceReferenceBase const& sRef)
+    {
+        auto boundServicesCacheHandle = boundServicesCache.lock();
+        auto& services = boundServicesCacheHandle->at(refName);
+        // std::remove_if doesn't actually remove the elements from
+        // 'services'. Instead it shifts them to the end of the range
+        // and returns a past-the-end iterator for the new end range.
+        // erase is then called to remove all elements that were shifted,
+        // which are those starting from the past-the-end iterator to
+        // the end of `services`.
+        services.erase(std::remove_if(services.begin(),
+                                      services.end(),
+                                      [&sRef](std::pair<ServiceReferenceBase, InterfaceMapConstPtr> const& service)
+                                      { return (std::get<0>(service) == sRef); }),
+                       services.end());
+        return;
+    }
 
-        void
-        ComponentContextImpl::RemoveFromBoundServicesCache(std::string const& refName,
-                                                           cppmicroservices::ServiceReferenceBase const& sRef)
-        {
-            auto boundServicesCacheHandle = boundServicesCache.lock();
-            auto& services = boundServicesCacheHandle->at(refName);
-            // std::remove_if doesn't actually remove the elements from
-            // 'services'. Instead it shifts them to the end of the range
-            // and returns a past-the-end iterator for the new end range.
-            // erase is then called to remove all elements that were shifted,
-            // which are those starting from the past-the-end iterator to
-            // the end of `services`.
-            services.erase(std::remove_if(services.begin(),
-                                          services.end(),
-                                          [&sRef](std::pair<ServiceReferenceBase, InterfaceMapConstPtr> const& service)
-                                          { return (std::get<0>(service) == sRef); }),
-                           services.end());
-            return;
-        }
-
-    } // namespace scrimpl
-} // namespace cppmicroservices
+} // namespace cppmicroservices::scrimpl

--- a/compendium/DeclarativeServices/src/SCRActivator.cpp
+++ b/compendium/DeclarativeServices/src/SCRActivator.cpp
@@ -45,198 +45,193 @@
 using cppmicroservices::logservice::SeverityLevel;
 using cppmicroservices::service::component::ComponentConstants::SERVICE_COMPONENT;
 
-namespace cppmicroservices
+namespace cppmicroservices::scrimpl
 {
-    namespace scrimpl
+    void
+    SCRActivator::Start(BundleContext context)
     {
+        runtimeContext = context;
 
-        void
-        SCRActivator::Start(BundleContext context)
+        // Create the component registry
+        componentRegistry = std::make_shared<ComponentRegistry>();
+
+        // Create the Logger object used by this runtime
+        logger = std::make_shared<SCRLogger>(context);
+        logger->Log(SeverityLevel::LOG_DEBUG, "Starting SCR bundle");
+
+        asyncWorkService = std::make_shared<SCRAsyncWorkService>(context, logger);
+
+        // Create SCRExtension Registry
+        bundleRegistry = std::make_shared<SCRExtensionRegistry>(logger);
+
+        // Create configuration object notifier
+        configNotifier = std::make_shared<ConfigurationNotifier>(context, logger, asyncWorkService, bundleRegistry);
+        activatorStopped = std::make_shared<bool>(false);
+        notificationLock = std::make_shared<std::shared_mutex>();
+
+        // Add bundle listener
+        bundleListenerToken = context.AddBundleListener(
+            [this, activatorStoppedCopy = activatorStopped, notificationLockCopy = notificationLock](
+                cppmicroservices::BundleEvent const& evt)
+            {
+                ReadLock l(*notificationLockCopy);
+                if (*activatorStoppedCopy)
+                {
+                    return;
+                }
+                this->BundleChanged(evt);
+            });
+        // HACK: Workaround for lack of Bundle Tracker. Iterate over all bundles and call the tracker method
+        // manually
+        for (auto const& bundle : context.GetBundles())
         {
-            runtimeContext = context;
-
-            // Create the component registry
-            componentRegistry = std::make_shared<ComponentRegistry>();
-
-            // Create the Logger object used by this runtime
-            logger = std::make_shared<SCRLogger>(context);
-            logger->Log(SeverityLevel::LOG_DEBUG, "Starting SCR bundle");
-
-            asyncWorkService = std::make_shared<SCRAsyncWorkService>(context, logger);
-
-            // Create SCRExtension Registry
-            bundleRegistry = std::make_shared<SCRExtensionRegistry>(logger);
-
-            // Create configuration object notifier
-            configNotifier = std::make_shared<ConfigurationNotifier>(context, logger, asyncWorkService, bundleRegistry);
-            activatorStopped = std::make_shared<bool>(false);
-            notificationLock = std::make_shared<std::shared_mutex>();
-
-            // Add bundle listener
-            bundleListenerToken
-                = context.AddBundleListener([this, activatorStoppedCopy = activatorStopped, notificationLockCopy = notificationLock](cppmicroservices::BundleEvent
-                    const& evt) {
-                    ReadLock l(*notificationLockCopy);
-                    if (*activatorStoppedCopy) {
-                        return;
-                    }
-                    this->BundleChanged(evt);
-                });
-            // HACK: Workaround for lack of Bundle Tracker. Iterate over all bundles and call the tracker method
-            // manually
-            for (auto const& bundle : context.GetBundles())
+            if (bundle.GetState() & cppmicroservices::Bundle::State::STATE_ACTIVE)
             {
-                if (bundle.GetState() & cppmicroservices::Bundle::State::STATE_ACTIVE)
-                {
-                    cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
-                    BundleChanged(evt);
-                }
-            }
-            // Publish ServiceComponentRuntimeService
-            auto service = std::make_shared<ServiceComponentRuntimeImpl>(runtimeContext, componentRegistry, logger);
-            scrServiceReg = context.RegisterService<ServiceComponentRuntime>(std::move(service));
-
-            // Publish ConfigurationListener
-            auto configListener
-                = std::make_shared<cppmicroservices::service::cm::ConfigurationListenerImpl>(runtimeContext,
-                                                                                             logger,
-                                                                                             configNotifier);
-            configListenerReg = context.RegisterService<cppmicroservices::service::cm::ConfigurationListener>(
-                std::move(configListener));
-        }
-
-        void
-        SCRActivator::Stop(cppmicroservices::BundleContext context)
-        {
-            WriteLock l(*notificationLock);
-            *activatorStopped = true;
-            try
-            {
-                // remove the bundle listener
-                context.RemoveListener(std::move(bundleListenerToken));
-                // remove the runtime service from the framework
-                scrServiceReg.Unregister();
-                // remove the configuration listener service from the framework
-                configListenerReg.Unregister();
-
-                // dispose all components created by SCR
-                auto const bundles = context.GetBundles();
-                for (auto const& bundle : bundles)
-                {
-                    DisposeExtension(bundle);
-                }
-
-                // clear bundle registry
-                bundleRegistry->Clear();
-
-                // clear component registry
-                componentRegistry->Clear();
-
-                logger->Log(SeverityLevel::LOG_DEBUG, "SCR Bundle stopped.");
-            }
-            catch (...)
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG,
-                            "Exception while stopping the declarative services runtime bundle",
-                            std::current_exception());
-            }
-            logger->StopTracking();
-            asyncWorkService->StopTracking();
-        }
-
-        void
-        SCRActivator::CreateExtension(cppmicroservices::Bundle const& bundle)
-        {
-            auto const& headers = bundle.GetHeaders();
-            // bundle has no "scr" property
-            if (headers.count(SERVICE_COMPONENT) == 0u)
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG, "No SCR components found in bundle " + bundle.GetSymbolicName());
-                return;
-            }
-
-            //create the extension which will load the components
-            if (!bundleRegistry->Find(bundle.GetBundleId()))
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG, "Creating SCRBundleExtension ... " + bundle.GetSymbolicName());
-                try
-                {
-                    auto const& scrMap = ref_any_cast<cppmicroservices::AnyMap>(headers.at(SERVICE_COMPONENT));
-                    auto ba = std::make_shared<SCRBundleExtension>(bundle,
-                                                                   componentRegistry,
-                                                                   logger,
-                                                                   configNotifier);
-                    bundleRegistry->Add(bundle.GetBundleId(), ba);
-                    // Create the ComponentManagerImpl object to manage the component configurations.
-                    ba->Initialize(scrMap, asyncWorkService);
-                 }
-                catch (cppmicroservices::SharedLibraryException const&)
-                {
-                    throw;
-                }
-                catch (cppmicroservices::SecurityException const&)
-                {
-                    throw;
-                }
-                catch (std::exception const&)
-                {
-                    logger->Log(SeverityLevel::LOG_DEBUG,
-                                "Failed to create SCRBundleExtension for " + bundle.GetSymbolicName(),
-                                std::current_exception());
-                }
-            }
-            else
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG,
-                            "SCR components already loaded from bundle " + bundle.GetSymbolicName());
+                cppmicroservices::BundleEvent evt(cppmicroservices::BundleEvent::BUNDLE_STARTED, bundle);
+                BundleChanged(evt);
             }
         }
+        // Publish ServiceComponentRuntimeService
+        auto service = std::make_shared<ServiceComponentRuntimeImpl>(runtimeContext, componentRegistry, logger);
+        scrServiceReg = context.RegisterService<ServiceComponentRuntime>(std::move(service));
 
-        void
-        SCRActivator::DisposeExtension(cppmicroservices::Bundle const& bundle)
+        // Publish ConfigurationListener
+        auto configListener
+            = std::make_shared<cppmicroservices::service::cm::ConfigurationListenerImpl>(runtimeContext,
+                                                                                         logger,
+                                                                                         configNotifier);
+        configListenerReg
+            = context.RegisterService<cppmicroservices::service::cm::ConfigurationListener>(std::move(configListener));
+    }
+
+    void
+    SCRActivator::Stop(cppmicroservices::BundleContext context)
+    {
+        WriteLock l(*notificationLock);
+        *activatorStopped = true;
+        try
         {
-            auto const& headers = bundle.GetHeaders();
-            // bundle has no scr-component property
-            if (headers.count(SERVICE_COMPONENT) == 0u)
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCR Metadata for " + bundle.GetSymbolicName());
-                return;
-            }
+            // remove the bundle listener
+            context.RemoveListener(std::move(bundleListenerToken));
+            // remove the runtime service from the framework
+            scrServiceReg.Unregister();
+            // remove the configuration listener service from the framework
+            configListenerReg.Unregister();
 
-             if (bundleRegistry->Find(bundle.GetBundleId()))
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG, "Found SCRBundleExtension for " + bundle.GetSymbolicName());
-                // remove the bundle extension object from the map.
-                bundleRegistry->Remove(bundle.GetBundleId());
-            }
-            else
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCRBundleExtension for " + bundle.GetSymbolicName());
-            }
-        }
-
-        void
-        SCRActivator::BundleChanged(cppmicroservices::BundleEvent const& evt)
-        {
-            auto bundle = evt.GetBundle();
-            auto const eventType = evt.GetType();
-            if (bundle == runtimeContext.GetBundle()) // skip events for this (runtime) bundle
-            {
-                return;
-            }
-
-            // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
-            if (eventType & cppmicroservices::BundleEvent::BUNDLE_STARTED)
-            {
-                CreateExtension(bundle);
-            }
-            else if (eventType & cppmicroservices::BundleEvent::BUNDLE_STOPPING)
+            // dispose all components created by SCR
+            auto const bundles = context.GetBundles();
+            for (auto const& bundle : bundles)
             {
                 DisposeExtension(bundle);
             }
-            // else ignore
+
+            // clear bundle registry
+            bundleRegistry->Clear();
+
+            // clear component registry
+            componentRegistry->Clear();
+
+            logger->Log(SeverityLevel::LOG_DEBUG, "SCR Bundle stopped.");
         }
-    } // namespace scrimpl
-} // namespace cppmicroservices
+        catch (...)
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG,
+                        "Exception while stopping the declarative services runtime bundle",
+                        std::current_exception());
+        }
+        logger->StopTracking();
+        asyncWorkService->StopTracking();
+    }
+
+    void
+    SCRActivator::CreateExtension(cppmicroservices::Bundle const& bundle)
+    {
+        auto const& headers = bundle.GetHeaders();
+        // bundle has no "scr" property
+        if (headers.count(SERVICE_COMPONENT) == 0u)
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG, "No SCR components found in bundle " + bundle.GetSymbolicName());
+            return;
+        }
+
+        // create the extension which will load the components
+        if (!bundleRegistry->Find(bundle.GetBundleId()))
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG, "Creating SCRBundleExtension ... " + bundle.GetSymbolicName());
+            try
+            {
+                auto const& scrMap = ref_any_cast<cppmicroservices::AnyMap>(headers.at(SERVICE_COMPONENT));
+                auto ba = std::make_shared<SCRBundleExtension>(bundle, componentRegistry, logger, configNotifier);
+                bundleRegistry->Add(bundle.GetBundleId(), ba);
+                // Create the ComponentManagerImpl object to manage the component configurations.
+                ba->Initialize(scrMap, asyncWorkService);
+            }
+            catch (cppmicroservices::SharedLibraryException const&)
+            {
+                throw;
+            }
+            catch (cppmicroservices::SecurityException const&)
+            {
+                throw;
+            }
+            catch (std::exception const&)
+            {
+                logger->Log(SeverityLevel::LOG_DEBUG,
+                            "Failed to create SCRBundleExtension for " + bundle.GetSymbolicName(),
+                            std::current_exception());
+            }
+        }
+        else
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG,
+                        "SCR components already loaded from bundle " + bundle.GetSymbolicName());
+        }
+    }
+
+    void
+    SCRActivator::DisposeExtension(cppmicroservices::Bundle const& bundle)
+    {
+        auto const& headers = bundle.GetHeaders();
+        // bundle has no scr-component property
+        if (headers.count(SERVICE_COMPONENT) == 0u)
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCR Metadata for " + bundle.GetSymbolicName());
+            return;
+        }
+
+        if (bundleRegistry->Find(bundle.GetBundleId()))
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG, "Found SCRBundleExtension for " + bundle.GetSymbolicName());
+            // remove the bundle extension object from the map.
+            bundleRegistry->Remove(bundle.GetBundleId());
+        }
+        else
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG, "Found No SCRBundleExtension for " + bundle.GetSymbolicName());
+        }
+    }
+
+    void
+    SCRActivator::BundleChanged(cppmicroservices::BundleEvent const& evt)
+    {
+        auto bundle = evt.GetBundle();
+        auto const eventType = evt.GetType();
+        if (bundle == runtimeContext.GetBundle()) // skip events for this (runtime) bundle
+        {
+            return;
+        }
+
+        // TODO: revisit to include LAZY_ACTIVATION when supported by the framework
+        if (eventType & cppmicroservices::BundleEvent::BUNDLE_STARTED)
+        {
+            CreateExtension(bundle);
+        }
+        else if (eventType & cppmicroservices::BundleEvent::BUNDLE_STOPPING)
+        {
+            DisposeExtension(bundle);
+        }
+        // else ignore
+    }
+} // namespace cppmicroservices::scrimpl
 
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::scrimpl::SCRActivator) // NOLINT

--- a/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/src/SCRAsyncWorkService.cpp
@@ -27,179 +27,171 @@
 #include "boost/asio/post.hpp"
 #include "boost/asio/thread_pool.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::scrimpl
 {
-    namespace scrimpl
+    using AWSInt = cppmicroservices::async::AsyncWorkService;
+
+    /**
+     * FallbackAsyncWorkService represents the fallback strategy in the event
+     * that a AsyncWorkService is not present within the framework. It implements
+     * the public interface for AsyncWorkService and is created in the event that
+     * a user-provided service was not given or if the user-provided service
+     * which implements the AsyncWorkService interface was unregistered.
+     */
+    class FallbackAsyncWorkService final : public AWSInt
     {
-        using AWSInt = cppmicroservices::async::AsyncWorkService;
-
-        /**
-         * FallbackAsyncWorkService represents the fallback strategy in the event
-         * that a AsyncWorkService is not present within the framework. It implements
-         * the public interface for AsyncWorkService and is created in the event that
-         * a user-provided service was not given or if the user-provided service
-         * which implements the AsyncWorkService interface was unregistered.
-         */
-        class FallbackAsyncWorkService final : public AWSInt
+      public:
+        FallbackAsyncWorkService(std::shared_ptr<cppmicroservices::logservice::LogService> const& logger_)
+            : logger(logger_)
         {
-          public:
-            FallbackAsyncWorkService(std::shared_ptr<cppmicroservices::logservice::LogService> const& logger_)
-                : logger(logger_)
-            {
-                Initialize();
-            }
-
-            void
-            Initialize()
-            {
-                threadpool = std::make_shared<boost::asio::thread_pool>(2);
-            }
-
-            void
-            Shutdown()
-            {
-                if (threadpool)
-                {
-                    try
-                    {
-                        threadpool->join();
-                        threadpool->stop();
-                        threadpool.reset();
-                    }
-                    catch (...)
-                    {
-                        auto exceptionPtr = std::current_exception();
-                        std::string msg = "An exception has occurred while trying to shutdown "
-                                          "the fallback AWSInt "
-                                          "instance.";
-                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING, msg, exceptionPtr);
-                    }
-                }
-            }
-
-            ~FallbackAsyncWorkService() { Shutdown(); }
-
-            void
-            post(std::packaged_task<void()>&& task) override
-            {
-                if (threadpool)
-                {
-                    using Sig = void();
-                    using Result = boost::asio::async_result<decltype(task), Sig>;
-                    using Handler = typename Result::completion_handler_type;
-
-                    Handler handler(std::forward<decltype(task)>(task));
-
-                    boost::asio::post(threadpool->get_executor(),
-                                      [handler = std::move(handler)]() mutable { handler(); });
-                }
-            }
-
-          private:
-            std::shared_ptr<boost::asio::thread_pool> threadpool;
-            std::shared_ptr<cppmicroservices::logservice::LogService> logger;
-        };
-
-        SCRAsyncWorkService::SCRAsyncWorkService(
-            cppmicroservices::BundleContext context,
-            std::shared_ptr<cppmicroservices::logservice::LogService> const& logger_)
-            : scrContext(context)
-            , serviceTracker(
-                  std::make_unique<cppmicroservices::ServiceTracker<AWSInt>>(context, this))
-            , usingFallback(true)
-            , asyncWorkService(nullptr)
-            , logger(logger_)
-        {
-            {
-                if (auto asyncWSSRef = context.GetServiceReference<AWSInt>(); asyncWSSRef)
-                {
-                    usingFallback = false;
-                    currRef = asyncWSSRef;
-                    asyncWorkService = context.GetService<AWSInt>(asyncWSSRef);
-                }
-                else
-                {
-                    usingFallback = true;
-                    asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger_);
-                }
-            }
-
-            serviceTracker->Open();
+            Initialize();
         }
-
-        SCRAsyncWorkService::~SCRAsyncWorkService() noexcept { asyncWorkService.reset(); }
 
         void
-        SCRAsyncWorkService::StopTracking()
+        Initialize()
         {
-            if (serviceTracker)
-            {
-                serviceTracker->Close();
-                serviceTracker.reset();
-            }
+            threadpool = std::make_shared<boost::asio::thread_pool>(2);
         }
 
-        std::shared_ptr<AWSInt>
-        SCRAsyncWorkService::AddingService(ServiceReference<AWSInt> const& reference)
+        void
+        Shutdown()
         {
-            std::unique_lock<std::mutex> lock{m};
-            auto currAsync = asyncWorkService;
-            std::shared_ptr<AWSInt> newService;
-            if (reference)
+            if (threadpool)
             {
                 try
                 {
-                    newService = scrContext.GetService<AWSInt>(reference);
-                    // if the new ref exists and:
-                        // we are using the fallback OR
-                        // our current < new (based on ranking and id), reassign
-                    if (newService && (usingFallback || currRef < reference))
-                    {
-                        asyncWorkService = newService;
-                    }
+                    threadpool->join();
+                    threadpool->stop();
+                    threadpool.reset();
                 }
                 catch (...)
                 {
                     auto exceptionPtr = std::current_exception();
-                    std::string msg = "An exception was caught while retrieving an instance of "
-                                      "cppmicroservices::async::AsyncWorkService. Falling "
-                                      "back to the default.";
+                    std::string msg = "An exception has occurred while trying to shutdown "
+                                      "the fallback AWSInt "
+                                      "instance.";
                     logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING, msg, exceptionPtr);
                 }
             }
-            return newService;
         }
 
-        void
-        SCRAsyncWorkService::ModifiedService(
-            ServiceReference<AWSInt> const& /* reference */,
-            std::shared_ptr<AWSInt> const& /* service */)
-        {
-            // no-op
-        }
+        ~FallbackAsyncWorkService() { Shutdown(); }
 
         void
-        SCRAsyncWorkService::RemovedService(
-            ServiceReference<AWSInt> const& /* reference */,
-            std::shared_ptr<AWSInt> const& service)
+        post(std::packaged_task<void()>&& task) override
         {
-            std::unique_lock<std::mutex> lock{m};
-            auto currAsync = asyncWorkService;
-            if (service == currAsync)
+            if (threadpool)
             {
-                currRef = ServiceReference<AWSInt>();
-                usingFallback = true;
-                // replace existing asyncWorkService with a fallbackAsyncWorkService
-                asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger);
+                using Sig = void();
+                using Result = boost::asio::async_result<decltype(task), Sig>;
+                using Handler = typename Result::completion_handler_type;
+
+                Handler handler(std::forward<decltype(task)>(task));
+
+                boost::asio::post(threadpool->get_executor(), [handler = std::move(handler)]() mutable { handler(); });
             }
         }
 
-        void
-        SCRAsyncWorkService::post(std::packaged_task<void()>&& task)
+      private:
+        std::shared_ptr<boost::asio::thread_pool> threadpool;
+        std::shared_ptr<cppmicroservices::logservice::LogService> logger;
+    };
+
+    SCRAsyncWorkService::SCRAsyncWorkService(cppmicroservices::BundleContext context,
+                                             std::shared_ptr<cppmicroservices::logservice::LogService> const& logger_)
+        : scrContext(context)
+        , serviceTracker(std::make_unique<cppmicroservices::ServiceTracker<AWSInt>>(context, this))
+        , usingFallback(true)
+        , asyncWorkService(nullptr)
+        , logger(logger_)
+    {
         {
-            std::unique_lock<std::mutex> lock{m};
-            asyncWorkService->post(std::move(task));
+            if (auto asyncWSSRef = context.GetServiceReference<AWSInt>(); asyncWSSRef)
+            {
+                usingFallback = false;
+                currRef = asyncWSSRef;
+                asyncWorkService = context.GetService<AWSInt>(asyncWSSRef);
+            }
+            else
+            {
+                usingFallback = true;
+                asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger_);
+            }
         }
 
-    } // namespace scrimpl
-} // namespace cppmicroservices
+        serviceTracker->Open();
+    }
+
+    SCRAsyncWorkService::~SCRAsyncWorkService() noexcept { asyncWorkService.reset(); }
+
+    void
+    SCRAsyncWorkService::StopTracking()
+    {
+        if (serviceTracker)
+        {
+            serviceTracker->Close();
+            serviceTracker.reset();
+        }
+    }
+
+    std::shared_ptr<AWSInt>
+    SCRAsyncWorkService::AddingService(ServiceReference<AWSInt> const& reference)
+    {
+        std::unique_lock<std::mutex> lock { m };
+        auto currAsync = asyncWorkService;
+        std::shared_ptr<AWSInt> newService;
+        if (reference)
+        {
+            try
+            {
+                newService = scrContext.GetService<AWSInt>(reference);
+                // if the new ref exists and:
+                // we are using the fallback OR
+                // our current < new (based on ranking and id), reassign
+                if (newService && (usingFallback || currRef < reference))
+                {
+                    asyncWorkService = newService;
+                }
+            }
+            catch (...)
+            {
+                auto exceptionPtr = std::current_exception();
+                std::string msg = "An exception was caught while retrieving an instance of "
+                                  "cppmicroservices::async::AsyncWorkService. Falling "
+                                  "back to the default.";
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING, msg, exceptionPtr);
+            }
+        }
+        return newService;
+    }
+
+    void
+    SCRAsyncWorkService::ModifiedService(ServiceReference<AWSInt> const& /* reference */,
+                                         std::shared_ptr<AWSInt> const& /* service */)
+    {
+        // no-op
+    }
+
+    void
+    SCRAsyncWorkService::RemovedService(ServiceReference<AWSInt> const& /* reference */,
+                                        std::shared_ptr<AWSInt> const& service)
+    {
+        std::unique_lock<std::mutex> lock { m };
+        auto currAsync = asyncWorkService;
+        if (service == currAsync)
+        {
+            currRef = ServiceReference<AWSInt>();
+            usingFallback = true;
+            // replace existing asyncWorkService with a fallbackAsyncWorkService
+            asyncWorkService = std::make_shared<FallbackAsyncWorkService>(logger);
+        }
+    }
+
+    void
+    SCRAsyncWorkService::post(std::packaged_task<void()>&& task)
+    {
+        std::unique_lock<std::mutex> lock { m };
+        asyncWorkService->post(std::move(task));
+    }
+
+} // namespace cppmicroservices::scrimpl

--- a/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
+++ b/compendium/DeclarativeServices/src/SCRBundleExtension.cpp
@@ -34,138 +34,132 @@
 
 using cppmicroservices::service::component::ComponentConstants::SERVICE_COMPONENT;
 
-namespace cppmicroservices
+namespace cppmicroservices::scrimpl
 {
-    namespace scrimpl
+
+    using metadata::ComponentMetadata;
+    using util::ObjectValidator;
+
+    SCRBundleExtension::SCRBundleExtension(cppmicroservices::Bundle const& bundle,
+                                           std::shared_ptr<ComponentRegistry> const& registry,
+                                           std::shared_ptr<LogService> const& logger,
+                                           std::shared_ptr<ConfigurationNotifier> const& configNotifier)
+        : bundle_(bundle)
+        , registry(registry)
+        , logger(logger)
+        , configNotifier(configNotifier)
     {
-
-        using metadata::ComponentMetadata;
-        using util::ObjectValidator;
-
-        SCRBundleExtension::SCRBundleExtension(cppmicroservices::Bundle const& bundle,
-                                               std::shared_ptr<ComponentRegistry> const& registry,
-                                               std::shared_ptr<LogService> const& logger,
-                                               std::shared_ptr<ConfigurationNotifier> const& configNotifier)
-            : bundle_(bundle)
-            , registry(registry)
-            , logger(logger)
-            , configNotifier(configNotifier)
+        if (!bundle || !registry || !logger || !configNotifier)
         {
-            if (!bundle || !registry || !logger || !configNotifier)
-            {
-                throw std::invalid_argument("Invalid parameters passed to SCRBundleExtension constructor");
-            }
+            throw std::invalid_argument("Invalid parameters passed to SCRBundleExtension constructor");
+        }
+    }
+
+    void
+    SCRBundleExtension::Initialize(cppmicroservices::AnyMap const& scrMetadata,
+                                   std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWorkService)
+    {
+        if (scrMetadata.empty() || !asyncWorkService)
+        {
+            throw std::invalid_argument("Invalid parameters passed to SCRBundleExtension::Initialize");
         }
 
-        void
-        SCRBundleExtension::Initialize(
-            cppmicroservices::AnyMap const& scrMetadata,
-            std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWorkService)
+        auto version = ObjectValidator(scrMetadata, "version").GetValue<int>();
+        auto metadataparser = metadata::MetadataParserFactory::Create(version, logger);
+        std::vector<std::shared_ptr<ComponentMetadata>> componentsMetadata;
+        componentsMetadata = metadataparser->ParseAndGetComponentsMetadata(scrMetadata);
+        for (auto& oneCompMetadata : componentsMetadata)
         {
-            if (scrMetadata.empty() || !asyncWorkService)
+            try
             {
-                throw std::invalid_argument("Invalid parameters passed to SCRBundleExtension::Initialize");
-            }
-
-            auto version = ObjectValidator(scrMetadata, "version").GetValue<int>();
-            auto metadataparser = metadata::MetadataParserFactory::Create(version, logger);
-            std::vector<std::shared_ptr<ComponentMetadata>> componentsMetadata;
-            componentsMetadata = metadataparser->ParseAndGetComponentsMetadata(scrMetadata);
-            for (auto& oneCompMetadata : componentsMetadata)
-            {
-                try
+                auto compManager = std::make_shared<ComponentManagerImpl>(oneCompMetadata,
+                                                                          registry,
+                                                                          bundle_.GetBundleContext(),
+                                                                          logger,
+                                                                          asyncWorkService,
+                                                                          configNotifier);
+                if (registry->AddComponentManager(compManager))
                 {
-                    auto compManager = std::make_shared<ComponentManagerImpl>(oneCompMetadata,
-                                                                              registry,
-                                                                              bundle_.GetBundleContext(),
-                                                                              logger,
-                                                                              asyncWorkService,
-                                                                              configNotifier);
-                    if (registry->AddComponentManager(compManager))
                     {
-                        {
-                            std::unique_lock<std::mutex> l(managersMutex);
-                            managers.push_back(compManager);
-                        }
-                        compManager->Initialize();
+                        std::unique_lock<std::mutex> l(managersMutex);
+                        managers.push_back(compManager);
                     }
-                }
-                catch (cppmicroservices::SharedLibraryException const&)
-                {
-                    throw;
-                }
-                catch (cppmicroservices::SecurityException const&)
-                {
-                    std::unique_lock<std::mutex> l(managersMutex);
-                    DisableAndRemoveAllComponentManagers();
-                    managers.clear();
-                    throw;
-                }
-                catch (std::exception const&)
-                {
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                                "Failed to create ComponentManager with name " + oneCompMetadata->name
-                                    + " from bundle with Id " + std::to_string(bundle_.GetBundleId()),
-                                std::current_exception());
+                    compManager->Initialize();
                 }
             }
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "Created instance of SCRBundleExtension for " + bundle_.GetSymbolicName());
-        }
-
-        SCRBundleExtension::~SCRBundleExtension()
-        {
+            catch (cppmicroservices::SharedLibraryException const&)
+            {
+                throw;
+            }
+            catch (cppmicroservices::SecurityException const&)
             {
                 std::unique_lock<std::mutex> l(managersMutex);
-                try
-                {
-                    DisableAndRemoveAllComponentManagers();
-                }
-                catch (...)
-                {
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
-                                "Exception while removing component managers for bundle " + bundle_.GetSymbolicName(),
-                                std::current_exception());
-                }
-
+                DisableAndRemoveAllComponentManagers();
                 managers.clear();
+                throw;
             }
-            registry.reset();
-        }
-
-        void
-        SCRBundleExtension::DisableAndRemoveAllComponentManagers()
-        {
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "Deleting instance of SCRBundleExtension for " + bundle_.GetSymbolicName());
-            for (auto& compManager : managers)
+            catch (std::exception const&)
             {
-                auto singleInvoke = std::make_shared<SingleInvokeTask>();
-                auto fut = compManager->Disable(singleInvoke);
-                registry->RemoveComponentManager(compManager);
-                try
-                {
-                    // since this happens when the bundle is stopped,
-                    // wait until the disable is finished on the other thread.
-                    compManager->WaitForFuture(fut, singleInvoke);
-                }
-                catch (...)
-                {
-                    std::string errMsg("An exception occurred while disabling "
-                                       "component manager: ");
-                    errMsg += compManager->GetName();
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
-                                errMsg,
-                                std::current_exception());
-                }
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                            "Failed to create ComponentManager with name " + oneCompMetadata->name
+                                + " from bundle with Id " + std::to_string(bundle_.GetBundleId()),
+                            std::current_exception());
             }
         }
-        void
-        SCRBundleExtension::AddComponentManager(std::shared_ptr<ComponentManager> compManager)
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "Created instance of SCRBundleExtension for " + bundle_.GetSymbolicName());
+    }
+
+    SCRBundleExtension::~SCRBundleExtension()
+    {
         {
             std::unique_lock<std::mutex> l(managersMutex);
-            managers.push_back(std::move(compManager));
-        }
+            try
+            {
+                DisableAndRemoveAllComponentManagers();
+            }
+            catch (...)
+            {
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
+                            "Exception while removing component managers for bundle " + bundle_.GetSymbolicName(),
+                            std::current_exception());
+            }
 
-    } // namespace scrimpl
-} // namespace cppmicroservices
+            managers.clear();
+        }
+        registry.reset();
+    }
+
+    void
+    SCRBundleExtension::DisableAndRemoveAllComponentManagers()
+    {
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "Deleting instance of SCRBundleExtension for " + bundle_.GetSymbolicName());
+        for (auto& compManager : managers)
+        {
+            auto singleInvoke = std::make_shared<SingleInvokeTask>();
+            auto fut = compManager->Disable(singleInvoke);
+            registry->RemoveComponentManager(compManager);
+            try
+            {
+                // since this happens when the bundle is stopped,
+                // wait until the disable is finished on the other thread.
+                compManager->WaitForFuture(fut, singleInvoke);
+            }
+            catch (...)
+            {
+                std::string errMsg("An exception occurred while disabling "
+                                   "component manager: ");
+                errMsg += compManager->GetName();
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING, errMsg, std::current_exception());
+            }
+        }
+    }
+    void
+    SCRBundleExtension::AddComponentManager(std::shared_ptr<ComponentManager> compManager)
+    {
+        std::unique_lock<std::mutex> l(managersMutex);
+        managers.push_back(std::move(compManager));
+    }
+
+} // namespace cppmicroservices::scrimpl

--- a/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.cpp
+++ b/compendium/DeclarativeServices/src/ServiceComponentRuntimeImpl.cpp
@@ -37,251 +37,245 @@ using cppmicroservices::service::component::runtime::dto::ReferenceDTO;
 using std::chrono::steady_clock;
 using std::chrono::system_clock;
 
-namespace cppmicroservices
+namespace cppmicroservices::scrimpl
 {
-    namespace scrimpl
+    /**
+     * Utility Methods used in ServiceComponentRuntimeImpl
+     */
+    time_t
+    steady_clock_to_time_t(steady_clock::time_point t)
     {
-        /**
-         * Utility Methods used in ServiceComponentRuntimeImpl
-         */
-        time_t
-        steady_clock_to_time_t(steady_clock::time_point t)
-        {
-            return system_clock::to_time_t(
-                system_clock::now() + std::chrono::duration_cast<system_clock::duration>(t - steady_clock::now()));
-        }
+        return system_clock::to_time_t(system_clock::now()
+                                       + std::chrono::duration_cast<system_clock::duration>(t - steady_clock::now()));
+    }
 
-        BundleDTO
-        ToDTO(cppmicroservices::Bundle const& bundle)
-        {
-            BundleDTO bundleDTO = {};
-            bundleDTO.id = bundle.GetBundleId();
-            bundleDTO.symbolicName = bundle.GetSymbolicName();
-            bundleDTO.lastModified = static_cast<unsigned long>(steady_clock_to_time_t(bundle.GetLastModified()));
-            bundleDTO.state = bundle.GetState();
-            bundleDTO.version = bundle.GetVersion().ToString();
-            return bundleDTO;
-        }
+    BundleDTO
+    ToDTO(cppmicroservices::Bundle const& bundle)
+    {
+        BundleDTO bundleDTO = {};
+        bundleDTO.id = bundle.GetBundleId();
+        bundleDTO.symbolicName = bundle.GetSymbolicName();
+        bundleDTO.lastModified = static_cast<unsigned long>(steady_clock_to_time_t(bundle.GetLastModified()));
+        bundleDTO.state = bundle.GetState();
+        bundleDTO.version = bundle.GetVersion().ToString();
+        return bundleDTO;
+    }
 
-        ServiceReferenceDTO
-        ToDTO(cppmicroservices::ServiceReferenceBase const& sRef)
+    ServiceReferenceDTO
+    ToDTO(cppmicroservices::ServiceReferenceBase const& sRef)
+    {
+        ServiceReferenceDTO refDTO = {};
+        refDTO.id = cppmicroservices::any_cast<long>(sRef.GetProperty(cppmicroservices::Constants::SERVICE_ID));
+        refDTO.bundle = sRef ? sRef.GetBundle().GetBundleId() : 0;
+        std::vector<std::string> keys;
+        sRef.GetPropertyKeys(keys);
+        for (auto& key : keys)
         {
-            ServiceReferenceDTO refDTO = {};
-            refDTO.id = cppmicroservices::any_cast<long>(sRef.GetProperty(cppmicroservices::Constants::SERVICE_ID));
-            refDTO.bundle = sRef ? sRef.GetBundle().GetBundleId() : 0;
-            std::vector<std::string> keys;
-            sRef.GetPropertyKeys(keys);
-            for (auto& key : keys)
+            cppmicroservices::Any val = sRef.GetProperty(key);
+            refDTO.properties.insert(std::make_pair(key, val));
+        }
+        std::vector<cppmicroservices::Bundle> bundles = sRef.GetUsingBundles();
+        for (auto& bundle : bundles)
+        {
+            if (bundle)
             {
-                cppmicroservices::Any val = sRef.GetProperty(key);
-                refDTO.properties.insert(std::make_pair(key, val));
+                refDTO.usingBundles.push_back(bundle.GetBundleId());
             }
-            std::vector<cppmicroservices::Bundle> bundles = sRef.GetUsingBundles();
+        }
+        return refDTO;
+    }
+
+    ReferenceDTO
+    ToDTO(ReferenceMetadata const& refData)
+    {
+        ReferenceDTO refDTO = {};
+        refDTO.cardinality = refData.cardinality;
+        refDTO.interfaceName = refData.interfaceName;
+        refDTO.name = refData.name;
+        refDTO.policy = refData.policy;
+        refDTO.policyOption = refData.policyOption;
+        refDTO.scope = refData.scope;
+        refDTO.target = refData.target;
+        return refDTO;
+    }
+
+    ServiceComponentRuntimeImpl::ServiceComponentRuntimeImpl(
+        cppmicroservices::BundleContext context,
+        std::shared_ptr<ComponentRegistry> componentRegistry,
+        std::shared_ptr<cppmicroservices::logservice::LogService> logger)
+        : scrContext(std::move(context))
+        , registry(std::move(componentRegistry))
+        , logger(std::move(logger))
+    {
+        if (!scrContext || !registry || !(this->logger))
+        {
+            throw std::invalid_argument("ServiceComponentRuntimeImpl Constructor "
+                                        "provided with invalid arguments");
+        }
+    }
+
+    std::vector<ComponentDescriptionDTO>
+    ServiceComponentRuntimeImpl::GetComponentDescriptionDTOs(std::vector<cppmicroservices::Bundle> const& bundles) const
+    {
+        std::vector<std::shared_ptr<ComponentManager>> compMgrs;
+        if (bundles.empty())
+        {
+            compMgrs = registry->GetComponentManagers();
+        }
+        else
+        {
             for (auto& bundle : bundles)
             {
-                if (bundle)
-                {
-                    refDTO.usingBundles.push_back(bundle.GetBundleId());
-                }
-            }
-            return refDTO;
-        }
-
-        ReferenceDTO
-        ToDTO(ReferenceMetadata const& refData)
-        {
-            ReferenceDTO refDTO = {};
-            refDTO.cardinality = refData.cardinality;
-            refDTO.interfaceName = refData.interfaceName;
-            refDTO.name = refData.name;
-            refDTO.policy = refData.policy;
-            refDTO.policyOption = refData.policyOption;
-            refDTO.scope = refData.scope;
-            refDTO.target = refData.target;
-            return refDTO;
-        }
-
-        ServiceComponentRuntimeImpl::ServiceComponentRuntimeImpl(
-            cppmicroservices::BundleContext context,
-            std::shared_ptr<ComponentRegistry> componentRegistry,
-            std::shared_ptr<cppmicroservices::logservice::LogService> logger)
-            : scrContext(std::move(context))
-            , registry(std::move(componentRegistry))
-            , logger(std::move(logger))
-        {
-            if (!scrContext || !registry || !(this->logger))
-            {
-                throw std::invalid_argument("ServiceComponentRuntimeImpl Constructor "
-                                            "provided with invalid arguments");
+                auto managersInBundle = registry->GetComponentManagers(bundle.GetBundleId());
+                compMgrs.insert(std::end(compMgrs), std::begin(managersInBundle), std::end(managersInBundle));
             }
         }
-
-        std::vector<ComponentDescriptionDTO>
-        ServiceComponentRuntimeImpl::GetComponentDescriptionDTOs(
-            std::vector<cppmicroservices::Bundle> const& bundles) const
+        std::vector<ComponentDescriptionDTO> componentDTOs;
+        for (auto holder : compMgrs)
         {
-            std::vector<std::shared_ptr<ComponentManager>> compMgrs;
-            if (bundles.empty())
+            componentDTOs.push_back(CreateDTO(holder));
+        }
+        return componentDTOs;
+    }
+
+    ComponentDescriptionDTO
+    ServiceComponentRuntimeImpl::GetComponentDescriptionDTO(cppmicroservices::Bundle const& bundle,
+                                                            std::string const& name) const
+    {
+        ComponentDescriptionDTO compDTO = {};
+        try
+        {
+            std::shared_ptr<ComponentManager> manager = registry->GetComponentManager(bundle.GetBundleId(), name);
+            compDTO = CreateDTO(manager);
+        }
+        catch (std::exception const&)
+        {
+            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                        "Exception: ",
+                        std::current_exception());
+        }
+        return compDTO;
+    }
+
+    std::vector<ComponentConfigurationDTO>
+    ServiceComponentRuntimeImpl::GetComponentConfigurationDTOs(ComponentDescriptionDTO const& description) const
+    {
+        std::vector<ComponentConfigurationDTO> compConfigDTOs;
+        std::shared_ptr<ComponentManager> manager
+            = registry->GetComponentManager(description.bundle.id, description.name);
+        if (manager)
+        {
+            std::vector<std::shared_ptr<ComponentConfiguration>> configs = manager->GetComponentConfigurations();
+            for (auto& aConfig : configs)
             {
-                compMgrs = registry->GetComponentManagers();
+                auto compConfigDTO = CreateComponentConfigurationDTO(aConfig);
+                compConfigDTO.description = CreateDTO(manager);
+                compConfigDTOs.push_back(compConfigDTO);
+            }
+        }
+        return compConfigDTOs;
+    }
+
+    bool
+    ServiceComponentRuntimeImpl::IsComponentEnabled(ComponentDescriptionDTO const& description) const
+    {
+        std::shared_ptr<ComponentManager> mgr = registry->GetComponentManager(description.bundle.id, description.name);
+        return mgr ? mgr->IsEnabled() : false;
+    }
+
+    std::shared_future<void>
+    ServiceComponentRuntimeImpl::EnableComponent(ComponentDescriptionDTO const& description)
+    {
+        std::shared_ptr<ComponentManager> holder
+            = registry->GetComponentManager(description.bundle.id, description.name);
+        return holder->Enable();
+    }
+
+    std::shared_future<void>
+    ServiceComponentRuntimeImpl::DisableComponent(ComponentDescriptionDTO const& description)
+    {
+        std::shared_ptr<ComponentManager> holder
+            = registry->GetComponentManager(description.bundle.id, description.name);
+        return holder->Disable();
+    }
+
+    ComponentDescriptionDTO
+    ServiceComponentRuntimeImpl::CreateDTO(std::shared_ptr<ComponentManager> const& compManager) const
+    {
+        ComponentDescriptionDTO compDescription = {};
+        auto compMetadata = compManager->GetMetadata();
+        if (compMetadata)
+        {
+            compDescription.name = compMetadata->name;
+            auto bundleId = compManager->GetBundleId();
+            compDescription.bundle = ToDTO(scrContext.GetBundle(bundleId));
+            compDescription.immediate = compMetadata->immediate;
+            compDescription.activate = compMetadata->activateMethodName;
+            compDescription.deactivate = compMetadata->deactivateMethodName;
+            compDescription.modified = compMetadata->modifiedMethodName;
+            auto serviceData = compMetadata->serviceMetadata;
+            compDescription.scope = serviceData.scope;
+            compDescription.serviceInterfaces = serviceData.interfaces;
+            compDescription.implementationClass = compMetadata->implClassName;
+            compDescription.defaultEnabled = compMetadata->enabled;
+            compDescription.properties = compMetadata->properties;
+            for (auto oneRef : compMetadata->refsMetadata)
+            {
+                compDescription.references.push_back(ToDTO(oneRef));
+            }
+        }
+        return compDescription;
+    }
+
+    ComponentConfigurationDTO
+    ServiceComponentRuntimeImpl::CreateComponentConfigurationDTO(
+        std::shared_ptr<ComponentConfiguration> const& config) const
+    {
+        ComponentConfigurationDTO configDTO = {};
+        configDTO.id = config->GetId();
+        configDTO.properties = config->GetProperties();
+        configDTO.state = config->GetConfigState();
+        auto refManagers = config->GetAllDependencyManagers();
+        for (auto& refManager : refManagers)
+        {
+            if (refManager->IsSatisfied())
+            {
+                configDTO.satisfiedReferences.push_back(CreateSatisfiedReferenceDTO(refManager));
             }
             else
             {
-                for (auto& bundle : bundles)
-                {
-                    auto managersInBundle = registry->GetComponentManagers(bundle.GetBundleId());
-                    compMgrs.insert(std::end(compMgrs), std::begin(managersInBundle), std::end(managersInBundle));
-                }
+                configDTO.unsatisfiedReferences.push_back(CreateUnsatisfiedReferenceDTO(refManager));
             }
-            std::vector<ComponentDescriptionDTO> componentDTOs;
-            for (auto holder : compMgrs)
-            {
-                componentDTOs.push_back(CreateDTO(holder));
-            }
-            return componentDTOs;
         }
+        return configDTO;
+    }
 
-        ComponentDescriptionDTO
-        ServiceComponentRuntimeImpl::GetComponentDescriptionDTO(cppmicroservices::Bundle const& bundle,
-                                                                std::string const& name) const
+    SatisfiedReferenceDTO
+    ServiceComponentRuntimeImpl::CreateSatisfiedReferenceDTO(std::shared_ptr<ReferenceManager> const& refManager) const
+    {
+        SatisfiedReferenceDTO refDTO = {};
+        refDTO.name = refManager->GetReferenceName();
+        refDTO.target = refManager->GetLDAPString();
+        auto sRefs = refManager->GetBoundReferences();
+        for (auto& sRef : sRefs)
         {
-            ComponentDescriptionDTO compDTO = {};
-            try
-            {
-                std::shared_ptr<ComponentManager> manager = registry->GetComponentManager(bundle.GetBundleId(), name);
-                compDTO = CreateDTO(manager);
-            }
-            catch (std::exception const&)
-            {
-                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                            "Exception: ",
-                            std::current_exception());
-            }
-            return compDTO;
+            refDTO.boundServices.push_back(ToDTO(sRef));
         }
+        return refDTO;
+    }
 
-        std::vector<ComponentConfigurationDTO>
-        ServiceComponentRuntimeImpl::GetComponentConfigurationDTOs(ComponentDescriptionDTO const& description) const
+    UnsatisfiedReferenceDTO
+    ServiceComponentRuntimeImpl::CreateUnsatisfiedReferenceDTO(
+        std::shared_ptr<ReferenceManager> const& refManager) const
+    {
+        UnsatisfiedReferenceDTO refDTO = {};
+        refDTO.name = refManager->GetReferenceName();
+        refDTO.target = refManager->GetLDAPString();
+        auto sRefs = refManager->GetTargetReferences();
+        for (auto& sRef : sRefs)
         {
-            std::vector<ComponentConfigurationDTO> compConfigDTOs;
-            std::shared_ptr<ComponentManager> manager
-                = registry->GetComponentManager(description.bundle.id, description.name);
-            if (manager)
-            {
-                std::vector<std::shared_ptr<ComponentConfiguration>> configs = manager->GetComponentConfigurations();
-                for (auto& aConfig : configs)
-                {
-                    auto compConfigDTO = CreateComponentConfigurationDTO(aConfig);
-                    compConfigDTO.description = CreateDTO(manager);
-                    compConfigDTOs.push_back(compConfigDTO);
-                }
-            }
-            return compConfigDTOs;
+            refDTO.targetServices.push_back(ToDTO(sRef));
         }
-
-        bool
-        ServiceComponentRuntimeImpl::IsComponentEnabled(ComponentDescriptionDTO const& description) const
-        {
-            std::shared_ptr<ComponentManager> mgr
-                = registry->GetComponentManager(description.bundle.id, description.name);
-            return mgr ? mgr->IsEnabled() : false;
-        }
-
-        std::shared_future<void>
-        ServiceComponentRuntimeImpl::EnableComponent(ComponentDescriptionDTO const& description)
-        {
-            std::shared_ptr<ComponentManager> holder
-                = registry->GetComponentManager(description.bundle.id, description.name);
-            return holder->Enable();
-        }
-
-        std::shared_future<void>
-        ServiceComponentRuntimeImpl::DisableComponent(ComponentDescriptionDTO const& description)
-        {
-            std::shared_ptr<ComponentManager> holder
-                = registry->GetComponentManager(description.bundle.id, description.name);
-            return holder->Disable();
-        }
-
-        ComponentDescriptionDTO
-        ServiceComponentRuntimeImpl::CreateDTO(std::shared_ptr<ComponentManager> const& compManager) const
-        {
-            ComponentDescriptionDTO compDescription = {};
-            auto compMetadata = compManager->GetMetadata();
-            if (compMetadata)
-            {
-                compDescription.name = compMetadata->name;
-                auto bundleId = compManager->GetBundleId();
-                compDescription.bundle = ToDTO(scrContext.GetBundle(bundleId));
-                compDescription.immediate = compMetadata->immediate;
-                compDescription.activate = compMetadata->activateMethodName;
-                compDescription.deactivate = compMetadata->deactivateMethodName;
-                compDescription.modified = compMetadata->modifiedMethodName;
-                auto serviceData = compMetadata->serviceMetadata;
-                compDescription.scope = serviceData.scope;
-                compDescription.serviceInterfaces = serviceData.interfaces;
-                compDescription.implementationClass = compMetadata->implClassName;
-                compDescription.defaultEnabled = compMetadata->enabled;
-                compDescription.properties = compMetadata->properties;
-                for (auto oneRef : compMetadata->refsMetadata)
-                {
-                    compDescription.references.push_back(ToDTO(oneRef));
-                }
-            }
-            return compDescription;
-        }
-
-        ComponentConfigurationDTO
-        ServiceComponentRuntimeImpl::CreateComponentConfigurationDTO(
-            std::shared_ptr<ComponentConfiguration> const& config) const
-        {
-            ComponentConfigurationDTO configDTO = {};
-            configDTO.id = config->GetId();
-            configDTO.properties = config->GetProperties();
-            configDTO.state = config->GetConfigState();
-            auto refManagers = config->GetAllDependencyManagers();
-            for (auto& refManager : refManagers)
-            {
-                if (refManager->IsSatisfied())
-                {
-                    configDTO.satisfiedReferences.push_back(CreateSatisfiedReferenceDTO(refManager));
-                }
-                else
-                {
-                    configDTO.unsatisfiedReferences.push_back(CreateUnsatisfiedReferenceDTO(refManager));
-                }
-            }
-            return configDTO;
-        }
-
-        SatisfiedReferenceDTO
-        ServiceComponentRuntimeImpl::CreateSatisfiedReferenceDTO(
-            std::shared_ptr<ReferenceManager> const& refManager) const
-        {
-            SatisfiedReferenceDTO refDTO = {};
-            refDTO.name = refManager->GetReferenceName();
-            refDTO.target = refManager->GetLDAPString();
-            auto sRefs = refManager->GetBoundReferences();
-            for (auto& sRef : sRefs)
-            {
-                refDTO.boundServices.push_back(ToDTO(sRef));
-            }
-            return refDTO;
-        }
-
-        UnsatisfiedReferenceDTO
-        ServiceComponentRuntimeImpl::CreateUnsatisfiedReferenceDTO(
-            std::shared_ptr<ReferenceManager> const& refManager) const
-        {
-            UnsatisfiedReferenceDTO refDTO = {};
-            refDTO.name = refManager->GetReferenceName();
-            refDTO.target = refManager->GetLDAPString();
-            auto sRefs = refManager->GetTargetReferences();
-            for (auto& sRef : sRefs)
-            {
-                refDTO.targetServices.push_back(ToDTO(sRef));
-            }
-            return refDTO;
-        }
-    } // namespace scrimpl
-} // namespace cppmicroservices
+        return refDTO;
+    }
+} // namespace cppmicroservices::scrimpl

--- a/compendium/LogServiceImpl/src/Activator.cpp
+++ b/compendium/LogServiceImpl/src/Activator.cpp
@@ -2,29 +2,23 @@
 #include "LoggerFactoryImpl.hpp"
 #include "LogServiceImpl.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::logservice::impl
 {
-    namespace logservice
+    void
+    Activator::Start(cppmicroservices::BundleContext bc)
     {
-        namespace impl
-        {
-            void
-            Activator::Start(cppmicroservices::BundleContext bc)
-            { 
-		const cppmicroservices::Bundle bundle = bc.GetBundle();
-		const std::string bsn = bundle.GetSymbolicName();
-		const std::string logger_name = "LogService." + bsn;
-		auto svc
-                    = std::make_shared<cppmicroservices::logservice::LogServiceImpl>(logger_name);
-                bc.RegisterService<cppmicroservices::logservice::LogService, cppmicroservices::logservice::LoggerFactory>(std::move(svc));
-            }
+        const cppmicroservices::Bundle bundle = bc.GetBundle();
+        const std::string bsn = bundle.GetSymbolicName();
+        const std::string logger_name = "LogService." + bsn;
+        auto svc = std::make_shared<cppmicroservices::logservice::LogServiceImpl>(logger_name);
+        bc.RegisterService<cppmicroservices::logservice::LogService, cppmicroservices::logservice::LoggerFactory>(
+            std::move(svc));
+    }
 
-            void
-            Activator::Stop(cppmicroservices::BundleContext)
-            {
-            }
-        } // namespace impl
-    }     // namespace logservice
-} // namespace cppmicroservices
+    void
+    Activator::Stop(cppmicroservices::BundleContext)
+    {
+    }
+} // namespace cppmicroservices::logservice::impl
 
 CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(cppmicroservices::logservice::impl::Activator)


### PR DESCRIPTION
Signed-off-by: The MathWorks, Inc. vkatiyar@mathworks.com