### PR TITLE
701 [ci skip] Update clang tidy github actions (#1051)

### DIFF
--- a/.github/workflows/clang_tidy_diff_review.yml
+++ b/.github/workflows/clang_tidy_diff_review.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout submodules
       run: git submodule update --init --recursive
 
-    - uses: ZedThree/clang-tidy-review@v0.14.0
+    - uses: ZedThree/clang-tidy-review@v0.20.1
       id: review
       with:
         split_workflow: true
@@ -31,7 +31,7 @@ jobs:
           cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
           
     # Uploads an artefact containing clang_fixes.json
-    - uses: ZedThree/clang-tidy-review/upload@v0.14.0
+    - uses: ZedThree/clang-tidy-review/upload@v0.20.1
       id: upload-review
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0

--- a/.github/workflows/clang_tidy_post_diff_review_comments.yml
+++ b/.github/workflows/clang_tidy_post_diff_review_comments.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.14.0
+      - uses: ZedThree/clang-tidy-review/post@v0.20.1
         # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
           # adjust options as necessary


### PR DESCRIPTION
[ci skip] Update ZedThree/clang-tidy-review to latest version

cherry-pick of commit [c11980f](https://github.com/CppMicroServices/CppMicroServices/commit/c11980ff777f9b058d8b49e2c7eba9c4b6a5e53a) (PR #1051)

see discussion #701