### PR TITLE
701  framework/include/cppmicroservces: add missing cstdint includes #1057 

### DIFF
--- a/framework/include/cppmicroservices/Any.h
+++ b/framework/include/cppmicroservices/Any.h
@@ -46,6 +46,7 @@ DEALINGS IN THE SOFTWARE.
 #include <typeinfo>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 namespace cppmicroservices
 {

--- a/framework/include/cppmicroservices/BundleEvent.h
+++ b/framework/include/cppmicroservices/BundleEvent.h
@@ -27,6 +27,7 @@
 
 #include <iostream>
 #include <memory>
+#include <cstdint>
 
 // 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
 US_MSVC_PUSH_DISABLE_WARNING(4251)

--- a/framework/include/cppmicroservices/FrameworkEvent.h
+++ b/framework/include/cppmicroservices/FrameworkEvent.h
@@ -27,6 +27,7 @@
 
 #include <iostream>
 #include <memory>
+#include <cstdint>
 
 US_MSVC_PUSH_DISABLE_WARNING(
     4251) // 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'


### PR DESCRIPTION
framework/include/cppmicroservces: add missing cstdint includes #1057 

With GCC 15 the code fails to compile due to undefined uint8_t and uint32_t types. The release notes for GCC 15 caution:
```
  In particular, the following headers are used less widely within
  libstdc++ and may need to be included explicitly when compiling
  with GCC 15:

    <stdint.h> (for int8_t, int32_t etc.) and <cstdint> (for
    std::int8_t, std::int32_t etc.)
    <ostream> (for std::endl, std::flush etc.)
```

cherry-pick of commit [54f7a26](https://github.com/CppMicroServices/CppMicroServices/commit/54f7a26df60049ea3b83e3901014dfc7f0fc91b2)

see discussion #701