### PR TITLE
Fix race for bundle starts and framework stop

### DIFF
--- a/framework/src/bundle/CoreBundleContext.cpp
+++ b/framework/src/bundle/CoreBundleContext.cpp
@@ -252,12 +252,11 @@ namespace cppmicroservices
         return std::string();
     }
 
-    WriteLock
-    CoreBundleContext::SetFrameworkStateAndBlockUntilComplete(bool desiredState)
+    void
+    CoreBundleContext::SetFrameworkStoppedState(bool desiredState)
     {
         WriteLock lock(stoppedLock);
         stopped = desiredState;
-        return lock;
     }
 
     std::unique_ptr<FrameworkShutdownBlocker>

--- a/framework/src/bundle/CoreBundleContext.h
+++ b/framework/src/bundle/CoreBundleContext.h
@@ -204,7 +204,7 @@ namespace cppmicroservices
          *     - other calls to start or stop the framework
          *     - calls to start bundles
          */
-        WriteLock SetFrameworkStateAndBlockUntilComplete(bool desiredState);
+        void SetFrameworkStoppedState(bool desiredState);
 
         /**
          * Called when bundle startup is occuring

--- a/framework/src/util/FrameworkPrivate.cpp
+++ b/framework/src/util/FrameworkPrivate.cpp
@@ -113,10 +113,12 @@ namespace cppmicroservices
             = coreCtx->frameworkProperties.find(cppmicroservices::Constants::FRAMEWORK_EXTRA_SHUTDOWN_FUNC);
         bool successful_wait = false;
         detail::ScopeGuard extraFunc(
-            [func = shutdownFuncIter == coreCtx->frameworkProperties.end() ? Any() : shutdownFuncIter->second, &successful_wait]()
+            [func = shutdownFuncIter == coreCtx->frameworkProperties.end() ? Any() : shutdownFuncIter->second,
+             &successful_wait]()
             {
                 // if we didn't finish the wait, don't invoke the callback
-                if(!successful_wait){
+                if (!successful_wait)
+                {
                     return;
                 }
                 if (!func.Empty())
@@ -213,7 +215,7 @@ namespace cppmicroservices
         {
             auto l = Lock();
             US_UNUSED(l);
-            auto writerLock = coreCtx->SetFrameworkStateAndBlockUntilComplete(false);
+            coreCtx->SetFrameworkStoppedState(false);
 
             switch (state.load())
             {
@@ -316,14 +318,15 @@ namespace cppmicroservices
             }
             coreCtx->listeners.BundleChanged(
                 BundleEvent(BundleEvent::BUNDLE_STOPPING, MakeBundle(this->shared_from_this())));
+
+            coreCtx->SetFrameworkStoppedState(true);
+
             if (wasActive)
             {
                 StopAllBundles();
             }
-            {
-                auto lock = coreCtx->SetFrameworkStateAndBlockUntilComplete(true);
-                coreCtx->Uninit0();
-            }
+            coreCtx->Uninit0();
+        
             {
                 auto l = Lock();
                 US_UNUSED(l);

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -897,8 +897,6 @@ TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
     };
 
 #else
-    // since all bundles are embedded in the main executable, all bundles are
-    // installed at framework start.
     auto installAndStart = [&barrier, &fmc](std::string const& libName, bool wait = true)
     {
         if (wait)

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -905,7 +905,7 @@ TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
         {
             barrier.Wait();
         }
-        cppmicroservices::testing::GetBundle("TestBundleB", fmc).Start()
+        cppmicroservices::testing::GetBundle(libName, fmc).Start();
     };
 #endif
 

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -22,10 +22,12 @@ limitations under the License.
 
 #include <chrono>
 #include <fstream>
+#include <future>
 #include <mutex>
 #include <thread>
 #include <type_traits>
 
+#include "ConcurrencyTestUtil.hpp"
 #include "TestUtilBundleListener.h"
 #include "TestUtils.h"
 #include "cppmicroservices/Bundle.h"
@@ -852,4 +854,89 @@ TEST(FrameworkTest, ConfigurationWithExtraShutdownWork)
     f.WaitForStop(std::chrono::milliseconds::zero());
     ASSERT_EQ(capt.load(), 2);
 }
+
+TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
+{
+    auto f = FrameworkFactory().NewFramework();
+
+    f.Start();
+
+    auto fmc = f.GetBundleContext();
+    bool hasSeenStop = false;
+    fmc.AddBundleListener(
+        [&hasSeenStop](cppmicroservices::BundleEvent const& event) mutable
+        {
+            static std::mutex m;
+            std::unique_lock lock(m);
+            auto type = event.GetType();
+            if (type == cppmicroservices::BundleEvent::BUNDLE_STOPPING && event.GetBundle().GetBundleId() != 0)
+            {
+                hasSeenStop = true;
+            }
+            else if (type == cppmicroservices::BundleEvent::BUNDLE_STARTING && hasSeenStop)
+            {
+                ASSERT_TRUE(false) << "bundle stop event followed by bundle start event -- not allowed";
+            }
+        });
+    cppmicroservices::detail::test::Barrier barrier(6);
+
+#ifdef US_BUILD_SHARED_LIBS
+    auto installAndStart = [&barrier, &fmc](std::string const& libName, bool wait = true)
+    {
+        if (wait)
+        {
+            barrier.Wait();
+        }
+        try
+        {
+            cppmicroservices::testing::InstallLib(fmc, libName).Start();
+        }
+        catch (...)
+        {
+        }
+    };
+
+#else
+    // since all bundles are embedded in the main executable, all bundles are
+    // installed at framework start.
+    auto installAndStart = [&barrier, &fmc](std::string const& libName, bool wait = true)
+    {
+        if (wait)
+        {
+            barrier.Wait();
+        }
+        cppmicroservices::testing::GetBundle("TestBundleB", fmc).Start()
+    };
+#endif
+
+    installAndStart("TestBundleA", false);
+    installAndStart("TestBundleA2", false);
+    installAndStart("TestBundleB", false);
+    installAndStart("TestBundleH", false);
+    installAndStart("TestBundleLQ", false);
+    installAndStart("TestBundleM", false);
+    installAndStart("TestBundleR", false);
+    installAndStart("TestBundleRA", false);
+
+    std::vector<std::shared_future<void>> futures;
+    // Launch asynchronous tasks using std::async
+    futures.emplace_back(std::async(std::launch::async, installAndStart, "TestBundleRL"));
+    futures.emplace_back(std::async(std::launch::async, installAndStart, "TestBundleS"));
+    futures.emplace_back(std::async(std::launch::async, installAndStart, "TestBundleSL1"));
+    futures.emplace_back(std::async(std::launch::async, installAndStart, "TestBundleSL3"));
+    futures.emplace_back(std::async(std::launch::async, installAndStart, "TestBundleSL4"));
+    futures.emplace_back(std::async(std::launch::async,
+                                    [&f, &barrier]()
+                                    {
+                                        barrier.Wait();
+                                        f.Stop();
+                                        f.WaitForStop(std::chrono::milliseconds::zero());
+                                    }));
+
+    for (auto& fut : futures)
+    {
+        fut.get();
+    }
+}
+
 US_MSVC_POP_WARNING

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -905,7 +905,13 @@ TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
         {
             barrier.Wait();
         }
-        cppmicroservices::testing::GetBundle(libName, fmc).Start();
+        try
+        {
+            cppmicroservices::testing::GetBundle(libName, fmc).Start();
+        }
+        catch (...)
+        {
+        }
     };
 #endif
 

--- a/framework/test/gtest/FrameworkTest.cpp
+++ b/framework/test/gtest/FrameworkTest.cpp
@@ -855,6 +855,7 @@ TEST(FrameworkTest, ConfigurationWithExtraShutdownWork)
     ASSERT_EQ(capt.load(), 2);
 }
 
+#ifdef US_ENABLE_THREADING_SUPPORT
 TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
 {
     auto f = FrameworkFactory().NewFramework();
@@ -942,5 +943,5 @@ TEST(FrameworkTest, BundleStartAfterFrameworkStopKitchenSink)
         fut.get();
     }
 }
-
+#endif
 US_MSVC_POP_WARNING

--- a/framework/test/util/ConcurrencyTestUtil.hpp
+++ b/framework/test/util/ConcurrencyTestUtil.hpp
@@ -14,6 +14,37 @@ namespace cppmicroservices
     {
         namespace test
         {
+
+        class Barrier
+        {
+        public:
+            Barrier(std::size_t count) : threshold(count), count(count), generation(0) {}
+
+            void
+            Wait()
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                auto gen = generation;
+                if (--count == 0)
+                {
+                    generation++;
+                    count = threshold;
+                    cond.notify_all();
+                }
+                else
+                {
+                    cond.wait(lock, [this, gen] { return gen != generation; });
+                }
+            }
+
+        private:
+            std::mutex mutex;
+            std::condition_variable cond;
+            std::size_t threshold;
+            std::size_t count;
+            std::size_t generation{0};
+        };
+
             /**
              * Util method to determine if a future object is ready
              */
@@ -33,30 +64,21 @@ namespace cppmicroservices
             {
                 // test concurrent calls to enable and disable from multiple threads
                 std::vector<R> returnVals;
-                std::promise<void> go;
-                std::shared_future<void> ready(go.get_future());
                 size_t numCalls = std::max(64u, std::thread::hardware_concurrency());
-                std::vector<std::promise<void>> readies(numCalls);
 
                 // TODO: use std::barrier when available
+                Barrier beforeWork(numCalls);
+
                 std::vector<std::future<R>> enable_async_futs(numCalls);
                 for (size_t i = 0; i < numCalls; ++i)
                 {
                     enable_async_futs[i] = std::async(std::launch::async,
-                                                      [&readies, i, &ready, &func]()
+                                                      [&beforeWork, &func]()
                                                       {
-                                                          readies[i].set_value();
-                                                          ready.wait();
+                                                          beforeWork.Wait();
                                                           return func();
                                                       });
                 }
-
-                for (size_t i = 0; i < numCalls; ++i)
-                {
-                    readies[i].get_future().wait();
-                }
-
-                go.set_value();
 
                 for (size_t i = 0; i < numCalls; ++i)
                 {


### PR DESCRIPTION
Latent race identified by Conor. 

New test failed ~50% before fix, 0 times in 1k after. 

I think this new test exposes the issue we have been seeing with bundle state changes concurrently with framework shutting down is causing problems. On this new branch or the current tip, the test fails primarily in serviceRegistry with segfaults... I think we are missing a race here external to the one this geck solves. 