### PR TITLE
701 Remove linking to library rt from Android build as it is apart of stdc++ (#1038)

### DIFF
--- a/compendium/ConfigurationAdmin/test/CMakeLists.txt
+++ b/compendium/ConfigurationAdmin/test/CMakeLists.txt
@@ -151,7 +151,7 @@ add_dependencies(${us_configurationadmin_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_configurationadmin_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/DeclarativeServices/test/bench/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/bench/CMakeLists.txt
@@ -139,7 +139,7 @@ add_dependencies(${us_declarativeservices_bench_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_declarativeservices_bench_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
+++ b/compendium/DeclarativeServices/test/gtest/CMakeLists.txt
@@ -237,7 +237,7 @@ add_dependencies(${us_declarativeservices_test_exe_name}
 )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_declarativeservices_test_exe_name} PRIVATE rt)
 endif()
 

--- a/compendium/LogServiceImpl/test/CMakeLists.txt
+++ b/compendium/LogServiceImpl/test/CMakeLists.txt
@@ -105,7 +105,7 @@ target_include_directories(${us_logservice_test_exe_name} PRIVATE
   )
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_logservice_test_exe_name} PRIVATE rt)
 endif()
 

--- a/framework/test/bench/CMakeLists.txt
+++ b/framework/test/bench/CMakeLists.txt
@@ -49,7 +49,7 @@ set_property(TARGET ${us_bench_test_exe_name} PROPERTY US_BUNDLE_NAME main)
 
 
 # Needed for clock_gettime with glibc < 2.17
-if(UNIX AND NOT APPLE)
+if((UNIX AND NOT APPLE) AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   target_link_libraries(${us_bench_test_exe_name} rt)
 endif()
 


### PR DESCRIPTION
cherry-pick of commit [9c87715](https://github.com/CppMicroServices/CppMicroServices/commit/9c877153496c289e1afaa8b2c7e14c1a731001a4) (PR #1038)

see discussion #701