### PR TITLE
701 fix #1163

### DIFF
--- a/compendium/LogService/include/cppmicroservices/logservice/Logger.hpp
+++ b/compendium/LogService/include/cppmicroservices/logservice/Logger.hpp
@@ -8,7 +8,9 @@
 #include <functional>
 #include <string>
 
-namespace cppmicroservices::logservice
+namespace cppmicroservices
+{
+namespace logservice
 {
     /**
      \defgroup gr_logservice Logger
@@ -315,6 +317,7 @@ namespace cppmicroservices::logservice
          */
         virtual void warn(std::string const& message, ServiceReferenceBase const& sr, const std::exception_ptr ex) = 0;
     };
-} // namespace cppmicroservices::logservice
+} // namespace logservice
+} // namespace cppmicroservices
 
 #endif // CPPMICROSERVICES_LOG_SERVICE_H__

--- a/compendium/LogServiceImpl/src/LogServiceImpl.cpp
+++ b/compendium/LogServiceImpl/src/LogServiceImpl.cpp
@@ -9,7 +9,9 @@
 #include "LoggerFactoryImpl.hpp"
 #include "LoggerImpl.hpp"
 
-namespace cppmicroservices::logservice
+namespace cppmicroservices
+{
+namespace logservice
 {     
         LogServiceImpl::LogServiceImpl(std::string const& loggerName)
         {
@@ -94,4 +96,5 @@ namespace cppmicroservices::logservice
 	    std::shared_ptr<LoggerImpl> logimpl = std::dynamic_pointer_cast<LoggerImpl>(currLogger);
             logimpl->AddSink(sink);
         }
-} // namespace cppmicroservices::logservice
+} // namespace logservice
+} // namespace cppmicroservices

--- a/compendium/LogServiceImpl/src/LoggerFactoryImpl.hpp
+++ b/compendium/LogServiceImpl/src/LoggerFactoryImpl.hpp
@@ -1,7 +1,9 @@
 #include "cppmicroservices/logservice/LoggerFactory.hpp"
 #include <mutex>
 
-namespace cppmicroservices::logservice
+namespace cppmicroservices
+{
+namespace logservice
 {
         class LoggerFactoryImpl final : public LoggerFactory
         {
@@ -28,4 +30,5 @@ namespace cppmicroservices::logservice
 	  private:
 	      mutable std::mutex mutex; // Mutex for synchronization
         };
-} // namespace cppmicroservices::logservice
+} // namespace logservice
+} // namespace cppmicroservices

--- a/compendium/LogServiceImpl/src/LoggerImpl.cpp
+++ b/compendium/LogServiceImpl/src/LoggerImpl.cpp
@@ -7,7 +7,9 @@
 
 #include "LoggerImpl.hpp"
 
-namespace cppmicroservices::logservice
+namespace cppmicroservices
+{
+namespace logservice
 {
         inline std::string
         GetExceptionMessage(std::exception_ptr const& ex)
@@ -308,4 +310,5 @@ namespace cppmicroservices::logservice
             m_Logger->sinks().push_back(sink);
         }
 
-} // namespace cppmicroservices::logservice
+} // namespace logservice
+} // namespace cppmicroservices

--- a/compendium/LogServiceImpl/src/LoggerImpl.hpp
+++ b/compendium/LogServiceImpl/src/LoggerImpl.hpp
@@ -12,7 +12,9 @@ namespace spdlog
     using sink_ptr = std::shared_ptr<sinks::sink>;
 } // namespace spdlog
 
-namespace cppmicroservices::logservice
+namespace cppmicroservices
+{
+namespace logservice
 {
 
         class LoggerImpl final : public Logger
@@ -98,4 +100,5 @@ namespace cppmicroservices::logservice
             private:
                 std::shared_ptr<::spdlog::logger> m_Logger;
         };
-} // namespace cppmicroservices::logservice
+} // namespace logservice
+} // namespace cppmicroservices


### PR DESCRIPTION
With #1163 the original PR #1109 has been cherry-picked to branch c++14-compliant.
Unfortunately some changes are not conform to C++14 standard:

"nested namespace definition is a C++17 extension; define each namespace separately [clang-diagnostic-c++17-extensions]"