### PR TITLE
701 Bundle Start after Framework Stop race fix (#990)

### DIFF
--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -160,7 +160,6 @@ namespace cppmicroservices
     {
         auto l = Lock();
         US_UNUSED(l);
-        auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
         bool wasActive = false;
         switch (static_cast<Bundle::State>(state.load()))
         {
@@ -305,7 +304,10 @@ namespace cppmicroservices
             {
                 StopAllBundles();
             }
-            coreCtx->Uninit0();
+            {
+                auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
+                coreCtx->Uninit0();
+            }
             {
                 auto l = Lock();
                 US_UNUSED(l);


### PR DESCRIPTION
cherry-pick of commit [fb6628a](https://github.com/CppMicroServices/CppMicroServices/commit/fb6628aefd1872652a2234de2c64f786a5eb8f32) (PR #990)

see discussion #701

With #1132 the same change set was already merged, but some dependent PR(s) were not merged yet, causing build failures. Thus this was reverted again with #1138. Now it is good to go