### PR TITLE
remove virtual method on non inherited final class

### DIFF
--- a/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
+++ b/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp
@@ -54,7 +54,7 @@ namespace cppmicroservices
             ConfigurationManager(ConfigurationManager&&) = delete;
             ConfigurationManager& operator=(ConfigurationManager const&) = delete;
             ConfigurationManager& operator=(ConfigurationManager&&) = delete;
-            virtual ~ConfigurationManager() = default;
+            ~ConfigurationManager() = default;
 
             /**
              * Method to initialize a newly constructed Configuration Manager.

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -243,8 +243,7 @@ namespace cppmicroservices
     std::shared_ptr<void>
     BundleContext::GetService(ServiceReferenceBase const& reference)
     {
-        // if (!reference.d.Load()->coreInfo)
-        if (!reference)
+        if (!reference.d.Load()->coreInfo)
         {
             throw std::invalid_argument("Default constructed ServiceReference is not a "
                                         "valid input to GetService()");
@@ -265,8 +264,7 @@ namespace cppmicroservices
     InterfaceMapConstPtr
     BundleContext::GetService(ServiceReferenceU const& reference)
     {
-        // if (!reference.d.Load()->coreInfo)
-        if (!reference)
+        if (!reference.d.Load()->coreInfo)
         {
             throw std::invalid_argument("Default constructed ServiceReference is not a "
                                         "valid input to GetService()");

--- a/framework/src/bundle/BundleContext.cpp
+++ b/framework/src/bundle/BundleContext.cpp
@@ -243,6 +243,7 @@ namespace cppmicroservices
     std::shared_ptr<void>
     BundleContext::GetService(ServiceReferenceBase const& reference)
     {
+        // if (!reference.d.Load()->coreInfo)
         if (!reference)
         {
             throw std::invalid_argument("Default constructed ServiceReference is not a "
@@ -264,6 +265,7 @@ namespace cppmicroservices
     InterfaceMapConstPtr
     BundleContext::GetService(ServiceReferenceU const& reference)
     {
+        // if (!reference.d.Load()->coreInfo)
         if (!reference)
         {
             throw std::invalid_argument("Default constructed ServiceReference is not a "

--- a/framework/test/gtest/BundleContextTest.cpp
+++ b/framework/test/gtest/BundleContextTest.cpp
@@ -146,7 +146,7 @@ TEST_F(BundleContextTest, BundleContextThrowWhenInvalid)
         << "GetServiceReference(string) on invalid BundleContext did not throw.";
     EXPECT_THROW({ (void)context2.GetServiceReference<bc_tests::TestService>(); }, std::runtime_error)
         << "GetServiceReference() on invalid BundleContext did not throw.";
-    EXPECT_THROW({ (void)context2.GetService<bc_tests::TestService>(sRef); }, std::invalid_argument)
+    EXPECT_THROW({ (void)context2.GetService<bc_tests::TestService>(sRef); }, std::runtime_error)
         << "GetService() on invalid BundleContext did not throw.";
     EXPECT_THROW({ (void)context2.GetServiceObjects<bc_tests::TestService>(sRef); }, std::runtime_error)
         << "GetServiceObjects() on invalid BundleContext did not throw.";

--- a/framework/test/gtest/BundleTest.cpp
+++ b/framework/test/gtest/BundleTest.cpp
@@ -957,4 +957,35 @@ TEST_F(BundleTest, TestFrameworkAccessDuringFrameworkShutdown)
 }
 #endif
 
+TEST_F(BundleTest, TestGetServiceWithDefaultConstructedReferenceThrows)
+{
+    EXPECT_THROW(context.GetService(ServiceReferenceU()), std::invalid_argument);
+
+    ServiceReference<int> typedDefault;
+    EXPECT_THROW(context.GetService<int>(typedDefault), std::invalid_argument);
+}
+
+TEST_F(BundleTest, TestGetServiceWithUnregisteredReferenceReturnsNull)
+{
+    struct IService
+    {
+        virtual ~IService() = default;
+    };
+    struct ServiceImpl : IService
+    {
+    };
+
+    auto reg = context.RegisterService<IService>(std::make_shared<ServiceImpl>());
+    auto ref = context.GetServiceReference<IService>();
+    ASSERT_TRUE(ref);
+
+    reg.Unregister();
+
+    EXPECT_FALSE(ref) << "Reference should evaluate to false after unregistration";
+    EXPECT_NO_THROW({
+        auto svc = context.GetService<IService>(ref);
+        EXPECT_EQ(svc, nullptr) << "GetService on an unregistered reference should return null, not throw";
+    });
+}
+
 US_MSVC_POP_WARNING


### PR DESCRIPTION
To fix the error below in our runners:

```
/Users/runner/work/CppMicroServices/CppMicroServices/compendium/DeclarativeServices/src/manager/ConfigurationManager.hpp:57:21: error: virtual method '~ConfigurationManager' is inside a 'final' class and can never be overridden [-Werror,-Wunnecessary-virtual-specifier]
   57 |             virtual ~ConfigurationManager() = default;
      |                     ^
1 error generated.
```

This change exposed an issue (just because the test that exposed it wasn't running on mac where there seems to have been a sporadic failures as a result of `getService` called on `serviceReference`s of unregistered services. 

This, according to our doc should return an empty object (nullptr)

https://github.com/CppMicroServices/CppMicroServices/blob/e7d90bd67b56a6840d3209a318e6a650484c5aa7/framework/include/cppmicroservices/BundleContext.h#L552-L567

But instead, we are throwing. 

I fixed this and added tests that verify behavior. 

Not sure why this flew under the radar so long, I'm guessing just because more code that calls `getService` does not distinguish between these two flavors of failures (actual non existent `serviceReference` vs `serviceReference` to service that is gone). In either case the service is not available. 