### PR TITLE
Ensure that the `ComponentConfigurationImpl` is stopped and `referenceManager`s `stopTracking` before destruction

### DIFF
--- a/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
+++ b/compendium/DeclarativeServices/src/manager/states/CMEnabledState.cpp
@@ -101,7 +101,14 @@ namespace cppmicroservices
                 auto configs = std::move(configurations);
                 for (auto const& config : configs)
                 {
-                    config->Deactivate();
+                    try
+                    {
+                        config->Deactivate();
+                    }
+                    catch (...)
+                    {
+                        // do nothing, just make sure that the config is stopped
+                    }
                     config->Stop();
                 }
             }


### PR DESCRIPTION
We cannot reproduce this failure, but I believe that we are seeing `Deactivate` throw in the wild, and that causes the tracker to not stop in `referenceManager` until its destruction which causes callbacks to be made to the dying `referenceManager`. 