### PR TITLE
localize locking more to remove deadlock potential

### DIFF
--- a/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
+++ b/compendium/DeclarativeServices/src/ComponentContextImpl.cpp
@@ -76,15 +76,16 @@ namespace cppmicroservices::scrimpl
                               {
                                   ServiceReferenceU sRefU(sRef);
                                   auto bc = GetBundleContext();
-                                  auto boundServicesCacheHandle = boundServicesCache.lock();
-                                  auto& serviceMap = (*boundServicesCacheHandle)[refName];
-                                  // get us the service instance
+                                  // Acquire the service outside the boundServicesCache lock to
+                                  // avoid lock inversion with oneAtATimeMutex (see issue #1192).
                                   cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(sRefU);
                                   auto interfaceMap = sObjs.GetService();
                                   if (interfaceMap && !interfaceMap->empty())
                                   {
                                       foundAtLeastOneValidBoundService = true;
-                                      serviceMap.emplace_back(std::make_pair(sRef, interfaceMap));
+                                      auto boundServicesCacheHandle = boundServicesCache.lock();
+                                      (*boundServicesCacheHandle)[refName].emplace_back(
+                                          std::make_pair(sRef, interfaceMap));
                                   }
                               }
                           });
@@ -419,13 +420,13 @@ namespace cppmicroservices::scrimpl
     {
         auto bc = GetBundleContext();
         cppmicroservices::ServiceObjects<void> sObjs = bc.GetServiceObjects(ServiceReferenceU(sRef));
-        auto boundServicesCacheHandle = boundServicesCache.lock();
         auto interfaceMap = sObjs.GetService();
         if (!interfaceMap || interfaceMap->empty())
         {
             return nullptr;
         }
         std::shared_ptr<void> svcToBind = interfaceMap->begin()->second;
+        auto boundServicesCacheHandle = boundServicesCache.lock();
         (*boundServicesCacheHandle)[refName].emplace_back(std::make_pair(sRef, interfaceMap));
         return svcToBind;
     }


### PR DESCRIPTION
### Thread 1: serviceA rebinding, fetches serviceB

```
ComponentContextImpl::AddToBoundServicesCache(serviceA)
  <- LOCK boundServicesCache (serviceA)
  └─ ServiceObjects::GetService
     └─ SingletonComponentConfigurationImpl::GetService(serviceB)
        └─ CCActiveState::Activate(serviceB)
           <- LOCK oneAtATimeMutex (serviceB)
```

### Thread 2: serviceB is Modified, cascades into serviceA destruction

```
CCActiveState::Modified(serviceB)
  <- LOCK oneAtATimeMutex (serviceB)
  └─ SetRegistrationProperties
     └─ ServiceListeners::ServiceChanged
        └─ serviceA becomes unsatisfied
           └─ Deactivate(serviceA)
              └─ DestroyComponentInstances
                 └─ ComponentContextImpl::Invalidate(serviceA)
                    <- LOCK boundServicesCache (serviceA)
```

### Fix

In `AddToBoundServicesCache` (and `InitializeServicesCache`), call `GetService` before locking `boundServicesCache`. Lock only for the insert.
@Burgch To answer your points from the issue linked, #1192, 

1. "Do we need to be holding a lock on the boundServicesCache whilst we're calling GetService..." -- no I think you are right. We do not technically need to. The problem is it is a `guarded` data member which means we are forced to lock it at some point for access, but it does NOT need to be around the `getService` call. 
2. "should be queued to run after the Activate..." I am not sure if this is a question or a statement, but I am guessing it is a statement because that is what I believe after reading back through code. The `Deactivate` will be blocked till the `Activate` transition task is finished. 