### PR TITLE
701 Update GitHub workflows (#1042)

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -84,7 +84,7 @@ jobs:
 
     # Upload SARIF file as an Artifact to download and view
     - name: Upload SARIF as an Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: sarif-file
         path: ${{ steps.run-msvc-analysis.outputs.sarif }}

--- a/.github/workflows/performance_windows.yml
+++ b/.github/workflows/performance_windows.yml
@@ -58,7 +58,7 @@ jobs:
       run: ${{ env.BUILD_DIR }}\bin\Release\usFrameworkBenchTests.exe  --benchmark_format=json | tee ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json
 
     - name: Upload Performance Results as Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Performance Results - ${{ github.event.head_commit.author.name }} - ${{ github.sha }}
         path: ${{ env.BUILD_DIR }}\bin\Release\benchmark_result.json


### PR DESCRIPTION
* Update actions/upload-artifact in workflows

update deprecated instances of actions/upload-artifact to use latest version. v1 and v2 are no longer available.

cherry-pick of commit [3aff05c](https://github.com/CppMicroServices/CppMicroServices/commit/3aff05c5a71121164b773e59b3d9416a03312301) (PR #1042)

see discussion #701 