### PR TITLE
Update Mac github runners

### DIFF
--- a/.github/workflows/build_and_test_nix.yml
+++ b/.github/workflows/build_and_test_nix.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, macos-15]
         # build configurations:
         # 0 = threading ON / shared lib ON
         # 1 = threading ON / shared lib OFF


### PR DESCRIPTION
MACOS 13 runners are being deprecated. Updated to use 14 and 15