### PR TITLE
701 Attempt to resolve a valgrind issue (#1066)

### DIFF
--- a/compendium/DeclarativeServices/test/TestUtils.cpp
+++ b/compendium/DeclarativeServices/test/TestUtils.cpp
@@ -281,23 +281,11 @@ namespace test
 
     AsyncWorkServiceThreadPool::~AsyncWorkServiceThreadPool()
     {
-        try
+        if (threadpool)
         {
-            if (threadpool)
-            {
-                try
-                {
-                    threadpool->join();
-                }
-                catch (...)
-                {
-                    //
-                }
-            }
-        }
-        catch (...)
-        {
-            //
+            threadpool->join();
+            threadpool->stop();
+            threadpool.reset();
         }
     }
 

--- a/compendium/DeclarativeServices/test/TestUtils.hpp
+++ b/compendium/DeclarativeServices/test/TestUtils.hpp
@@ -107,6 +107,10 @@ namespace test
      */
     bool isBundleLoadedInThisProcess(std::string bundleName);
 
+    /**
+     * Implementation of AsyncWorkService that uses a boost::asio::thread_pool
+     * to execute asynchronous tasks.
+     */
     class AsyncWorkServiceThreadPool : public cppmicroservices::async::AsyncWorkService
     {
       public:

--- a/compendium/DeclarativeServices/test/gtest/TestAsyncWorkService.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestAsyncWorkService.cpp
@@ -432,7 +432,6 @@ namespace test
 
         // ASYNCWORKSERVICE
         auto reg = context.RegisterService<cppmicroservices::async::AsyncWorkService>(param);
-        US_UNUSED(reg);
 
         // CA
         ::test::InstallAndStartConfigAdmin(context);
@@ -466,6 +465,8 @@ namespace test
         auto serviceRef = context.GetServiceReference<test::CAInterface>();
         auto service = context.GetService<test::CAInterface>(serviceRef);
         ASSERT_TRUE(service) << "GetService failed for CAInterface";
+
+        ASSERT_NO_THROW(reg.Unregister());
     }
 
 }; // namespace test


### PR DESCRIPTION
trying to resolve this valgrind reported issue:

26: ==24460==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
26: ==24460==    by 0x40147D9: calloc (rtld-malloc.h:44)
26: ==24460==    by 0x40147D9: allocate_dtv (dl-tls.c:375)
26: ==24460==    by 0x40147D9: _dl_allocate_tls (dl-tls.c:634)
26: ==24460==    by 0x4E5B7B4: allocate_stack (allocatestack.c:430)
26: ==24460==    by 0x4E5B7B4: pthread_create@@GLIBC_2.34 (pthread_create.c:647)
26: ==24460==    by 0x91D5EE: boost::asio::thread_pool::thread_pool(unsigned long) (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/bin/usDeclarativeServicesTests)
26: ==24460==    by 0x916EDF: test::AsyncWorkServiceThreadPool::AsyncWorkServiceThreadPool(int) (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/bin/usDeclarativeServicesTests)
26: ==24460==    by 0x53FCF9: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<test::AsyncWorkServiceThreadPool, std::allocator<test::AsyncWorkServiceThreadPool>, int>(test::AsyncWorkServiceThreadPool*&, std::_Sp_alloc_shared_tag<std::allocator<test::AsyncWorkServiceThreadPool> >, int&&) (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/bin/usDeclarativeServicesTests)
26: ==24460==    by 0x52906B: test::TestAsyncWorkServiceEndToEnd_testUpdateConfigFromWithinModifiedCallback_Test::TestBody() (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/bin/usDeclarativeServicesTests)
26: ==24460==    by 0x491AEC0: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/lib/libgtest.so.1.14.0)
26: ==24460==    by 0x48FB4E5: testing::Test::Run() (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/lib/libgtest.so.1.14.0)
26: ==24460==    by 0x48FB6A4: testing::TestInfo::Run() (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/lib/libgtest.so.1.14.0)
26: ==24460==    by 0x48FB868: testing::TestSuite::Run() (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/lib/libgtest.so.1.14.0)
26: ==24460==    by 0x491015E: testing::internal::UnitTestImpl::RunAllTests() (in /home/runner/work/CppMicroServices/CppMicroServices/build_0/lib/libgtest.so.1.14.0)

cherry-pick of commit [136ca8d](https://github.com/CppMicroServices/CppMicroServices/commit/136ca8d6c7636a4a7e5f897f757e111b1ec384b1) (PR #1066)

see discussion #701