### PR TITLE
701 Allow for global namespacing in interface definitions and manifests (#1048))

### DIFF
--- a/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
+++ b/compendium/DeclarativeServices/src/metadata/MetadataParserImpl.cpp
@@ -38,6 +38,17 @@ namespace cppmicroservices
         namespace metadata
         {
 
+            std::string
+            removeLeadingNamespacing(std::string const& className)
+            {
+                auto ind = className.find_first_not_of(':');
+                if (ind == std::string::npos)
+                {
+                    return className;
+                }
+                return className.substr(ind);
+            }
+
             ServiceMetadata
             MetadataParserImplV1::CreateServiceMetadata(AnyMap const& metadata) const
             {
@@ -49,8 +60,9 @@ namespace cppmicroservices
                 std::transform(std::begin(interfaces),
                                std::end(interfaces),
                                std::back_inserter(serviceMetadata.interfaces),
-                               [](auto const& interface)
-                               { return ObjectValidator(interface).GetValue<std::string>(); });
+                               [](auto const& interface) {
+                                   return removeLeadingNamespacing(ObjectValidator(interface).GetValue<std::string>());
+                               });
 
                 // service.scope
                 auto const object = ObjectValidator(metadata, "scope", /*isOptional=*/true);
@@ -67,7 +79,7 @@ namespace cppmicroservices
 
                 // reference.interface (Mandatory)
                 ObjectValidator(metadata, "interface").AssignValueTo(refMetadata.interfaceName);
-
+                refMetadata.interfaceName = removeLeadingNamespacing(refMetadata.interfaceName);
                 // reference.name (Mandatory)
                 ObjectValidator(metadata, "name").AssignValueTo(refMetadata.name);
 
@@ -271,5 +283,5 @@ namespace cppmicroservices
             }
 
         } // namespace metadata
-    }     // namespace scrimpl
+    } // namespace scrimpl
 } // namespace cppmicroservices

--- a/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestComponentConfigurationImpl.cpp
@@ -742,7 +742,7 @@ namespace cppmicroservices
                 EXPECT_CALL(*mockFactory, GetService(testing::_, testing::_))
                     .Times(1)
                     .WillRepeatedly(testing::Invoke(
-                        [&](const cppmicroservices::Bundle& b, const cppmicroservices::ServiceRegistrationBase&)
+                        [&](cppmicroservices::Bundle const& b, cppmicroservices::ServiceRegistrationBase const&)
                         {
                             fakeCompConfig->Activate(b);
                             return instanceMap;

--- a/compendium/DeclarativeServices/test/gtest/TestMetadataParserImplV1.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestMetadataParserImplV1.cpp
@@ -168,6 +168,23 @@ namespace
         ASSERT_EQ(component->implClassName, "Foo::Impl2");
     }
 
+    TEST_F(MetadataParserImplV1Test, ParseValidManifestWithGlobalNamespacing)
+    {
+        auto metadataparser = MetadataParserFactory::Create(1, GetLogger());
+        auto components
+            = metadataparser->ParseAndGetComponentsMetadata(ManifestHelper::GetTestManifest("valid_manifest_with_global_namespacing"));
+        auto const component = components[0];
+        ASSERT_EQ(component->activateMethodName, std::string("Activate"));
+        ASSERT_EQ(component->deactivateMethodName, std::string("Deactivate"));
+        ASSERT_EQ(component->modifiedMethodName, std::string("Modified"));
+        ASSERT_EQ(component->immediate, false);
+        ASSERT_EQ(component->enabled, true);
+        ASSERT_EQ(component->name, "DSSpellCheck::SpellCheckImpl");
+        ASSERT_EQ(component->implClassName, "DSSpellCheck::SpellCheckImpl");
+        ASSERT_THAT(component->properties, ::testing::SizeIs(0));
+    }
+
+
     // For the SCR map specified in "scr", we expect the exception message
     // output by the Metadata Parser to be exactly errorOutput.
     // Instead, if we expect the errorOutput to be contained in the generated error message,

--- a/compendium/DeclarativeServices/test/gtest/manifest.json
+++ b/compendium/DeclarativeServices/test/gtest/manifest.json
@@ -60,6 +60,22 @@
                 }]
             }
         },
+        "valid_manifest_with_global_namespacing": {
+            "scr": {
+                "version": 1,
+                "components": [{
+                    "implementation-class": "DSSpellCheck::SpellCheckImpl",
+                    "service": {
+                        "scope": "singleton",
+                        "interfaces": ["::SpellCheck::ISpellCheckService"]
+                    },
+                    "references": [{
+                        "name": "dictionary",
+                        "interface": "::DictionaryService::IDictionaryService"
+                    }]
+                }]
+            }
+        },
         "manifest_dyn": {
             "scr": {
                 "version": 1,

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -36,6 +36,17 @@
 namespace cppmicroservices
 {
 
+    std::string
+    removeLeadingNamespacing(std::string const& className)
+    {
+        auto ind = className.find_first_not_of(':');
+        if (ind == std::string::npos)
+        {
+            return className;
+        }
+        return className.substr(ind);
+    }
+
     void
     ServiceRegistry::Clear()
     {
@@ -93,10 +104,10 @@ namespace cppmicroservices
 
         // Check if we got a service factory
         bool isFactory = service->count("org.cppmicroservices.factory") > 0;
-        bool isPrototypeFactory
-            = (isFactory ? static_cast<bool>(std::dynamic_pointer_cast<PrototypeServiceFactory>(
-                   std::static_pointer_cast<ServiceFactory>(service->find("org.cppmicroservices.factory")->second)))
-                         : false);
+        bool isPrototypeFactory = (isFactory ? static_cast<bool>(std::dynamic_pointer_cast<PrototypeServiceFactory>(
+                                                   std::static_pointer_cast<ServiceFactory>(
+                                                       service->find("org.cppmicroservices.factory")->second)))
+                                             : false);
 
         std::vector<std::string> classes;
         // Check if service implements claimed classes and that they exist.
@@ -106,7 +117,7 @@ namespace cppmicroservices
             {
                 throw std::invalid_argument("Can't register as null class");
             }
-            classes.push_back(i.first);
+            classes.push_back(removeLeadingNamespacing(i.first));
         }
 
         ServiceRegistrationBase res(bundle,
@@ -148,7 +159,7 @@ namespace cppmicroservices
     void
     ServiceRegistry::Get(std::string const& clazz, std::vector<ServiceRegistrationBase>& serviceRegs) const
     {
-        this->Lock(), Get_unlocked(clazz, serviceRegs);
+        this->Lock(), Get_unlocked(removeLeadingNamespacing(clazz), serviceRegs);
     }
 
     void
@@ -169,7 +180,7 @@ namespace cppmicroservices
         try
         {
             std::vector<ServiceReferenceBase> srs;
-            Get_unlocked(clazz, "", bundle, srs);
+            Get_unlocked(removeLeadingNamespacing(clazz), "", bundle, srs);
             DIAG_LOG(*core->sink) << "get service ref " << clazz << " for bundle " << bundle->symbolicName << " = "
                                   << srs.size() << " refs";
 
@@ -191,7 +202,7 @@ namespace cppmicroservices
                          BundlePrivate* bundle,
                          std::vector<ServiceReferenceBase>& res) const
     {
-        this->Lock(), Get_unlocked(clazz, filter, bundle, res);
+        this->Lock(), Get_unlocked(removeLeadingNamespacing(clazz), filter, bundle, res);
     }
 
     void

--- a/framework/test/gtest/ServiceRegistryTest.cpp
+++ b/framework/test/gtest/ServiceRegistryTest.cpp
@@ -79,7 +79,31 @@ TEST_F(ServiceRegistryTest, TestServiceInterfaceId)
 {
     ASSERT_EQ(us_service_interface_iid<int>(), "int");
     ASSERT_EQ(us_service_interface_iid<ITestServiceA>(), "ITestServiceA");
+    ASSERT_EQ(us_service_interface_iid<::ITestServiceA>(), "ITestServiceA");
     ASSERT_EQ(us_service_interface_iid<ITestServiceB>(), "com.mycompany.ITestService/1.0");
+}
+
+TEST_F(ServiceRegistryTest, TestGlobalNamespaceOnServiceRegistration)
+{
+    auto s1 = std::make_shared<TestServiceA>();
+
+    ServiceRegistration<ITestServiceA> reg1 = context.RegisterService<::ITestServiceA>(s1);
+
+    // Test for two registered ITestServiceA services
+    ServiceReference<ITestServiceA> ref = context.GetServiceReference("ITestServiceA");
+    ASSERT_TRUE(ref);
+
+    ref = context.GetServiceReference("::ITestServiceA");
+    ASSERT_TRUE(ref);
+
+    // Test for no ITestServiceA services
+    reg1.Unregister();
+    ref = context.GetServiceReference("::ITestServiceA");
+    ASSERT_FALSE(ref);
+
+    // Test for invalid service reference
+    ref = context.GetServiceReference<ITestServiceA>();
+    ASSERT_FALSE(ref);
 }
 
 TEST_F(ServiceRegistryTest, TestMultipleServiceRegistrations)


### PR DESCRIPTION
* first commit figuring out what DOESN'T work
* tests passing
* remove superfluous cout
* update to ensure no segfault
* create a bundle exclusively for fragile test
* no need for new bundle
* compartmentalize tests
* remove superfluous test
---------

cherry-pick of commit [be6d700](https://github.com/CppMicroServices/CppMicroServices/commit/be6d700ac3bb187bba9ce4e6a99038590ec03730) (PR #1048)

see discussion #701