### PR TITLE
701 Fixed uninitialized vars warnings (#978)

### DIFF
--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/BundleDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/BundleDTO.hpp
@@ -51,21 +51,21 @@ namespace cppmicroservices
                  *
                  * @see Bundle#GetBundleId()
                  */
-                unsigned long id;
+                unsigned long id = 0;
 
                 /**
                  * The time when the bundle was last modified.
                  *
                  * @see Bundle#GetLastModified()
                  */
-                unsigned long lastModified;
+                unsigned long lastModified = 0;
 
                 /**
                  * The bundle's state.
                  *
                  * @see Bundle#GetState()
                  */
-                uint32_t state;
+                uint32_t state = 0;
 
                 /**
                  * The bundle's symbolic name.

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentConfigurationDTO.hpp
@@ -96,7 +96,7 @@ namespace cppmicroservices
                          * {@link #ComponentState::UNSATISFIED_REFERENCE}, {@link #ComponentState::SATISFIED} or {@link
                          * #ComponentState::ACTIVE}.
                          */
-                        ComponentState state;
+                        ComponentState state = ComponentState::UNSATISFIED_REFERENCE;
 
                         /**
                          * The id of the component configuration.
@@ -107,7 +107,7 @@ namespace cppmicroservices
                          * of this field is unspecified if the state of this component configuration
                          * is unsatisfied.
                          */
-                        unsigned long id;
+                        unsigned long id = 0;
 
                         /**
                          * The component properties for the component configuration.

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ComponentDescriptionDTO.hpp
@@ -95,7 +95,7 @@ namespace cppmicroservices
                          * This is declared in the \c enabled attribute of the
                          * \c component element.
                          */
-                        bool defaultEnabled;
+                        bool defaultEnabled = false;
 
                         /**
                          * The immediate state.
@@ -104,7 +104,7 @@ namespace cppmicroservices
                          * This is declared in the \c immediate attribute of the
                          * \c component element.
                          */
-                        bool immediate;
+                        bool immediate = false;
 
                         /**
                          * The fully qualified names of the service interfaces.

--- a/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ServiceReferenceDTO.hpp
+++ b/compendium/ServiceComponent/include/cppmicroservices/servicecomponent/runtime/dto/ServiceReferenceDTO.hpp
@@ -54,14 +54,14 @@ namespace cppmicroservices
                  *
                  * @see Constants#SERVICE_ID
                  */
-                unsigned long id;
+                unsigned long id = 0;
 
                 /**
                  * The id of the bundle that registered the service.
                  *
                  * @see ServiceReference#GetBundle()
                  */
-                unsigned long bundle;
+                unsigned long bundle = 0;
 
                 /**
                  * The properties for the service.

--- a/compendium/tools/SCRCodeGen/ComponentInfo.hpp
+++ b/compendium/tools/SCRCodeGen/ComponentInfo.hpp
@@ -52,7 +52,7 @@ namespace codegen
             std::string name;
             std::string implClassName;
             std::string configurationPolicy;
-            bool injectReferences;
+            bool injectReferences = false;
             ServiceInfo service;
             std::vector<ReferenceInfo> references;
             static const std::string CONFIG_POLICY_IGNORE;


### PR DESCRIPTION
Fixes #976

cherry-pick of commit [a5aeadd](https://github.com/CppMicroServices/CppMicroServices/commit/a5aeadd4ffb7e83e7bade4268dc17176d15d1208) (PR #978)

see discussion #701