### PR TITLE
clang-tidy lint fixes

### DIFF
--- a/compendium/ConfigurationAdmin/src/CMConstants.cpp
+++ b/compendium/ConfigurationAdmin/src/CMConstants.cpp
@@ -24,55 +24,48 @@
 
 #include "CMConstants.hpp"
 
-namespace cppmicroservices
-{
-    namespace cmimpl
-    {
-
         /**
          * Defines standard names for CM Constants.
          */
-        namespace CMConstants
-        {
-            /**
-             * Manifest key specifying the CM configuration object.
-             * <p>
-             * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-             * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
-             */
-            const std::string CM_KEY = "cm";
+namespace cppmicroservices::cmimpl::CMConstants
+{
+    /**
+     * Manifest key specifying the CM configuration object.
+     * <p>
+     * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+     * object returned by the {@code Bundle.GetHeaders} method using {@code AnyMap.at}
+     */
+    const std::string CM_KEY = "cm";
 
-            /**
-             * Manifest key specifying the version of the CM configuration.
-             * <p>
-             * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
-             * object associated with the CM_KEY entry.
-             */
-            const std::string CM_VERSION = "version";
+    /**
+     * Manifest key specifying the version of the CM configuration.
+     * <p>
+     * The attribute value may be retrieved from the {@code cppmicroservices::AnyMap}
+     * object associated with the CM_KEY entry.
+     */
+    const std::string CM_VERSION = "version";
 
-            /**
-             * Top level service property to declare the PID of a ManagedService or
-             * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
-             */
-            const std::string CM_SERVICE_KEY = "service";
+    /**
+     * Top level service property to declare the PID of a ManagedService or
+     * ManagedServiceFactory. If found, CM_SERVICE_SUBKEY could yield the PID.
+     */
+    const std::string CM_SERVICE_KEY = "service";
 
-            /**
-             * Subkey to obtain the PID
-             */
-            const std::string CM_SERVICE_SUBKEY = "pid";
+    /**
+     * Subkey to obtain the PID
+     */
+    const std::string CM_SERVICE_SUBKEY = "pid";
 
-            /**
-             * Top level property added by DeclarativeServices, use as fallback if no service.pid
-             * property can be found for a ManagedService or ManagedServiceFactory. If found,
-             * CM_COMPONENT_SUBKEY could yield an alternative PID.
-             */
-            const std::string CM_COMPONENT_KEY = "component";
+    /**
+     * Top level property added by DeclarativeServices, use as fallback if no service.pid
+     * property can be found for a ManagedService or ManagedServiceFactory. If found,
+     * CM_COMPONENT_SUBKEY could yield an alternative PID.
+     */
+    const std::string CM_COMPONENT_KEY = "component";
 
-            /**
-             * Subkey to obtain an alternative PID
-             */
-            const std::string CM_COMPONENT_SUBKEY = "name";
+    /**
+     * Subkey to obtain an alternative PID
+     */
+    const std::string CM_COMPONENT_SUBKEY = "name";
 
-        } // namespace CMConstants
-    }     // namespace cmimpl
-} // namespace cppmicroservices
+} // namespace cppmicroservices::cmimpl::CMConstants

--- a/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationAdminImpl.cpp
@@ -190,962 +190,959 @@ namespace
     }
 } // namespace
 
-namespace cppmicroservices
+namespace cppmicroservices::cmimpl
 {
-    namespace cmimpl
+    ConfigurationAdminImpl::ConfigurationAdminImpl(
+        cppmicroservices::BundleContext context,
+        std::shared_ptr<cppmicroservices::logservice::LogService> const& lggr,
+        std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWS)
+        : cmContext(std::move(context))
+        , logger(lggr)
+        , asyncWorkService(asyncWS)
+        , futuresID { 0u }
+        , managedServiceTracker(cmContext, this)
+        , managedServiceFactoryTracker(cmContext, this)
+        , configListenerTracker(cmContext)
     {
-        ConfigurationAdminImpl::ConfigurationAdminImpl(
-            cppmicroservices::BundleContext context,
-            std::shared_ptr<cppmicroservices::logservice::LogService> const& lggr,
-            std::shared_ptr<cppmicroservices::async::AsyncWorkService> const& asyncWS)
-            : cmContext(std::move(context))
-            , logger(lggr)
-            , asyncWorkService(asyncWS)
-            , futuresID { 0u }
-            , managedServiceTracker(cmContext, this)
-            , managedServiceFactoryTracker(cmContext, this)
-            , configListenerTracker(cmContext)
+        managedServiceTracker.Open();
+        managedServiceFactoryTracker.Open();
+        configListenerTracker.Open();
+    }
+
+    ConfigurationAdminImpl::~ConfigurationAdminImpl()
+    {
+        auto managedServiceWrappers = managedServiceTracker.GetServices();
+        auto managedServiceFactoryWrappers = managedServiceFactoryTracker.GetServices();
+
+        try
         {
-            managedServiceTracker.Open();
-            managedServiceFactoryTracker.Open();
-            configListenerTracker.Open();
+            managedServiceFactoryTracker.Close();
+            managedServiceTracker.Close();
+            configListenerTracker.Close();
+        }
+        catch (...)
+        {
+            auto thrownByMessage = "thrown by ConfiguratonAdminImpl destructor "
+                                    "while closing the service trackers.\n\t ";
+            logger->Log(SeverityLevel::LOG_ERROR, thrownByMessage);
         }
 
-        ConfigurationAdminImpl::~ConfigurationAdminImpl()
+        decltype(factoryInstances) factoryInstancesCopy;
+        decltype(configurations) configurationsToInvalidate;
         {
-            auto managedServiceWrappers = managedServiceTracker.GetServices();
-            auto managedServiceFactoryWrappers = managedServiceFactoryTracker.GetServices();
-
-            try
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+            factoryInstancesCopy.swap(factoryInstances);
+            configurationsToInvalidate.swap(configurations);
+        }
+        for (auto const& configuration : configurationsToInvalidate)
+        {
+            configuration.second->Invalidate();
+        }
+        AnyMap emptyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+        for (auto const& managedService : managedServiceWrappers)
+        {
+            // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
+            // that we aren't tracking. We must be careful not to dereference these!
+            if (managedService)
             {
-                managedServiceFactoryTracker.Close();
-                managedServiceTracker.Close();
-                configListenerTracker.Close();
-            }
-            catch (...)
-            {
-                auto thrownByMessage = "thrown by ConfiguratonAdminImpl destructor "
-                                       "while closing the service trackers.\n\t ";
-                logger->Log(SeverityLevel::LOG_ERROR, thrownByMessage);
-            }
-
-            decltype(factoryInstances) factoryInstancesCopy;
-            decltype(configurations) configurationsToInvalidate;
-            {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-                factoryInstancesCopy.swap(factoryInstances);
-                configurationsToInvalidate.swap(configurations);
-            }
-            for (auto const& configuration : configurationsToInvalidate)
-            {
-                configuration.second->Invalidate();
-            }
-            AnyMap emptyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
-            for (auto const& managedService : managedServiceWrappers)
-            {
-                // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
-                // that we aren't tracking. We must be careful not to dereference these!
-                if (managedService)
+                // can only send a Removed notification if the managedService has previously
+                // received an Updated notification.
+                auto const it = configurationsToInvalidate.find(managedService->getPid());
+                if (it != std::end(configurationsToInvalidate) && it->second->HasBeenUpdatedAtLeastOnce())
                 {
-                    // can only send a Removed notification if the managedService has previously
-                    // received an Updated notification.
-                    auto const it = configurationsToInvalidate.find(managedService->getPid());
-                    if (it != std::end(configurationsToInvalidate) && it->second->HasBeenUpdatedAtLeastOnce())
-                    {
-                        notifyServiceUpdated(managedService->getPid(),
-                                             *(managedService->getTrackedService()),
-                                             emptyMap,
-                                             *logger);
-                    }
+                    notifyServiceUpdated(managedService->getPid(),
+                                            *(managedService->getTrackedService()),
+                                            emptyMap,
+                                            *logger);
                 }
             }
-            for (auto const& managedServiceFactory : managedServiceFactoryWrappers)
+        }
+        for (auto const& managedServiceFactory : managedServiceFactoryWrappers)
+        {
+            // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
+            // that we aren't tracking. We must be careful not to dereference these!
+            if (!managedServiceFactory)
             {
-                // The ServiceTracker will return a default constructed shared_ptr for each ManagedServiceFactory
-                // that we aren't tracking. We must be careful not to dereference these!
-                if (!managedServiceFactory)
+                continue;
+            }
+            auto it = factoryInstancesCopy.find(managedServiceFactory->getPid());
+            if (it == std::end(factoryInstancesCopy))
+            {
+                continue;
+            }
+            for (auto const& pid : it->second)
+            {
+                // can only send a Removed notification if the managedServiceFactory has previously
+                // received an Updated notification.
+
+                auto const it = configurationsToInvalidate.find(pid);
+                if (it != std::end(configurationsToInvalidate) && (it->second->HasBeenUpdatedAtLeastOnce()))
+                {
+                    notifyServiceRemoved(pid, *(managedServiceFactory->getTrackedService()), *logger);
+                }
+            }
+        }
+        std::unique_lock<std::mutex> ul { futuresMutex };
+        if (!incompleteFutures.empty())
+        {
+            futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
+        }
+    }
+
+    std::shared_ptr<cppmicroservices::service::cm::Configuration>
+    ConfigurationAdminImpl::GetConfiguration(std::string const& pid)
+    {
+        std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
+        auto created = false;
+        {
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+            auto it = configurations.find(pid);
+            if (it == std::end(configurations))
+            {
+                auto factoryPid = getFactoryPid(pid);
+                AddFactoryInstanceIfRequired(pid, factoryPid);
+                it = configurations
+                            .emplace(pid,
+                                    std::make_shared<ConfigurationImpl>(
+                                        this,
+                                        pid,
+                                        std::move(factoryPid),
+                                        AnyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
+                            .first;
+                created = true;
+            }
+            result = it->second;
+        }
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "GetConfiguration: returning " + (created ? std::string("new") : "existing")
+                        + " Configuration instance with PID " + pid);
+        return result;
+    }
+
+    std::shared_ptr<cppmicroservices::service::cm::Configuration>
+    ConfigurationAdminImpl::CreateFactoryConfiguration(std::string const& factoryPid)
+    {
+        std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
+        auto pid = factoryPid + "~" + RandomInstanceName();
+        {
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+            auto it = configurations.find(pid);
+            while (it != std::end(configurations))
+            {
+                pid = factoryPid + "~" + RandomInstanceName();
+                it = configurations.find(pid);
+            }
+            AddFactoryInstanceIfRequired(pid, factoryPid);
+            it = configurations
+                        .emplace(
+                            pid,
+                            std::make_shared<ConfigurationImpl>(this,
+                                                                pid,
+                                                                factoryPid,
+                                                                AnyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
+                        .first;
+            result = it->second;
+        }
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "CreateFactoryConfiguration: returning new Configuration "
+                    "instance with PID "
+                        + pid);
+        return result;
+    }
+
+    std::shared_ptr<cppmicroservices::service::cm::Configuration>
+    ConfigurationAdminImpl::GetFactoryConfiguration(std::string const& factoryPid, std::string const& instanceName)
+    {
+        auto const pid = factoryPid + "~" + instanceName;
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "GetFactoryConfiguration: deferring to GetConfiguration for PID " + pid);
+        return GetConfiguration(pid);
+    }
+    /* ListConfigurations looks for configuration objects in the repository that match the
+        * input parameter. An LDAP filter expression can be used to filter based on any property of the
+        * configuration, including the pid or factory pid. Typical inputs for a filter string might
+        * be "pid=startup.options", (to search for a configuration object with a matching pid)
+        * "pid=virtualfilesystem~user1", (to search for a configuration object with a matching factory pid)
+        *  "key1=abc" (to search for a configuration object containing a property with key "key1" with a value "abc".
+        * Regular expressions are allowed.
+        */
+    std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>>
+    ConfigurationAdminImpl::ListConfigurations(std::string const& filter)
+    {
+        std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>> result;
+        {
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+
+            // return all configuration objects if the filter is empty
+            if (filter.empty())
+            {
+                result.reserve(configurations.size());
+                for (auto const& it : configurations)
+                {
+                    if (it.second->HasBeenUpdatedAtLeastOnce())
+                    {
+                        result.push_back(it.second);
+                    }
+                }
+                return result;
+            }
+
+            // filter is not empty so look for pid and property matches
+            LDAPFilter ldap { filter };
+            cppmicroservices::AnyMap pidMap { cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+
+            for (auto const& it : configurations)
+            {
+                // configurations that have not yet been updated cannot be
+                // returned.
+                if (!it.second->HasBeenUpdatedAtLeastOnce())
                 {
                     continue;
                 }
-                auto it = factoryInstancesCopy.find(managedServiceFactory->getPid());
-                if (it == std::end(factoryInstancesCopy))
-                {
-                    continue;
-                }
-                for (auto const& pid : it->second)
-                {
-                    // can only send a Removed notification if the managedServiceFactory has previously
-                    // received an Updated notification.
+                /* Create an AnyMap containing the pid or factoryPid so that the ldap filter
+                    * functionality can be used to match the pid to the
+                    * input parameter. Easy way to do the comparison since input parameter could
+                    * contain a regular expression
+                    */
+                pidMap["pid"] = it.first;
 
-                    auto const it = configurationsToInvalidate.find(pid);
-                    if (it != std::end(configurationsToInvalidate) && (it->second->HasBeenUpdatedAtLeastOnce()))
+                if (ldap.Match(pidMap))
+                {
+                    // This configuration object has a matching pid.
+                    result.emplace_back(it.second);
+                }
+                else
+                {
+                    // The pid wasn't a match but the properties might be. Check those.
+                    auto props = it.second->GetProperties();
+                    if (ldap.Match(props))
                     {
-                        notifyServiceRemoved(pid, *(managedServiceFactory->getTrackedService()), *logger);
+                        result.emplace_back(it.second);
                     }
                 }
-            }
-            std::unique_lock<std::mutex> ul { futuresMutex };
-            if (!incompleteFutures.empty())
-            {
-                futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
-            }
+            } // end for
         }
+        return result;
+    }
 
-        std::shared_ptr<cppmicroservices::service::cm::Configuration>
-        ConfigurationAdminImpl::GetConfiguration(std::string const& pid)
+    std::vector<ConfigurationAddedInfo>
+    ConfigurationAdminImpl::AddConfigurations(std::vector<metadata::ConfigurationMetadata> configurationMetadata)
+    {
+        std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
+        std::vector<bool> createdOrUpdated;
+        std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
+
         {
-            std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
-            auto created = false;
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+            for (auto const& configMetadata : configurationMetadata)
             {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
+                unsigned long changeCount { 0ul };
+                auto& pid = configMetadata.pid;
                 auto it = configurations.find(pid);
                 if (it == std::end(configurations))
                 {
                     auto factoryPid = getFactoryPid(pid);
                     AddFactoryInstanceIfRequired(pid, factoryPid);
-                    it = configurations
-                             .emplace(pid,
-                                      std::make_shared<ConfigurationImpl>(
-                                          this,
-                                          pid,
-                                          std::move(factoryPid),
-                                          AnyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
-                             .first;
-                    created = true;
+                    // construct the Configuration Object with a changeCount of 1
+                    // since configuration objects created from metadata already
+                    // have their properties (if any) present. The create operation
+                    // counts as a create and an update operation.
+                    auto newConfig = std::make_shared<ConfigurationImpl>(this,
+                                                                            pid,
+                                                                            std::move(factoryPid),
+                                                                            configMetadata.properties,
+                                                                            1u);
+                    changeCount = newConfig->GetChangeCount();
+                    it = configurations.emplace(pid, std::move(newConfig)).first;
+                    pidsAndChangeCountsAndIDs.emplace_back(pid,
+                                                            changeCount,
+                                                            reinterpret_cast<std::uintptr_t>(it->second.get()));
+                    createdOrUpdated.push_back(true);
+                    continue;
                 }
-                result = it->second;
-            }
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "GetConfiguration: returning " + (created ? std::string("new") : "existing")
-                            + " Configuration instance with PID " + pid);
-            return result;
-        }
-
-        std::shared_ptr<cppmicroservices::service::cm::Configuration>
-        ConfigurationAdminImpl::CreateFactoryConfiguration(std::string const& factoryPid)
-        {
-            std::shared_ptr<cppmicroservices::service::cm::Configuration> result;
-            auto pid = factoryPid + "~" + RandomInstanceName();
-            {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-                auto it = configurations.find(pid);
-                while (it != std::end(configurations))
+                // else Configuration already exists
+                try
                 {
-                    pid = factoryPid + "~" + RandomInstanceName();
-                    it = configurations.find(pid);
+                    auto const updatedAndChangeCount
+                        = it->second->UpdateWithoutNotificationIfDifferent(configMetadata.properties);
+                    changeCount = updatedAndChangeCount.second;
+                    pidsAndChangeCountsAndIDs.emplace_back(pid,
+                                                            std::get<1>(updatedAndChangeCount),
+                                                            reinterpret_cast<std::uintptr_t>(it->second.get()));
+                    createdOrUpdated.push_back(std::get<0>(updatedAndChangeCount));
                 }
-                AddFactoryInstanceIfRequired(pid, factoryPid);
-                it = configurations
-                         .emplace(
-                             pid,
-                             std::make_shared<ConfigurationImpl>(this,
-                                                                 pid,
-                                                                 factoryPid,
-                                                                 AnyMap { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS }))
-                         .first;
-                result = it->second;
-            }
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "CreateFactoryConfiguration: returning new Configuration "
-                        "instance with PID "
-                            + pid);
-            return result;
-        }
-
-        std::shared_ptr<cppmicroservices::service::cm::Configuration>
-        ConfigurationAdminImpl::GetFactoryConfiguration(std::string const& factoryPid, std::string const& instanceName)
-        {
-            auto const pid = factoryPid + "~" + instanceName;
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "GetFactoryConfiguration: deferring to GetConfiguration for PID " + pid);
-            return GetConfiguration(pid);
-        }
-        /* ListConfigurations looks for configuration objects in the repository that match the
-         * input parameter. An LDAP filter expression can be used to filter based on any property of the
-         * configuration, including the pid or factory pid. Typical inputs for a filter string might
-         * be "pid=startup.options", (to search for a configuration object with a matching pid)
-         * "pid=virtualfilesystem~user1", (to search for a configuration object with a matching factory pid)
-         *  "key1=abc" (to search for a configuration object containing a property with key "key1" with a value "abc".
-         * Regular expressions are allowed.
-         */
-        std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>>
-        ConfigurationAdminImpl::ListConfigurations(std::string const& filter)
-        {
-            std::vector<std::shared_ptr<cppmicroservices::service::cm::Configuration>> result;
-            {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-
-                // return all configuration objects if the filter is empty
-                if (filter.empty())
+                catch (std::runtime_error const&) // Configuration has been Removed by someone else, but we've won
+                                                    // the race to handle that.
                 {
-                    result.reserve(configurations.size());
-                    for (auto const& it : configurations)
-                    {
-                        if (it.second->HasBeenUpdatedAtLeastOnce())
-                        {
-                            result.push_back(it.second);
-                        }
-                    }
-                    return result;
-                }
-
-                // filter is not empty so look for pid and property matches
-                LDAPFilter ldap { filter };
-                cppmicroservices::AnyMap pidMap { cppmicroservices::AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
-
-                for (auto const& it : configurations)
-                {
-                    // configurations that have not yet been updated cannot be
-                    // returned.
-                    if (!it.second->HasBeenUpdatedAtLeastOnce())
-                    {
-                        continue;
-                    }
-                    /* Create an AnyMap containing the pid or factoryPid so that the ldap filter
-                     * functionality can be used to match the pid to the
-                     * input parameter. Easy way to do the comparison since input parameter could
-                     * contain a regular expression
-                     */
-                    pidMap["pid"] = it.first;
-
-                    if (ldap.Match(pidMap))
-                    {
-                        // This configuration object has a matching pid.
-                        result.emplace_back(it.second);
-                    }
-                    else
-                    {
-                        // The pid wasn't a match but the properties might be. Check those.
-                        auto props = it.second->GetProperties();
-                        if (ldap.Match(props))
-                        {
-                            result.emplace_back(it.second);
-                        }
-                    }
-                } // end for
-            }
-            return result;
-        }
-
-        std::vector<ConfigurationAddedInfo>
-        ConfigurationAdminImpl::AddConfigurations(std::vector<metadata::ConfigurationMetadata> configurationMetadata)
-        {
-            std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs;
-            std::vector<bool> createdOrUpdated;
-            std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
-
-            {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-                for (auto const& configMetadata : configurationMetadata)
-                {
-                    unsigned long changeCount { 0ul };
-                    auto& pid = configMetadata.pid;
-                    auto it = configurations.find(pid);
-                    if (it == std::end(configurations))
-                    {
-                        auto factoryPid = getFactoryPid(pid);
-                        AddFactoryInstanceIfRequired(pid, factoryPid);
-                        // construct the Configuration Object with a changeCount of 1
-                        // since configuration objects created from metadata already
-                        // have their properties (if any) present. The create operation
-                        // counts as a create and an update operation.
-                        auto newConfig = std::make_shared<ConfigurationImpl>(this,
-                                                                             pid,
-                                                                             std::move(factoryPid),
-                                                                             configMetadata.properties,
-                                                                             1u);
-                        changeCount = newConfig->GetChangeCount();
-                        it = configurations.emplace(pid, std::move(newConfig)).first;
-                        pidsAndChangeCountsAndIDs.emplace_back(pid,
-                                                               changeCount,
-                                                               reinterpret_cast<std::uintptr_t>(it->second.get()));
-                        createdOrUpdated.push_back(true);
-                        continue;
-                    }
-                    // else Configuration already exists
-                    try
-                    {
-                        auto const updatedAndChangeCount
-                            = it->second->UpdateWithoutNotificationIfDifferent(configMetadata.properties);
-                        changeCount = updatedAndChangeCount.second;
-                        pidsAndChangeCountsAndIDs.emplace_back(pid,
-                                                               std::get<1>(updatedAndChangeCount),
-                                                               reinterpret_cast<std::uintptr_t>(it->second.get()));
-                        createdOrUpdated.push_back(std::get<0>(updatedAndChangeCount));
-                    }
-                    catch (std::runtime_error const&) // Configuration has been Removed by someone else, but we've won
-                                                      // the race to handle that.
-                    {
-                        configurationsToInvalidate.push_back(std::move(it->second));
-                        it->second = std::make_shared<ConfigurationImpl>(this,
-                                                                         pid,
-                                                                         getFactoryPid(pid),
-                                                                         configMetadata.properties);
-                        pidsAndChangeCountsAndIDs.emplace_back(pid,
-                                                               changeCount,
-                                                               reinterpret_cast<std::uintptr_t>(it->second.get()));
-                        createdOrUpdated.push_back(true);
-                    }
+                    configurationsToInvalidate.push_back(std::move(it->second));
+                    it->second = std::make_shared<ConfigurationImpl>(this,
+                                                                        pid,
+                                                                        getFactoryPid(pid),
+                                                                        configMetadata.properties);
+                    pidsAndChangeCountsAndIDs.emplace_back(pid,
+                                                            changeCount,
+                                                            reinterpret_cast<std::uintptr_t>(it->second.get()));
+                    createdOrUpdated.push_back(true);
                 }
             }
-            // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
-            for (auto const& configurationToInvalidate : configurationsToInvalidate)
+        }
+        // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
+        for (auto const& configurationToInvalidate : configurationsToInvalidate)
+        {
+            configurationToInvalidate->Invalidate();
+        }
+        auto idx = 0u;
+        for (auto const& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
+        {
+            auto const& pid = pidAndChangeCountAndID.pid;
+            if (createdOrUpdated[idx])
             {
-                configurationToInvalidate->Invalidate();
+                NotifyConfigurationUpdated(pid, pidAndChangeCountAndID.changeCount);
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                            "AddConfigurations: Created or Updated Configuration instance with PID " + pid);
             }
-            auto idx = 0u;
+            else
+            {
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                            "AddConfigurations: Configuration already existed with identical properties with PID "
+                                + pid);
+            }
+            ++idx;
+        }
+        return pidsAndChangeCountsAndIDs;
+    }
+
+    void
+    ConfigurationAdminImpl::RemoveConfigurations(std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs)
+    {
+        std::vector<std::pair<bool, bool>> removedAndUpdated;
+        std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
+        bool hasBeenUpdated = false;
+        {
+            std::lock_guard<std::mutex> lk { configurationsMutex };
             for (auto const& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
             {
                 auto const& pid = pidAndChangeCountAndID.pid;
-                if (createdOrUpdated[idx])
+                auto const it = configurations.find(pid);
+                if (it == std::end(configurations))
                 {
-                    NotifyConfigurationUpdated(pid, pidAndChangeCountAndID.changeCount);
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                "AddConfigurations: Created or Updated Configuration instance with PID " + pid);
+                    removedAndUpdated.emplace_back(false, false);
+                    continue;
                 }
-                else
+                // else Configuration still exists
+                if (reinterpret_cast<std::uintptr_t>(it->second.get()) != pidAndChangeCountAndID.configurationId)
                 {
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                "AddConfigurations: Configuration already existed with identical properties with PID "
-                                    + pid);
+                    // This Configuration is not the same one that was originally created by the CMBundleExtension.
+                    // It must have been removed and re-added by someone else in the interim.
+                    removedAndUpdated.emplace_back(false, false);
+                    continue;
                 }
-                ++idx;
-            }
-            return pidsAndChangeCountsAndIDs;
-        }
-
-        void
-        ConfigurationAdminImpl::RemoveConfigurations(std::vector<ConfigurationAddedInfo> pidsAndChangeCountsAndIDs)
-        {
-            std::vector<std::pair<bool, bool>> removedAndUpdated;
-            std::vector<std::shared_ptr<ConfigurationImpl>> configurationsToInvalidate;
-            bool hasBeenUpdated = false;
-            {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-                for (auto const& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
+                try
                 {
-                    auto const& pid = pidAndChangeCountAndID.pid;
-                    auto const it = configurations.find(pid);
-                    if (it == std::end(configurations))
+                    hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
+                    auto const configurationWasRemoved = it->second->RemoveWithoutNotificationIfChangeCountEquals(
+                        pidAndChangeCountAndID.changeCount);
+                    if (configurationWasRemoved)
                     {
-                        removedAndUpdated.emplace_back(false, false);
-                        continue;
-                    }
-                    // else Configuration still exists
-                    if (reinterpret_cast<std::uintptr_t>(it->second.get()) != pidAndChangeCountAndID.configurationId)
-                    {
-                        // This Configuration is not the same one that was originally created by the CMBundleExtension.
-                        // It must have been removed and re-added by someone else in the interim.
-                        removedAndUpdated.emplace_back(false, false);
-                        continue;
-                    }
-                    try
-                    {
-                        hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
-                        auto const configurationWasRemoved = it->second->RemoveWithoutNotificationIfChangeCountEquals(
-                            pidAndChangeCountAndID.changeCount);
-                        if (configurationWasRemoved)
-                        {
-                            configurationsToInvalidate.push_back(std::move(it->second));
-                            removedAndUpdated.emplace_back(true, hasBeenUpdated);
-                            configurations.erase(it);
-                            RemoveFactoryInstanceIfRequired(pid);
-                            continue;
-                        }
-                        // else Configuration now differs from the one the CMBundleExtension added. Do not remove it.
-                        removedAndUpdated.emplace_back(false, false);
-                    }
-                    catch (std::runtime_error const&)
-                    {
-                        // Configuration already Removed by someone else, but we've won the race to handle that in
-                        // ComponentAdminImpl
                         configurationsToInvalidate.push_back(std::move(it->second));
                         removedAndUpdated.emplace_back(true, hasBeenUpdated);
                         configurations.erase(it);
                         RemoveFactoryInstanceIfRequired(pid);
+                        continue;
                     }
+                    // else Configuration now differs from the one the CMBundleExtension added. Do not remove it.
+                    removedAndUpdated.emplace_back(false, false);
                 }
-            }
-            // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
-            for (auto const& configurationToInvalidate : configurationsToInvalidate)
-            {
-                configurationToInvalidate->Invalidate();
-            }
-            auto idx = 0u;
-            for (auto const& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
-            {
-                auto const& pid = pidAndChangeCountAndID.pid;
-                if (removedAndUpdated[idx].first)
+                catch (std::runtime_error const&)
                 {
-                    if (removedAndUpdated[idx].second)
-                    {
-                        NotifyConfigurationUpdated(pid, pidAndChangeCountAndID.changeCount);
-                    }
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                "RemoveConfigurations: Removed Configuration instance with PID " + pid);
+                    // Configuration already Removed by someone else, but we've won the race to handle that in
+                    // ComponentAdminImpl
+                    configurationsToInvalidate.push_back(std::move(it->second));
+                    removedAndUpdated.emplace_back(true, hasBeenUpdated);
+                    configurations.erase(it);
+                    RemoveFactoryInstanceIfRequired(pid);
                 }
-                else
-                {
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                "RemoveConfigurations: Configuration with PID " + pid
-                                    + " was not removed (either already removed, or it has been subsequently updated)");
-                }
-                ++idx;
             }
         }
-
-        std::shared_ptr<ThreadpoolSafeFuturePrivate>
-        ConfigurationAdminImpl::NotifyConfigurationUpdated(std::string const& pid, unsigned long const changeCount)
+        // This cannot be called whilst holding the configurationsMutex as it could cause a deadlock.
+        for (auto const& configurationToInvalidate : configurationsToInvalidate)
         {
-            // NotifyConfigurationUpdated will only send a notification to the service if
-            // the configuration object has been updated at least once. In order to determine whether or not
-            // a configuration object has been updated, it calls the HasBeenUpdatedAtLeastOnce method for
-            // the configuration object. For a remove operation the configuration object
-            // is not available and that method cannot be called. For this reason, NotifyConfigurationUpdated
-            // should not be called for Remove operations unless the caller has already confirmed
-            // the configuration object has been updated at least once.
-            return PerformAsync(
-                [this, pid, changeCount]
-                {
-                    AnyMap properties { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
-                    std::string fPid;
-                    std::string nonFPid;
-                    auto removed = false;
-                    auto hasBeenUpdated = false;
-                    std::vector<std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>>
-                        managedServiceWrappers;
-                    std::vector<
-                        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>>
-                        managedServiceFactoryWrappers;
-                    {
-                        std::lock_guard<std::mutex> lk { configurationsMutex };
-                        auto const it = configurations.find(pid);
-                        if (it == std::end(configurations))
-                        {
-                            removed = true;
-                            hasBeenUpdated = true;
-                        }
-                        else
-                        {
-                            try
-                            {
-                                hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
-                                properties = it->second->GetProperties();
-                            }
-                            catch (std::runtime_error const&)
-                            {
-                                // Configuration is being removed
-                                removed = true;
-                            }
-                        }
-
-                        // We can only send update notifications for configuration objects that have
-                        // been updated. Just return without sending the notification for objects
-                        // that have not yet been updated.
-                        if (!hasBeenUpdated)
-                        {
-                            return;
-                        }
-
-                        if (pid.find('~') != std::string::npos)
-                        {
-                            // this is a factory pid
-                            fPid = pid;
-                        }
-                        else
-                        {
-                            nonFPid = pid;
-                        }
-                        managedServiceWrappers = trackedManagedServices_;
-                        managedServiceFactoryWrappers = trackedManagedServiceFactories_;
-                    }
-
-                    auto type = removed ? cppmicroservices::service::cm::ConfigurationEventType::CM_DELETED
-                                        : cppmicroservices::service::cm::ConfigurationEventType::CM_UPDATED;
-
-                    auto configurationListeners = configListenerTracker.GetServices();
-                    auto configAdminRef = cmContext.GetServiceReference<ConfigurationAdmin>();
-                    for (auto const& it : configurationListeners)
-                    {
-                        auto configEvent
-                            = cppmicroservices::service::cm::ConfigurationEvent(configAdminRef, type, fPid, nonFPid);
-                        it->configurationEvent((configEvent));
-                    }
-
-                    std::for_each(
-                        managedServiceWrappers.begin(),
-                        managedServiceWrappers.end(),
-                        [&](auto const& managedServiceWrapper)
-                        {
-                            // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
-                            // that we aren't tracking. We must be careful not to dereference these!
-                            if ((managedServiceWrapper) && (managedServiceWrapper->getPid() == pid)
-                                && (removed
-                                    || (!removed
-                                        && managedServiceWrapper->needsAnUpdateNotification(pid, changeCount))))
-                            {
-                                notifyServiceUpdated(pid,
-                                                     *(managedServiceWrapper->getTrackedService()),
-                                                     properties,
-                                                     *logger);
-                                if (removed)
-                                {
-                                    managedServiceWrapper->removeLastUpdatedChangeCount(pid);
-                                }
-                                else
-                                {
-                                    managedServiceWrapper->setLastUpdatedChangeCount(pid, changeCount);
-                                }
-                            }
-                        });
-
-                    if (auto const factoryPid = getFactoryPid(pid); !factoryPid.empty())
-                    {
-                        std::for_each(
-                            managedServiceFactoryWrappers.begin(),
-                            managedServiceFactoryWrappers.end(),
-                            [&](auto const& managedServiceFactoryWrapper)
-                            {
-                                // The ServiceTracker will return a default constructed shared_ptr for each
-                                // ManagedServiceFactory that we aren't tracking. We must be careful not to dereference
-                                // these!
-                                if ((managedServiceFactoryWrapper)
-                                    && (managedServiceFactoryWrapper->getPid() == factoryPid))
-                                {
-                                    if (removed)
-                                    {
-                                        notifyServiceRemoved(pid,
-                                                             *(managedServiceFactoryWrapper->getTrackedService()),
-                                                             *logger);
-                                        managedServiceFactoryWrapper->removeLastUpdatedChangeCount(pid);
-                                    }
-                                    else if (managedServiceFactoryWrapper->needsAnUpdateNotification(pid, changeCount))
-                                    {
-                                        notifyServiceUpdated(pid,
-                                                             *(managedServiceFactoryWrapper->getTrackedService()),
-                                                             properties,
-                                                             *logger);
-                                        managedServiceFactoryWrapper->setLastUpdatedChangeCount(pid, changeCount);
-                                    }
-                                }
-                            });
-                    }
-                    if (!removed)
-                    {
-                        std::ostringstream configValue;
-                        any_value_to_json(configValue, properties);
-
-                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                    "Configuration Updated: Configuration instance with PID " + pid + " version: "
-                                        + std::to_string(changeCount) + " properties: " + configValue.str());
-                    }
-                });
+            configurationToInvalidate->Invalidate();
         }
-
-        std::shared_ptr<ThreadpoolSafeFuturePrivate>
-        ConfigurationAdminImpl::NotifyConfigurationRemoved(std::string const& pid,
-                                                           std::uintptr_t configurationId,
-                                                           unsigned long changeCount)
+        auto idx = 0u;
+        for (auto const& pidAndChangeCountAndID : pidsAndChangeCountsAndIDs)
         {
-            std::promise<void> ready;
-            auto alreadyRemoved = std::make_shared<ThreadpoolSafeFuturePrivate>(ready.get_future().share());
-            std::shared_ptr<ConfigurationImpl> configurationToInvalidate;
-            bool hasBeenUpdated = false;
+            auto const& pid = pidAndChangeCountAndID.pid;
+            if (removedAndUpdated[idx].first)
             {
-                std::lock_guard<std::mutex> lk { configurationsMutex };
-                auto it = configurations.find(pid);
-                if (it == std::end(configurations))
+                if (removedAndUpdated[idx].second)
                 {
-                    // This Configuration has already been removed. The thread which removed it will have triggered
-                    // the notification of any ManagedService or ManagedServiceFactory, so nothing more to do.
-                    ready.set_value();
-                    return alreadyRemoved;
+                    NotifyConfigurationUpdated(pid, pidAndChangeCountAndID.changeCount);
                 }
-                if (configurationId != reinterpret_cast<std::uintptr_t>(it->second.get()))
-                {
-                    // The Configuration with this PID has already been removed and replaced by a new one, and the
-                    // thread which did that will have triggered the notification of any ManagedService or
-                    // ManagedServiceFactory, so nothing more to do.
-                    ready.set_value();
-                    return alreadyRemoved;
-                }
-                configurationToInvalidate = it->second;
-                hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
-                configurations.erase(it);
-                RemoveFactoryInstanceIfRequired(pid);
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                            "RemoveConfigurations: Removed Configuration instance with PID " + pid);
             }
-            if (configurationToInvalidate && hasBeenUpdated)
+            else
             {
-                auto removeFuture = NotifyConfigurationUpdated(pid, changeCount);
-                // This functor will run on another thread. Just being overly cautious to guarantee that the
-                // ConfigurationImpl which has called this method doesn't run its own destructor.
-                PerformAsync(
-                    [this, pid, configuration = std::move(configurationToInvalidate)]
-                    {
-                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                    "Configuration with PID " + pid + " has been removed.");
-                    });
-
-                return removeFuture;
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                            "RemoveConfigurations: Configuration with PID " + pid
+                                + " was not removed (either already removed, or it has been subsequently updated)");
             }
-            ready.set_value();
-            return alreadyRemoved;
+            ++idx;
         }
+    }
 
-        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
-        ConfigurationAdminImpl::AddingService(
-            ServiceReference<cppmicroservices::service::cm::ManagedService> const& reference)
-        {
-            // GetService can cause entry into user code, so don't hold a lock.
-            auto managedService = cmContext.GetService(reference);
-            if (!managedService)
-            {
-                logger->Log(SeverityLevel::LOG_WARNING,
-                            "Ignoring ManagedService as a valid service could not be "
-                            "obtained from the BundleContext");
-                return nullptr;
-            }
-
-            // Lock the configurations repository so no configuration objects can be
-            // added or removed while AddingService is processing the new service.
-            std::lock_guard<std::mutex> lk { configurationsMutex };
-
-            auto pid = getPidFromServiceReference(reference);
-            if (pid.empty())
-            {
-                auto const bundle = reference.GetBundle();
-                auto const serviceID
-                    = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
-                logger->Log(SeverityLevel::LOG_WARNING,
-                            "Ignoring ManagedService with ID " + serviceID + " from bundle "
-                                + (bundle ? bundle.GetSymbolicName() : "Unknown")
-                                + " as it does not have a service.pid or component.name property");
-                return nullptr;
-            }
-
-            // Send a notification in case a valid configuration object
-            // was created before the service was active. The service's properties
-            // need to be updated.
-            unsigned long initialChangeCount { 0ul };
-
-            if (auto const it = configurations.find(pid); it != std::end(configurations))
+    std::shared_ptr<ThreadpoolSafeFuturePrivate>
+    ConfigurationAdminImpl::NotifyConfigurationUpdated(std::string const& pid, unsigned long const changeCount)
+    {
+        // NotifyConfigurationUpdated will only send a notification to the service if
+        // the configuration object has been updated at least once. In order to determine whether or not
+        // a configuration object has been updated, it calls the HasBeenUpdatedAtLeastOnce method for
+        // the configuration object. For a remove operation the configuration object
+        // is not available and that method cannot be called. For this reason, NotifyConfigurationUpdated
+        // should not be called for Remove operations unless the caller has already confirmed
+        // the configuration object has been updated at least once.
+        return PerformAsync(
+            [this, pid, changeCount]
             {
                 AnyMap properties { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
-                // Only send notifications for configuration objects that have been
-                // Updated.
-                if (it->second->HasBeenUpdatedAtLeastOnce())
+                std::string fPid;
+                std::string nonFPid;
+                auto removed = false;
+                auto hasBeenUpdated = false;
+                std::vector<std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>>
+                    managedServiceWrappers;
+                std::vector<
+                    std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>>
+                    managedServiceFactoryWrappers;
                 {
-                    try
+                    std::lock_guard<std::mutex> lk { configurationsMutex };
+                    auto const it = configurations.find(pid);
+                    if (it == std::end(configurations))
                     {
-                        properties = it->second->GetProperties();
-                        // specifically set the initial change count here because there is
-                        // a race between the call to GetChangeCount() and HasBeenUpdatedAtLeastOnce().
-                        // The logic is that, if HasBeenUpdatedAtLeastOnce() returns true, the change
-                        // count will always be > 1 and should at this point be captured for the
-                        // tracked object to eliminate redundant config updates.
-                        initialChangeCount = it->second->GetChangeCount();
+                        removed = true;
+                        hasBeenUpdated = true;
                     }
-                    catch (std::runtime_error const&)
+                    else
                     {
-                        // Configuration is being removed
-                        logger->Log(SeverityLevel::LOG_WARNING,
-                                    "Attempted to retrieve properties from a configuration "
-                                    "which has been removed.",
-                                    std::current_exception());
-                    }
-
-                    PerformAsync([this, pid, managedService, properties]
-                                 { notifyServiceUpdated(pid, *managedService, properties, *logger); });
-
-                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                                "Async configuration update queued for new ManagedService with PID " + pid + ".");
-                }
-            }
-
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "New ManagedService with PID " + pid + " has been added.");
-
-            std::unordered_map<std::string, unsigned long> initialChangeCountByPid = {
-                { pid, initialChangeCount }
-            };
-            auto trackedManagedService
-                = std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>(
-                    pid,
-                    std::move(initialChangeCountByPid),
-                    std::move(managedService));
-            trackedManagedServices_.emplace_back(trackedManagedService);
-            return trackedManagedService;
-        }
-
-        void
-        ConfigurationAdminImpl::ModifiedService(
-            ServiceReference<cppmicroservices::service::cm::ManagedService> const& /* reference */,
-            std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> const& /* service */)
-        {
-            // Assume the PID and component.name properties will never change, so noop
-        }
-
-        void
-        ConfigurationAdminImpl::RemovedService(
-            ServiceReference<cppmicroservices::service::cm::ManagedService> const& /* reference */,
-            std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> const& service)
-        {
-            // Lock because we are modifying the container of tracked managed services.
-            std::lock_guard<std::mutex> lk { configurationsMutex };
-
-            auto elemIter = std::find_if(
-                std::begin(trackedManagedServices_),
-                std::end(trackedManagedServices_),
-                [&service](auto const& trackedServiceWrapper)
-                { return (service->getTrackedService() == trackedServiceWrapper->getTrackedService()); });
-            if (elemIter != trackedManagedServices_.end())
-            {
-                trackedManagedServices_.erase(elemIter);
-            }
-            // ManagedService won't receive any more updates to its Configuration.
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "ManagedService with PID " + service->getPid() + " has been removed.");
-        }
-
-        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
-        ConfigurationAdminImpl::AddingService(
-            ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& reference)
-        {
-            // GetService can cause entry into user code, so don't hold a lock.
-            auto managedServiceFactory = cmContext.GetService(reference);
-            if (!managedServiceFactory)
-            {
-                logger->Log(SeverityLevel::LOG_DEBUG,
-                            "Ignoring ManagedServiceFactory as a valid service could not "
-                            "be obtained from the BundleContext");
-                return nullptr;
-            }
-
-            std::lock_guard<std::mutex> lk { configurationsMutex };
-
-            auto pid = getPidFromServiceReference(reference);
-            if (pid.empty())
-            {
-                auto const bundle = reference.GetBundle();
-                auto const serviceID
-                    = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
-                logger->Log(SeverityLevel::LOG_WARNING,
-                            "Ignoring ManagedServiceFactory with ID " + serviceID + " from bundle "
-                                + (bundle ? bundle.GetSymbolicName() : "Unknown")
-                                + " as it does not have a service.pid or component.name property");
-                return nullptr;
-            }
-
-            std::vector<std::pair<std::string, AnyMap>> pidsAndProperties;
-            std::unordered_map<std::string, unsigned long> initialChangeCountPerPid;
-
-            auto const it = factoryInstances.find(pid);
-            if (it != std::end(factoryInstances))
-            {
-                for (auto const& instance : it->second)
-                {
-                    auto const configurationIt = configurations.find(instance);
-                    assert(configurationIt != std::end(configurations) && "Invalid Configuration iterator");
-                    try
-                    {
-                        // Notifications can only be sent for configuration objects that
-                        // been Updated. Only add it to the notification list if it has
-                        // been Updated.
-                        if (configurationIt->second->HasBeenUpdatedAtLeastOnce())
+                        try
                         {
-                            auto properties = configurationIt->second->GetProperties();
-                            initialChangeCountPerPid[configurationIt->second->GetPid()]
-                                = configurationIt->second->GetChangeCount();
-                            pidsAndProperties.emplace_back(instance, std::move(properties));
+                            hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
+                            properties = it->second->GetProperties();
+                        }
+                        catch (std::runtime_error const&)
+                        {
+                            // Configuration is being removed
+                            removed = true;
                         }
                     }
-                    catch (std::runtime_error const&)
-                    {
-                        // Configuration is being removed
-                        logger->Log(SeverityLevel::LOG_WARNING,
-                                    "Attempted to retrieve properties for a configuration "
-                                    "which has been removed.",
-                                    std::current_exception());
-                    }
-                }
-            }
 
-            if (pidsAndProperties.size() > 0)
-            {
-                PerformAsync(
-                    [this, pid, managedServiceFactory, pidsAndProperties]
+                    // We can only send update notifications for configuration objects that have
+                    // been updated. Just return without sending the notification for objects
+                    // that have not yet been updated.
+                    if (!hasBeenUpdated)
                     {
-                        for (auto const& pidAndProperties : pidsAndProperties)
+                        return;
+                    }
+
+                    if (pid.find('~') != std::string::npos)
+                    {
+                        // this is a factory pid
+                        fPid = pid;
+                    }
+                    else
+                    {
+                        nonFPid = pid;
+                    }
+                    managedServiceWrappers = trackedManagedServices_;
+                    managedServiceFactoryWrappers = trackedManagedServiceFactories_;
+                }
+
+                auto type = removed ? cppmicroservices::service::cm::ConfigurationEventType::CM_DELETED
+                                    : cppmicroservices::service::cm::ConfigurationEventType::CM_UPDATED;
+
+                auto configurationListeners = configListenerTracker.GetServices();
+                auto configAdminRef = cmContext.GetServiceReference<ConfigurationAdmin>();
+                for (auto const& it : configurationListeners)
+                {
+                    auto configEvent
+                        = cppmicroservices::service::cm::ConfigurationEvent(configAdminRef, type, fPid, nonFPid);
+                    it->configurationEvent((configEvent));
+                }
+
+                std::for_each(
+                    managedServiceWrappers.begin(),
+                    managedServiceWrappers.end(),
+                    [&](auto const& managedServiceWrapper)
+                    {
+                        // The ServiceTracker will return a default constructed shared_ptr for each ManagedService
+                        // that we aren't tracking. We must be careful not to dereference these!
+                        if ((managedServiceWrapper) && (managedServiceWrapper->getPid() == pid)
+                            && (removed
+                                || (!removed
+                                    && managedServiceWrapper->needsAnUpdateNotification(pid, changeCount))))
                         {
-                            notifyServiceUpdated(pidAndProperties.first,
-                                                 *managedServiceFactory,
-                                                 pidAndProperties.second,
-                                                 *logger);
+                            notifyServiceUpdated(pid,
+                                                    *(managedServiceWrapper->getTrackedService()),
+                                                    properties,
+                                                    *logger);
+                            if (removed)
+                            {
+                                managedServiceWrapper->removeLastUpdatedChangeCount(pid);
+                            }
+                            else
+                            {
+                                managedServiceWrapper->setLastUpdatedChangeCount(pid, changeCount);
+                            }
                         }
                     });
-            }
 
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "New ManagedServiceFactory with PID " + pid
-                            + " has been added, and async Update has been queued for all updated instances.");
-            auto trackedManagedServiceFactory
-                = std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>(
-                    pid,
-                    std::move(initialChangeCountPerPid),
-                    std::move(managedServiceFactory));
-            trackedManagedServiceFactories_.emplace_back(trackedManagedServiceFactory);
-            return trackedManagedServiceFactory;
-        }
-
-        void
-        ConfigurationAdminImpl::ModifiedService(
-            ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& /* reference */,
-            std::shared_ptr<
-                TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> const& /* service */)
-        {
-            // Assume the PID and component.name properties will never change, so noop
-        }
-
-        void
-        ConfigurationAdminImpl::RemovedService(
-            ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& /* reference */,
-            std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> const& service)
-        {
-            // Lock because we are modifying the container of tracked managed services.
-            std::lock_guard<std::mutex> lk { configurationsMutex };
-
-            auto elemIter = std::find_if(
-                std::begin(trackedManagedServiceFactories_),
-                std::end(trackedManagedServiceFactories_),
-                [&service](auto const& trackedServiceWrapper)
-                { return (service->getTrackedService() == trackedServiceWrapper->getTrackedService()); });
-            if (elemIter != trackedManagedServiceFactories_.end())
-            {
-                trackedManagedServiceFactories_.erase(elemIter);
-            }
-
-            // ManagedServiceFactory won't receive any more updates to any of its Configurations.
-            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
-                        "ManagedServiceFactory with PID " + service->getPid() + " has been removed.");
-        }
-
-        using PostTask = std::packaged_task<void()>;
-
-        template <typename Functor>
-        std::shared_ptr<ThreadpoolSafeFuturePrivate>
-        ConfigurationAdminImpl::PerformAsync(Functor&& f)
-        {
-
-            std::lock_guard<std::mutex> lk { futuresMutex };
-            // if this configAdminImpl has been marked as inactive by the CMActivator, it should not queue any work
-            if (!active)
-            {
-                // we return a default future which will always return immediately if waited on...
-                // this isn't really a 'valid' future, but when the activator has stopped the bundle,
-                // configAdmin can be assumed to be non functional
-                return std::make_shared<ThreadpoolSafeFuturePrivate>();
-            }
-            decltype(completeFutures) {}.swap(completeFutures);
-            auto id = ++futuresID;
-
-            PostTask task(
-                [this, func = std::forward<Functor>(f), id]() mutable
+                if (auto const factoryPid = getFactoryPid(pid); !factoryPid.empty())
                 {
-                    // func() can throw, make sure that the futures
-                    // are correctly cleaned up if an exception occurs.
-                    detail::ScopeGuard cleanupFutures(
-                        [this, id]()
+                    std::for_each(
+                        managedServiceFactoryWrappers.begin(),
+                        managedServiceFactoryWrappers.end(),
+                        [&](auto const& managedServiceFactoryWrapper)
                         {
-                            std::lock_guard<std::mutex> lk { futuresMutex };
-                            auto it = incompleteFutures.find(id);
-                            assert(it != std::end(incompleteFutures) && "Invalid future iterator");
-                            completeFutures.push_back(std::move(it->second));
-                            incompleteFutures.erase(it);
-                            if (incompleteFutures.empty())
+                            // The ServiceTracker will return a default constructed shared_ptr for each
+                            // ManagedServiceFactory that we aren't tracking. We must be careful not to dereference
+                            // these!
+                            if ((managedServiceFactoryWrapper)
+                                && (managedServiceFactoryWrapper->getPid() == factoryPid))
                             {
-                                futuresCV.notify_one();
+                                if (removed)
+                                {
+                                    notifyServiceRemoved(pid,
+                                                            *(managedServiceFactoryWrapper->getTrackedService()),
+                                                            *logger);
+                                    managedServiceFactoryWrapper->removeLastUpdatedChangeCount(pid);
+                                }
+                                else if (managedServiceFactoryWrapper->needsAnUpdateNotification(pid, changeCount))
+                                {
+                                    notifyServiceUpdated(pid,
+                                                            *(managedServiceFactoryWrapper->getTrackedService()),
+                                                            properties,
+                                                            *logger);
+                                    managedServiceFactoryWrapper->setLastUpdatedChangeCount(pid, changeCount);
+                                }
                             }
                         });
-                    func();
-                });
-            std::shared_future<void> fut = task.get_future().share();
-
-            auto singleInvokeTask = std::make_shared<SingleInvokeTask>(std::make_shared<PostTask>(std::move(task)));
-
-            PostTask post_task([singleInvokeTask]() mutable { (*singleInvokeTask)(); });
-
-            incompleteFutures.emplace(id, fut);
-
-            asyncWorkService->post(std::move(post_task));
-
-            return std::make_shared<ThreadpoolSafeFuturePrivate>(fut, singleInvokeTask);
-        }
-
-        std::string
-        ConfigurationAdminImpl::RandomInstanceName()
-        {
-            thread_local static std::mt19937 randomGenerator(std::random_device {}());
-            static auto const characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-            std::uniform_int_distribution<> dist(0, 61);
-            std::string randomString(6, '\0');
-            for (auto& c : randomString)
-            {
-                c = characters[dist(randomGenerator)];
-            }
-            return randomString;
-        }
-
-        void
-        ConfigurationAdminImpl::AddFactoryInstanceIfRequired(std::string const& pid, std::string const& factoryPid)
-        {
-            if (factoryPid.empty())
-            {
-                return;
-            }
-            auto it = factoryInstances.find(factoryPid);
-            if (it == std::end(factoryInstances))
-            {
-                it = factoryInstances.emplace(factoryPid, std::set<std::string> {}).first;
-            }
-            it->second.insert(pid);
-        }
-
-        void
-        ConfigurationAdminImpl::RemoveFactoryInstanceIfRequired(std::string const& pid)
-        {
-            auto const factoryPid = getFactoryPid(pid);
-            if (factoryPid.empty())
-            {
-                return;
-            }
-            auto it = factoryInstances.find(factoryPid);
-            if (it != std::end(factoryInstances))
-            {
-                it->second.erase(pid);
-                if (it->second.empty())
+                }
+                if (!removed)
                 {
-                    factoryInstances.erase(it);
+                    std::ostringstream configValue;
+                    any_value_to_json(configValue, properties);
+
+                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                                "Configuration Updated: Configuration instance with PID " + pid + " version: "
+                                    + std::to_string(changeCount) + " properties: " + configValue.str());
+                }
+            });
+    }
+
+    std::shared_ptr<ThreadpoolSafeFuturePrivate>
+    ConfigurationAdminImpl::NotifyConfigurationRemoved(std::string const& pid,
+                                                        std::uintptr_t configurationId,
+                                                        unsigned long changeCount)
+    {
+        std::promise<void> ready;
+        auto alreadyRemoved = std::make_shared<ThreadpoolSafeFuturePrivate>(ready.get_future().share());
+        std::shared_ptr<ConfigurationImpl> configurationToInvalidate;
+        bool hasBeenUpdated = false;
+        {
+            std::lock_guard<std::mutex> lk { configurationsMutex };
+            auto it = configurations.find(pid);
+            if (it == std::end(configurations))
+            {
+                // This Configuration has already been removed. The thread which removed it will have triggered
+                // the notification of any ManagedService or ManagedServiceFactory, so nothing more to do.
+                ready.set_value();
+                return alreadyRemoved;
+            }
+            if (configurationId != reinterpret_cast<std::uintptr_t>(it->second.get()))
+            {
+                // The Configuration with this PID has already been removed and replaced by a new one, and the
+                // thread which did that will have triggered the notification of any ManagedService or
+                // ManagedServiceFactory, so nothing more to do.
+                ready.set_value();
+                return alreadyRemoved;
+            }
+            configurationToInvalidate = it->second;
+            hasBeenUpdated = it->second->HasBeenUpdatedAtLeastOnce();
+            configurations.erase(it);
+            RemoveFactoryInstanceIfRequired(pid);
+        }
+        if (configurationToInvalidate && hasBeenUpdated)
+        {
+            auto removeFuture = NotifyConfigurationUpdated(pid, changeCount);
+            // This functor will run on another thread. Just being overly cautious to guarantee that the
+            // ConfigurationImpl which has called this method doesn't run its own destructor.
+            PerformAsync(
+                [this, pid, configuration = std::move(configurationToInvalidate)]
+                {
+                    logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                                "Configuration with PID " + pid + " has been removed.");
+                });
+
+            return removeFuture;
+        }
+        ready.set_value();
+        return alreadyRemoved;
+    }
+
+    std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>
+    ConfigurationAdminImpl::AddingService(
+        ServiceReference<cppmicroservices::service::cm::ManagedService> const& reference)
+    {
+        // GetService can cause entry into user code, so don't hold a lock.
+        auto managedService = cmContext.GetService(reference);
+        if (!managedService)
+        {
+            logger->Log(SeverityLevel::LOG_WARNING,
+                        "Ignoring ManagedService as a valid service could not be "
+                        "obtained from the BundleContext");
+            return nullptr;
+        }
+
+        // Lock the configurations repository so no configuration objects can be
+        // added or removed while AddingService is processing the new service.
+        std::lock_guard<std::mutex> lk { configurationsMutex };
+
+        auto pid = getPidFromServiceReference(reference);
+        if (pid.empty())
+        {
+            auto const bundle = reference.GetBundle();
+            auto const serviceID
+                = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
+            logger->Log(SeverityLevel::LOG_WARNING,
+                        "Ignoring ManagedService with ID " + serviceID + " from bundle "
+                            + (bundle ? bundle.GetSymbolicName() : "Unknown")
+                            + " as it does not have a service.pid or component.name property");
+            return nullptr;
+        }
+
+        // Send a notification in case a valid configuration object
+        // was created before the service was active. The service's properties
+        // need to be updated.
+        unsigned long initialChangeCount { 0ul };
+
+        if (auto const it = configurations.find(pid); it != std::end(configurations))
+        {
+            AnyMap properties { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+            // Only send notifications for configuration objects that have been
+            // Updated.
+            if (it->second->HasBeenUpdatedAtLeastOnce())
+            {
+                try
+                {
+                    properties = it->second->GetProperties();
+                    // specifically set the initial change count here because there is
+                    // a race between the call to GetChangeCount() and HasBeenUpdatedAtLeastOnce().
+                    // The logic is that, if HasBeenUpdatedAtLeastOnce() returns true, the change
+                    // count will always be > 1 and should at this point be captured for the
+                    // tracked object to eliminate redundant config updates.
+                    initialChangeCount = it->second->GetChangeCount();
+                }
+                catch (std::runtime_error const&)
+                {
+                    // Configuration is being removed
+                    logger->Log(SeverityLevel::LOG_WARNING,
+                                "Attempted to retrieve properties from a configuration "
+                                "which has been removed.",
+                                std::current_exception());
+                }
+
+                PerformAsync([this, pid, managedService, properties]
+                                { notifyServiceUpdated(pid, *managedService, properties, *logger); });
+
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                            "Async configuration update queued for new ManagedService with PID " + pid + ".");
+            }
+        }
+
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "New ManagedService with PID " + pid + " has been added.");
+
+        std::unordered_map<std::string, unsigned long> initialChangeCountByPid = {
+            { pid, initialChangeCount }
+        };
+        auto trackedManagedService
+            = std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>>(
+                pid,
+                std::move(initialChangeCountByPid),
+                std::move(managedService));
+        trackedManagedServices_.emplace_back(trackedManagedService);
+        return trackedManagedService;
+    }
+
+    void
+    ConfigurationAdminImpl::ModifiedService(
+        ServiceReference<cppmicroservices::service::cm::ManagedService> const& /* reference */,
+        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> const& /* service */)
+    {
+        // Assume the PID and component.name properties will never change, so noop
+    }
+
+    void
+    ConfigurationAdminImpl::RemovedService(
+        ServiceReference<cppmicroservices::service::cm::ManagedService> const& /* reference */,
+        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedService>> const& service)
+    {
+        // Lock because we are modifying the container of tracked managed services.
+        std::lock_guard<std::mutex> lk { configurationsMutex };
+
+        auto elemIter = std::find_if(
+            std::begin(trackedManagedServices_),
+            std::end(trackedManagedServices_),
+            [&service](auto const& trackedServiceWrapper)
+            { return (service->getTrackedService() == trackedServiceWrapper->getTrackedService()); });
+        if (elemIter != trackedManagedServices_.end())
+        {
+            trackedManagedServices_.erase(elemIter);
+        }
+        // ManagedService won't receive any more updates to its Configuration.
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "ManagedService with PID " + service->getPid() + " has been removed.");
+    }
+
+    std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>
+    ConfigurationAdminImpl::AddingService(
+        ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& reference)
+    {
+        // GetService can cause entry into user code, so don't hold a lock.
+        auto managedServiceFactory = cmContext.GetService(reference);
+        if (!managedServiceFactory)
+        {
+            logger->Log(SeverityLevel::LOG_DEBUG,
+                        "Ignoring ManagedServiceFactory as a valid service could not "
+                        "be obtained from the BundleContext");
+            return nullptr;
+        }
+
+        std::lock_guard<std::mutex> lk { configurationsMutex };
+
+        auto pid = getPidFromServiceReference(reference);
+        if (pid.empty())
+        {
+            auto const bundle = reference.GetBundle();
+            auto const serviceID
+                = std::to_string(cppmicroservices::any_cast<long>(reference.GetProperty(Constants::SERVICE_ID)));
+            logger->Log(SeverityLevel::LOG_WARNING,
+                        "Ignoring ManagedServiceFactory with ID " + serviceID + " from bundle "
+                            + (bundle ? bundle.GetSymbolicName() : "Unknown")
+                            + " as it does not have a service.pid or component.name property");
+            return nullptr;
+        }
+
+        std::vector<std::pair<std::string, AnyMap>> pidsAndProperties;
+        std::unordered_map<std::string, unsigned long> initialChangeCountPerPid;
+
+        auto const it = factoryInstances.find(pid);
+        if (it != std::end(factoryInstances))
+        {
+            for (auto const& instance : it->second)
+            {
+                auto const configurationIt = configurations.find(instance);
+                assert(configurationIt != std::end(configurations) && "Invalid Configuration iterator");
+                try
+                {
+                    // Notifications can only be sent for configuration objects that
+                    // been Updated. Only add it to the notification list if it has
+                    // been Updated.
+                    if (configurationIt->second->HasBeenUpdatedAtLeastOnce())
+                    {
+                        auto properties = configurationIt->second->GetProperties();
+                        initialChangeCountPerPid[configurationIt->second->GetPid()]
+                            = configurationIt->second->GetChangeCount();
+                        pidsAndProperties.emplace_back(instance, std::move(properties));
+                    }
+                }
+                catch (std::runtime_error const&)
+                {
+                    // Configuration is being removed
+                    logger->Log(SeverityLevel::LOG_WARNING,
+                                "Attempted to retrieve properties for a configuration "
+                                "which has been removed.",
+                                std::current_exception());
                 }
             }
         }
 
-        void
-        ConfigurationAdminImpl::WaitForAllAsync()
+        if (pidsAndProperties.size() > 0)
         {
-            std::unique_lock<std::mutex> ul { futuresMutex };
-            if (!incompleteFutures.empty())
+            PerformAsync(
+                [this, pid, managedServiceFactory, pidsAndProperties]
+                {
+                    for (auto const& pidAndProperties : pidsAndProperties)
+                    {
+                        notifyServiceUpdated(pidAndProperties.first,
+                                                *managedServiceFactory,
+                                                pidAndProperties.second,
+                                                *logger);
+                    }
+                });
+        }
+
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "New ManagedServiceFactory with PID " + pid
+                        + " has been added, and async Update has been queued for all updated instances.");
+        auto trackedManagedServiceFactory
+            = std::make_shared<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>>(
+                pid,
+                std::move(initialChangeCountPerPid),
+                std::move(managedServiceFactory));
+        trackedManagedServiceFactories_.emplace_back(trackedManagedServiceFactory);
+        return trackedManagedServiceFactory;
+    }
+
+    void
+    ConfigurationAdminImpl::ModifiedService(
+        ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& /* reference */,
+        std::shared_ptr<
+            TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> const& /* service */)
+    {
+        // Assume the PID and component.name properties will never change, so noop
+    }
+
+    void
+    ConfigurationAdminImpl::RemovedService(
+        ServiceReference<cppmicroservices::service::cm::ManagedServiceFactory> const& /* reference */,
+        std::shared_ptr<TrackedServiceWrapper<cppmicroservices::service::cm::ManagedServiceFactory>> const& service)
+    {
+        // Lock because we are modifying the container of tracked managed services.
+        std::lock_guard<std::mutex> lk { configurationsMutex };
+
+        auto elemIter = std::find_if(
+            std::begin(trackedManagedServiceFactories_),
+            std::end(trackedManagedServiceFactories_),
+            [&service](auto const& trackedServiceWrapper)
+            { return (service->getTrackedService() == trackedServiceWrapper->getTrackedService()); });
+        if (elemIter != trackedManagedServiceFactories_.end())
+        {
+            trackedManagedServiceFactories_.erase(elemIter);
+        }
+
+        // ManagedServiceFactory won't receive any more updates to any of its Configurations.
+        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_DEBUG,
+                    "ManagedServiceFactory with PID " + service->getPid() + " has been removed.");
+    }
+
+    using PostTask = std::packaged_task<void()>;
+
+    template <typename Functor>
+    std::shared_ptr<ThreadpoolSafeFuturePrivate>
+    ConfigurationAdminImpl::PerformAsync(Functor&& f)
+    {
+
+        std::lock_guard<std::mutex> lk { futuresMutex };
+        // if this configAdminImpl has been marked as inactive by the CMActivator, it should not queue any work
+        if (!active)
+        {
+            // we return a default future which will always return immediately if waited on...
+            // this isn't really a 'valid' future, but when the activator has stopped the bundle,
+            // configAdmin can be assumed to be non functional
+            return std::make_shared<ThreadpoolSafeFuturePrivate>();
+        }
+        decltype(completeFutures) {}.swap(completeFutures);
+        auto id = ++futuresID;
+
+        PostTask task(
+            [this, func = std::forward<Functor>(f), id]() mutable
             {
-                futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
+                // func() can throw, make sure that the futures
+                // are correctly cleaned up if an exception occurs.
+                detail::ScopeGuard cleanupFutures(
+                    [this, id]()
+                    {
+                        std::lock_guard<std::mutex> lk { futuresMutex };
+                        auto it = incompleteFutures.find(id);
+                        assert(it != std::end(incompleteFutures) && "Invalid future iterator");
+                        completeFutures.push_back(std::move(it->second));
+                        incompleteFutures.erase(it);
+                        if (incompleteFutures.empty())
+                        {
+                            futuresCV.notify_one();
+                        }
+                    });
+                func();
+            });
+        std::shared_future<void> fut = task.get_future().share();
+
+        auto singleInvokeTask = std::make_shared<SingleInvokeTask>(std::make_shared<PostTask>(std::move(task)));
+
+        PostTask post_task([singleInvokeTask]() mutable { (*singleInvokeTask)(); });
+
+        incompleteFutures.emplace(id, fut);
+
+        asyncWorkService->post(std::move(post_task));
+
+        return std::make_shared<ThreadpoolSafeFuturePrivate>(fut, singleInvokeTask);
+    }
+
+    std::string
+    ConfigurationAdminImpl::RandomInstanceName()
+    {
+        thread_local static std::mt19937 randomGenerator(std::random_device {}());
+        static auto const characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        std::uniform_int_distribution<> dist(0, 61);
+        std::string randomString(6, '\0');
+        for (auto& c : randomString)
+        {
+            c = characters[dist(randomGenerator)];
+        }
+        return randomString;
+    }
+
+    void
+    ConfigurationAdminImpl::AddFactoryInstanceIfRequired(std::string const& pid, std::string const& factoryPid)
+    {
+        if (factoryPid.empty())
+        {
+            return;
+        }
+        auto it = factoryInstances.find(factoryPid);
+        if (it == std::end(factoryInstances))
+        {
+            it = factoryInstances.emplace(factoryPid, std::set<std::string> {}).first;
+        }
+        it->second.insert(pid);
+    }
+
+    void
+    ConfigurationAdminImpl::RemoveFactoryInstanceIfRequired(std::string const& pid)
+    {
+        auto const factoryPid = getFactoryPid(pid);
+        if (factoryPid.empty())
+        {
+            return;
+        }
+        auto it = factoryInstances.find(factoryPid);
+        if (it != std::end(factoryInstances))
+        {
+            it->second.erase(pid);
+            if (it->second.empty())
+            {
+                factoryInstances.erase(it);
             }
         }
-        void
-        ConfigurationAdminImpl::StopAndWaitForAllAsync()
+    }
+
+    void
+    ConfigurationAdminImpl::WaitForAllAsync()
+    {
+        std::unique_lock<std::mutex> ul { futuresMutex };
+        if (!incompleteFutures.empty())
         {
-            {
-                std::lock_guard<std::mutex> lk { futuresMutex };
-                active = false;
-            }
-            WaitForAllAsync();
+            futuresCV.wait(ul, [this] { return incompleteFutures.empty(); });
         }
-    } // namespace cmimpl
-} // namespace cppmicroservices
+    }
+    void
+    ConfigurationAdminImpl::StopAndWaitForAllAsync()
+    {
+        {
+            std::lock_guard<std::mutex> lk { futuresMutex };
+            active = false;
+        }
+        WaitForAllAsync();
+    }
+} // namespace cppmicroservices::cmimpl

--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -30,224 +30,220 @@ namespace
     constexpr auto REMOVED_EXCEPTION_MESSAGE = "This Configuration has been Removed";
 }
 
-namespace cppmicroservices
+namespace cppmicroservices::cmimpl
 {
-    namespace cmimpl
+
+    ConfigurationImpl::ConfigurationImpl(ConfigurationAdminPrivate* configAdmin,
+                                         std::string thePid,
+                                         std::string theFactoryPid,
+                                         AnyMap props,
+                                         unsigned long const cCount)
+        : configAdminImpl(configAdmin)
+        , pid(std::move(thePid))
+        , factoryPid(std::move(theFactoryPid))
+        , properties(std::move(props))
+        , changeCount { cCount }
+        , removed { false }
     {
-
-        ConfigurationImpl::ConfigurationImpl(ConfigurationAdminPrivate* configAdmin,
-                                             std::string thePid,
-                                             std::string theFactoryPid,
-                                             AnyMap props,
-                                             unsigned long const cCount)
-            : configAdminImpl(configAdmin)
-            , pid(std::move(thePid))
-            , factoryPid(std::move(theFactoryPid))
-            , properties(std::move(props))
-            , changeCount { cCount }
-            , removed { false }
+        assert(configAdminImpl != nullptr && "Invalid ConfigurationAdminPrivate pointer");
+        // constructing a configuration object with properties is the equivalent
+        // of a Create and an Update operation.
+        if ((properties.size() > 0) && (changeCount == 0u))
         {
-            assert(configAdminImpl != nullptr && "Invalid ConfigurationAdminPrivate pointer");
-            // constructing a configuration object with properties is the equivalent
-            // of a Create and an Update operation.
-            if ((properties.size() > 0) && (changeCount == 0u))
-            {
-                changeCount++;
-            }
+            changeCount++;
         }
+    }
 
-        std::string
-        ConfigurationImpl::GetPid() const
+    std::string
+    ConfigurationImpl::GetPid() const
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        return pid;
+    }
+
+    std::string
+    ConfigurationImpl::GetFactoryPid() const
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        return factoryPid;
+    }
+
+    AnyMap
+    ConfigurationImpl::GetProperties() const
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        return properties;
+    }
+
+    unsigned long
+    ConfigurationImpl::GetChangeCount() const
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        return changeCount;
+    }
+
+    std::shared_future<void>
+    ConfigurationImpl::Update(AnyMap newProperties)
+    {
+        return SafeUpdateImpl(newProperties)->retrieveFuture();
+    }
+
+    std::shared_ptr<ThreadpoolSafeFuture>
+    ConfigurationImpl::SafeUpdate(AnyMap newProperties)
+    {
+        return SafeUpdateImpl(newProperties);
+    }
+
+    std::shared_ptr<ThreadpoolSafeFuturePrivate>
+    ConfigurationImpl::SafeUpdateImpl(AnyMap newProperties)
+    {
         {
             std::lock_guard<std::mutex> lk { propertiesMutex };
             if (removed)
             {
                 throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-            }
-            return pid;
-        }
-
-        std::string
-        ConfigurationImpl::GetFactoryPid() const
-        {
-            std::lock_guard<std::mutex> lk { propertiesMutex };
-            if (removed)
-            {
-                throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-            }
-            return factoryPid;
-        }
-
-        AnyMap
-        ConfigurationImpl::GetProperties() const
-        {
-            std::lock_guard<std::mutex> lk { propertiesMutex };
-            if (removed)
-            {
-                throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-            }
-            return properties;
-        }
-
-        unsigned long
-        ConfigurationImpl::GetChangeCount() const
-        {
-            std::lock_guard<std::mutex> lk { propertiesMutex };
-            if (removed)
-            {
-                throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-            }
-            return changeCount;
-        }
-
-        std::shared_future<void>
-        ConfigurationImpl::Update(AnyMap newProperties)
-        {
-            return SafeUpdateImpl(newProperties)->retrieveFuture();
-        }
-
-        std::shared_ptr<ThreadpoolSafeFuture>
-        ConfigurationImpl::SafeUpdate(AnyMap newProperties)
-        {
-            return SafeUpdateImpl(newProperties);
-        }
-
-        std::shared_ptr<ThreadpoolSafeFuturePrivate>
-        ConfigurationImpl::SafeUpdateImpl(AnyMap newProperties)
-        {
-            {
-                std::lock_guard<std::mutex> lk { propertiesMutex };
-                if (removed)
-                {
-                    throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-                }
-                properties = std::move(newProperties);
-                ++changeCount;
-            }
-            std::lock_guard<std::mutex> lk { configAdminMutex };
-            if (configAdminImpl)
-            {
-                return configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
-            }
-            std::promise<void> ready;
-            std::shared_future<void> fut = ready.get_future();
-            ready.set_value();
-            return std::make_shared<ThreadpoolSafeFuturePrivate>(fut);
-        }
-
-        std::pair<bool, std::shared_future<void>>
-        ConfigurationImpl::UpdateIfDifferent(AnyMap newProperties)
-        {
-            auto tup = SafeUpdateIfDifferentImpl(newProperties);
-
-            return std::make_pair(std::get<0>(tup), std::get<1>(tup)->retrieveFuture());
-        }
-
-        std::pair<bool, std::shared_ptr<ThreadpoolSafeFuture>>
-        ConfigurationImpl::SafeUpdateIfDifferent(AnyMap newProperties)
-        {
-            return SafeUpdateIfDifferentImpl(newProperties);
-        }
-
-        std::pair<bool, std::shared_ptr<ThreadpoolSafeFuturePrivate>>
-        ConfigurationImpl::SafeUpdateIfDifferentImpl(AnyMap newProperties)
-        {
-            std::promise<void> ready;
-            std::shared_future<void> fut = ready.get_future();
-            auto const updated = UpdateWithoutNotificationIfDifferent(std::move(newProperties));
-            if (!updated.first)
-            {
-                ready.set_value();
-                return std::pair<bool, std::shared_ptr<ThreadpoolSafeFuturePrivate>>(
-                    updated.first,
-                    std::make_shared<ThreadpoolSafeFuturePrivate>(fut));
-            }
-            std::lock_guard<std::mutex> lk { configAdminMutex };
-            if (configAdminImpl)
-            {
-                auto fut = configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
-                return std::pair<bool, std::shared_ptr<ThreadpoolSafeFuturePrivate>>(true, fut);
-            }
-
-            ready.set_value();
-            return std::pair<bool, std::shared_ptr<ThreadpoolSafeFuturePrivate>>(
-                true,
-                std::make_shared<ThreadpoolSafeFuturePrivate>(fut));
-        }
-
-        std::shared_future<void>
-        ConfigurationImpl::Remove()
-        {
-            return SafeRemoveImpl()->retrieveFuture();
-        }
-        std::shared_ptr<ThreadpoolSafeFuture>
-        ConfigurationImpl::SafeRemove()
-        {
-            return SafeRemoveImpl();
-        }
-
-        std::shared_ptr<ThreadpoolSafeFuturePrivate>
-        ConfigurationImpl::SafeRemoveImpl()
-        {
-            {
-                std::lock_guard<std::mutex> lk { propertiesMutex };
-                if (removed)
-                {
-                    throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-                }
-                removed = true;
-            }
-            std::lock_guard<std::mutex> lk { configAdminMutex };
-            if (configAdminImpl)
-            {
-                auto fut = configAdminImpl->NotifyConfigurationRemoved(pid,
-                                                                       reinterpret_cast<std::uintptr_t>(this),
-                                                                       changeCount);
-                configAdminImpl = nullptr;
-                return fut;
-            }
-            std::promise<void> ready;
-            std::shared_future<void> fut = ready.get_future();
-            ready.set_value();
-            return std::make_shared<ThreadpoolSafeFuturePrivate>(fut);
-        }
-        std::pair<bool, unsigned long>
-        ConfigurationImpl::UpdateWithoutNotificationIfDifferent(AnyMap newProperties)
-        {
-            std::lock_guard<std::mutex> lk { propertiesMutex };
-            if (removed)
-            {
-                throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
-            }
-            if (properties == newProperties)
-            {
-                return std::pair<bool, unsigned long> { false, 0u };
             }
             properties = std::move(newProperties);
-            return std::pair<bool, unsigned long> { true, ++changeCount };
+            ++changeCount;
+        }
+        std::lock_guard<std::mutex> lk { configAdminMutex };
+        if (configAdminImpl)
+        {
+            return configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
+        }
+        std::promise<void> ready;
+        std::shared_future<void> fut = ready.get_future();
+        ready.set_value();
+        return std::make_shared<ThreadpoolSafeFuturePrivate>(fut);
+    }
+
+    std::pair<bool, std::shared_future<void>>
+    ConfigurationImpl::UpdateIfDifferent(AnyMap newProperties)
+    {
+        auto tup = SafeUpdateIfDifferentImpl(newProperties);
+
+        return std::make_pair(std::get<0>(tup), std::get<1>(tup)->retrieveFuture());
+    }
+
+    std::pair<bool, std::shared_ptr<ThreadpoolSafeFuture>>
+    ConfigurationImpl::SafeUpdateIfDifferent(AnyMap newProperties)
+    {
+        return SafeUpdateIfDifferentImpl(newProperties);
+    }
+
+    std::pair<bool, std::shared_ptr<ThreadpoolSafeFuturePrivate>>
+    ConfigurationImpl::SafeUpdateIfDifferentImpl(AnyMap newProperties)
+    {
+        std::promise<void> ready;
+        std::shared_future<void> fut = ready.get_future();
+        auto const updated = UpdateWithoutNotificationIfDifferent(std::move(newProperties));
+        if (!updated.first)
+        {
+            ready.set_value();
+            return {
+                updated.first,
+                std::make_shared<ThreadpoolSafeFuturePrivate>(fut)};
+        }
+        std::lock_guard<std::mutex> lk { configAdminMutex };
+        if (configAdminImpl)
+        {
+            auto fut = configAdminImpl->NotifyConfigurationUpdated(pid, changeCount);
+            return {true, fut};
         }
 
-        bool
-        ConfigurationImpl::RemoveWithoutNotificationIfChangeCountEquals(unsigned long expectedChangeCount)
+        ready.set_value();
+        return {
+            true,
+            std::make_shared<ThreadpoolSafeFuturePrivate>(fut)};
+    }
+
+    std::shared_future<void>
+    ConfigurationImpl::Remove()
+    {
+        return SafeRemoveImpl()->retrieveFuture();
+    }
+    std::shared_ptr<ThreadpoolSafeFuture>
+    ConfigurationImpl::SafeRemove()
+    {
+        return SafeRemoveImpl();
+    }
+
+    std::shared_ptr<ThreadpoolSafeFuturePrivate>
+    ConfigurationImpl::SafeRemoveImpl()
+    {
         {
             std::lock_guard<std::mutex> lk { propertiesMutex };
             if (removed)
             {
                 throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
             }
-            if (expectedChangeCount == changeCount)
-            {
-                removed = true;
-                return true;
-            }
-            return false;
+            removed = true;
         }
-
-        void
-        ConfigurationImpl::Invalidate()
+        std::lock_guard<std::mutex> lk { configAdminMutex };
+        if (configAdminImpl)
         {
-            std::lock_guard<std::mutex> lk { configAdminMutex };
+            auto fut
+                = configAdminImpl->NotifyConfigurationRemoved(pid, reinterpret_cast<std::uintptr_t>(this), changeCount);
             configAdminImpl = nullptr;
+            return fut;
         }
-    } // namespace cmimpl
-} // namespace cppmicroservices
+        std::promise<void> ready;
+        std::shared_future<void> fut = ready.get_future();
+        ready.set_value();
+        return std::make_shared<ThreadpoolSafeFuturePrivate>(fut);
+    }
+    std::pair<bool, unsigned long>
+    ConfigurationImpl::UpdateWithoutNotificationIfDifferent(AnyMap newProperties)
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        if (properties == newProperties)
+        {
+            return std::pair<bool, unsigned long> { false, 0u };
+        }
+        properties = std::move(newProperties);
+        return std::pair<bool, unsigned long> { true, ++changeCount };
+    }
+
+    bool
+    ConfigurationImpl::RemoveWithoutNotificationIfChangeCountEquals(unsigned long expectedChangeCount)
+    {
+        std::lock_guard<std::mutex> lk { propertiesMutex };
+        if (removed)
+        {
+            throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
+        }
+        if (expectedChangeCount == changeCount)
+        {
+            removed = true;
+            return true;
+        }
+        return false;
+    }
+
+    void
+    ConfigurationImpl::Invalidate()
+    {
+        std::lock_guard<std::mutex> lk { configAdminMutex };
+        configAdminImpl = nullptr;
+    }
+} // namespace cppmicroservices::cmimpl

--- a/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.cpp
+++ b/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.cpp
@@ -28,8 +28,8 @@ namespace cppmicroservices::cmimpl
 {
     ThreadpoolSafeFuturePrivate::ThreadpoolSafeFuturePrivate(std::shared_future<void> future,
                                                              std::shared_ptr<SingleInvokeTask> task)
-        : future(future)
-        , task(task)
+        : future(std::move(future))
+        , task(std::move(task))
     {
     }
     void

--- a/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/metadata/MetadataParserImpl.cpp
@@ -27,52 +27,46 @@
 #include "ConfigurationMetadata.hpp"
 #include "MetadataParserImpl.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::cmimpl::metadata
 {
-    namespace cmimpl
+
+    MetadataParserImplV1::MetadataParserImplV1(std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
+        : logger(std::move(lggr))
     {
-        namespace metadata
+    }
+
+    std::vector<ConfigurationMetadata>
+    MetadataParserImplV1::ParseAndGetConfigurationMetadata(cppmicroservices::AnyMap const& cmMap) const
+    {
+        std::vector<ConfigurationMetadata> configurationMetadata;
+
+        // Will throw if the object doesn't exist or has the wrong type
+        if (0u == cmMap.count("configurations"))
         {
+            throw std::runtime_error("Metadata is missing mandatory 'configurations' property");
+        }
+        auto& configurations
+            = cppmicroservices::ref_any_cast<std::vector<cppmicroservices::Any>>(cmMap.at("configurations"));
 
-            MetadataParserImplV1::MetadataParserImplV1(std::shared_ptr<cppmicroservices::logservice::LogService> lggr)
-                : logger(std::move(lggr))
+        std::size_t index = 0;
+        for (auto const& configurationAny : configurations)
+        {
+            // Allow exception to escape if any Configuration isn't an AnyMap
+            auto& config = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(configurationAny);
+            try
             {
+                auto pid = cppmicroservices::any_cast<std::string>(config.at("pid"));
+                auto properties = cppmicroservices::any_cast<cppmicroservices::AnyMap>(config.at("properties"));
+                configurationMetadata.emplace_back(std::move(pid), std::move(properties));
             }
-
-            std::vector<ConfigurationMetadata>
-            MetadataParserImplV1::ParseAndGetConfigurationMetadata(cppmicroservices::AnyMap const& cmMap) const
+            catch (std::exception const& ex)
             {
-                std::vector<ConfigurationMetadata> configurationMetadata;
-
-                // Will throw if the object doesn't exist or has the wrong type
-                if (0u == cmMap.count("configurations"))
-                {
-                    throw std::runtime_error("Metadata is missing mandatory 'configurations' property");
-                }
-                auto& configurations
-                    = cppmicroservices::ref_any_cast<std::vector<cppmicroservices::Any>>(cmMap.at("configurations"));
-
-                std::size_t index = 0;
-                for (auto const& configurationAny : configurations)
-                {
-                    // Allow exception to escape if any Configuration isn't an AnyMap
-                    auto& config = cppmicroservices::ref_any_cast<cppmicroservices::AnyMap>(configurationAny);
-                    try
-                    {
-                        auto pid = cppmicroservices::any_cast<std::string>(config.at("pid"));
-                        auto properties = cppmicroservices::any_cast<cppmicroservices::AnyMap>(config.at("properties"));
-                        configurationMetadata.emplace_back(std::move(pid), std::move(properties));
-                    }
-                    catch (std::exception const& ex)
-                    {
-                        auto msg = std::string(ex.what());
-                        msg += " Could not load the configuration with index: " + std::to_string(index);
-                        logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, msg);
-                    }
-                    ++index;
-                }
-                return configurationMetadata;
+                auto msg = std::string(ex.what());
+                msg += " Could not load the configuration with index: " + std::to_string(index);
+                logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR, msg);
             }
-        } // namespace metadata
-    }     // namespace cmimpl
-} // namespace cppmicroservices
+            ++index;
+        }
+        return configurationMetadata;
+    }
+} // namespace cppmicroservices::cmimpl::metadata

--- a/compendium/ServiceComponent/src/ComponentConstants.cpp
+++ b/compendium/ServiceComponent/src/ComponentConstants.cpp
@@ -24,75 +24,65 @@
 
 #include "cppmicroservices/servicecomponent/ComponentConstants.hpp"
 
-namespace cppmicroservices
-{
-    namespace service
-    {
-        namespace component
-        {
-
             /**
              * Defines standard names for Service Component constants.
              */
-            namespace ComponentConstants
-            {
-                /**
-                 * Name of the object that contains Service Component descriptions in
-                 * the bundle's metadata.
-                 * <p>
-                 * The value may be retrieved from the {@code cppmicroservices::AnyMap} object
-                 * returned by the {@code Bundle.GetHeaders} method.
-                 */
-                const std::string SERVICE_COMPONENT = "scr";
+namespace cppmicroservices::service::component::ComponentConstants
+{
+    /**
+     * Name of the object that contains Service Component descriptions in
+     * the bundle's metadata.
+     * <p>
+     * The value may be retrieved from the {@code cppmicroservices::AnyMap} object
+     * returned by the {@code Bundle.GetHeaders} method.
+     */
+    const std::string SERVICE_COMPONENT = "scr";
 
-                /**
-                 * A component property for a component configuration that contains the name
-                 * of the component as specified in the {@code name} attribute of the
-                 * {@code component} element. The value of this property must be of type
-                 * {@code std::string}.
-                 */
-                const std::string COMPONENT_NAME = "component.name";
+    /**
+     * A component property for a component configuration that contains the name
+     * of the component as specified in the {@code name} attribute of the
+     * {@code component} element. The value of this property must be of type
+     * {@code std::string}.
+     */
+    const std::string COMPONENT_NAME = "component.name";
 
-                /**
-                 * A component property that contains the generated id for a component
-                 * configuration. The value of this property must be of type {@code unsigned long}.
-                 *
-                 * <p>
-                 * The value of this property is assigned by Service Component Runtime when
-                 * a component configuration is created. Service Component Runtime assigns a
-                 * unique value that is larger than all previously assigned values since
-                 * Service Component Runtime was started. These values are NOT persistent
-                 * across restarts of Service Component Runtime.
-                 */
-                const std::string COMPONENT_ID = "component.id";
+    /**
+     * A component property that contains the generated id for a component
+     * configuration. The value of this property must be of type {@code unsigned long}.
+     *
+     * <p>
+     * The value of this property is assigned by Service Component Runtime when
+     * a component configuration is created. Service Component Runtime assigns a
+     * unique value that is larger than all previously assigned values since
+     * Service Component Runtime was started. These values are NOT persistent
+     * across restarts of Service Component Runtime.
+     */
+    const std::string COMPONENT_ID = "component.id";
 
-                /**
-                 * A service registration property for a Component Factory that contains the
-                 * value of the {@code factory} attribute. The value of this property must
-                 * be of type {@code std::string}.
-                 */
-                const std::string COMPONENT_FACTORY = "component.factory";
+    /**
+     * A service registration property for a Component Factory that contains the
+     * value of the {@code factory} attribute. The value of this property must
+     * be of type {@code std::string}.
+     */
+    const std::string COMPONENT_FACTORY = "component.factory";
 
-                /**
-                 * The suffix for reference target properties. These properties contain the
-                 * filter to select the target services for a reference. The value of this
-                 * property must be of type {@code std::string}.
-                 */
-                const std::string REFERENCE_TARGET_SUFFIX = ".target";
+    /**
+     * The suffix for reference target properties. These properties contain the
+     * filter to select the target services for a reference. The value of this
+     * property must be of type {@code std::string}.
+     */
+    const std::string REFERENCE_TARGET_SUFFIX = ".target";
 
-                /**
-                 * Scope to indicate the reference must be a servcie registered with PROTOTYPE scope.
-                 */
+    /**
+     * Scope to indicate the reference must be a servcie registered with PROTOTYPE scope.
+     */
 
-                const std::string REFERENCE_SCOPE_PROTOTYPE_REQUIRED = "prototype_required";
+    const std::string REFERENCE_SCOPE_PROTOTYPE_REQUIRED = "prototype_required";
 
-                /**
-                 * Constants used for ComponentMetadata Configuration Policy.
-                 */
-                const std::string CONFIG_POLICY_IGNORE = "ignore";
-                const std::string CONFIG_POLICY_REQUIRE = "require";
-                const std::string CONFIG_POLICY_OPTIONAL = "optional";
-            } // namespace ComponentConstants
-        }     // namespace component
-    }         // namespace service
-} // namespace cppmicroservices
+    /**
+     * Constants used for ComponentMetadata Configuration Policy.
+     */
+    const std::string CONFIG_POLICY_IGNORE = "ignore";
+    const std::string CONFIG_POLICY_REQUIRE = "require";
+    const std::string CONFIG_POLICY_OPTIONAL = "optional";
+} // namespace cppmicroservices::service::component::ComponentConstants

--- a/compendium/ServiceComponent/src/ComponentContext.cpp
+++ b/compendium/ServiceComponent/src/ComponentContext.cpp
@@ -22,15 +22,8 @@
 
 #include "cppmicroservices/servicecomponent/ComponentContext.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::service::component
 {
-    namespace service
-    {
-        namespace component
-        {
+    ComponentContext::~ComponentContext() noexcept {};
 
-            ComponentContext::~ComponentContext() noexcept {};
-
-        }
-    } // namespace service
-} // namespace cppmicroservices
+}// namespace cppmicroservices::service::component

--- a/compendium/ServiceComponent/src/ComponentException.cpp
+++ b/compendium/ServiceComponent/src/ComponentException.cpp
@@ -22,17 +22,11 @@
 
 #include "cppmicroservices/servicecomponent/ComponentException.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::service::component
 {
-    namespace service
-    {
-        namespace component
-        {
-            ComponentException::ComponentException(std::string const& message) : std::runtime_error(message) {}
+    ComponentException::ComponentException(std::string const& message) : std::runtime_error(message) {}
 
-            ComponentException::ComponentException(char const* message) : std::runtime_error(message) {}
+    ComponentException::ComponentException(char const* message) : std::runtime_error(message) {}
 
-            ComponentException::~ComponentException() noexcept {}
-        } // namespace component
-    }     // namespace service
-} // namespace cppmicroservices
+    ComponentException::~ComponentException() noexcept {}
+} // namespace cppmicroservices::service::component

--- a/compendium/ServiceComponent/src/ComponentInstance.cpp
+++ b/compendium/ServiceComponent/src/ComponentInstance.cpp
@@ -22,16 +22,7 @@
 
 #include "cppmicroservices/servicecomponent/detail/ComponentInstance.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::service::component::detail
 {
-    namespace service
-    {
-        namespace component
-        {
-            namespace detail
-            {
-                ComponentInstance::~ComponentInstance() noexcept {}
-            } // namespace detail
-        }     // namespace component
-    }         // namespace service
-} // namespace cppmicroservices
+    ComponentInstance::~ComponentInstance() noexcept {}
+} // namespace cppmicroservices::service::component::detail

--- a/compendium/ServiceComponent/src/ServiceComponentRuntime.cpp
+++ b/compendium/ServiceComponent/src/ServiceComponentRuntime.cpp
@@ -22,18 +22,9 @@
 
 #include "cppmicroservices/servicecomponent/runtime/ServiceComponentRuntime.hpp"
 
-namespace cppmicroservices
+namespace cppmicroservices::service::component::runtime
 {
-    namespace service
-    {
-        namespace component
-        {
-            namespace runtime
-            {
 
-                ServiceComponentRuntime::~ServiceComponentRuntime() noexcept {}
+    ServiceComponentRuntime::~ServiceComponentRuntime() noexcept {}
 
-            } // namespace runtime
-        }     // namespace component
-    }         // namespace service
-} // namespace cppmicroservices
+} // namespace cppmicroservices::service::component::runtime

--- a/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentCallbackGenerator.hpp
@@ -151,8 +151,8 @@ namespace codegen
             }
         }
 
-        std::vector<std::string> const mHeaderIncludes;
-        std::vector<ComponentInfo> const mComponentInfos;
+        std::vector<std::string> mHeaderIncludes;
+        std::vector<ComponentInfo> mComponentInfos;
         std::stringstream mStrStream;
     };
 

--- a/compendium/tools/SCRCodeGen/ComponentInfo.cpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.cpp
@@ -26,13 +26,11 @@
 #include "ComponentInfo.hpp"
 #include "cppmicroservices/util/StringReplace.h"
 
-namespace codegen
+namespace codegen::datamodel
 {
-    namespace datamodel
-    {
-        std::string const ComponentInfo::CONFIG_POLICY_IGNORE = "ignore";
-        std::string const ComponentInfo::CONFIG_POLICY_REQUIRE = "require";
-        std::string const ComponentInfo::CONFIG_POLICY_OPTIONAL = "optional";
+	std::string const ComponentInfo::CONFIG_POLICY_IGNORE = "ignore";
+	std::string const ComponentInfo::CONFIG_POLICY_REQUIRE = "require";
+	std::string const ComponentInfo::CONFIG_POLICY_OPTIONAL = "optional";
 
         std::string
         GetComponentNameStr(ComponentInfo const& compInfo)
@@ -107,6 +105,4 @@ namespace codegen
                          << ", &{0}::Unbind" << ref.name << ")";
             return binderObjStr.str();
         }
-
-    } // namespace datamodel
-} // namespace codegen
+}

--- a/compendium/tools/SCRCodeGen/Main.cpp
+++ b/compendium/tools/SCRCodeGen/Main.cpp
@@ -53,44 +53,44 @@ main(int argc, char const** argv, char**)
     int returnCode = 0;
     int const FailureReturnCode = -1;
 
-    std::vector<std::string> args(argv, argv + argc);
-
-    // Validate program options ordering.
-    // Return the iterator corresponding to the option argument.
-    // Error conditions:
-    // 1. the option doesn't exist
-    // 2. the option argument doesn't exist
-    // 3. the option argument starts with a '-'
-    auto findOrThrow = [&args](std::string const& key)
-    {
-        auto it = std::find(std::begin(args), std::end(args), key);
-        if (it == args.end())
-        {
-            throw std::runtime_error("Cannot find option " + key);
-        }
-        ++it;
-        if (it == args.end())
-        {
-            throw std::runtime_error("No argument provided for option " + key);
-        }
-        if (it->at(0) == '-')
-        {
-            throw std::runtime_error("The argument " + key + " cannot be an option i.e. it cannot start with -");
-        }
-        return it;
-    };
-
-    // Validate if file stream is open. Otherwise, throw
-    auto checkFileOpenOrThrow = [](auto const& fstream)
-    {
-        if (!fstream.is_open())
-        {
-            throw std::runtime_error("Failed to open manifest file");
-        }
-    };
-
     try
     {
+        std::vector<std::string> args(argv, argv + argc);
+
+    	// Validate program options ordering.
+	// Return the iterator corresponding to the option argument.
+    	// Error conditions:
+    	// 1. the option doesn't exist
+    	// 2. the option argument doesn't exist
+    	// 3. the option argument starts with a '-'
+    	auto findOrThrow = [&args](std::string const& key)
+    	{
+            auto it = std::find(std::begin(args), std::end(args), key);
+            if (it == args.end())
+            {
+                throw std::runtime_error("Cannot find option " + key);
+            }
+            ++it;
+            if (it == args.end())
+            {
+                throw std::runtime_error("No argument provided for option " + key);
+            }
+            if (it->at(0) == '-')
+            {
+                throw std::runtime_error("The argument " + key + " cannot be an option i.e. it cannot start with -");
+            }
+            return it;
+        };
+
+    	// Validate if file stream is open. Otherwise, throw
+    	auto checkFileOpenOrThrow = [](auto const& fstream)
+    	{
+            if (!fstream.is_open())
+            {
+                throw std::runtime_error("Failed to open manifest file");
+            }
+    	};
+
         auto it = findOrThrow("--manifest");
         std::string manifestFilePath = *it;
         it = findOrThrow("--out-file");

--- a/compendium/tools/SCRCodeGen/ManifestParser.hpp
+++ b/compendium/tools/SCRCodeGen/ManifestParser.hpp
@@ -44,7 +44,7 @@ class ManifestParser
 {
   public:
     virtual ~ManifestParser() = default;
-    virtual std::vector<ComponentInfo> ParseAndGetComponentInfos(Json::Value const& scr) const = 0;
+    [[nodiscard]] virtual std::vector<ComponentInfo> ParseAndGetComponentInfos(Json::Value const& scr) const = 0;
 };
 
 #endif // MANIFESTPARSER_HPP

--- a/compendium/tools/SCRCodeGen/Util.hpp
+++ b/compendium/tools/SCRCodeGen/Util.hpp
@@ -50,8 +50,8 @@ namespace codegen
             JsonValueValidator(Json::Value const& data, std::string name, Json::ValueType type)
                 : jsonName(std::move(name))
                 , msg("Invalid value for the name '" + jsonName + "'. Expected ")
+		, jsonVal(data[jsonName.c_str()])
             {
-                jsonVal = data[jsonName.c_str()];
                 if (Json::Value::nullRef == jsonVal)
                 {
                     std::string msg = "Mandatory name '" + jsonName + "' missing from the manifest";
@@ -71,10 +71,10 @@ namespace codegen
             JsonValueValidator(Json::Value const& data, std::string name, ValidChoices<S> const& choices)
                 : jsonName(std::move(name))
                 , msg("Invalid value for the name '" + jsonName + "'. Expected ")
+		, jsonVal(data[jsonName.c_str()])
             {
                 static_assert(S > 0, "Choices cannot be empty!");
 
-                jsonVal = data[jsonName.c_str()];
                 if (Json::Value::nullRef == jsonVal)
                 {
                     jsonVal = choices.front();
@@ -131,7 +131,7 @@ namespace codegen
             // Return the string representation of the Json value data[name]
             // Throw if data[name] is not of Json String type
             // (data and name are the Json data and name specified in the constructors)
-            std::string
+            [[nodiscard]] std::string
             GetString() const
             {
                 if (!jsonVal.isString())

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -667,13 +667,11 @@ namespace codegen
     // Instead, if we expect the errorOutput to be contained in the generated error message,
     // we set isPartial = true. (This is useful when we don't want to specify really long error messages)
 
-    struct ManifestPath { std::string value; };
-    struct ErrorOutput { std::string value; };
     struct CodegenInvalidManifestState
     {
-        CodegenInvalidManifestState(ManifestPath _manifest, ErrorOutput _errorOutput, bool _isPartial = false)
-            : manifest(std::move(_manifest.value))
-            , errorOutput(std::move(_errorOutput.value))
+        CodegenInvalidManifestState(std::string _manifest, std::string _errorOutput, bool _isPartial = false)
+            : manifest(std::move(_manifest))
+            , errorOutput(std::move(_errorOutput))
             , isPartial(_isPartial)
         {
         }

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -666,11 +666,14 @@ namespace codegen
     // output by the code-generator to be exactly errorOutput.
     // Instead, if we expect the errorOutput to be contained in the generated error message,
     // we set isPartial = true. (This is useful when we don't want to specify really long error messages)
+
+    struct ManifestPath { std::string value; };
+    struct ErrorOutput { std::string value; };
     struct CodegenInvalidManifestState
     {
-        CodegenInvalidManifestState(std::string _manifest, std::string _errorOutput, bool _isPartial = false)
-            : manifest(std::move(_manifest))
-            , errorOutput(std::move(_errorOutput))
+        CodegenInvalidManifestState(ManifestPath _manifest, ErrorOutput _errorOutput, bool _isPartial = false)
+            : manifest(std::move(_manifest.value))
+            , errorOutput(std::move(_errorOutput.value))
             , isPartial(_isPartial)
         {
         }

--- a/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
+++ b/compendium/tools/SCRCodeGen/test/TestCodeGenerator.cpp
@@ -701,7 +701,8 @@ namespace codegen
             auto scr = GetManifestSCRData(ics.manifest);
             auto version = util::JsonValueValidator(scr, "version", Json::ValueType::intValue)();
             auto manifestParser = ManifestParserFactory::Create(version.asInt());
-            manifestParser->ParseAndGetComponentInfos(scr);
+            auto componentInfos = manifestParser->ParseAndGetComponentInfos(scr);
+	    (void)componentInfos;
             FAIL() << "This failure suggests that parsing has succeeded. "
                       "Shouldn't happen for failure mode tests";
         }


### PR DESCRIPTION
## Warnings Addressed:

📄ComponentCallbackGenerator.cpp
Line 44: Constructor does not initialize fields: mHeaderIncludes, mComponentInfos
Line 154: Member mHeaderIncludes of type const int is const qualified
Line 155: Member mComponentInfos of type const int is const qualified


### 📄 ComponentInfo.cpp
Line 29: Nested namespaces can be concatenated

### 📄 Main.cpp
Line 51: An exception may be thrown in function main which should not throw exceptions


### 📄 ManifestParser.hpp
Line 47: Function ParseAndGetComponentInfos should be marked [[nodiscard]]


### 📄 TestCodeGenerator.cpp
Line 671: Two adjacent parameters of CodegenInvalidManifestState of similar type (std::string) are easily swapped by mistake


### 📄 Util.hpp
Line 35: Nested namespaces can be concatenated
Line 50: Constructor does not initialize field: jsonVal
Line 71: Constructor does not initialize field: jsonVal
Line 134: Function GetString should be marked [[nodiscard]]

