### PR TITLE
updateIfDifferent(emptyMap) on first update SHOULD cause notification

### DIFF
--- a/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/src/ConfigurationImpl.cpp
@@ -224,7 +224,10 @@ namespace cppmicroservices
             {
                 throw std::runtime_error(REMOVED_EXCEPTION_MESSAGE);
             }
-            if (properties == newProperties)
+            // Per OSGi Compendium R7 §104.7.4, a never-updated Configuration has null
+            // properties — distinct from "updated to empty". The first update must always
+            // be treated as different, even if newProperties is empty, so listeners fire.
+            if (changeCount > 0 && properties == newProperties)
             {
                 return std::pair<bool, unsigned long> { false, 0u };
             }

--- a/compendium/ConfigurationAdmin/test/gtest/TestConfigurationAdminImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/gtest/TestConfigurationAdminImpl.cpp
@@ -389,8 +389,12 @@ namespace cppmicroservices
 
             auto result = configAdmin.AddConfigurations(std::move(configs));
 
+            // test.pid was previously fetched via GetConfiguration but never updated,
+            // so its current state is null-properties (per OSGi Compendium R7 §104.7.4).
+            // AddConfigurations now supplies empty properties — which is different from
+            // null — so this is a first-update transition: changeCount goes 0 -> 1.
             decltype(result) expected {
-                {  "test.pid", 0ul,  reinterpret_cast<std::uintptr_t>(conf.get()) },
+                {  "test.pid", 1ul,  reinterpret_cast<std::uintptr_t>(conf.get()) },
                 { "test.pid2", 2ul, reinterpret_cast<std::uintptr_t>(conf2.get()) }
             };
 

--- a/compendium/ConfigurationAdmin/test/gtest/TestConfigurationImpl.cpp
+++ b/compendium/ConfigurationAdmin/test/gtest/TestConfigurationImpl.cpp
@@ -169,6 +169,58 @@ namespace cppmicroservices
             EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(props), std::make_pair(true, 2ul));
         }
 
+        // Per OSGi Compendium R7 §104.7.4, a never-updated Configuration has null
+        // properties — distinct from "updated to empty". The first call to
+        // UpdateIfDifferent on a freshly-created (no initial properties) Configuration
+        // must therefore behave like Update even when the new properties are empty:
+        // it must report `true` and fire the listener notification.
+        TEST(TestConfigurationImpl, VerifyUpdateIfDifferentNotifiesOnFirstEmptyUpdate)
+        {
+            auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+            AnyMap emptyProps { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+            std::string pid { "test~instance" };
+            std::string factoryPid { "test" };
+            ConfigurationImpl conf { mockConfigAdmin.get(),
+                                     pid,
+                                     factoryPid,
+                                     emptyProps,
+                                     std::make_shared<async::MockAsyncWorkService>(),
+                                     1 };
+            auto validFuture = std::make_shared<ThreadpoolSafeFuturePrivate>();
+
+            EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(pid, testing::_, testing::_))
+                .Times(1)
+                .WillOnce(testing::Return(validFuture));
+
+            auto result = conf.UpdateIfDifferent(emptyProps);
+            EXPECT_TRUE(result.first);
+
+            // A second call with the same (empty) properties must now be a no-op.
+            result = conf.UpdateIfDifferent(emptyProps);
+            EXPECT_FALSE(result.first);
+        }
+
+        // Same invariant at the without-notification layer: the first call on a
+        // never-updated Configuration must return {true, 1u} even when newProperties
+        // is empty, because "no properties" and "empty properties" are not the same.
+        TEST(TestConfigurationImpl, VerifyUpdateWithoutNotificationIfDifferentFirstEmptyUpdate)
+        {
+            auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();
+            AnyMap emptyProps { AnyMap::UNORDERED_MAP_CASEINSENSITIVE_KEYS };
+            std::string pid { "test~instance" };
+            std::string factoryPid { "test" };
+            ConfigurationImpl conf { mockConfigAdmin.get(),
+                                     pid,
+                                     factoryPid,
+                                     emptyProps,
+                                     std::make_shared<async::MockAsyncWorkService>(),
+                                     1 };
+            EXPECT_CALL(*mockConfigAdmin, NotifyConfigurationUpdated(testing::_, testing::_, testing::_)).Times(0);
+
+            EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(emptyProps), std::make_pair(true, 1ul));
+            EXPECT_EQ(conf.UpdateWithoutNotificationIfDifferent(emptyProps), std::make_pair(false, 0ul));
+        }
+
         TEST(TestConfigurationImpl, VerifyRemoveWithoutNotificationIfChangeCountEquals)
         {
             auto mockConfigAdmin = std::make_shared<testing::NiceMock<MockConfigurationAdminPrivate>>();


### PR DESCRIPTION
According to OSGI: [When no update has occurred since this object was created, getProperties returns null](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.cm.html#service.cm-updating.configuration:~:text=When%20no%20update%20has%20occurred%20since%20this%20object%20was%20created%2C%20getProperties%20returns%20null)

This means that a series of calls like this:

```
configAdmin->GetConfiguration("UpdateIfDifferent")->UpdateIfDifferent().second.get();
```

SHOULD update the configuration and trigger a notification because `emptyAnymap != null`