### PR TITLE
701 moved google benchmark to v1.9.0 (#1049)

### DIFF
--- a/third_party/README
+++ b/third_party/README
@@ -152,7 +152,7 @@ Google benchmark
 See https://github.com/google/benchmark/blob/master/LICENSE for license information
 
 https://github.com/google/benchmark
-4124223bf5303d1d65fe2c40f33e28372bbb986c
+12235e24652fc7f809373e7c11a5f73c5763fc4c
 
 Abseil (absl)
 -------------


### PR DESCRIPTION
moved google benchmark to v1.9.0 (#1049)

cherry-pick of merge commit [c8140f9](https://github.com/CppMicroServices/CppMicroServices/commit/c8140f9a05ffa8002fc0376dce3340693cce1135) for branch c++14-compliant

see issue #701 