### PR TITLE
701  I0268 (#1100)

### DIFF
--- a/framework/doc/bundle_properties.rst
+++ b/framework/doc/bundle_properties.rst
@@ -17,7 +17,9 @@ Bundle authors must always add the following property to their bundle's
 ``manifest.json`` file:
 
 -  ``bundle.symbolic_name`` - The human readable name of the bundle (type
-   ``std::string``)
+   ``std::string``). The name must start with either an underscore or
+   letter and contain only underscores, letters, or numbers (i.e. must be
+   a correct c-identifier).
 
 C++ Micro Services will not install any bundle which doesn't contain a
 valid 'bundle.symbolic_name' property in its ``manifest.json`` file.

--- a/schemas/manifest_schema.json
+++ b/schemas/manifest_schema.json
@@ -6,7 +6,7 @@
     "bundle.symbolic_name": {
       "id": "/properties/bundle.symbolic_name",
       "type": "string",
-      "pattern": "^([a-zA-Z0-9_]+)$"
+      "pattern": "^([a-zA-Z_][a-zA-Z0-9_]*)$"
     },
     "bundle.activator": {
       "id": "/properties/bundle.activator",


### PR DESCRIPTION
I0268 #1100 

Issue #268 

    Updated schema to correctly check that the symbolic_name follows c identifier rules
    Updated bundle documentation with those requirements.

cherry-pick of commit [a0c5000](https://github.com/CppMicroServices/CppMicroServices/commit/a0c50001a43d839cad5f79910961004d3da3048f)

see discussion #701 