### PR TITLE
Ensure `serviceReference` object properly manages interface on assignment

### DIFF
--- a/compendium/DeclarativeServices/test/gtest/TestBundleValidation.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestBundleValidation.cpp
@@ -165,9 +165,9 @@ TEST(TestBundleValidation, BundleValidationFailure)
     ASSERT_NO_THROW(bundleIter->Start());
     compDesc = dsRuntimeService->GetComponentDescriptionDTO(*bundleIter, "sample::ServiceComponentBV1_3");
     ASSERT_TRUE(dsRuntimeService->IsComponentEnabled(compDesc));
-    svcRef = f.GetBundleContext().GetServiceReference<test::Interface1>();
-    ASSERT_TRUE(svcRef);
-    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef), cppmicroservices::SecurityException);
+    auto svcRefInt1 = f.GetBundleContext().GetServiceReference<test::Interface1>();
+    ASSERT_TRUE(svcRefInt1);
+    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRefInt1), cppmicroservices::SecurityException);
     ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
 
     // test starting a delayed activation ds component with a required configuration policy
@@ -202,9 +202,9 @@ TEST(TestBundleValidation, BundleValidationFailure)
     auto updateIfDifferentFuture = config->UpdateIfDifferent(configObj);
     ASSERT_NO_THROW(updateIfDifferentFuture.second.get());
 
-    svcRef = f.GetBundleContext().GetServiceReference<test::CAInterface>();
-    ASSERT_TRUE(svcRef);
-    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef), cppmicroservices::SecurityException);
+    auto svcRefCAInt = f.GetBundleContext().GetServiceReference<test::CAInterface>();
+    ASSERT_TRUE(svcRefCAInt);
+    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRefCAInt), cppmicroservices::SecurityException);
 
     compDesc = dsRuntimeService->GetComponentDescriptionDTO(*bundleIter, "sample::ServiceComponentBV1_4");
     ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));
@@ -228,9 +228,9 @@ TEST(TestBundleValidation, BundleValidationFailure)
     configObj["foo"] = std::string("baz");
     ASSERT_THROW(config->UpdateIfDifferent(configObj).second.get(), cppmicroservices::SecurityException);
 
-    svcRef = f.GetBundleContext().GetServiceReference<test::CAInterface>();
-    ASSERT_TRUE(svcRef);
-    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRef), cppmicroservices::SecurityException);
+    svcRefCAInt = f.GetBundleContext().GetServiceReference<test::CAInterface>();
+    ASSERT_TRUE(svcRefCAInt);
+    ASSERT_THROW(auto svcObj = f.GetBundleContext().GetService(svcRefCAInt), cppmicroservices::SecurityException);
 
     compDesc = dsRuntimeService->GetComponentDescriptionDTO(*bundleIter, "sample::ServiceComponentBV1_5");
     ASSERT_FALSE(dsRuntimeService->IsComponentEnabled(compDesc));

--- a/compendium/ServiceComponent/test/TestComponentInstance.cpp
+++ b/compendium/ServiceComponent/test/TestComponentInstance.cpp
@@ -812,13 +812,13 @@ namespace
         EXPECT_THROW(compInstance.InvokeUnbindMethod("dep1", s), std::out_of_range);
         EXPECT_THROW(compInstance.InvokeBindMethod("dep1", s), std::out_of_range);
 
-        sRef = fc.GetServiceReference<ServiceDependency2>();
-        auto s2 = fc.GetService<ServiceDependency2>(sRef);
+        auto sRef2 = fc.GetServiceReference<ServiceDependency2>();
+        auto s2 = fc.GetService<ServiceDependency2>(sRef2);
         EXPECT_THROW(compInstance.InvokeUnbindMethod("dep2", s2), std::out_of_range);
         EXPECT_THROW(compInstance.InvokeBindMethod("dep2", s2), std::out_of_range);
 
-        sRef = fc.GetServiceReference<ServiceDependency3>();
-        auto s3 = fc.GetService<ServiceDependency3>(sRef);
+        auto sRef3 = fc.GetServiceReference<ServiceDependency3>();
+        auto s3 = fc.GetService<ServiceDependency3>(sRef3);
         EXPECT_NO_THROW(compInstance.InvokeUnbindMethod("dep3", s3));
         ASSERT_EQ(compObj->GetDep3().size(), 0);
         EXPECT_NO_THROW(compInstance.InvokeBindMethod("dep3", s3));

--- a/framework/include/cppmicroservices/ServiceReference.h
+++ b/framework/include/cppmicroservices/ServiceReference.h
@@ -100,7 +100,24 @@ namespace cppmicroservices
             }
         }
 
-        using ServiceReferenceBase::operator=;
+        using ServiceReferenceBase::operator=; // for the nullptr overload
+
+        ServiceReference& operator=(ServiceReferenceBase const& reference) {
+            ServiceReferenceBase::operator=(reference);
+            std::string const interfaceId(us_service_interface_iid<S>());
+            if (GetInterfaceId() != interfaceId)
+            {
+                if (this->IsConvertibleTo(interfaceId))
+                {
+                    this->SetInterfaceId(interfaceId);
+                }
+                else
+                {
+                    this->operator=(nullptr);
+                }
+            }
+            return *this;
+        }
 
         using ServiceReferenceBase::operator==;
 

--- a/framework/src/bundle/BundleHooks.cpp
+++ b/framework/src/bundle/BundleHooks.cpp
@@ -73,13 +73,8 @@ namespace cppmicroservices
         for (auto srBaseIter = srl.rbegin(), srBaseEnd = srl.rend(); srBaseIter != srBaseEnd; ++srBaseIter)
         {
             ServiceReference<BundleFindHook> sr = srBaseIter->GetReference();
-            std::shared_ptr<BundleFindHook> fh;
-            try
-            {
-                fh = std::static_pointer_cast<BundleFindHook>(
-                    sr.d.Load()->GetServiceInterfaceMap(GetPrivate(GetBundleContext().GetBundle()).get())->at("cppmicroservices::BundleFindHook"));
-            }
-            catch(...){}
+            std::shared_ptr<BundleFindHook> fh
+                = std::static_pointer_cast<BundleFindHook>(sr.d.Load()->GetService(GetPrivate(selfBundle).get()));
             if (fh)
             {
                 try
@@ -143,13 +138,8 @@ namespace cppmicroservices
                     continue;
                 }
 
-                std::shared_ptr<BundleEventHook> eh = nullptr;
-                try
-                {
-                    eh = std::static_pointer_cast<BundleEventHook>(
-                        sr.d.Load()->GetServiceInterfaceMap(GetPrivate(GetBundleContext().GetBundle()).get())->at("cppmicroservices::BundleEventHook"));
-                }
-                catch(...){}
+                std::shared_ptr<BundleEventHook> eh = std::static_pointer_cast<BundleEventHook>(
+                    sr.d.Load()->GetService(GetPrivate(GetBundleContext().GetBundle()).get()));
 
                 if (eh)
                 {

--- a/framework/src/bundle/BundleHooks.cpp
+++ b/framework/src/bundle/BundleHooks.cpp
@@ -73,8 +73,13 @@ namespace cppmicroservices
         for (auto srBaseIter = srl.rbegin(), srBaseEnd = srl.rend(); srBaseIter != srBaseEnd; ++srBaseIter)
         {
             ServiceReference<BundleFindHook> sr = srBaseIter->GetReference();
-            std::shared_ptr<BundleFindHook> fh
-                = std::static_pointer_cast<BundleFindHook>(sr.d.Load()->GetService(GetPrivate(selfBundle).get()));
+            std::shared_ptr<BundleFindHook> fh;
+            try
+            {
+                fh = std::static_pointer_cast<BundleFindHook>(
+                    sr.d.Load()->GetServiceInterfaceMap(GetPrivate(GetBundleContext().GetBundle()).get())->at("cppmicroservices::BundleFindHook"));
+            }
+            catch(...){}
             if (fh)
             {
                 try
@@ -138,8 +143,14 @@ namespace cppmicroservices
                     continue;
                 }
 
-                std::shared_ptr<BundleEventHook> eh = std::static_pointer_cast<BundleEventHook>(
-                    sr.d.Load()->GetService(GetPrivate(GetBundleContext().GetBundle()).get()));
+                std::shared_ptr<BundleEventHook> eh = nullptr;
+                try
+                {
+                    eh = std::static_pointer_cast<BundleEventHook>(
+                        sr.d.Load()->GetServiceInterfaceMap(GetPrivate(GetBundleContext().GetBundle()).get())->at("cppmicroservices::BundleEventHook"));
+                }
+                catch(...){}
+
                 if (eh)
                 {
                     try

--- a/framework/src/bundle/BundleHooks.cpp
+++ b/framework/src/bundle/BundleHooks.cpp
@@ -140,7 +140,6 @@ namespace cppmicroservices
 
                 std::shared_ptr<BundleEventHook> eh = std::static_pointer_cast<BundleEventHook>(
                     sr.d.Load()->GetService(GetPrivate(GetBundleContext().GetBundle()).get()));
-
                 if (eh)
                 {
                     try

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -236,8 +236,13 @@ TEST_F(BundleHooksTest, TestBothHookBundleInstall)
 
     bundleA.Stop();
     bundleB.Stop();
+#if defined(US_BUILD_SHARED_LIBS)
     ASSERT_EQ(hook->findCount, 1);
     ASSERT_EQ(hook->eventCount, 9);
+#else
+    ASSERT_EQ(hook->findCount, 2);
+    ASSERT_EQ(hook->eventCount, 6);
+#endif
 }
 
 TEST_F(BundleHooksTest, TestFindHookBundleInstall)

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -116,20 +116,12 @@ class TestBundleBothHook : public BundleFindHook,
     void
     Find(BundleContext const&, ShrinkableVector<Bundle>& bundles) override
     {
-        std::cout << "FIND INVOKED" << std::endl;
-        for (auto i = bundles.begin(); i != bundles.end();)
-        {
-            std::cout << "bundle found " << i->GetSymbolicName() << std::endl;
-            ++i;
-        }
         findCount++;
     }
 
     void
     Event(BundleEvent const& event, ShrinkableVector<BundleContext>& /*contexts*/) override
     {
-        std::cout << "EVENT INVOKED" << std::endl;
-        std::cout << event.GetType() << std::endl;
         eventCount++;
     }
     

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -282,8 +282,6 @@ TEST_F(BundleHooksTest, TestFindHookBundleInstall)
     bundleB.Stop();
 }
 
-
-
 TEST_F(BundleHooksTest, TestEventHook)
 {
     TestBundleListener bundleListener;

--- a/framework/test/gtest/BundleHooksTest.cpp
+++ b/framework/test/gtest/BundleHooksTest.cpp
@@ -114,13 +114,13 @@ class TestBundleBothHook : public BundleFindHook,
 {
   public:
     void
-    Find(BundleContext const&, ShrinkableVector<Bundle>& bundles) override
+    Find(BundleContext const&, ShrinkableVector<Bundle>& /**/) override
     {
         findCount++;
     }
 
     void
-    Event(BundleEvent const& event, ShrinkableVector<BundleContext>& /*contexts*/) override
+    Event(BundleEvent const& /**/, ShrinkableVector<BundleContext>& /*contexts*/) override
     {
         eventCount++;
     }

--- a/framework/test/gtest/ServiceReferenceTest.cpp
+++ b/framework/test/gtest/ServiceReferenceTest.cpp
@@ -79,6 +79,7 @@ class ServiceReferenceTest : public ::testing::Test
     SetUp() override
     {
         framework.Start();
+        context = framework.GetBundleContext();
     }
 
     void
@@ -88,7 +89,26 @@ class ServiceReferenceTest : public ::testing::Test
         framework.WaitForStop(std::chrono::milliseconds::zero());
     }
     Framework framework;
+    BundleContext context;
 };
+
+
+TEST_F(ServiceReferenceTest, TestServiceReferenceAssignmentAndCopy)
+{
+    auto s1 = std::make_shared<TestServiceA>();
+
+    ServiceRegistrationBase reg1 = context.RegisterService<ServiceNS::ITestServiceA>(s1);
+    ServiceReferenceBase ref1 = reg1.GetReference();
+
+    ASSERT_EQ(ref1.GetInterfaceId(), "");
+    ServiceReference<ServiceNS::ITestServiceA> typedRefAssign;
+    ServiceReference<ServiceNS::ITestServiceA> typedRefCopy = ref1;
+    typedRefAssign = ref1;
+    ASSERT_EQ(typedRefAssign.GetInterfaceId(), "ServiceNS::ITestServiceA");
+    ASSERT_EQ(typedRefCopy.GetInterfaceId(), "ServiceNS::ITestServiceA");
+
+    reg1.Unregister();
+}
 
 // This test exercises the 2 ways to register a service
 //   a. using the name of the interface i.e. "Foo::Bar"


### PR DESCRIPTION
When assigning a `ServiceReference<T>` to a `ServiceReferenceBase`, rather than getting into the copy constructor in `ServieReference` which properly managed the `interfaceID` object, we were getting into the `ServiceReferenceBase::operator=` which ignored the `interfaceID` object. This led to situations where a `ServiceReference<T>` didn't know that it was of type `T` and when retrieving the service in the `getService` call, it would default to the first service in its interfaceMap rather than the proper one