### PR TITLE
Fix issue with concurrent creation of `configuration`s to trigger `factoryInstance` and `bundle.stop`

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -179,10 +179,10 @@ namespace cppmicroservices::scrimpl
         {
             throw;
         }
-        catch (...)
+        catch (std::exception const& e)
         {
             logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
-                        "Failed to create ComponentManager with name " + newMetadata->name);
+                        "Failed to create ComponentManager with name " + newMetadata->name + ": " + e.what());
         }
     }
 

--- a/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ComponentFactoryImpl.cpp
@@ -179,6 +179,11 @@ namespace cppmicroservices::scrimpl
         {
             throw;
         }
+        catch (...)
+        {
+            logger->Log(cppmicroservices::logservice::SeverityLevel::LOG_ERROR,
+                        "Failed to create ComponentManager with name " + newMetadata->name);
+        }
     }
 
 } // namespace cppmicroservices::scrimpl

--- a/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestFactoryPid.cpp
@@ -212,8 +212,9 @@ namespace test
         EXPECT_EQ(instances.size(), count);
     }
 
-    /* test concurrentFactoryCreation.
+    /* test factory creation concurrent with bundle stop.
      * This test creates 100 factory objects concurrently
+     * while at the same time stopping their owning bundle
      */
     TEST_F(tServiceComponent, testConcurrentFactoryCreationAndBundleStop)
     {


### PR DESCRIPTION
This test failed ~100% of the time before the fix, with the ComponentManager throwing an uncaught exception because the `bundleContext` was bad in its constructor

I ran it 5000 times after and it didn't fail. That being said, this feels a bit like a bandaid. I made this issue: https://github.com/CppMicroServices/CppMicroServices/issues/1218 because I feel like there are a lot of places where we rely on `bundleId` to index data. And as soon as the bundle is no longer good, that indexing is no longer accessible. I feel like maybe `bundle` objects and `bundlePrivates` should maybe both own the same `std::shared_ptr<const long> id` and then the id is alive and is persistent for a given `bundle` object

Not that the above issue means this isn't a good patch, but I do think we maybe need to delve into the lifetime of the objects we use as keys in key-value structures