### PR TITLE
Create custom error for invalid bundleContext

### DIFF
--- a/framework/include/CMakeLists.txt
+++ b/framework/include/CMakeLists.txt
@@ -50,6 +50,7 @@ set(_public_headers
   cppmicroservices/Bundle.h
   cppmicroservices/BundleActivator.h
   cppmicroservices/BundleContext.h
+  cppmicroservices/BundleContextException.h
   cppmicroservices/BundleEvent.h
   cppmicroservices/BundleEventHook.h
   cppmicroservices/BundleFindHook.h

--- a/framework/include/cppmicroservices/BundleContext.h
+++ b/framework/include/cppmicroservices/BundleContext.h
@@ -29,6 +29,7 @@
 #include "cppmicroservices/ListenerToken.h"
 #include "cppmicroservices/ServiceInterface.h"
 #include "cppmicroservices/ServiceRegistration.h"
+#include "cppmicroservices/BundleContextException.h"
 
 #include <memory>
 
@@ -651,7 +652,7 @@ namespace cppmicroservices
         {
             if (!d)
             {
-                throw std::runtime_error("The bundle context is no longer valid");
+                throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
             }
             return ServiceObjects<S>(d, reference);
         }

--- a/framework/include/cppmicroservices/BundleContextException.h
+++ b/framework/include/cppmicroservices/BundleContextException.h
@@ -1,0 +1,52 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=============================================================================*/
+
+#ifndef CPPMICROSERVICES_BUNDLECONTEXTEXCEPTION_H
+#define CPPMICROSERVICES_BUNDLECONTEXTEXCEPTION_H
+
+#include "cppmicroservices/Bundle.h"
+#include "cppmicroservices/FrameworkConfig.h"
+
+#include <stdexcept>
+
+// ignore warning c4275 per MS documentation
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4275)
+#endif
+
+namespace cppmicroservices
+{
+
+    class US_Framework_EXPORT BundleContextException final : public std::runtime_error
+    {
+      public:
+        explicit BundleContextException(std::string what);
+        ~BundleContextException() override;
+    };
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif
+} // namespace cppmicroservices
+
+#endif /* CPPMICROSERVICES_BUNDLECONTEXTEXCEPTION_H */

--- a/framework/src/CMakeLists.txt
+++ b/framework/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_srcs
   util/SecurityException.cpp
   util/SharedLibrary.cpp
   util/SharedLibraryException.cpp
+  util/BundleContextException.cpp
   util/Utils.cpp
   util/ServiceRegistrationLocks.cpp
   util/ThreadpoolSafeFuture.cpp

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -49,7 +49,7 @@ namespace cppmicroservices
             auto b = (d->Lock(), d->bundle.lock());
             if (!b)
             {
-                throw std::runtime_error("The bundle context is no longer valid");
+                throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
             }
 
             return b;
@@ -96,7 +96,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -111,7 +111,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -125,7 +125,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -139,14 +139,15 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
         auto b = GetAndCheckBundlePrivate(d);
 
         // if the requesting bundle is NOT the system bundle, filter
-        if (b->id != 0){
+        if (b->id != 0)
+        {
             return b->coreCtx->bundleHooks.FilterBundle(*this, MakeBundle(b->coreCtx->bundleRegistry.GetBundle(id)));
         }
         return MakeBundle(b->coreCtx->bundleRegistry.GetBundle(id));
@@ -157,7 +158,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -176,7 +177,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -188,7 +189,8 @@ namespace cppmicroservices
             bus.emplace_back(MakeBundle(bu));
         }
         // if the requesting bundle is NOT the system bundle, filter
-        if (b->id != 0){
+        if (b->id != 0)
+        {
             b->coreCtx->bundleHooks.FilterBundles(*this, bus);
         }
         return bus;
@@ -199,7 +201,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -213,7 +215,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -229,7 +231,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -249,7 +251,7 @@ namespace cppmicroservices
 
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -270,7 +272,7 @@ namespace cppmicroservices
 
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -287,7 +289,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -301,7 +303,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -315,7 +317,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -329,7 +331,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -343,7 +345,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -357,7 +359,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -371,7 +373,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -385,7 +387,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -399,7 +401,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -413,7 +415,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -427,7 +429,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -441,7 +443,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();
@@ -464,7 +466,7 @@ namespace cppmicroservices
     {
         if (!d)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
 
         d->CheckValid();

--- a/framework/src/bundle/BundleContextPrivate.cpp
+++ b/framework/src/bundle/BundleContextPrivate.cpp
@@ -77,7 +77,7 @@ namespace cppmicroservices
     {
         if (!valid)
         {
-            throw std::runtime_error("The bundle context is no longer valid");
+            throw cppmicroservices::BundleContextException("The bundle context is no longer valid");
         }
     }
 

--- a/framework/src/util/BundleContextException.cpp
+++ b/framework/src/util/BundleContextException.cpp
@@ -1,0 +1,34 @@
+/*=============================================================================
+
+  Library: CppMicroServices
+
+  Copyright (c) The CppMicroServices developers. See the COPYRIGHT
+  file at the top-level directory of this distribution and at
+  https://github.com/CppMicroServices/CppMicroServices/COPYRIGHT .
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=============================================================================*/
+
+#include "cppmicroservices/BundleContextException.h"
+
+namespace cppmicroservices
+{
+
+    BundleContextException::~BundleContextException() = default;
+
+    BundleContextException::BundleContextException(std::string msg)
+        : std::runtime_error(std::move(msg))
+    {
+    }
+} // namespace cppmicroservices


### PR DESCRIPTION
Create custom error for easy catch logic for invalid bundle Contexts. As this is a common occurrence, adding this functionality helps to clarify client code. 