### PR TITLE
Concurrent access to coreInfo bundle

### DIFF
--- a/framework/include/cppmicroservices/ServiceRegistrationBase.h
+++ b/framework/include/cppmicroservices/ServiceRegistrationBase.h
@@ -26,6 +26,7 @@
 #include "cppmicroservices/ServiceProperties.h"
 #include "cppmicroservices/ServiceReference.h"
 #include <functional>
+#include <utility>
 
 namespace cppmicroservices
 {
@@ -202,6 +203,8 @@ namespace cppmicroservices
         ServiceRegistrationBase(BundlePrivate* bundle, InterfaceMapConstPtr const& service, Properties&& props);
 
         ServiceRegistrationLocks LockServiceRegistration() const;
+
+        std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>> LockAndGetBundle() const;
 
         std::shared_ptr<ServiceRegistrationBasePrivate> d;
     };

--- a/framework/include/cppmicroservices/ServiceRegistrationBase.h
+++ b/framework/include/cppmicroservices/ServiceRegistrationBase.h
@@ -204,7 +204,7 @@ namespace cppmicroservices
 
         ServiceRegistrationLocks LockServiceRegistration() const;
 
-        std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>> LockAndGetBundle() const;
+        std::shared_ptr<BundlePrivate> SafelyGetBundle() const;
 
         std::shared_ptr<ServiceRegistrationBasePrivate> d;
     };

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -102,13 +102,13 @@ namespace cppmicroservices
             return Bundle();
         }
 
-        auto l = refP->LockServiceRegistration();
+        auto [l, bundle] = refP->LockAndGetBundle();
         US_UNUSED(l);
-        if (refP->coreInfo->bundle_.lock() == nullptr)
+        if (!bundle)
         {
             return Bundle();
         }
-        return MakeBundle(refP->coreInfo->bundle_.lock()->shared_from_this());
+        return MakeBundle(bundle->shared_from_this());
     }
 
     std::vector<Bundle>

--- a/framework/src/service/ServiceReferenceBase.cpp
+++ b/framework/src/service/ServiceReferenceBase.cpp
@@ -102,10 +102,11 @@ namespace cppmicroservices
             return Bundle();
         }
 
-        auto [l, bundle] = refP->LockAndGetBundle();
+        auto l = refP->LockServiceRegistration();
         US_UNUSED(l);
-        if (!bundle)
-        {
+        auto bundle = refP->coreInfo->bundle_.lock();
+        if (bundle == nullptr)
+            {
             return Bundle();
         }
         return MakeBundle(bundle->shared_from_this());

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -93,8 +93,8 @@ namespace cppmicroservices
                         MakeBundle(bundle->shared_from_this()),
                         message,
                         std::make_exception_ptr(ServiceException(message, ServiceException::Type::FACTORY_ERROR))));
-                    return smap;
                 }
+                return smap;
             }
             {
                 std::shared_ptr<BundlePrivate> bundleSnapshot;

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -64,6 +64,7 @@ namespace cppmicroservices
     ServiceReferenceBasePrivate::SafelyGetBundle() const
     {
         auto regLock = LockServiceRegistration();
+        US_UNUSED(regLock);
         auto bundle = coreInfo->bundle_.lock();
         return bundle;
     }

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -71,7 +71,13 @@ namespace cppmicroservices
                                                             ServiceRegistrationBase(registration.lock()));
             if (!smap || smap->empty())
             {
-                if (auto bundle_ = coreInfo->bundle_.lock())
+                std::shared_ptr<BundlePrivate> bundle_;
+                {
+                    auto regLock = LockServiceRegistration();
+                    US_UNUSED(regLock);
+                    bundle_ = coreInfo->bundle_.lock();
+                }
+                if (bundle_)
                 {
                     std::string message = "ServiceFactory returned an empty or nullptr interface map.";
                     bundle_->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
@@ -79,10 +85,16 @@ namespace cppmicroservices
                         MakeBundle(bundle->shared_from_this()),
                         message,
                         std::make_exception_ptr(ServiceException(message, ServiceException::Type::FACTORY_ERROR))));
+                    return smap;
                 }
-                return smap;
             }
             {
+                std::shared_ptr<BundlePrivate> bundleSnapshot;
+                {
+                    auto regLock = LockServiceRegistration();
+                    US_UNUSED(regLock);
+                    bundleSnapshot = coreInfo->bundle_.lock();
+                }
                 auto l = coreInfo->properties.Lock();
                 US_UNUSED(l);
                 for (auto const& clazz : ref_any_cast<std::vector<std::string>>(
@@ -90,10 +102,10 @@ namespace cppmicroservices
                 {
                     if (smap->find(clazz) == smap->end() && clazz != "org.cppmicroservices.factory")
                     {
-                        if (auto bundle_ = coreInfo->bundle_.lock())
+                        if (bundleSnapshot)
                         {
                             std::string message("ServiceFactory produced an object that did not implement: " + clazz);
-                            bundle_->coreCtx->listeners.SendFrameworkEvent(
+                            bundleSnapshot->coreCtx->listeners.SendFrameworkEvent(
                                 FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_WARNING,
                                                MakeBundle(bundle->shared_from_this()),
                                                message,
@@ -107,12 +119,18 @@ namespace cppmicroservices
         }
         catch (cppmicroservices::SharedLibraryException const& ex)
         {
-            if (auto bundle = coreInfo->bundle_.lock())
+            std::shared_ptr<BundlePrivate> regBundle;
             {
-                bundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
-                                                                             ex.GetBundle(),
-                                                                             "Failed to load shared library",
-                                                                             std::current_exception()));
+                auto regLock = LockServiceRegistration();
+                US_UNUSED(regLock);
+                regBundle = coreInfo->bundle_.lock();
+            }
+            if (regBundle)
+            {
+                regBundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
+                                                                              ex.GetBundle(),
+                                                                              "Failed to load shared library",
+                                                                              std::current_exception()));
             }
             throw;
         }
@@ -131,7 +149,13 @@ namespace cppmicroservices
         catch (std::exception const& ex)
         {
             std::string message = "ServiceFactory threw an unknown exception.";
-            if (auto bundle_ = coreInfo->bundle_.lock())
+            std::shared_ptr<BundlePrivate> bundle_;
+            {
+                auto regLock = LockServiceRegistration();
+                US_UNUSED(regLock);
+                bundle_ = coreInfo->bundle_.lock();
+            }
+            if (bundle_)
             {
                 bundle_->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
                     FrameworkEvent::Type::FRAMEWORK_ERROR,
@@ -340,7 +364,13 @@ namespace cppmicroservices
                 }
                 catch (std::exception const& ex)
                 {
-                    if (auto bundle_ = coreInfo->bundle_.lock())
+                    std::shared_ptr<BundlePrivate> bundle_;
+                    {
+                        auto regLock = LockServiceRegistration();
+                        US_UNUSED(regLock);
+                        bundle_ = coreInfo->bundle_.lock();
+                    }
+                    if (bundle_)
                     {
                         std::string message("ServiceFactory threw an exception");
                         bundle_->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
@@ -445,7 +475,13 @@ namespace cppmicroservices
             }
             catch (std::exception const& ex)
             {
-                if (auto bundle_ = coreInfo->bundle_.lock())
+                std::shared_ptr<BundlePrivate> bundle_;
+                {
+                    auto regLock = LockServiceRegistration();
+                    US_UNUSED(regLock);
+                    bundle_ = coreInfo->bundle_.lock();
+                }
+                if (bundle_)
                 {
                     std::string message("ServiceFactory threw an exception");
                     bundle_->coreCtx->listeners.SendFrameworkEvent(

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -60,12 +60,12 @@ namespace cppmicroservices
         return ServiceRegistrationLocks(registration.lock(), coreInfo);
     }
 
-    std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>>
-    ServiceReferenceBasePrivate::LockAndGetBundle() const
+    std::shared_ptr<BundlePrivate>
+    ServiceReferenceBasePrivate::SafelyGetBundle() const
     {
         auto regLock = LockServiceRegistration();
         auto bundle = coreInfo->bundle_.lock();
-        return { std::move(regLock), std::move(bundle) };
+        return bundle;
     }
 
     InterfaceMapConstPtr
@@ -79,12 +79,7 @@ namespace cppmicroservices
                                                             ServiceRegistrationBase(registration.lock()));
             if (!smap || smap->empty())
             {
-                std::shared_ptr<BundlePrivate> bundle_;
-                {
-                    auto [l, b] = LockAndGetBundle();
-                    US_UNUSED(l);
-                    bundle_ = std::move(b);
-                }
+                std::shared_ptr<BundlePrivate> bundle_ = SafelyGetBundle();
                 if (bundle_)
                 {
                     std::string message = "ServiceFactory returned an empty or nullptr interface map.";
@@ -97,12 +92,8 @@ namespace cppmicroservices
                 return smap;
             }
             {
-                std::shared_ptr<BundlePrivate> bundleSnapshot;
-                {
-                    auto [l, bundleSnapshot_] = LockAndGetBundle();
-                    US_UNUSED(l);
-                    bundleSnapshot = std::move(bundleSnapshot_);
-                }
+                std::shared_ptr<BundlePrivate> bundleSnapshot = SafelyGetBundle();
+
                 auto l = coreInfo->properties.Lock();
                 US_UNUSED(l);
                 for (auto const& clazz : ref_any_cast<std::vector<std::string>>(
@@ -127,12 +118,7 @@ namespace cppmicroservices
         }
         catch (cppmicroservices::SharedLibraryException const& ex)
         {
-            std::shared_ptr<BundlePrivate> regBundle;
-            {
-                auto [l, b] = LockAndGetBundle();
-                US_UNUSED(l);
-                regBundle = std::move(b);
-            }
+            std::shared_ptr<BundlePrivate> regBundle = SafelyGetBundle();
             if (regBundle)
             {
                 regBundle->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(FrameworkEvent::Type::FRAMEWORK_ERROR,
@@ -157,12 +143,7 @@ namespace cppmicroservices
         catch (std::exception const& ex)
         {
             std::string message = "ServiceFactory threw an unknown exception.";
-            std::shared_ptr<BundlePrivate> bundle_;
-            {
-                auto [l, b] = LockAndGetBundle();
-                US_UNUSED(l);
-                bundle_ = std::move(b);
-            }
+            std::shared_ptr<BundlePrivate> bundle_ = SafelyGetBundle();
             if (bundle_)
             {
                 bundle_->coreCtx->listeners.SendFrameworkEvent(FrameworkEvent(
@@ -372,12 +353,7 @@ namespace cppmicroservices
                 }
                 catch (std::exception const& ex)
                 {
-                    std::shared_ptr<BundlePrivate> bundle_;
-                    {
-                        auto [l, b] = LockAndGetBundle();
-                        US_UNUSED(l);
-                        bundle_ = std::move(b);
-                    }
+                    std::shared_ptr<BundlePrivate> bundle_ = SafelyGetBundle();
                     if (bundle_)
                     {
                         std::string message("ServiceFactory threw an exception");
@@ -483,12 +459,7 @@ namespace cppmicroservices
             }
             catch (std::exception const& ex)
             {
-                std::shared_ptr<BundlePrivate> bundle_;
-                {
-                    auto [l, b] = LockAndGetBundle();
-                    US_UNUSED(l);
-                    bundle_ = std::move(b);
-                }
+                std::shared_ptr<BundlePrivate> bundle_ = SafelyGetBundle();
                 if (bundle_)
                 {
                     std::string message("ServiceFactory threw an exception");

--- a/framework/src/service/ServiceReferenceBasePrivate.cpp
+++ b/framework/src/service/ServiceReferenceBasePrivate.cpp
@@ -60,6 +60,14 @@ namespace cppmicroservices
         return ServiceRegistrationLocks(registration.lock(), coreInfo);
     }
 
+    std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>>
+    ServiceReferenceBasePrivate::LockAndGetBundle() const
+    {
+        auto regLock = LockServiceRegistration();
+        auto bundle = coreInfo->bundle_.lock();
+        return { std::move(regLock), std::move(bundle) };
+    }
+
     InterfaceMapConstPtr
     ServiceReferenceBasePrivate::GetServiceFromFactory(BundlePrivate* bundle,
                                                        std::shared_ptr<ServiceFactory> const& factory)
@@ -73,9 +81,9 @@ namespace cppmicroservices
             {
                 std::shared_ptr<BundlePrivate> bundle_;
                 {
-                    auto regLock = LockServiceRegistration();
-                    US_UNUSED(regLock);
-                    bundle_ = coreInfo->bundle_.lock();
+                    auto [l, b] = LockAndGetBundle();
+                    US_UNUSED(l);
+                    bundle_ = std::move(b);
                 }
                 if (bundle_)
                 {
@@ -91,9 +99,9 @@ namespace cppmicroservices
             {
                 std::shared_ptr<BundlePrivate> bundleSnapshot;
                 {
-                    auto regLock = LockServiceRegistration();
-                    US_UNUSED(regLock);
-                    bundleSnapshot = coreInfo->bundle_.lock();
+                    auto [l, bundleSnapshot_] = LockAndGetBundle();
+                    US_UNUSED(l);
+                    bundleSnapshot = std::move(bundleSnapshot_);
                 }
                 auto l = coreInfo->properties.Lock();
                 US_UNUSED(l);
@@ -121,9 +129,9 @@ namespace cppmicroservices
         {
             std::shared_ptr<BundlePrivate> regBundle;
             {
-                auto regLock = LockServiceRegistration();
-                US_UNUSED(regLock);
-                regBundle = coreInfo->bundle_.lock();
+                auto [l, b] = LockAndGetBundle();
+                US_UNUSED(l);
+                regBundle = std::move(b);
             }
             if (regBundle)
             {
@@ -151,9 +159,9 @@ namespace cppmicroservices
             std::string message = "ServiceFactory threw an unknown exception.";
             std::shared_ptr<BundlePrivate> bundle_;
             {
-                auto regLock = LockServiceRegistration();
-                US_UNUSED(regLock);
-                bundle_ = coreInfo->bundle_.lock();
+                auto [l, b] = LockAndGetBundle();
+                US_UNUSED(l);
+                bundle_ = std::move(b);
             }
             if (bundle_)
             {
@@ -366,9 +374,9 @@ namespace cppmicroservices
                 {
                     std::shared_ptr<BundlePrivate> bundle_;
                     {
-                        auto regLock = LockServiceRegistration();
-                        US_UNUSED(regLock);
-                        bundle_ = coreInfo->bundle_.lock();
+                        auto [l, b] = LockAndGetBundle();
+                        US_UNUSED(l);
+                        bundle_ = std::move(b);
                     }
                     if (bundle_)
                     {
@@ -477,9 +485,9 @@ namespace cppmicroservices
             {
                 std::shared_ptr<BundlePrivate> bundle_;
                 {
-                    auto regLock = LockServiceRegistration();
-                    US_UNUSED(regLock);
-                    bundle_ = coreInfo->bundle_.lock();
+                    auto [l, b] = LockAndGetBundle();
+                    US_UNUSED(l);
+                    bundle_ = std::move(b);
                 }
                 if (bundle_)
                 {

--- a/framework/src/service/ServiceReferenceBasePrivate.h
+++ b/framework/src/service/ServiceReferenceBasePrivate.h
@@ -37,6 +37,7 @@
 
 #include <atomic>
 #include <string>
+#include <utility>
 
 namespace cppmicroservices
 {
@@ -62,6 +63,13 @@ namespace cppmicroservices
         ~ServiceReferenceBasePrivate();
 
         ServiceRegistrationLocks LockServiceRegistration() const;
+
+        /**
+         * Lock the service registration and return the locked bundle along with the held lock.
+         *
+         * @return A pair of the RAII lock object and the locked bundle shared_ptr.
+         */
+        std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>> LockAndGetBundle() const;
 
         /**
          * Get the service object.

--- a/framework/src/service/ServiceReferenceBasePrivate.h
+++ b/framework/src/service/ServiceReferenceBasePrivate.h
@@ -65,11 +65,11 @@ namespace cppmicroservices
         ServiceRegistrationLocks LockServiceRegistration() const;
 
         /**
-         * Lock the service registration and return the locked bundle along with the held lock.
+         * Lock the service registration and return the locked bundle.
          *
-         * @return A pair of the RAII lock object and the locked bundle shared_ptr.
+         * @return bundle shared_ptr.
          */
-        std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>> LockAndGetBundle() const;
+        std::shared_ptr<BundlePrivate> SafelyGetBundle() const;
 
         /**
          * Get the service object.

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -133,9 +133,9 @@ namespace cppmicroservices
         {
             std::shared_ptr<BundlePrivate> bundle;
             {
-                auto l = LockServiceRegistration();
+                auto [l, b] = LockAndGetBundle();
                 US_UNUSED(l);
-                bundle = d->coreInfo->bundle_.lock();
+                bundle = std::move(b);
             }
             if (bundle)
             {
@@ -193,9 +193,9 @@ namespace cppmicroservices
             auto const& classes = ref_any_cast<std::vector<std::string>>(objectClasses);
             std::shared_ptr<BundlePrivate> bundle;
             {
-                auto l = LockServiceRegistration();
+                auto [l, b] = LockAndGetBundle();
                 US_UNUSED(l);
-                bundle = d->coreInfo->bundle_.lock();
+                bundle = std::move(b);
             }
             if (bundle)
             {
@@ -208,9 +208,9 @@ namespace cppmicroservices
         {
             std::shared_ptr<BundlePrivate> bundle;
             {
-                auto l = LockServiceRegistration();
+                auto [l, b] = LockAndGetBundle();
                 US_UNUSED(l);
-                bundle = d->coreInfo->bundle_.lock();
+                bundle = std::move(b);
             }
             if (bundle)
             {
@@ -362,6 +362,14 @@ namespace cppmicroservices
     ServiceRegistrationBase::LockServiceRegistration() const
     {
         return ServiceRegistrationLocks(d, d->coreInfo);
+    }
+
+    std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>>
+    ServiceRegistrationBase::LockAndGetBundle() const
+    {
+        auto regLock = LockServiceRegistration();
+        auto bundle = d->coreInfo->bundle_.lock();
+        return { std::move(regLock), std::move(bundle) };
     }
 
     bool

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -131,12 +131,7 @@ namespace cppmicroservices
 
         // This calls into service event listener hooks. We must not hold any locks here
         {
-            std::shared_ptr<BundlePrivate> bundle;
-            {
-                auto [l, b] = LockAndGetBundle();
-                US_UNUSED(l);
-                bundle = std::move(b);
-            }
+            std::shared_ptr<BundlePrivate> bundle = SafelyGetBundle();
             if (bundle)
             {
                 bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEndMatchEvent, before);
@@ -191,12 +186,7 @@ namespace cppmicroservices
         if (old_rank != new_rank)
         {
             auto const& classes = ref_any_cast<std::vector<std::string>>(objectClasses);
-            std::shared_ptr<BundlePrivate> bundle;
-            {
-                auto [l, b] = LockAndGetBundle();
-                US_UNUSED(l);
-                bundle = std::move(b);
-            }
+            std::shared_ptr<BundlePrivate> bundle = SafelyGetBundle();
             if (bundle)
             {
                 bundle->coreCtx->services.UpdateServiceRegistrationOrder(classes);
@@ -206,12 +196,7 @@ namespace cppmicroservices
         // Notify listeners, we must not hold any locks here
         ServiceListeners::ServiceListenerEntries matchingListeners;
         {
-            std::shared_ptr<BundlePrivate> bundle;
-            {
-                auto [l, b] = LockAndGetBundle();
-                US_UNUSED(l);
-                bundle = std::move(b);
-            }
+            std::shared_ptr<BundlePrivate> bundle = SafelyGetBundle();
             if (bundle)
             {
                 bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEvent, matchingListeners);
@@ -364,12 +349,12 @@ namespace cppmicroservices
         return ServiceRegistrationLocks(d, d->coreInfo);
     }
 
-    std::pair<ServiceRegistrationLocks, std::shared_ptr<BundlePrivate>>
-    ServiceRegistrationBase::LockAndGetBundle() const
+    std::shared_ptr<BundlePrivate>
+    ServiceRegistrationBase::SafelyGetBundle() const
     {
         auto regLock = LockServiceRegistration();
         auto bundle = d->coreInfo->bundle_.lock();
-        return { std::move(regLock), std::move(bundle) };
+        return bundle;
     }
 
     bool

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -130,9 +130,17 @@ namespace cppmicroservices
         }
 
         // This calls into service event listener hooks. We must not hold any locks here
-        if (auto bundle = d->coreInfo->bundle_.lock())
         {
-            bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEndMatchEvent, before);
+            std::shared_ptr<BundlePrivate> bundle;
+            {
+                auto l = LockServiceRegistration();
+                US_UNUSED(l);
+                bundle = d->coreInfo->bundle_.lock();
+            }
+            if (bundle)
+            {
+                bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEndMatchEvent, before);
+            }
         }
 
         int old_rank = 0;
@@ -183,7 +191,13 @@ namespace cppmicroservices
         if (old_rank != new_rank)
         {
             auto const& classes = ref_any_cast<std::vector<std::string>>(objectClasses);
-            if (auto bundle = d->coreInfo->bundle_.lock())
+            std::shared_ptr<BundlePrivate> bundle;
+            {
+                auto l = LockServiceRegistration();
+                US_UNUSED(l);
+                bundle = d->coreInfo->bundle_.lock();
+            }
+            if (bundle)
             {
                 bundle->coreCtx->services.UpdateServiceRegistrationOrder(classes);
             }
@@ -191,11 +205,19 @@ namespace cppmicroservices
 
         // Notify listeners, we must not hold any locks here
         ServiceListeners::ServiceListenerEntries matchingListeners;
-        if (auto bundle = d->coreInfo->bundle_.lock())
         {
-            bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEvent, matchingListeners);
-            bundle->coreCtx->listeners.ServiceChanged(matchingListeners, modifiedEvent, before);
-            bundle->coreCtx->listeners.ServiceChanged(before, modifiedEndMatchEvent);
+            std::shared_ptr<BundlePrivate> bundle;
+            {
+                auto l = LockServiceRegistration();
+                US_UNUSED(l);
+                bundle = d->coreInfo->bundle_.lock();
+            }
+            if (bundle)
+            {
+                bundle->coreCtx->listeners.GetMatchingServiceListeners(modifiedEvent, matchingListeners);
+                bundle->coreCtx->listeners.ServiceChanged(matchingListeners, modifiedEvent, before);
+                bundle->coreCtx->listeners.ServiceChanged(before, modifiedEndMatchEvent);
+            }
         }
     }
 

--- a/framework/src/service/ServiceRegistrationBase.cpp
+++ b/framework/src/service/ServiceRegistrationBase.cpp
@@ -353,6 +353,7 @@ namespace cppmicroservices
     ServiceRegistrationBase::SafelyGetBundle() const
     {
         auto regLock = LockServiceRegistration();
+        US_UNUSED(regLock);
         auto bundle = d->coreInfo->bundle_.lock();
         return bundle;
     }

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -340,9 +340,9 @@ namespace cppmicroservices
 
         for (auto& sr : serviceRegistrations)
         {
-            auto regLock = sr.LockServiceRegistration();
+            auto [regLock, bundle_] = sr.LockAndGetBundle();
             US_UNUSED(regLock);
-            if (auto bundle_ = sr.d->coreInfo->bundle_.lock())
+            if (bundle_)
             {
                 if (bundle_.get() == p)
                 {

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -28,6 +28,7 @@
 #include "BundlePrivate.h"
 #include "CoreBundleContext.h"
 #include "ServiceRegistrationBasePrivate.h"
+#include "ServiceRegistrationLocks.h"
 
 #include <cassert>
 #include <iterator>
@@ -107,7 +108,7 @@ namespace cppmicroservices
         bool isPrototypeFactory = (isFactory ? static_cast<bool>(std::dynamic_pointer_cast<PrototypeServiceFactory>(
                                                    std::static_pointer_cast<ServiceFactory>(
                                                        service->find("org.cppmicroservices.factory")->second)))
-                                             : false);
+                         : false);
 
         std::vector<std::string> classes;
         // Check if service implements claimed classes and that they exist.
@@ -339,6 +340,7 @@ namespace cppmicroservices
 
         for (auto& sr : serviceRegistrations)
         {
+            auto regLock = sr.LockServiceRegistration();
             if (auto bundle_ = sr.d->coreInfo->bundle_.lock())
             {
                 if (bundle_.get() == p)

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -341,6 +341,7 @@ namespace cppmicroservices
         for (auto& sr : serviceRegistrations)
         {
             auto regLock = sr.LockServiceRegistration();
+            US_UNUSED(regLock);
             if (auto bundle_ = sr.d->coreInfo->bundle_.lock())
             {
                 if (bundle_.get() == p)

--- a/framework/src/service/ServiceRegistry.cpp
+++ b/framework/src/service/ServiceRegistry.cpp
@@ -56,6 +56,7 @@ namespace cppmicroservices
         services.clear();
         classServices.clear();
         serviceRegistrations.clear();
+        bundleServices.clear();
     }
 
     Properties
@@ -129,6 +130,7 @@ namespace cppmicroservices
             US_UNUSED(l);
             services.insert(std::make_pair(res, classes));
             serviceRegistrations.push_back(res);
+            bundleServices[bundle].push_back(res);
             for (auto& clazz : classes)
             {
                 auto& s = classServices[clazz];
@@ -318,6 +320,19 @@ namespace cppmicroservices
         services.erase(sr);
         serviceRegistrations.erase(std::remove(serviceRegistrations.begin(), serviceRegistrations.end(), sr),
                                    serviceRegistrations.end());
+        if (auto bundle = sr.d->coreInfo->bundle_.lock())
+        {
+            auto it = bundleServices.find(bundle.get());
+            if (it != bundleServices.end())
+            {
+                auto& regs = it->second;
+                regs.erase(std::remove(regs.begin(), regs.end(), sr), regs.end());
+                if (regs.empty())
+                {
+                    bundleServices.erase(it);
+                }
+            }
+        }
         for (auto& clazz : classes)
         {
             auto& s = classServices[clazz];
@@ -338,17 +353,10 @@ namespace cppmicroservices
         auto l = this->Lock();
         US_UNUSED(l);
 
-        for (auto& sr : serviceRegistrations)
+        auto it = bundleServices.find(p);
+        if (it != bundleServices.end())
         {
-            auto [regLock, bundle_] = sr.LockAndGetBundle();
-            US_UNUSED(regLock);
-            if (bundle_)
-            {
-                if (bundle_.get() == p)
-                {
-                    res.push_back(sr);
-                }
-            }
+            res = it->second;
         }
     }
 

--- a/framework/src/service/ServiceRegistry.h
+++ b/framework/src/service/ServiceRegistry.h
@@ -60,6 +60,7 @@ namespace cppmicroservices
 
         using MapServiceClasses = std::unordered_map<ServiceRegistrationBase, std::vector<std::string>>;
         using MapClassServices = std::unordered_map<std::string, std::vector<ServiceRegistrationBase>>;
+        using MapBundleServices = std::unordered_map<BundlePrivate*, std::vector<ServiceRegistrationBase>>;
 
         /**
          * All registered services in the current framework.
@@ -76,6 +77,11 @@ namespace cppmicroservices
          * ranked service first.
          */
         MapClassServices classServices;
+
+        /**
+         * Mapping of bundle to its registered services.
+         */
+        MapBundleServices bundleServices;
 
         CoreBundleContext* core;
 

--- a/framework/test/gtest/ServiceRegistryTest.cpp
+++ b/framework/test/gtest/ServiceRegistryTest.cpp
@@ -28,7 +28,11 @@
 #include "TestUtils.h"
 #include "gtest/gtest.h"
 
+#include <atomic>
+#include <future>
+#include <thread>
 #include <unordered_set>
+#include <vector>
 
 using namespace cppmicroservices;
 
@@ -229,3 +233,62 @@ TEST_F(ServiceRegistryTest, TestServicePropertiesUpdate)
     reg2.Unregister();
     ASSERT_TRUE(context.GetServiceReferences<ITestServiceA>().empty());
 }
+
+
+
+#if defined(US_ENABLE_THREADING_SUPPORT)
+
+#include "ConcurrencyTestUtil.hpp"
+
+// This test exercises a data race between concurrent bundle_.lock() reads
+// (in SetProperties) and bundle_.reset() writes (in Unregister) on the
+// shared coreInfo->bundle_ weak_ptr.
+//
+// Without the fix (LockServiceRegistration around bundle_.lock() reads),
+// this crashes or triggers TSAN reports.
+TEST_F(ServiceRegistryTest, NoDataRaceOnConcurrentUnregisterAndSetProperties)
+{
+    constexpr int kIterations = 500;
+
+    for (int i = 0; i < kIterations; ++i)
+    {
+        auto reg = context.RegisterService<ITestServiceA>(std::make_shared<TestServiceA>());
+
+        cppmicroservices::detail::test::Barrier barrier(2);
+
+        auto f1 = std::async(
+            std::launch::async,
+            [&]()
+            {
+                barrier.Wait();
+                try
+                {
+                    ServiceProperties props;
+                    props["key"] = std::string("value");
+                    reg.SetProperties(std::move(props));
+                }
+                catch (...)
+                {
+                }
+            });
+
+        auto f2 = std::async(
+            std::launch::async,
+            [&]()
+            {
+                barrier.Wait();
+                try
+                {
+                    reg.Unregister();
+                }
+                catch (...)
+                {
+                }
+            });
+
+        f1.get();
+        f2.get();
+    }
+}
+
+#endif


### PR DESCRIPTION
the running theory here is as follows:

`coreInfo->bundle_` is read via `.lock()` in many places under only the ServiceRegistry lock, while `Unregister()` calls `bundle_.reset()` under `LockServiceRegistration()`. These are different locks, so concurrent `weak_ptr::lock()` and `weak_ptr::reset()` on the same object could result in something like a segfault like this:

cppmicroservices::ServiceRegistry::GetRegisteredByBundle at [ServiceRegistry.cpp](https://github.com/CppMicroServices/CppMicroServices/blob/f71ad06d42ef5d44f7656d702bbf5c5a6332e274/framework/src/service/ServiceRegistry.cpp#L342-L343)
cppmicroservices::Bundle::GetRegisteredServices at [Bundle.cpp](https://github.com/CppMicroServices/CppMicroServices/blob/f71ad06d42ef5d44f7656d702bbf5c5a6332e274/framework/src/bundle/Bundle.cpp#L284-L285)