### PR TITLE
Revert "Bundle Start after Framework Stop race fix (#990) (#1132)"

### DIFF
--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -290,10 +290,7 @@ namespace cppmicroservices
             {
                 StopAllBundles();
             }
-            {
-                auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
-                coreCtx->Uninit0();
-            }
+            coreCtx->Uninit0();
             {
                 auto l = Lock();
                 US_UNUSED(l);


### PR DESCRIPTION
reverting #1132 as this fix was related to code changes which were not cherry-picked to c++14-compliant branch thus causing build errors