### PR TITLE
701 Turn off clang-tidy 'modernize-use-trailing-return-type' (#992)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
+Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*,-modernize-use-trailing-return-type'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     file


### PR DESCRIPTION
cherry-pick of commit [de4ca54](https://github.com/CppMicroServices/CppMicroServices/commit/de4ca54b09f4c4382f064bef1d5f6a49bf3623f6) (PR #992)

see discussion #701