### PR TITLE
701  Bundle Start after Framework Stop race fix (#990)

### DIFF
--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -290,7 +290,10 @@ namespace cppmicroservices
             {
                 StopAllBundles();
             }
-            coreCtx->Uninit0();
+            {
+                auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
+                coreCtx->Uninit0();
+            }
             {
                 auto l = Lock();
                 US_UNUSED(l);


### PR DESCRIPTION
Bundle Start after Framework Stop race fix #990

We were setting the bundle stopping value prior to the async call to notify the listeners for a config event. So the framework was being marked as stopped before a listener was alerted. Now, that is done after the call to notify listeners.

cherry-pick of commit [fb6628a](https://github.com/CppMicroServices/CppMicroServices/commit/fb6628aefd1872652a2234de2c64f786a5eb8f32)

see discussion #701 

When this is merged, PR #979 shall be cherry-picked, too