### PR TITLE
701  Ensure safe concurrent destruction of bundles and framework stopping (#983)

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.cpp
@@ -1,24 +1,24 @@
- /*=============================================================================
+/*=============================================================================
 
-  Library: CppMicroServices
+ Library: CppMicroServices
 
-  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
-  file at the top-level directory of this distribution and at
-  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+ Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+ file at the top-level directory of this distribution and at
+ https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 
-  =============================================================================*/
+ =============================================================================*/
 
 #include "cppmicroservices/FrameworkFactory.h"
 
@@ -53,7 +53,7 @@ namespace cppmicroservices
         std::atomic<unsigned long> ComponentConfigurationImpl::idCounter(0);
 
         ComponentConfigurationImpl::ComponentConfigurationImpl(
-            std::shared_ptr<const metadata::ComponentMetadata> metadata,
+            std::shared_ptr<metadata::ComponentMetadata const> metadata,
             Bundle const& bundle,
             std::shared_ptr<ComponentRegistry> registry,
             std::shared_ptr<cppmicroservices::logservice::LogService> logger,
@@ -70,7 +70,7 @@ namespace cppmicroservices
             , deleteCompInstanceFunc(nullptr)
         {
             if (!this->metadata || !this->bundle || !this->registry || !this->logger || !this->configNotifier)
-           {
+            {
                 throw std::invalid_argument("ComponentConfigurationImpl - Invalid arguments passed to constructor");
             }
 
@@ -107,7 +107,7 @@ namespace cppmicroservices
             std::for_each(
                 referenceManagerTokens.begin(),
                 referenceManagerTokens.end(),
-                [](const std::unordered_map<std::shared_ptr<ReferenceManager>, ListenerTokenId>::value_type& kvpair)
+                [](std::unordered_map<std::shared_ptr<ReferenceManager>, ListenerTokenId>::value_type const& kvpair)
                 { (kvpair.first)->UnregisterListener(kvpair.second); });
 
             referenceManagerTokens.clear();
@@ -140,7 +140,7 @@ namespace cppmicroservices
                         props.emplace(item.first, item.second);
                     }
                 }
-                else 
+                else
                 {
                     props = metadata->properties;
                 }
@@ -364,7 +364,7 @@ namespace cppmicroservices
                 return (state);
             }
             void
-            operator()(const std::unordered_map<std::string, std::shared_ptr<ReferenceManager>>::value_type& item)
+            operator()(std::unordered_map<std::string, std::shared_ptr<ReferenceManager>>::value_type const& item)
             {
                 if (skipKey.empty() || item.first != skipKey)
                 {

--- a/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentManagerImpl.hpp
@@ -50,13 +50,13 @@ namespace cppmicroservices
         class ComponentManagerImpl : public ComponentManager
         {
           public:
-            ComponentManagerImpl(std::shared_ptr<const metadata::ComponentMetadata> metadata,
+            ComponentManagerImpl(std::shared_ptr<metadata::ComponentMetadata const> metadata,
                                  std::shared_ptr<ComponentRegistry> registry,
                                  cppmicroservices::BundleContext bundleContext,
                                  std::shared_ptr<cppmicroservices::logservice::LogService> logger,
                                  std::shared_ptr<cppmicroservices::async::AsyncWorkService> asyncWorkService,
                                  std::shared_ptr<ConfigurationNotifier> configNotifier);
-             ComponentManagerImpl(ComponentManagerImpl const&) = delete;
+            ComponentManagerImpl(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl(ComponentManagerImpl&&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl const&) = delete;
             ComponentManagerImpl& operator=(ComponentManagerImpl&&) = delete;
@@ -90,7 +90,7 @@ namespace cppmicroservices
             /** @copydoc ComponentManager::GetMetadata()
              * Returns the stored component description
              */
-            std::shared_ptr<const metadata::ComponentMetadata>
+            std::shared_ptr<metadata::ComponentMetadata const>
             GetMetadata() const override
             {
                 return compDesc;
@@ -206,11 +206,11 @@ namespace cppmicroservices
           private:
             FRIEND_TEST(ComponentManagerImplParameterizedTest, TestAccumulateFutures);
 
-            const std::shared_ptr<ComponentRegistry>
+            std::shared_ptr<ComponentRegistry> const
                 registry; ///< component registry associated with the current runtime
-            const std::shared_ptr<const metadata::ComponentMetadata> compDesc; ///< the component description
+            std::shared_ptr<metadata::ComponentMetadata const> const compDesc; ///< the component description
             cppmicroservices::BundleContext bundleContext; ///< context of the bundle which contains the component
-            const std::shared_ptr<cppmicroservices::logservice::LogService>
+            std::shared_ptr<cppmicroservices::logservice::LogService> const
                 logger;                                   ///< logger associated with the current runtime
             std::shared_ptr<ComponentManagerState> state; ///< This member is always accessed using atomic operations
             std::vector<std::shared_future<void>>
@@ -221,7 +221,7 @@ namespace cppmicroservices
             std::mutex
                 transitionMutex; ///< mutex to make the state transition and posting of the async operations atomic
             std::shared_ptr<ConfigurationNotifier> configNotifier;
-       };
+        };
     } // namespace scrimpl
 } // namespace cppmicroservices
 

--- a/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CCActiveState.cpp
@@ -105,7 +105,16 @@ namespace cppmicroservices
                     // the latch counts down to 0, thereby allowing all Activate, Rebind and Modified
                     // activities to complete.
                     currentState->WaitForTransitionTask(); // wait for the previous transition to finish
-                    mgr.UnregisterService();
+                    try
+                    {
+                        mgr.UnregisterService();
+                    }
+                    catch (...)
+                    {
+                        mgr.GetLogger()->Log(cppmicroservices::logservice::SeverityLevel::LOG_WARNING,
+                                             "Failed to unregister the service.",
+                                             std::current_exception());
+                    }
                     mgr.DestroyComponentInstances();
                     transitionAction.set_value();
                 }

--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
@@ -47,7 +47,7 @@ namespace cppmicroservices
         }
 
         void
-        CMEnabledState::CreateConfigurations(std::shared_ptr<const metadata::ComponentMetadata> compDesc,
+        CMEnabledState::CreateConfigurations(std::shared_ptr<metadata::ComponentMetadata const> compDesc,
                                              cppmicroservices::Bundle const& bundle,
                                              std::shared_ptr<ComponentRegistry> registry,
                                              std::shared_ptr<logservice::LogService> logger,
@@ -60,7 +60,7 @@ namespace cppmicroservices
                                                                                     registry,
                                                                                     logger,
                                                                                     configNotifier);
-               configurations.push_back(cc);
+                configurations.push_back(cc);
             }
             catch (cppmicroservices::SharedLibraryException const&)
             {

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -128,7 +128,7 @@ namespace cppmicroservices
                                                                                        mockRegistry,
                                                                                        fakeLogger,
                                                                                        notifier);
-                 EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
+                EXPECT_EQ(fakeCompConfig->GetConfigState(), ComponentState::UNSATISFIED_REFERENCE);
                 EXPECT_EQ(fakeCompConfig->regManager, nullptr);
                 EXPECT_EQ(fakeCompConfig->referenceManagers.size(), static_cast<size_t>(0));
             });
@@ -147,9 +147,9 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService,
-                                                                    extRegistry); 
+                                                                    extRegistry);
             std::set<unsigned long> idSet;
-            const size_t iterCount = 10;
+            size_t const iterCount = 10;
             for (size_t i = 0; i < iterCount; ++i)
             {
                 EXPECT_NO_THROW({
@@ -201,7 +201,7 @@ namespace cppmicroservices
                                                                                    mockRegistry,
                                                                                    fakeLogger,
                                                                                    notifier);
-           EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
+            EXPECT_CALL(*fakeCompConfig, GetFactory()).Times(1).WillOnce(testing::Return(mockFactory));
             // add the mock reference managers to the config object
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref1", refMgr1));
             fakeCompConfig->referenceManagers.insert(std::make_pair("ref2", refMgr2));
@@ -225,7 +225,7 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
- 
+
             auto logger = std::make_shared<SCRLogger>(GetFramework().GetBundleContext());
             auto asyncWorkService
                 = std::make_shared<cppmicroservices::scrimpl::SCRAsyncWorkService>(GetFramework().GetBundleContext(),
@@ -270,7 +270,7 @@ namespace cppmicroservices
             auto mockMetadata = std::make_shared<metadata::ComponentMetadata>();
             auto mockRegistry = std::make_shared<MockComponentRegistry>();
             auto fakeLogger = std::make_shared<FakeLogger>();
- 
+
             // Test that a call to Register with a component containing both a service
             // and a reference to the same service interface will not cause a state change.
             scrimpl::metadata::ReferenceMetadata refMetadata {};
@@ -473,7 +473,7 @@ namespace cppmicroservices
             auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                     fakeLogger,
                                                                     asyncWorkService,
-                                                                    extRegistry); 
+                                                                    extRegistry);
             // Test for exception from user code
             auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
                                                                                    GetFramework(),
@@ -710,7 +710,7 @@ namespace cppmicroservices
                 auto notifier = std::make_shared<ConfigurationNotifier>(GetFramework().GetBundleContext(),
                                                                         fakeLogger,
                                                                         asyncWorkService,
-                                                                        extRegistry); 
+                                                                        extRegistry);
                 mockMetadata->serviceMetadata.interfaces = { us_service_interface_iid<dummy::ServiceImpl>() };
                 mockMetadata->immediate = false;
                 auto fakeCompConfig = std::make_shared<MockComponentConfigurationImpl>(mockMetadata,
@@ -718,7 +718,7 @@ namespace cppmicroservices
                                                                                        mockRegistry,
                                                                                        fakeLogger,
                                                                                        notifier);
-                 EXPECT_CALL(*fakeCompConfig, GetFactory())
+                EXPECT_CALL(*fakeCompConfig, GetFactory())
                     .Times(testing::AtLeast(1)) // 2
                     .WillRepeatedly(testing::Return(mockFactory));
                 fakeCompConfig->Initialize();
@@ -843,14 +843,14 @@ namespace cppmicroservices
                                                                         std::make_shared<MockComponentRegistry>(),
                                                                         fakeLogger,
                                                                         notifier);
- 
+
             auto fakeBundleProtoCompConfig = std::make_shared<BundleOrPrototypeComponentConfigurationImpl>(
                 mockMetadata,
                 GetFramework(),
                 std::make_shared<MockComponentRegistry>(),
                 fakeLogger,
                 notifier);
- 
+
             auto svcReg = GetFramework().GetBundleContext().RegisterService<dummy::ServiceImpl>(
                 std::make_shared<dummy::ServiceImpl>());
 
@@ -934,6 +934,61 @@ namespace cppmicroservices
 
             framework.Stop();
             framework.WaitForStop(std::chrono::milliseconds::zero());
+        }
+
+        TEST(ComponentConfigurationTests, TestConcurrentStop)
+        {
+            auto framework = cppmicroservices::FrameworkFactory().NewFramework();
+            framework.Start();
+            ASSERT_TRUE(framework);
+
+            auto context = framework.GetBundleContext();
+            ASSERT_TRUE(context);
+
+            test::InstallAndStartDS(context);
+
+            std::vector<cppmicroservices::Bundle> installedBundles
+                = { ::test::InstallAndStartBundle(context, "DSGraph01"),
+                    ::test::InstallAndStartBundle(context, "DSGraph02"),
+                    ::test::InstallAndStartBundle(context, "DSGraph03"),
+                    ::test::InstallAndStartBundle(context, "DSGraph04"),
+                    ::test::InstallAndStartBundle(context, "DSGraph05"),
+                    ::test::InstallAndStartBundle(context, "DSGraph06"),
+                    ::test::InstallAndStartBundle(context, "DSGraph07") };
+
+            std::vector<cppmicroservices::ServiceReferenceU> const interfaces {
+                context.GetServiceReference<test::DSGraph01>(), context.GetServiceReference<test::DSGraph02>(),
+                context.GetServiceReference<test::DSGraph03>(), context.GetServiceReference<test::DSGraph04>(),
+                context.GetServiceReference<test::DSGraph05>(), context.GetServiceReference<test::DSGraph06>(),
+                context.GetServiceReference<test::DSGraph07>()
+            };
+
+            for (auto const& sref : interfaces)
+            {
+                ASSERT_TRUE(static_cast<bool>(sref));
+                auto service = context.GetService(sref);
+                ASSERT_NE(service, nullptr);
+            }
+
+            EXPECT_NO_THROW({
+                std::thread bundleT = std::thread(
+                    [&installedBundles]()
+                    {
+                        for (auto& bundle : installedBundles)
+                        {
+                            bundle.Stop();
+                        }
+                    });
+                std::thread frameworkT = std::thread(
+                    [&framework]()
+                    {
+                        framework.Stop();
+                        framework.WaitForStop(std::chrono::milliseconds::zero());
+                    });
+
+                bundleT.join();
+                frameworkT.join();
+            });
         }
 
         // Note: This is different than the other tests in this suite as Declarative Services is actually

--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -827,8 +827,20 @@ namespace cppmicroservices
         coreCtx->services.GetUsedByBundle(this, srs);
         for (std::vector<ServiceRegistrationBase>::const_iterator i = srs.begin(); i != srs.end(); ++i)
         {
-            auto ref = i->GetReference(std::string());
-            ref.d.Load()->UngetService(this->shared_from_this(), false);
+            // wrap in try-catch to catch failures if service is already unregistered
+            // if service is unregistered, all work in UngetService is already done by Unregister() previously
+            try
+            {
+                auto ref = i->GetReference(std::string());
+                ref.d.Load()->UngetService(this->shared_from_this(), false);
+            }
+            catch (...)
+            {
+                coreCtx->logger->Log(logservice::SeverityLevel::LOG_WARNING,
+                                     "Some services already unregistered in Bundle " + symbolicName
+                                         + " (location=" + location + ")",
+                                     std::current_exception());
+            }
         }
     }
 

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -209,28 +209,32 @@ namespace cppmicroservices
 
         CoreBundleContext* coreContext = nullptr;
 
-        if (!d->coreInfo->available)
-        {
-            throw std::logic_error("Service is unregistered");
-        }
         bool isUnregistering(false); // expected state
-        if (atomic_compare_exchange_strong(&d->coreInfo->unregistering, &isUnregistering, true))
+
+        if (!atomic_compare_exchange_strong(&d->coreInfo->unregistering, &isUnregistering, true))
         {
-            if (auto bundle = d->coreInfo->bundle_.lock())
-            {
-                {
-                    auto l1 = bundle->coreCtx->services.Lock();
-                    US_UNUSED(l1);
-                    bundle->coreCtx->services.RemoveServiceRegistration_unlocked(*this);
-                }
-                coreContext = bundle->coreCtx;
-            }
+            // someone else is unregistering
+            return;
         }
 
-        if (isUnregistering)
+        // d->coreInfo->unregistering is now true
+
+        // if unavailable
+        if (!d->coreInfo->available)
         {
-            // another thread has changed the state to UNREGISTERING
-            return;
+            // set unregistering to false
+            d->coreInfo->unregistering = false;
+            throw std::logic_error("Service is unregistered");
+        }
+
+        if (auto bundle = d->coreInfo->bundle_.lock())
+        {
+            {
+                auto l1 = bundle->coreCtx->services.Lock();
+                US_UNUSED(l1);
+                bundle->coreCtx->services.RemoveServiceRegistration_unlocked(*this);
+            }
+            coreContext = bundle->coreCtx;
         }
 
         if (coreContext)
@@ -326,6 +330,8 @@ namespace cppmicroservices
             d->coreInfo->bundleServiceInstance.clear();
 
             d->reference = nullptr;
+
+            // reset d->coreInfo->unregistering to false
             d->coreInfo->unregistering = false;
         }
     }


### PR DESCRIPTION
Ensure safe concurrent destruction of bundles and framework stopping #983 

This addresses issues encountered when concurrently destroying bundles and stopping the framework. The solution was to allow a service to be already unregistered when the state was switching from active in the ComponentConfiguration.

cherry-pick of commit [64860b1](https://github.com/CppMicroServices/CppMicroServices/commit/64860b15acd0dd17a234651e19a393d77de89f21)

see discussion #701