### PR TITLE
Fix TSan reported data race and remove legacy GCC checks

### DIFF
--- a/framework/src/service/ServiceListenerHookPrivate.h
+++ b/framework/src/service/ServiceListenerHookPrivate.h
@@ -27,6 +27,8 @@
 
 #include "ServiceListenerEntry.h"
 
+#include <atomimc>
+
 namespace cppmicroservices
 {
 

--- a/framework/src/service/ServiceListenerHookPrivate.h
+++ b/framework/src/service/ServiceListenerHookPrivate.h
@@ -46,7 +46,7 @@ namespace cppmicroservices
         void* data;
         ListenerTokenId tokenId;
         std::string filter;
-        bool bRemoved;
+        std::atomic_bool bRemoved;
     };
 } // namespace cppmicroservices
 

--- a/framework/src/service/ServiceListenerHookPrivate.h
+++ b/framework/src/service/ServiceListenerHookPrivate.h
@@ -27,7 +27,7 @@
 
 #include "ServiceListenerEntry.h"
 
-#include <atomimc>
+#include <atomic>
 
 namespace cppmicroservices
 {

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -52,18 +52,6 @@ using cppmicroservices::testing::GetTempDirectory;
 using cppmicroservices::testing::MakeUniqueTempDirectory;
 using cppmicroservices::testing::TempDir;
 
-#if !defined(__clang__) && defined(__GNUC__)
-#    define US_GCC_VER (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
-
-// TODO: Remove all occurences of US_TYPE_OPERATIONS_AVAILABLE macro
-// once the minimum GCC compiler required is 4.7 or above
-#if defined(US_GCC_VER) && (US_GCC_VER < 40700)
-#    define US_TYPE_OPERATIONS_AVAILABLE 0
-#else
-#    define US_TYPE_OPERATIONS_AVAILABLE 1
-#endif
-
 US_MSVC_PUSH_DISABLE_WARNING(4996)
 
 namespace
@@ -97,10 +85,9 @@ namespace
 
 TEST(FrameworkTest, Ctor)
 {
-#if US_TYPE_OPERATIONS_AVAILABLE
     ASSERT_FALSE(std::is_default_constructible<Framework>::value);
     ASSERT_TRUE((std::is_constructible<Framework, Bundle>::value));
-#endif
+
     // Bundle b;
     // ASSERT_THROW(Framework(Bundle(b)), std::logic_error); This causes a crash. TODO: Fix crash and uncomment this
     // line.
@@ -118,9 +105,8 @@ TEST(FrameworkTest, Ctor)
 
 TEST(FrameworkTest, MoveCtor)
 {
-#if US_TYPE_OPERATIONS_AVAILABLE
     ASSERT_TRUE(std::is_move_constructible<Framework>::value);
-#endif
+
     auto f = FrameworkFactory().NewFramework();
     ASSERT_TRUE(f);
     f.Start();
@@ -131,9 +117,8 @@ TEST(FrameworkTest, MoveCtor)
 
 TEST(FrameworkTest, MoveAssign)
 {
-#if US_TYPE_OPERATIONS_AVAILABLE
     ASSERT_TRUE(std::is_move_assignable<Framework>::value);
-#endif
+
     auto f = FrameworkFactory().NewFramework();
     ASSERT_TRUE(f);
     f.Start();
@@ -147,9 +132,8 @@ TEST(FrameworkTest, MoveAssign)
 
 TEST(FrameworkTest, CopyCtor)
 {
-#if US_TYPE_OPERATIONS_AVAILABLE
     ASSERT_TRUE(std::is_copy_constructible<Framework>::value);
-#endif
+
     auto f = FrameworkFactory().NewFramework();
     ASSERT_TRUE(f);
     f.Start();
@@ -164,9 +148,8 @@ TEST(FrameworkTest, CopyCtor)
 
 TEST(FrameworkTest, CopyAssign)
 {
-#if US_TYPE_OPERATIONS_AVAILABLE
     ASSERT_TRUE(std::is_copy_assignable<Framework>::value);
-#endif
+
     auto f = FrameworkFactory().NewFramework();
     ASSERT_TRUE(f);
     f.Start();


### PR DESCRIPTION
Replaced the bRemoved boolean with std::atomic_bool in ServiceListenerHookPrivate for thread safety. Removed legacy GCC version checks and the US_TYPE_OPERATIONS_AVAILABLE macro from FrameworkTest.cpp, simplifying type trait tests.