### PR TITLE
Hoist ToLower(key) out of loop in LDAPExpr::Evaluate

### DIFF
--- a/framework/src/util/LDAPExpr.cpp
+++ b/framework/src/util/LDAPExpr.cpp
@@ -552,11 +552,11 @@ namespace cppmicroservices
                         auto value_iter = p->findUO_TypeChecked(key);
                         if (!matchCase && value_iter == p->endUO_TypeChecked())
                         {
+                            std::string lower = LDAPExpr::ToLower(key);
                             for (auto value_iter = p->beginUO_TypeChecked(); value_iter != p->endUO_TypeChecked();
                                  ++value_iter)
                             {
-                                if (std::string lower = LDAPExpr::ToLower(key);
-                                    LDAPExpr::ToLower(value_iter->first) == lower)
+                                if (LDAPExpr::ToLower(value_iter->first) == lower)
                                 {
                                     return value_iter;
                                 }
@@ -585,11 +585,11 @@ namespace cppmicroservices
                         auto value_iter = p->findOM_TypeChecked(key);
                         if (!matchCase && value_iter == p->endOM_TypeChecked())
                         {
+                            std::string lower = LDAPExpr::ToLower(key);
                             for (auto value_iter = p->beginOM_TypeChecked(); value_iter != p->endOM_TypeChecked();
                                  ++value_iter)
                             {
-                                if (std::string lower = LDAPExpr::ToLower(key);
-                                    LDAPExpr::ToLower(value_iter->first) == lower)
+                                if (LDAPExpr::ToLower(value_iter->first) == lower)
                                 {
                                     return value_iter;
                                 }


### PR DESCRIPTION
## Summary
- Fixes #1259
- Hoists `LDAPExpr::ToLower(key)` out of the case-insensitive search loops in `LDAPExpr::Evaluate`, eliminating redundant string transformations on every iteration
- Applied to both the `UNORDERED_MAP` and `ORDERED_MAP` code paths

## Test plan
- [x] Project builds cleanly (Release, MSVC 19.36)
- [x] All 27 existing tests pass