### PR TITLE
Add mutual exclusion between addition/removal of referenced services

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
@@ -183,6 +183,7 @@ namespace cppmicroservices
         cppmicroservices::InterfaceMapConstPtr
         ReferenceManagerBaseImpl::AddingService(cppmicroservices::ServiceReference<void> const& reference)
         {
+            std::unique_lock<std::mutex> l(stateChangeMutex);
             // Each service registered by DS contains a service property representing the component configuration name
             // to which it belongs. By checking the component configuration name of a service it can be determined
             // whether this service will satisfy its own reference. If it would, it is not a matched reference as
@@ -226,6 +227,7 @@ namespace cppmicroservices
         ReferenceManagerBaseImpl::RemovedService(cppmicroservices::ServiceReference<void> const& reference,
                                                  cppmicroservices::InterfaceMapConstPtr const& /*service*/)
         {
+            std::unique_lock<std::mutex> l(stateChangeMutex);
             { // acquire lock on matchedRefs
                 auto matchedRefsHandle = matchedRefs.lock();
                 matchedRefsHandle->erase(reference);

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
@@ -183,7 +183,7 @@ namespace cppmicroservices
         cppmicroservices::InterfaceMapConstPtr
         ReferenceManagerBaseImpl::AddingService(cppmicroservices::ServiceReference<void> const& reference)
         {
-            std::unique_lock<std::mutex> l(stateChangeMutex);
+            std::lock_guard<std::recursive_mutex> l(stateChangeMutex);
             // Each service registered by DS contains a service property representing the component configuration name
             // to which it belongs. By checking the component configuration name of a service it can be determined
             // whether this service will satisfy its own reference. If it would, it is not a matched reference as
@@ -227,7 +227,7 @@ namespace cppmicroservices
         ReferenceManagerBaseImpl::RemovedService(cppmicroservices::ServiceReference<void> const& reference,
                                                  cppmicroservices::InterfaceMapConstPtr const& /*service*/)
         {
-            std::unique_lock<std::mutex> l(stateChangeMutex);
+            std::lock_guard<std::recursive_mutex> l(stateChangeMutex);
             { // acquire lock on matchedRefs
                 auto matchedRefsHandle = matchedRefs.lock();
                 matchedRefsHandle->erase(reference);

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.cpp
@@ -183,7 +183,7 @@ namespace cppmicroservices
         cppmicroservices::InterfaceMapConstPtr
         ReferenceManagerBaseImpl::AddingService(cppmicroservices::ServiceReference<void> const& reference)
         {
-            std::lock_guard<std::recursive_mutex> l(stateChangeMutex);
+            std::lock_guard l(stateChangeMutex);
             // Each service registered by DS contains a service property representing the component configuration name
             // to which it belongs. By checking the component configuration name of a service it can be determined
             // whether this service will satisfy its own reference. If it would, it is not a matched reference as
@@ -227,7 +227,7 @@ namespace cppmicroservices
         ReferenceManagerBaseImpl::RemovedService(cppmicroservices::ServiceReference<void> const& reference,
                                                  cppmicroservices::InterfaceMapConstPtr const& /*service*/)
         {
-            std::lock_guard<std::recursive_mutex> l(stateChangeMutex);
+            std::lock_guard l(stateChangeMutex);
             { // acquire lock on matchedRefs
                 auto matchedRefsHandle = matchedRefs.lock();
                 matchedRefsHandle->erase(reference);

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -297,6 +297,7 @@ namespace cppmicroservices
                                                                                 /// listeners
 
             std::unique_ptr<BindingPolicy> bindingPolicy;
+            std::mutex stateChangeMutex;
         };
 
         /**

--- a/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
+++ b/compendium/DeclarativeServices/src/manager/ReferenceManagerImpl.hpp
@@ -297,7 +297,7 @@ namespace cppmicroservices
                                                                                 /// listeners
 
             std::unique_ptr<BindingPolicy> bindingPolicy;
-            std::mutex stateChangeMutex;
+            std::recursive_mutex stateChangeMutex;
         };
 
         /**


### PR DESCRIPTION
Reduced the failure of the test `TestAsyncWorkServiceEndToEnd.VerifyNoDuplicateDeactivate` from .33% to no failures after 10k runs. This merely enforces that the removal of a reference happens independently of the addition of a reference to make sure the notifications arrive at the binding policy in the same order they were found in the reference manager. Otherwise you get satisfied services that are marked as `satisfied->satisfied->unsatisfied` instead of `satisfied->unsatisfied->satisfied` with rapid removal and addition of references