### PR TITLE
update serviceTracker code flow to eliminate extraneous throws

### DIFF
--- a/framework/include/cppmicroservices/ServiceTracker.h
+++ b/framework/include/cppmicroservices/ServiceTracker.h
@@ -242,7 +242,7 @@ namespace cppmicroservices
          * <p>
          * This implementation calls GetService() to determine if a service
          * is being tracked.
-         * 
+         *
          * @throws std::logic_error If the <code>BundleContext</code>
          *         with which this <code>ServiceTracker</code> was created is no
          *         longer valid or became invalid while waiting on Service.
@@ -480,12 +480,15 @@ namespace cppmicroservices
       private:
         /**
          * Internal method to retrieve a reference following same rules for retrieval
-         * as exported <code>GetServiceReference</code> method
+         * as exported <code>GetServiceReference</code> method, except that if no service is tracked,
+         * we return a default <code>ServiceReference</code> rather than throw.
          *
          * @return A <code>ServiceReference</code> for a tracked service.
-         * @note If no services are being tracked, a default <code>ServiceReference</code> is returned
+         * @note If no services are being tracked, a default <code>ServiceReference</code> is returned.
+         * This is needed as throwing to control code flow in <code>GetService</code> causes performance
+         * bottlenecks
          */
-        virtual ServiceReference<S> GetServiceReference_internal() const;
+        virtual ServiceReference<S> GetServiceReference_internal() const noexcept;
 
         using TypeTraits = typename ServiceTrackerCustomizer<S, T>::TypeTraits;
 

--- a/framework/include/cppmicroservices/ServiceTracker.h
+++ b/framework/include/cppmicroservices/ServiceTracker.h
@@ -478,6 +478,15 @@ namespace cppmicroservices
                             std::shared_ptr<TrackedParamType> const& service) override;
 
       private:
+        /**
+         * Internal method to retrieve a reference following same rules for retrieval
+         * as exported <code>GetServiceReference</code> method
+         *
+         * @return A <code>ServiceReference</code> for a tracked service.
+         * @note If no services are being tracked, a default <code>ServiceReference</code> is returned
+         */
+        virtual ServiceReference<S> GetServiceReference_internal() const;
+
         using TypeTraits = typename ServiceTrackerCustomizer<S, T>::TypeTraits;
 
         using _ServiceTracker = ServiceTracker<S, T>;

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -331,7 +331,7 @@ namespace cppmicroservices
 
     template <class S, class T>
     ServiceReference<S>
-    ServiceTracker<S, T>::GetServiceReference_internal() const
+    ServiceTracker<S, T>::GetServiceReference_internal() const noexcept
     {
         ServiceReference<S> reference = d->cachedReference.Load();
         if (reference.GetBundle())

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -331,7 +331,7 @@ namespace cppmicroservices
         std::size_t length = references.size();
         if (length == 0)
         { /* if no service is being tracked */
-            throw ServiceException("No service is being tracked");
+            return ServiceReference<S>();
         }
         auto selectedRef = references.begin();
         if (length > 1)
@@ -442,21 +442,14 @@ namespace cppmicroservices
             return service;
         }
 
-        try
-        {
-            auto reference = GetServiceReference();
-            if (!reference.GetBundle())
-            {
-                return std::shared_ptr<TrackedParamType>();
-            }
-            service = GetService(reference);
-            d->cachedService.Store(service);
-            return service;
-        }
-        catch (ServiceException const&)
+        auto reference = GetServiceReference();
+        if (!reference || !reference.GetBundle())
         {
             return std::shared_ptr<TrackedParamType>();
         }
+        service = GetService(reference);
+        d->cachedService.Store(service);
+        return service;
     }
 
     template <class S, class T>

--- a/framework/include/cppmicroservices/detail/ServiceTracker.hpp
+++ b/framework/include/cppmicroservices/detail/ServiceTracker.hpp
@@ -322,6 +322,17 @@ namespace cppmicroservices
     ServiceReference<S>
     ServiceTracker<S, T>::GetServiceReference() const
     {
+        auto ref = GetServiceReference_internal();
+        if (!ref){
+            throw ServiceException("No service is being tracked");
+        }
+        return ref;
+    }
+
+    template <class S, class T>
+    ServiceReference<S>
+    ServiceTracker<S, T>::GetServiceReference_internal() const
+    {
         ServiceReference<S> reference = d->cachedReference.Load();
         if (reference.GetBundle())
         {
@@ -442,7 +453,7 @@ namespace cppmicroservices
             return service;
         }
 
-        auto reference = GetServiceReference();
+        auto reference = GetServiceReference_internal();
         if (!reference || !reference.GetBundle())
         {
             return std::shared_ptr<TrackedParamType>();


### PR DESCRIPTION
This causes hotspots in profiling code. Using an invalid `ServiceReference` instead is faster and cleaner. 