### PR TITLE
701 Ensure that bundle.Start() after the framework has stopped throws (#979)

### DIFF
--- a/framework/src/bundle/BundlePrivate.cpp
+++ b/framework/src/bundle/BundlePrivate.cpp
@@ -76,7 +76,7 @@ namespace cppmicroservices
 
             if (state == Bundle::STATE_UNINSTALLED)
             {
-                throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location + ") is uninstalled");
+                throw std::logic_error("Bundle " + symbolicName + " (location=" + location + ") is uninstalled");
             }
 
             if ((options & Bundle::STOP_TRANSIENT) == 0)
@@ -138,7 +138,7 @@ namespace cppmicroservices
             catch (...)
             {
                 res = std::make_exception_ptr(
-                    std::runtime_error("Bundle #" + util::ToString(id) + " (location=" + location
+                    std::runtime_error("Bundle " + symbolicName + " (location=" + location
                                        + "), BundleActivator::Stop() failed: " + util::GetLastExceptionStr()));
             }
 
@@ -167,8 +167,8 @@ namespace cppmicroservices
                 }
                 if (!cause.empty())
                 {
-                    res = std::make_exception_ptr(std::runtime_error(
-                        "Bundle #" + util::ToString(id) + " (location=" + location + ") stop failed: " + cause));
+                    res = std::make_exception_ptr(std::runtime_error("Bundle " + symbolicName + " (location=" + location
+                                                                     + ") stop failed: " + cause));
                 }
             }
             bactivator = nullptr;
@@ -288,10 +288,10 @@ namespace cppmicroservices
                 // This happens if call start from inside the BundleActivator.stop
                 // method.
                 // Don't allow it.
-                throw std::runtime_error("Bundle #" + util::ToString(id) + " (location=" + location
+                throw std::runtime_error("Bundle " + symbolicName + " (location=" + location
                                          + "), start called from BundleActivator::Stop");
             case Bundle::STATE_UNINSTALLED:
-                throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
+                throw std::logic_error("Bundle " + symbolicName + " (location=" + location
                                        + ") is in UNINSTALLED state");
         }
     }
@@ -306,7 +306,7 @@ namespace cppmicroservices
             switch (static_cast<Bundle::State>(state.load()))
             {
                 case Bundle::STATE_UNINSTALLED:
-                    throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
+                    throw std::logic_error("Bundle " + symbolicName + " (location=" + location
                                            + ") is in BUNDLE_UNINSTALLED state");
                 case Bundle::STATE_STARTING: // Lazy start
                 case Bundle::STATE_ACTIVE:
@@ -368,7 +368,7 @@ namespace cppmicroservices
                     if (state == Bundle::STATE_UNINSTALLED)
                     {
                         operation = BundlePrivate::OP_IDLE;
-                        throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
+                        throw std::logic_error("Bundle " + symbolicName + " (location=" + location
                                                + ") is in BUNDLE_UNINSTALLED state");
                     }
 
@@ -422,9 +422,15 @@ namespace cppmicroservices
     {
         auto l = this->Lock();
         US_UNUSED(l);
+        auto frameworkBlock = coreCtx->GetFrameworkStateAndBlock();
+        if (frameworkBlock->frameworkHasStopped)
+        {
+            throw std::runtime_error("Bundle " + symbolicName + " (location=" + location
+                                     + ") belongs to a stopped framework");
+        }
         if (state == Bundle::STATE_UNINSTALLED)
         {
-            throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location + ") is uninstalled");
+            throw std::logic_error("Bundle " + symbolicName + " (location=" + location + ") is uninstalled");
         }
 
         if (state == Bundle::STATE_ACTIVE)
@@ -494,7 +500,7 @@ namespace cppmicroservices
                 {
                     StartFailed();
                     return std::make_exception_ptr(SecurityException {
-                        "Bundle #" + util::ToString(id) + " (location=" + location + ") failed bundle validation.",
+                        "Bundle " + symbolicName + " (location=" + location + ") failed bundle validation.",
                         thisBundle });
                 }
             }
@@ -521,11 +527,11 @@ namespace cppmicroservices
                     if (!lib.IsLoaded())
                     {
                         coreCtx->logger->Log(logservice::SeverityLevel::LOG_INFO,
-                                             "Loading shared library for Bundle #" + util::ToString(id)
+                                             "Loading shared library for Bundle " + symbolicName
                                                  + " (location=" + location + ")");
                         lib.Load(coreCtx->libraryLoadOptions);
                         coreCtx->logger->Log(logservice::SeverityLevel::LOG_INFO,
-                                             "Finished loading shared library for Bundle #" + util::ToString(id)
+                                             "Finished loading shared library for Bundle " + symbolicName
                                                  + " (location=" + location + ")");
                     }
                     libHandle = lib.GetHandle();
@@ -561,13 +567,13 @@ namespace cppmicroservices
                 if (!createActivatorHook)
                 {
                     coreCtx->logger->Log(logservice::SeverityLevel::LOG_ERROR, create_activator_err);
-                    throw std::runtime_error("Bundle #" + util::ToString(id) + " (location=" + location
+                    throw std::runtime_error("Bundle " + symbolicName + " (location=" + location
                                              + ") activator constructor not found");
                 }
                 if (!destroyActivatorHook)
                 {
                     coreCtx->logger->Log(logservice::SeverityLevel::LOG_ERROR, destroy_activator_err);
-                    throw std::runtime_error("Bundle #" + util::ToString(id) + " (location=" + location
+                    throw std::runtime_error("Bundle " + symbolicName + " (location=" + location
                                              + ") activator destructor not found");
                 }
 
@@ -586,10 +592,9 @@ namespace cppmicroservices
             catch (...)
             {
                 coreCtx->logger->Log(logservice::SeverityLevel::LOG_INFO,
-                                     "Failed to start Bundle #" + util::ToString(id) + " (location=" + location + ")",
+                                     "Failed to start Bundle " + symbolicName + " (location=" + location + ")",
                                      std::current_exception());
-                res = std::make_exception_ptr(std::runtime_error("Bundle #" + util::ToString(id)
-                                                                 + " (location= " + location
+                res = std::make_exception_ptr(std::runtime_error("Bundle " + symbolicName + " (location= " + location
                                                                  + ") start failed: " + util::GetLastExceptionStr()));
             }
         }
@@ -626,8 +631,8 @@ namespace cppmicroservices
             }
             if (!cause.empty())
             {
-                res = std::make_exception_ptr(std::runtime_error(
-                    "Bundle #" + util::ToString(id) + " (location= " + location + ") start failed: " + cause));
+                res = std::make_exception_ptr(std::runtime_error("Bundle " + symbolicName + " (location= " + location
+                                                                 + ") start failed: " + cause));
             }
         }
 
@@ -793,7 +798,7 @@ namespace cppmicroservices
         auto snbl = coreCtx->bundleRegistry.GetBundles(symbolicName, version);
         if (!snbl.empty())
         {
-            throw std::invalid_argument("Bundle #" + util::ToString(id) + " (location=" + location
+            throw std::invalid_argument("Bundle " + symbolicName + " (location=" + location
                                         + "), a bundle with same symbolic name and version " + "is already installed ("
                                         + symbolicName + ", " + version.ToString() + ")");
         }
@@ -806,8 +811,7 @@ namespace cppmicroservices
     {
         if (state == Bundle::STATE_UNINSTALLED)
         {
-            throw std::logic_error("Bundle #" + util::ToString(id) + " (location=" + location
-                                   + ") is in UNINSTALLED state");
+            throw std::logic_error("Bundle " + symbolicName + " (location=" + location + ") is in UNINSTALLED state");
         }
     }
 

--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -94,6 +94,7 @@ namespace cppmicroservices
         , firstInit(true)
         , initCount(0)
         , libraryLoadOptions(0)
+        , stopped(false)
     {
         auto enableDiagLog = any_cast<bool>(frameworkProperties.at(Constants::FRAMEWORK_LOG));
         std::ostream* diagnosticLogger = (diagLogger) ? diagLogger : &std::clog;
@@ -131,7 +132,7 @@ namespace cppmicroservices
         }
 
         // We use a "pseudo" random UUID.
-        const std::string sid_base = "04f4f884-31bb-45c0-b176-";
+        std::string const sid_base = "04f4f884-31bb-45c0-b176-";
         std::stringstream ss;
         ss << sid_base << std::setfill('0') << std::setw(8) << std::hex << static_cast<int32_t>(id * 65536 + initCount);
 
@@ -249,5 +250,20 @@ namespace cppmicroservices
             return dataStorage + util::DIR_SEP + util::ToString(id);
         }
         return std::string();
+    }
+
+    WriteLock
+    CoreBundleContext::SetFrameworkStateAndBlockUntilComplete(bool desiredState)
+    {
+        WriteLock lock(stoppedLock);
+        stopped = desiredState;
+        return lock;
+    }
+
+    std::unique_ptr<FrameworkShutdownBlocker>
+    CoreBundleContext::GetFrameworkStateAndBlock() const
+    {
+        ReadLock lock(stoppedLock);
+        return std::make_unique<FrameworkShutdownBlocker>(stopped, std::move(lock));
     }
 } // namespace cppmicroservices

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -61,8 +61,8 @@ as specified in the OSGi R4.2 specifications.
 
 namespace cppmicroservices
 {
-    using WriteLock = std::unique_lock<std::shared_mutex>;
-    using ReadLock = std::shared_lock<std::shared_mutex>;
+    using WriteLock = std::unique_lock<std::shared_timed_mutex>;
+    using ReadLock = std::shared_lock<std::shared_timed_mutex>;
 
     struct FrameworkShutdownBlocker
     {
@@ -227,7 +227,7 @@ namespace cppmicroservices
 
         // Mutex required to be held when changing stopped.
         // ReadLock or WriteLock construction is done using this mutex.
-        mutable std::shared_mutex stoppedLock;
+        mutable std::shared_timed_mutex stoppedLock;
 
         // Flag for whether the Framework has been stopped. See mutex stoppedLock
         bool stopped;

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -56,10 +56,21 @@ as specified in the OSGi R4.2 specifications.
 
 #include <map>
 #include <ostream>
+#include <shared_mutex>
 #include <string>
 
 namespace cppmicroservices
 {
+    using WriteLock = std::unique_lock<std::shared_mutex>;
+    using ReadLock = std::shared_lock<std::shared_mutex>;
+
+    struct FrameworkShutdownBlocker
+    {
+        bool frameworkHasStopped;
+        ReadLock lock;
+
+        FrameworkShutdownBlocker(bool s, ReadLock l) : frameworkHasStopped(s), lock(std::move(l)) {}
+    };
 
     struct BundleStorage;
     class FrameworkPrivate;
@@ -188,6 +199,23 @@ namespace cppmicroservices
         void Uninit1();
 
         /**
+         * Called when framework shutdown/startup has begun.
+         * This blocks (while returned object is held):
+         *     - other calls to start or stop the framework
+         *     - calls to start bundles
+         */
+        WriteLock SetFrameworkStateAndBlockUntilComplete(bool desiredState);
+
+        /**
+         * Called when bundle startup is occuring
+         * This blocks (while returned object is held):
+         *    - calls to start or stop the framework
+         * And allows:
+         *    - concurrent calls for bundle startup on other bundles
+         */
+        std::unique_ptr<FrameworkShutdownBlocker> GetFrameworkStateAndBlock() const;
+
+        /**
          * Get private bundle data storage file handle.
          *
          */
@@ -196,6 +224,13 @@ namespace cppmicroservices
       private:
         // The core context is exclusively constructed by the FrameworkFactory class
         friend class FrameworkFactory;
+
+        // Mutex required to be held when changing stopped.
+        // ReadLock or WriteLock construction is done using this mutex.
+        mutable std::shared_mutex stoppedLock;
+
+        // Flag for whether the Framework has been stopped. See mutex stoppedLock
+        bool stopped;
 
         /**
          * Construct a core context

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -148,6 +148,7 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
+        auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -185,6 +186,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
+            auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(false);
 
             switch (state.load())
             {
@@ -200,6 +202,7 @@ namespace cppmicroservices
                 default:
                     std::stringstream ss;
                     ss << state;
+
                     throw std::runtime_error("INTERNAL ERROR, Illegal state, " + ss.str());
             }
             bundlesToStart = coreCtx->storage->GetStartOnLaunchBundles();
@@ -211,7 +214,7 @@ namespace cppmicroservices
             auto b = coreCtx->bundleRegistry.GetBundle(i);
             try
             {
-                const int32_t autostartSetting = b->barchive->GetAutostartSetting();
+                int32_t const autostartSetting = b->barchive->GetAutostartSetting();
                 // Launch must not change the autostart setting of a bundle
                 int option = Bundle::START_TRANSIENT;
                 if (Bundle::START_ACTIVATION_POLICY == autostartSetting)


### PR DESCRIPTION
This ensures that we don't have bundles starting after the framework has stopped as per OSGi spec

cherry-pick of commit [d4f63c3](https://github.com/CppMicroServices/CppMicroServices/commit/d4f63c3119d0a95e564e487c9792ba45fa49f849) (PR #979)

plus a commit to use `std::shared_timed_mutex` instead of `std::shared_mutex` since first one is already present in C++14

see discussion #701

A plain cherry-pick is not sufficient, as `std::shared_mutex` is not available with C++14