### PR TITLE
701 fix #1061 and #1062 for C++14

### DIFF
--- a/compendium/ConfigurationAdmin/src/SingleInvokeTask.hpp
+++ b/compendium/ConfigurationAdmin/src/SingleInvokeTask.hpp
@@ -36,7 +36,9 @@ DEALINGS IN THE SOFTWARE.
 #include <future>
 #include <mutex>
 
-namespace cppmicroservices::cmimpl
+namespace cppmicroservices
+{
+namespace cmimpl
 {
     using PostTask = std::packaged_task<void()>;
     class SingleInvokeTask
@@ -75,6 +77,7 @@ namespace cppmicroservices::cmimpl
         bool executed = false;
         std::shared_ptr<PostTask> task;
     };
-} // namespace cppmicroservices::cmimpl
+} // namespace cmimpl
+} // namespace cppmicroservices
 
 #endif // CPPMICROSERVICES_SINGLEINVOKETASK_H

--- a/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.cpp
+++ b/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.cpp
@@ -24,7 +24,9 @@
 #include <chrono>
 #include <future>
 
-namespace cppmicroservices::cmimpl
+namespace cppmicroservices
+{
+namespace cmimpl
 {
     ThreadpoolSafeFuturePrivate::ThreadpoolSafeFuturePrivate(std::shared_future<void> future,
                                                              std::shared_ptr<SingleInvokeTask> task)
@@ -59,4 +61,5 @@ namespace cppmicroservices::cmimpl
         return future.wait_for(std::chrono::milliseconds(timeout_duration_ms));
     }
 
-} // namespace cppmicroservices::cmimpl
+} // namespace cmimpl
+} // namespace cppmicroservices

--- a/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.hpp
+++ b/compendium/ConfigurationAdmin/src/ThreadpoolSafeFuturePrivate.hpp
@@ -38,7 +38,9 @@ DEALINGS IN THE SOFTWARE.
 
 #include <future>
 
-namespace cppmicroservices::cmimpl
+namespace cppmicroservices
+{
+namespace cmimpl
 {
     class ThreadpoolSafeFuturePrivate : public cppmicroservices::ThreadpoolSafeFuture
     {
@@ -69,6 +71,7 @@ namespace cppmicroservices::cmimpl
         std::shared_future<void> future;
         std::shared_ptr<SingleInvokeTask> task;
     };
-} // namespace cppmicroservices::cmimpl
+} // namespace cmimpl
+} // namespace cppmicroservices
 
 #endif // CPPMICROSERVICES_THREADPOOLSAFEFUTUREPRIVATE_H

--- a/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentConfigurationImpl.hpp
@@ -45,7 +45,9 @@
 using cppmicroservices::scrimpl::ReferenceManager;
 using cppmicroservices::service::component::detail::ComponentInstance;
 
-namespace cppmicroservices::scrimpl
+namespace cppmicroservices
+{
+    namespace scrimpl
     {
        class SCRExtensionRegistry;
 
@@ -435,5 +437,6 @@ namespace cppmicroservices::scrimpl
                 deleteCompInstanceFunc; ///< extern C function to delete an instance of the {@link ComponentInstance}
                                         ///< class from the component's bundle
         };
-    } // namespace cppmicroservices::scrimpl
+    } // namespace scrimpl
+} // namespace cppmicroservices
 #endif /* COMPONENTCONFIGURATIONIMPL_HPP__ */

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -33,7 +33,9 @@
 #include "cppmicroservices/cm/ConfigurationAdmin.hpp"
 
 
-namespace cppmicroservices::scrimpl
+namespace cppmicroservices
+{
+    namespace scrimpl
     {
         using cppmicroservices::scrimpl::metadata::ComponentMetadata;
 
@@ -138,4 +140,5 @@ namespace cppmicroservices::scrimpl
         }
 
  
-    } // namespace cppmicroservices::scrimpl
+    } // namespace scrimpl
+} // namespace cppmicroservices

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.hpp
@@ -27,7 +27,9 @@
 #include "cppmicroservices/asyncworkservice/AsyncWorkService.hpp"
 #include "cppmicroservices/cm/ConfigurationListener.hpp"
 
-namespace cppmicroservices::scrimpl {
+namespace cppmicroservices
+{
+namespace scrimpl {
     class SCRExtensionRegistry;
     class ComponentConfigurationImpl;
     class ComponentFactoryImpl final
@@ -67,5 +69,6 @@ namespace cppmicroservices::scrimpl {
          std::shared_ptr<SCRExtensionRegistry> extensionRegistry;
     };
 
-} // cppmicroservices::scrimpl namespace 
+} // scrimpl namespace
+} // cppmicroservices namespace
 #endif //__CPPMICROSERVICES_SCRIMPL_COMPONENTFACTORYIMPL_HPP__


### PR DESCRIPTION
With #1161 and #1162 the original PRs #977 and #1019 has been cherry-picked to branch c++14-compliant.
Unfortunately some changes are not conform to C++14 standard:

"nested namespace definition is a C++17 extension; define each namespace separately [clang-diagnostic-c++17-extensions]"