### PR TITLE
bug in change to `serviceObjects`

### DIFF
--- a/compendium/DeclarativeServices/test/gtest/TestInteg.cpp
+++ b/compendium/DeclarativeServices/test/gtest/TestInteg.cpp
@@ -118,6 +118,44 @@ namespace test
     }
 
     /**
+     * Verify that a DS-injected factory service remains usable on a background
+     * thread after the framework has shut down.  The dependent bundle's bind
+     * method spawns a thread that sleeps 200ms then invokes a virtual method on
+     * the injected service.  The framework is stopped while that thread is
+     * sleeping.  Without proper independent ownership of the service object
+     * (the deep-copy in GetServiceInterfaceMap), the service would be destroyed
+     * during shutdown and the deferred virtual call would crash
+     * (pure-virtual / use-after-free).
+     */
+    TEST_F(IntegrationTestFixture, testInjectedServiceOwnershipAfterShutdown)
+    {
+        auto context = framework.GetBundleContext();
+
+        ::test::InstallAndStartBundle(context, "ServiceFactoryBundle");
+        ::test::InstallAndStartBundle(context, "ServiceFactoryDependentBundle");
+
+        auto factoryRef = context.GetServiceReferences<cppmicroservices::ServiceFactory>("(mySvc=true)");
+        auto factorySvc = context.GetService<cppmicroservices::ServiceFactory>(factoryRef.front());
+        ASSERT_TRUE(factorySvc);
+
+        context.RegisterService<test::FactoryCreatedService>(
+            std::static_pointer_cast<cppmicroservices::ServiceFactory>(factorySvc));
+
+        auto dependentSvcRef = context.GetServiceReference<test::FactoryServiceDependent>();
+        auto dependentSvc = context.GetService<test::FactoryServiceDependent>(dependentSvcRef);
+        ASSERT_TRUE(dependentSvc && dependentSvc->didBind());
+
+        // The bind method spawned a thread with a 200ms delay.
+        // Stop the framework now — the thread's work will run after shutdown.
+        framework.Stop();
+        framework.WaitForStop(std::chrono::milliseconds::zero());
+
+        // The background thread should complete successfully: the injected
+        // service's virtual method must still be callable after framework shutdown.
+        EXPECT_EQ(dependentSvc->getAsyncSayHiResult(), "HELLO");
+    }
+
+    /**
      * Verify that a service's configuration can be updated from within a 'Modified' callback without
      * deadlocking the framework trying to get the lock in configNotifier
      */

--- a/compendium/test_bundles/ServiceFactoryDependentBundle/src/ServiceImpl.hpp
+++ b/compendium/test_bundles/ServiceFactoryDependentBundle/src/ServiceImpl.hpp
@@ -3,13 +3,21 @@
 
 #include "TestInterfaces/Interfaces.hpp"
 #include "cppmicroservices/ServiceReference.h"
+#include <future>
 #include <iostream>
+#include <thread>
 
 class dependentImpl : public test::FactoryServiceDependent
 {
   public:
     dependentImpl() = default;
-    ~dependentImpl() override = default;
+    ~dependentImpl() override
+    {
+        if (_worker.joinable())
+        {
+            _worker.join();
+        }
+    }
 
     void
     BindcreatedSvc(std::shared_ptr<test::FactoryCreatedService> factoryCreated)
@@ -25,6 +33,9 @@ class dependentImpl : public test::FactoryServiceDependent
             std::cout << "Exception getting ref: " << e.what() << std::endl;
             return;
         }
+
+        _factoryCreated = factoryCreated;
+        dispatchAsyncWork();
     }
 
     void UnbindcreatedSvc(std::shared_ptr<test::FactoryCreatedService> /**/) {};
@@ -34,8 +45,46 @@ class dependentImpl : public test::FactoryServiceDependent
     {
         return _bound;
     }
-    private:
-      bool _bound = false;
+
+    std::string
+    getAsyncSayHiResult() override
+    {
+        if (_asyncResult.valid())
+        {
+            return _asyncResult.get();
+        }
+        return "";
+    }
+
+  private:
+    void
+    dispatchAsyncWork()
+    {
+        if (!_factoryCreated || _asyncResult.valid())
+        {
+            return;
+        }
+        auto promise = std::make_shared<std::promise<std::string>>();
+        _asyncResult = promise->get_future();
+        _worker = std::thread(
+            [promise, svc = _factoryCreated]()
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                try
+                {
+                    promise->set_value(svc->sayHi());
+                }
+                catch (...)
+                {
+                    promise->set_exception(std::current_exception());
+                }
+            });
+    }
+
+    bool _bound = false;
+    std::shared_ptr<test::FactoryCreatedService> _factoryCreated;
+    std::future<std::string> _asyncResult;
+    std::thread _worker;
 };
 
 #endif // _SERVICE_IMPL_HPP_

--- a/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
+++ b/compendium/test_bundles/TestInterfaces/include/TestInterfaces/Interfaces.hpp
@@ -240,7 +240,7 @@ namespace test
         FactoryServiceDependent() = default;
         virtual ~FactoryServiceDependent() = default;
         virtual bool didBind() = 0;
-
+        virtual std::string getAsyncSayHiResult() = 0;
     };
 
 } // namespace test

--- a/framework/src/service/ServiceObjects.cpp
+++ b/framework/src/service/ServiceObjects.cpp
@@ -131,14 +131,18 @@ namespace cppmicroservices
         {
             return nullptr;
         }
-        auto sh = new ServiceHolder<void> { bundle_, d->m_reference, nullptr, interfaceMap };
+        // Deep-copy so that the entries in the copy share ownership of the
+        // underlying service objects independently of the original map.
+        auto deepCopy = std::make_shared<InterfaceMap const>(*interfaceMap);
+
+        auto sh = new ServiceHolder<void> { bundle_, d->m_reference, nullptr, deepCopy };
         std::shared_ptr<ServiceHolder<void>> h(sh, CustomServiceDeleter { sh });
 
         // Build a consumer-facing copy where each entry aliases through the
         // ServiceHolder, carrying the CustomServiceDeleter. This ensures
         // ServiceReferenceFromService works on any pointer extracted from the map.
         auto wrappedMap = std::make_shared<InterfaceMap>();
-        for (auto const& entry : *interfaceMap)
+        for (auto const& entry : *deepCopy)
         {
             wrappedMap->emplace(entry.first, std::shared_ptr<void>(h, entry.second.get()));
         }


### PR DESCRIPTION
deep-copy the `InterfaceMap` before wrapping it in a `ServiceHolder`, instead of aliasing the original map returned by the framework's internal cache.

```
// Before: ServiceHolder aliases the framework's cached map
auto sh = new ServiceHolder<void> { bundle_, d->m_reference, nullptr, interfaceMap };
```

```
// After: ServiceHolder owns an independent copy
auto deepCopy = std::make_shared<InterfaceMap const>(*interfaceMap);
auto sh = new ServiceHolder<void> { bundle_, d->m_reference, nullptr, deepCopy };
```

