### PR TITLE
 701 Fix more code scan warnings related to uninitialized variables (#973)

### DIFF
--- a/framework/src/bundle/BundleArchive.cpp
+++ b/framework/src/bundle/BundleArchive.cpp
@@ -56,6 +56,8 @@ namespace cppmicroservices
     BundleArchive::BundleArchive()
         : storage(nullptr)
         , bundleId(0)
+        , lastModified(now())
+        , autostartSetting(-1)
         , manifest(any_map::UNORDERED_MAP_CASEINSENSITIVE_KEYS)
     {
     }

--- a/framework/src/util/AnyMap.cpp
+++ b/framework/src/util/AnyMap.cpp
@@ -184,7 +184,7 @@ namespace cppmicroservices
 
     any_map::const_iter::const_iter() = default;
 
-    any_map::const_iter::const_iter(any_map::const_iter const& it) : iterator_base(it.type)
+    any_map::const_iter::const_iter(any_map::const_iter const& it) : iterator_base(it.type), it { nullptr }
     {
         switch (type)
         {
@@ -204,7 +204,7 @@ namespace cppmicroservices
         }
     }
 
-    any_map::const_iter::const_iter(any_map::iterator const& it) : iterator_base(it.type)
+    any_map::const_iter::const_iter(any_map::iterator const& it) : iterator_base(it.type), it { nullptr }
     {
         switch (type)
         {
@@ -406,7 +406,7 @@ namespace cppmicroservices
 
     any_map::iter::iter() = default;
 
-    any_map::iter::iter(iter const& it) : iterator_base(it.type)
+    any_map::iter::iter(iter const& it) : iterator_base(it.type), it { nullptr }
     {
         switch (type)
         {

--- a/framework/src/util/FrameworkPrivate.h
+++ b/framework/src/util/FrameworkPrivate.h
@@ -102,8 +102,8 @@ namespace cppmicroservices
          */
         struct FrameworkEventInternal
         {
-            bool valid;
-            FrameworkEvent::Type type;
+            bool valid { false };
+            FrameworkEvent::Type type { FrameworkEvent::FRAMEWORK_ERROR };
             std::string msg;
             std::exception_ptr excPtr;
         } stopEvent;


### PR DESCRIPTION
Fix more code scan warnings related to uninitialized variables #973 

Fixes #972
Fixes #971
Fixes #970

cherry-pick of commit [056a1c2](https://github.com/CppMicroServices/CppMicroServices/commit/056a1c20d9b12ff35a1292e38dcf67b3cb9a1575)

see discussion #701